### PR TITLE
docker_rust: install gcc 8

### DIFF
--- a/jenkins/Dockerfile/centos7_golang-1.13_rust
+++ b/jenkins/Dockerfile/centos7_golang-1.13_rust
@@ -5,14 +5,15 @@ MAINTAINER Liu Yin <liuy@pingcap.com>
 USER root
 WORKDIR /root
 
-RUN curl -L http://172.16.30.25/download/tools/cmake-3.10.0.tar.gz -o cmake-3.10.0.tar.gz \
-	&& tar xzf cmake-3.10.0.tar.gz \
-	&& cd cmake-3.10.0 \
-	&& ./bootstrap \
-	&& make \
-	&& make install \
+RUN yum install --nogpgcheck -y centos-release-scl \
+	&& yum install -y devtoolset-8 \
+	&& yum clean all
+
+RUN yum remove -y cmake \
+	&& curl -L https://github.com/Kitware/CMake/releases/download/v3.10.0/cmake-3.10.0-linux-x86_64.sh -o cmake-3.10.0.sh \
+	&& sh cmake-3.10.0.sh --skip-license --prefix=/usr/local \
 	&& cmake --version \
-	&& rm -rf /cmake-3.10.0.tar.gz /cmake-3.10.0
+	&& rm -rf cmake-3.10.0.sh
 
 RUN curl -L https://github.com/gflags/gflags/archive/v2.1.2.tar.gz -o gflags.tar.gz \
 	&& tar xf gflags.tar.gz \

--- a/jenkins/pipelines/tikv_ghpr_test.groovy
+++ b/jenkins/pipelines/tikv_ghpr_test.groovy
@@ -152,6 +152,10 @@ try {
                                 export ROCKSDB_SYS_SSE=1
                                 export RUST_BACKTRACE=1
                                 export LOG_LEVEL=INFO
+                                grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
+                                if [[ ! "0.8.0" > "$grpcio_ver" ]]; then
+                                  source scl_source enable devtoolset-8
+                                fi
                                 make clippy || (echo Please fix the clippy error; exit 1)
                                 """
 
@@ -297,6 +301,10 @@ try {
                                         export LOG_LEVEL=INFO
                                         # export CARGO_LOG=cargo::core::compiler::fingerprint=debug
 
+                                        grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
+                                        if [[ ! "0.8.0" > "$grpcio_ver" ]]; then
+                                            source scl_source enable devtoolset-8
+                                        fi
                                         set -o pipefail
 
                                         test="test"


### PR DESCRIPTION
We need gcc 8 to build latest grpc.