### PR TITLE
fix some miss go1.16 node setting on some test step

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
@@ -8,9 +8,6 @@ if (ghprbPullId != null && ghprbPullId != "") {
     specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
 }
 
-//def buildSlave = "${GO_BUILD_SLAVE}"
-def testSlave = "${GO_TEST_SLAVE}"
-
 def TIKV_BRANCH = params.getOrDefault("ghprbTargetBranch","")
 def PD_BRANCH = params.getOrDefault("ghprbTargetBranch","")
 
@@ -57,6 +54,7 @@ println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
 println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
 
 def buildSlave = "${GO_BUILD_SLAVE}"
+def testSlave = "${GO_TEST_SLAVE}"
 
 def sessionTestSuitesString = "testPessimisticSuite"
 

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_common_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_common_test.groovy
@@ -84,7 +84,7 @@ try {
         }
 
         def buildSlave = "${GO_BUILD_SLAVE}"
-        def testSlave = "test_go"
+        def testSlave = "${GO_TEST_SLAVE}"
 
         stage('Prepare') {
             def prepareStartTime = System.currentTimeMillis()


### PR DESCRIPTION
fix error when some ci test case not use go1.16, set test-slave node