### PR TITLE
Put go1.16 logic code after release test params setting

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
@@ -1,18 +1,4 @@
 def notRun = 1
-def buildSlave = "${GO_BUILD_SLAVE}"
-
-@Library("pingcap") _
-
-def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
-if (isNeedGo1160) {
-    println "This build use go1.16"
-    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
-    GO_TEST_SLAVE = GO1160_TEST_SLAVE
-} else {
-    println "This build use go1.13"
-}
-println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
-println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
 
 def slackcolor = 'good'
 def githash
@@ -56,6 +42,21 @@ if (m2) {
 }
 m2 = null
 println "PD_BRANCH=${PD_BRANCH}"
+
+@Library("pingcap") _
+
+def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
+if (isNeedGo1160) {
+    println "This build use go1.16"
+    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
+    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+} else {
+    println "This build use go1.13"
+}
+println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
+println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
+
+def buildSlave = "${GO_BUILD_SLAVE}"
 
 def sessionTestSuitesString = "testPessimisticSuite"
 

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_common_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_common_test.groovy
@@ -1,19 +1,4 @@
-@Library("pingcap") _
-
-def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
-if (isNeedGo1160) {
-    println "This build use go1.16"
-    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
-    GO_TEST_SLAVE = GO1160_TEST_SLAVE
-} else {
-    println "This build use go1.13"
-}
-println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
-println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
-
 def notRun = 1
-def buildSlave = "${GO_BUILD_SLAVE}"
-
 
 echo "release test: ${params.containsKey("release_test")}"
 if (params.containsKey("release_test")) {
@@ -39,6 +24,21 @@ if (m3) {
 // }
 m3 = null
 println "TIDB_TEST_BRANCH=${TIDB_TEST_BRANCH}"
+
+@Library("pingcap") _
+
+def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
+if (isNeedGo1160) {
+    println "This build use go1.16"
+    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
+    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+} else {
+    println "This build use go1.13"
+}
+println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
+println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
+
+def buildSlave = "${GO_BUILD_SLAVE}"
 
 def tidb_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb/pr/${ghprbActualCommit}/centos7/tidb-server.tar.gz"
 def tidb_done_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb/pr/${ghprbActualCommit}/centos7/done"

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_ddl_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_ddl_test.groovy
@@ -1,5 +1,4 @@
 def notRun = 1
-def buildSlave = "${GO_BUILD_SLAVE}"
 
 echo "release test: ${params.containsKey("release_test")}"
 if (params.containsKey("release_test")) {
@@ -63,6 +62,8 @@ if (isNeedGo1160) {
 }
 println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
 println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
+
+def buildSlave = "${GO_BUILD_SLAVE}"
 
 try {
     stage("Pre-check"){

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_mybatis.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_mybatis.groovy
@@ -1,16 +1,3 @@
-@Library("pingcap") _
-
-def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
-if (isNeedGo1160) {
-    println "This build use go1.16"
-    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
-    GO_TEST_SLAVE = GO1160_TEST_SLAVE
-} else {
-    println "This build use go1.13"
-}
-println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
-println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
-
 def notRun = 1
 if (!params.force){
     node("${GO_BUILD_SLAVE}"){
@@ -60,6 +47,19 @@ if (m4) {
 }
 m4 = null
 println "TIDB_PRIVATE_TEST_BRANCH=${TIDB_PRIVATE_TEST_BRANCH}"
+
+@Library("pingcap") _
+
+def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
+if (isNeedGo1160) {
+    println "This build use go1.16"
+    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
+    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+} else {
+    println "This build use go1.13"
+}
+println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
+println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
 
 try {
     stage('Mybatis Test') {

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_sqllogic_test_1.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_sqllogic_test_1.groovy
@@ -1,16 +1,3 @@
-@Library("pingcap") _
-
-def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
-if (isNeedGo1160) {
-    println "This build use go1.16"
-    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
-    GO_TEST_SLAVE = GO1160_TEST_SLAVE
-} else {
-    println "This build use go1.13"
-}
-println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
-println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
-
 def notRun = 1
 
 echo "release test: ${params.containsKey("release_test")}"
@@ -35,6 +22,19 @@ if (m3) {
 // }
 m3 = null
 println "TIDB_TEST_BRANCH=${TIDB_TEST_BRANCH}"
+
+@Library("pingcap") _
+
+def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
+if (isNeedGo1160) {
+    println "This build use go1.16"
+    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
+    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+} else {
+    println "This build use go1.13"
+}
+println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
+println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
 
 def tidb_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb-check/pr/${ghprbActualCommit}/centos7/tidb-server.tar.gz"
 def tidb_done_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb-check/pr/${ghprbActualCommit}/centos7/done"

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_sqllogic_test_2.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_sqllogic_test_2.groovy
@@ -1,16 +1,3 @@
-@Library("pingcap") _
-
-def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
-if (isNeedGo1160) {
-    println "This build use go1.16"
-    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
-    GO_TEST_SLAVE = GO1160_TEST_SLAVE
-} else {
-    println "This build use go1.13"
-}
-println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
-println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
-
 def notRun = 1
 
 echo "release test: ${params.containsKey("release_test")}"
@@ -35,6 +22,19 @@ if (m3) {
 // }
 m3 = null
 println "TIDB_TEST_BRANCH=${TIDB_TEST_BRANCH}"
+
+@Library("pingcap") _
+
+def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
+if (isNeedGo1160) {
+    println "This build use go1.16"
+    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
+    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+} else {
+    println "This build use go1.13"
+}
+println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
+println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
 
 def tidb_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb-check/pr/${ghprbActualCommit}/centos7/tidb-server.tar.gz"
 def tidb_done_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb-check/pr/${ghprbActualCommit}/centos7/done"


### PR DESCRIPTION
Put go1.16 logic code after release test params setting in case of job failed when triggered by qa_release.