### PR TITLE
make tidb_title_check more strict

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_check_title.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_check_title.groovy
@@ -16,7 +16,7 @@ $ghprbPullTitle
 EOT"""
             //echo "$ghprbPullLongDescription" > a.out
             //sh "echo \"$ghprbPullLongDescription\" > $ghprbActualCommit"
-            sh "egrep ':.+' $ghprbActualCommit/title.txt || ( echo 'Please format title' && exit 1) "
+            sh "egrep '.+: .+' $ghprbActualCommit/title.txt || ( echo 'Please format title' && exit 1) "
 
             //echo "GO: $goVersion BUILD: $buildSlave TEST: $testSlave"
         }


### PR DESCRIPTION
Disallow terrible titles like `foo:do something` or `: do something`