### PR TITLE
*: use source directly to enable devtoolset-8

### DIFF
--- a/jenkins/pipelines/build-linux-amd64-enterprise.groovy
+++ b/jenkins/pipelines/build-linux-amd64-enterprise.groovy
@@ -151,7 +151,7 @@ try {
                     grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                     if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                         echo using gcc 8
-                        source scl_source enable devtoolset-8
+                        source /opt/rh/devtoolset-8/enable
                     fi
                     TIKV_EDITION=Enterprise CARGO_TARGET_DIR=.target ROCKSDB_SYS_STATIC=1 ROCKSDB_SYS_SSE=0 make dist_release
                     tar --exclude=${target}.tar.gz -czvf ${target}.tar.gz *

--- a/jenkins/pipelines/cd/optimization-build-tidb-linux-amd.groovy
+++ b/jenkins/pipelines/cd/optimization-build-tidb-linux-amd.groovy
@@ -324,7 +324,7 @@ try {
                         grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                         if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                             echo using gcc 8
-                            source scl_source enable devtoolset-8
+                            source /opt/rh/devtoolset-8/enable
                         fi
                         CARGO_TARGET_DIR=.target ROCKSDB_SYS_STATIC=1 make dist_release
                         tar --exclude=${target}.tar.gz -czvf ${target}.tar.gz bin/*
@@ -360,7 +360,7 @@ try {
                         grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                         if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                             echo using gcc 8
-                            source scl_source enable devtoolset-8
+                            source /opt/rh/devtoolset-8/enable
                         fi
                         make release && mkdir -p bin/ && mv target/release/tikv-importer bin/
                         tar --exclude=${target}.tar.gz -czvf importer.tar.gz bin/*

--- a/jenkins/pipelines/cd/optimization-build-tidb-linux-arm.groovy
+++ b/jenkins/pipelines/cd/optimization-build-tidb-linux-arm.groovy
@@ -130,7 +130,7 @@ try {
                 grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                 if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                     echo using gcc 8
-                    source scl_source enable devtoolset-8
+                    source /opt/rh/devtoolset-8/enable
                 fi
                 CARGO_TARGET_DIR=.target ROCKSDB_SYS_STATIC=1 ROCKSDB_SYS_SSE=0 make dist_release
                 rm -rf ${target}
@@ -164,7 +164,7 @@ try {
                 grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                 if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                     echo using gcc 8
-                    source scl_source enable devtoolset-8
+                    source /opt/rh/devtoolset-8/enable
                 fi
                 ROCKSDB_SYS_SSE=0 make release
                 rm -rf ${target}

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_build_release.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_build_release.groovy
@@ -41,7 +41,7 @@ try {
                         grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                         if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                             echo using gcc 8
-                            source scl_source enable devtoolset-8
+                            source /opt/rh/devtoolset-8/enable
                         fi
                         CARGO_TARGET_DIR=/home/jenkins/agent/.target ROCKSDB_SYS_STATIC=1 ${release}
                         if [[ "${release}" =~ "make dist_release" ]];then

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_common_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_common_test.groovy
@@ -87,7 +87,7 @@ try {
                                     grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                                     if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                                         echo using gcc 8
-                                        source scl_source enable devtoolset-8
+                                        source /opt/rh/devtoolset-8/enable
                                     fi
                                     CARGO_TARGET_DIR=/home/jenkins/agent/.target ROCKSDB_SYS_STATIC=1 make ${release}
                                     # use make release

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_test.groovy
@@ -166,7 +166,7 @@ try {
                                 grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                                 if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                                   echo using gcc 8
-                                  source scl_source enable devtoolset-8
+                                  source /opt/rh/devtoolset-8/enable
                                 fi
                                 make clippy || (echo Please fix the clippy error; exit 1)
                                 """
@@ -320,7 +320,7 @@ try {
                                         grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                                         if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                                             echo using gcc 8
-                                            source scl_source enable devtoolset-8
+                                            source /opt/rh/devtoolset-8/enable
                                         fi
 
                                         set -o pipefail

--- a/jenkins/pipelines/copr-test-old.groovy
+++ b/jenkins/pipelines/copr-test-old.groovy
@@ -65,7 +65,7 @@ try {
                             grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                             if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                                 echo using gcc 8
-                                source scl_source enable devtoolset-8
+                                source /opt/rh/devtoolset-8/enable
                             fi
                             CARGO_TARGET_DIR=/home/jenkins/.target ROCKSDB_SYS_STATIC=1 make ${release}
                             mkdir bin

--- a/jenkins/pipelines/tikv_ghpr_integration_common_test.groovy
+++ b/jenkins/pipelines/tikv_ghpr_integration_common_test.groovy
@@ -79,7 +79,7 @@ try {
                                     grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                                     if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                                       echo using gcc 8
-                                      source scl_source enable devtoolset-8
+                                      source /opt/rh/devtoolset-8/enable
                                     fi
                                     CARGO_TARGET_DIR=/home/jenkins/agent/.target ROCKSDB_SYS_STATIC=1 make ${release}
                                     # use make release

--- a/jenkins/pipelines/tikv_ghpr_test.groovy
+++ b/jenkins/pipelines/tikv_ghpr_test.groovy
@@ -155,7 +155,7 @@ try {
                                 grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                                 if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                                   echo using gcc 8
-                                  source scl_source enable devtoolset-8
+                                  source /opt/rh/devtoolset-8/enable
                                 fi
                                 make clippy || (echo Please fix the clippy error; exit 1)
                                 """
@@ -305,7 +305,7 @@ try {
                                         grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
                                         if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
                                             echo using gcc 8
-                                            source scl_source enable devtoolset-8
+                                            source /opt/rh/devtoolset-8/enable
                                         fi
 
                                         set -o pipefail


### PR DESCRIPTION
We can't use scl_enable before
https://github.com/sclorg/scl-utils/pull/35 is released.