### PR TITLE
Update test path in parser

### DIFF
--- a/sync_ci/pkg/parser/regex_rules_test.go
+++ b/sync_ci/pkg/parser/regex_rules_test.go
@@ -197,7 +197,7 @@ func TestRegex_TiDB_MysqlTestError(t *testing.T) {
 	lines := FilesToLines("./rules_test/mysql_test_error.log")
 
 	info := ApplyRegexpRulesToLines("", lines)
-	if len(*info) == 1 {
+	if len(*info) == 2 {
 		if (*info)[0].Key == "case" && strings.Contains((*info)[0].Value, "[fatal] run test [window_functions] err: sql:SHOW CREATE VIEW v;: failed to run query") {
 			return
 		}

--- a/sync_ci/pkg/parser/regex_rules_test.go
+++ b/sync_ci/pkg/parser/regex_rules_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestRegex_Load(t *testing.T) {
-	if updateRegexpRules("./pkg/parser/regex_rules.json") != true {
+	if updateRegexpRules("./regex_rules.json") != true {
 		t.Error("load rule failed")
 	}
 }
 
 func TestRegex_TestRules(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/integration_fatal_error.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/integration_fatal_error.log")
 	result := ApplyRegexpRulesToLines("tidb_ghpr_check", lines)
 	if result == nil || len(*result) != 2 {
 		t.Error("test failed")
@@ -24,7 +24,7 @@ func TestRegex_TestRules(t *testing.T) {
 
 	for _, r := range *result {
 		if r.Key != "case" ||
-			strings.Contains(r.Value, `[FATAL] [main.go:694] ["run test"] [test=select] [error="sql:SELECT c2 from t where not (c2 > 2);: run` ) == false {
+			strings.Contains(r.Value, `[FATAL] [main.go:694] ["run test"] [test=select] [error="sql:SELECT c2 from t where not (c2 > 2);: run`) == false {
 			t.Error("test failed")
 		}
 	}
@@ -47,8 +47,8 @@ func FilesToLines(path string) []string {
 }
 
 func TestRegexp_TiKVCompileError(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/tikv_compile_error.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/tikv_compile_error.log")
 
 	info := ApplyRegexpRulesToLines("tikv_ghpr_test", lines)
 	for _, o := range *info {
@@ -61,8 +61,8 @@ func TestRegexp_TiKVCompileError(t *testing.T) {
 }
 
 func TestRegexp_TiDBPanic(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/tidb_panic.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/tidb_panic.log")
 
 	info := ApplyRegexpRulesToLines("tidb_ghpr_check", lines)
 	for _, o := range *info {
@@ -75,8 +75,8 @@ func TestRegexp_TiDBPanic(t *testing.T) {
 }
 
 func TestRegexp_ReferenceError(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/replace_error.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/replace_error.log")
 
 	info := ApplyRegexpRulesToLines("tidb_ghpr_check", lines)
 	for _, o := range *info {
@@ -89,8 +89,8 @@ func TestRegexp_ReferenceError(t *testing.T) {
 }
 
 func TestRegexp_TiKVTomlError(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/tikv_toml_error.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/tikv_toml_error.log")
 
 	info := ApplyRegexpRulesToLines("", lines)
 	for _, o := range *info {
@@ -103,8 +103,8 @@ func TestRegexp_TiKVTomlError(t *testing.T) {
 }
 
 //func TestRegex_TicsFail(t *testing.T) {
-//	updateRegexpRules("./pkg/parser/regex_rules.json")
-//	lines := FilesToLines("./pkg/parser/rules_test/tics_fail.log")
+//	updateRegexpRules("./regex_rules.json")
+//	lines := FilesToLines("./rules_test/tics_fail.log")
 //
 //	info := ApplyRegexpRulesToLines("tidb_ghpr_tics_test", lines)
 //	for _, o := range *info {
@@ -117,8 +117,8 @@ func TestRegexp_TiKVTomlError(t *testing.T) {
 //}
 
 func TestRegex_CoprTest(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/copr_test_case.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/copr_test_case.log")
 
 	info := ApplyRegexpRulesToLines("", lines)
 	for _, o := range *info {
@@ -131,8 +131,8 @@ func TestRegex_CoprTest(t *testing.T) {
 }
 
 func TestRegex_TiDBRaceBuildFailed(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/tidb_race_build_failed.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/tidb_race_build_failed.log")
 
 	info := ApplyRegexpRulesToLines("", lines)
 	for _, o := range *info {
@@ -145,8 +145,8 @@ func TestRegex_TiDBRaceBuildFailed(t *testing.T) {
 }
 
 func TestRegex_TiDB_IntegrationCommonTest(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/FAIL_integration_common_test.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/FAIL_integration_common_test.log")
 
 	info := ApplyRegexpRulesToLines("tidb_ghpr_integration_common_test", lines)
 	if len(*info) != 2 {
@@ -162,8 +162,8 @@ func TestRegex_TiDB_IntegrationCommonTest(t *testing.T) {
 }
 
 func TestRegex_TiDB_IntegrationCommonTest2(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/tidb_integration_fail.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/tidb_integration_fail.log")
 
 	info := ApplyRegexpRulesToLines("", lines)
 	if info == nil || len(*info) != 1 {
@@ -179,8 +179,8 @@ func TestRegex_TiDB_IntegrationCommonTest2(t *testing.T) {
 }
 
 func TestRegex_TiDB_PDBuildFailed(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/pd_build_failed.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/pd_build_failed.log")
 
 	info := ApplyRegexpRulesToLines("", lines)
 	if len(*info) == 1 {
@@ -193,8 +193,8 @@ func TestRegex_TiDB_PDBuildFailed(t *testing.T) {
 }
 
 func TestRegex_TiDB_MysqlTestError(t *testing.T) {
-	updateRegexpRules("./pkg/parser/regex_rules.json")
-	lines := FilesToLines("./pkg/parser/rules_test/mysql_test_error.log")
+	updateRegexpRules("./regex_rules.json")
+	lines := FilesToLines("./rules_test/mysql_test_error.log")
 
 	info := ApplyRegexpRulesToLines("", lines)
 	if len(*info) == 1 {

--- a/sync_ci/pkg/parser/rules_test.go
+++ b/sync_ci/pkg/parser/rules_test.go
@@ -1,9 +1,10 @@
 package parser
 
 import (
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTidbUtParser_Parse(t *testing.T) {
@@ -169,7 +170,7 @@ script returned exit code 1`,
 }
 
 func TestEnvParser_Parse(t *testing.T) {
-	if err := UpdateRules("./pkg/parser/envrules.json"); err != nil {
+	if err := UpdateRules("./envrules.json"); err != nil {
 		t.Error(err)
 	}
 	testData := []struct {
@@ -202,7 +203,7 @@ func TestIntegrationTestParser(t *testing.T) {
 	testData := []struct {
 		text string
 		res  string
-		job string
+		job  string
 	}{
 		{
 			`[2020-12-06T14:19:39.699Z] 2020/12/06 22:19:39 2020/12/06 22:19:37 Test fail: Outputs are not matching.


### PR DESCRIPTION
Pls check this before #39 
## Why
The tests in **parser** package now use path relative to /sync_ci, which make it have to be compiled and run manually from /sync_ci, rather than be processed along with other tests (although there's none for now) by `go test ./...`.
## What does this PR do
Change path to be relative to the /sync_ci/pkg/parser folder, namely to the test file it self.  