### PR TITLE
upgrade tikv ci go version from 1.13 to 1.16.4, only for branch master

### DIFF
--- a/jenkins/pipelines/ci/tikv/tikv_check_release_note.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_check_release_note.groovy
@@ -1,8 +1,32 @@
+def boolean isBranchMatched(List<String> branches, String targetBranch) {
+    for (String item : branches) {
+        if (targetBranch.startsWith(item)) {
+            println "targetBranch=${targetBranch} matched in ${branches}"
+            return true
+        }
+    }
+    return false
+}
+
+println "$GO1160_BUILD_SLAVE"
+println "$GO1160_TEST_SLAVE"
+
+def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
+if (isNeedGo1160) {
+    println "This build use go1.16 because ghprTargetBranch=master"
+    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
+    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+} else {
+    println "This build use go1.13"
+}
+println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
+println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
+
 catchError {
     stage("check release note") {
             //sh "echo $ghprbPullLongDescription | egrep 'Release note'"
             //sh "python -v"
-        node('build_go1130') {
+        node("BUILD_NODE_NAME") {
             //def goVersion = new Utils(this).detectGoVersion("https://raw.githubusercontent.com/pingcap/tidb/master/circle.yml")
             //buildSlave = GO_BUILD_SLAVE
             //testSlave = GO_TEST_SLAVE

--- a/jenkins/pipelines/ci/tikv/tikv_check_release_note.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_check_release_note.groovy
@@ -12,7 +12,7 @@ def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
 if (isNeedGo1160) {
     println "This build use go1.16 because ghprTargetBranch=master"
     GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
-    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+    GO_TEST_SLAVE = "test_heavy_go1160_memvolume"
 } else {
     println "This build use go1.13"
     GO_TEST_SLAVE = "test_tikv_go1130_memvolume"

--- a/jenkins/pipelines/ci/tikv/tikv_check_release_note.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_check_release_note.groovy
@@ -15,6 +15,7 @@ if (isNeedGo1160) {
     GO_TEST_SLAVE = GO1160_TEST_SLAVE
 } else {
     println "This build use go1.13"
+    GO_TEST_SLAVE = "test_tikv_go1130_memvolume"
 }
 println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
 println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
@@ -23,7 +24,7 @@ catchError {
     stage("check release note") {
             //sh "echo $ghprbPullLongDescription | egrep 'Release note'"
             //sh "python -v"
-        node("BUILD_NODE_NAME") {
+        node("${GO_BUILD_SLAVE}") {
             //def goVersion = new Utils(this).detectGoVersion("https://raw.githubusercontent.com/pingcap/tidb/master/circle.yml")
             //buildSlave = GO_BUILD_SLAVE
             //testSlave = GO_TEST_SLAVE

--- a/jenkins/pipelines/ci/tikv/tikv_check_release_note.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_check_release_note.groovy
@@ -8,9 +8,6 @@ def boolean isBranchMatched(List<String> branches, String targetBranch) {
     return false
 }
 
-println "$GO1160_BUILD_SLAVE"
-println "$GO1160_TEST_SLAVE"
-
 def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
 if (isNeedGo1160) {
     println "This build use go1.16 because ghprTargetBranch=master"

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_build_release.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_build_release.groovy
@@ -97,7 +97,7 @@ try {
 }
 
 stage("upload status"){
-    node{
+    node("master"){
         sh """curl --connect-timeout 2 --max-time 4 -d '{"job":"$JOB_NAME","id":$BUILD_NUMBER}' http://172.16.5.13:36000/api/v1/ci/job/sync || true"""
     }
 }

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration-copr-test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration-copr-test.groovy
@@ -53,7 +53,7 @@ def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
 if (isNeedGo1160) {
     println "This build use go1.16 because ghprTargetBranch=master"
     GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
-    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+    GO_TEST_SLAVE = "test_heavy_go1160_memvolume"
 } else {
     println "This build use go1.13"
     GO_TEST_SLAVE = "test_tikv_go1130_memvolume"

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration-copr-test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration-copr-test.groovy
@@ -56,6 +56,7 @@ if (isNeedGo1160) {
     GO_TEST_SLAVE = GO1160_TEST_SLAVE
 } else {
     println "This build use go1.13"
+    GO_TEST_SLAVE = "test_tikv_go1130_memvolume"
 }
 println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
 println "TEST_NODE_NAME=${GO_TEST_SLAVE}"

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration-copr-test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration-copr-test.groovy
@@ -39,6 +39,27 @@ if (ghprbPullId != null && ghprbPullId != "") {
     specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
 }
 
+def boolean isBranchMatched(List<String> branches, String targetBranch) {
+    for (String item : branches) {
+        if (targetBranch.startsWith(item)) {
+            println "targetBranch=${targetBranch} matched in ${branches}"
+            return true
+        }
+    }
+    return false
+}
+
+def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
+if (isNeedGo1160) {
+    println "This build use go1.16 because ghprTargetBranch=master"
+    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
+    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+} else {
+    println "This build use go1.13"
+}
+println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
+println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
+
 try {
     stage('Build') {
         node("build") {
@@ -178,7 +199,7 @@ finally {
 }
 
 stage("upload status"){
-    node{
+    node("master"){
         sh """curl --connect-timeout 2 --max-time 4 -d '{"job":"$JOB_NAME","id":$BUILD_NUMBER}' http://172.16.5.13:36000/api/v1/ci/job/sync || true"""
     }
 }

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_common_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_common_test.groovy
@@ -64,7 +64,7 @@ if (isNeedGo1160) {
     GO_TEST_SLAVE = "test_heavy_go1160_memvolume"
 } else {
     println "This build use go1.13"
-    GO_TEST_SLAVE = "test_go_heavy"
+    GO_TEST_SLAVE = "test_tikv_go1130_memvolume"
 }
 println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
 println "TEST_NODE_NAME=${GO_TEST_SLAVE}"

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_common_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_common_test.groovy
@@ -26,9 +26,6 @@ if (PD_BRANCH == "4.0-perf") {
 m2 = null
 println "PD_BRANCH=${PD_BRANCH}"
 
-def buildSlave = "${GO_BUILD_SLAVE}"
-def testSlave = "test_go_heavy"
-
 // parse tidb_test branch
 def m3 = ghprbCommentBody =~ /tidb[_\-]test\s*=\s*([^\s\\]+)(\s|\\|$)/
 if (m3) {
@@ -49,6 +46,28 @@ def tikv_url = "${FILE_SERVER_URL}/download/builds/pingcap/tikv/pr/${ghprbActual
 def release="release"
 
 def push_down_func_test_exist = false
+
+def boolean isBranchMatched(List<String> branches, String targetBranch) {
+    for (String item : branches) {
+        if (targetBranch.startsWith(item)) {
+            println "targetBranch=${targetBranch} matched in ${branches}"
+            return true
+        }
+    }
+    return false
+}
+
+def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
+if (isNeedGo1160) {
+    println "This build use go1.16 because ghprTargetBranch=master"
+    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
+    GO_TEST_SLAVE = "test_heavy_go1160_memvolume"
+} else {
+    println "This build use go1.13"
+    GO_TEST_SLAVE = "test_go_heavy"
+}
+println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
+println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
 
 try {
     stage('Prepare') {
@@ -116,10 +135,9 @@ try {
         }
 
         prepares["Part #2"] = {
-            node(GO_BUILD_SLAVE) {
+            node("${GO_BUILD_SLAVE}") {
                 def ws = pwd()
                 deleteDir()
-
 
 
                 container("golang") {
@@ -170,7 +188,7 @@ try {
         }
 
         prepares["Part #3"] = {
-            node(GO_BUILD_SLAVE) {
+            node("${GO_BUILD_SLAVE}") {
                 def ws = pwd()
                 deleteDir()
 
@@ -232,7 +250,7 @@ try {
         def tests = [:]
 
         def run = { test_dir, mytest, test_cmd ->
-            node(testSlave) {
+            node("${GO_TEST_SLAVE}") {
                 def ws = pwd()
                 deleteDir()
 
@@ -353,7 +371,7 @@ try {
         }
 
         tests["Integration Connection Test"] = {
-            node(testSlave) {
+            node("${GO_TEST_SLAVE}") {
                 def ws = pwd()
                 def mytest = "connectiontest"
                 deleteDir()
@@ -446,11 +464,9 @@ try {
                     }
                 }
 
-                node(testSlave) {
+                node("${GO_TEST_SLAVE}") {
                     def ws = pwd()
                     deleteDir()
-
-
 
                     unstash "tidb-test"
                     unstash "tidb-test-vendor"
@@ -585,7 +601,7 @@ finally {
 }
 
 stage("upload status"){
-    node{
+    node("master"){
         sh """curl --connect-timeout 2 --max-time 4 -d '{"job":"$JOB_NAME","id":$BUILD_NUMBER}' http://172.16.5.13:36000/api/v1/ci/job/sync || true"""
     }
 }

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_compatibility_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_compatibility_test.groovy
@@ -43,9 +43,30 @@ println "TIKV_OLD_BRANCH=${TIKV_OLD_BRANCH}"
 
 def tikv_url = "${FILE_SERVER_URL}/download/builds/pingcap/tikv/pr/${ghprbActualCommit}/centos7/tikv-server.tar.gz"
 
+def boolean isBranchMatched(List<String> branches, String targetBranch) {
+    for (String item : branches) {
+        if (targetBranch.startsWith(item)) {
+            println "targetBranch=${targetBranch} matched in ${branches}"
+            return true
+        }
+    }
+    return false
+}
+
+def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
+if (isNeedGo1160) {
+    println "This build use go1.16 because ghprTargetBranch=master"
+    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
+    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+} else {
+    println "This build use go1.13"
+}
+println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
+println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
+
 try {
     stage('Prepare') {
-        node(GO_TEST_SLAVE) {
+        node("${GO_TEST_SLAVE}") {
             def ws = pwd()
             deleteDir()
 
@@ -86,7 +107,7 @@ try {
     }
 
     stage('Integration Compatibility Test') {
-        node(GO_TEST_SLAVE) {
+        node("${GO_TEST_SLAVE}") {
             def ws = pwd()
             println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
             deleteDir()
@@ -197,7 +218,7 @@ finally {
 }
 
 stage("upload status"){
-    node{
+    node("master"){
         sh """curl --connect-timeout 2 --max-time 4 -d '{"job":"$JOB_NAME","id":$BUILD_NUMBER}' http://172.16.5.13:36000/api/v1/ci/job/sync || true"""
     }
 }

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_compatibility_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_compatibility_test.groovy
@@ -60,6 +60,7 @@ if (isNeedGo1160) {
     GO_TEST_SLAVE = GO1160_TEST_SLAVE
 } else {
     println "This build use go1.13"
+    GO_TEST_SLAVE = "test_tikv_go1130_memvolume"
 }
 println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
 println "TEST_NODE_NAME=${GO_TEST_SLAVE}"

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_compatibility_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_compatibility_test.groovy
@@ -57,7 +57,7 @@ def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
 if (isNeedGo1160) {
     println "This build use go1.16 because ghprTargetBranch=master"
     GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
-    GO_TEST_SLAVE = GO1160_TEST_SLAVE
+    GO_TEST_SLAVE = "test_heavy_go1160_memvolume"
 } else {
     println "This build use go1.13"
     GO_TEST_SLAVE = "test_tikv_go1130_memvolume"

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_ddl_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_ddl_test.groovy
@@ -14,7 +14,7 @@ if (m1) {
 }
 m1 = null
 println "TIDB_BRANCH=${TIDB_BRANCH}"
-def testSlave = "test_go_heavy"
+
 // parse pd branch
 def m2 = ghprbCommentBody =~ /pd\s*=\s*([^\s\\]+)(\s|\\|$)/
 if (m2) {
@@ -34,12 +34,34 @@ println "TIDB_TEST_BRANCH=${TIDB_TEST_BRANCH}"
 
 def tikv_url = "${FILE_SERVER_URL}/download/builds/pingcap/tikv/pr/${ghprbActualCommit}/centos7/tikv-server.tar.gz"
 
+def boolean isBranchMatched(List<String> branches, String targetBranch) {
+    for (String item : branches) {
+        if (targetBranch.startsWith(item)) {
+            println "targetBranch=${targetBranch} matched in ${branches}"
+            return true
+        }
+    }
+    return false
+}
+
+def isNeedGo1160 = isBranchMatched(["master"], ghprbTargetBranch)
+if (isNeedGo1160) {
+    println "This build use go1.16 because ghprTargetBranch=master"
+    GO_BUILD_SLAVE = GO1160_BUILD_SLAVE
+    GO_TEST_SLAVE = "test_heavy_go1160_memvolume"
+} else {
+    println "This build use go1.13"
+    GO_TEST_SLAVE = "test_go_heavy"
+}
+println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
+println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
+
 try {
     stage('Integration DLL Test') {
         def tests = [:]
 
         def run = { test_dir, mytest, ddltest ->
-            node(testSlave) {
+            node("${GO_TEST_SLAVE}") {
                 def ws = pwd()
                 deleteDir()
 
@@ -202,7 +224,7 @@ finally {
 }
 
 stage("upload status"){
-    node{
+    node("master"){
         sh """curl --connect-timeout 2 --max-time 4 -d '{"job":"$JOB_NAME","id":$BUILD_NUMBER}' http://172.16.5.13:36000/api/v1/ci/job/sync || true"""
     }
 }

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_ddl_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration_ddl_test.groovy
@@ -51,7 +51,7 @@ if (isNeedGo1160) {
     GO_TEST_SLAVE = "test_heavy_go1160_memvolume"
 } else {
     println "This build use go1.13"
-    GO_TEST_SLAVE = "test_go_heavy"
+    GO_TEST_SLAVE = "test_tikv_go1130_memvolume"
 }
 println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
 println "TEST_NODE_NAME=${GO_TEST_SLAVE}"


### PR DESCRIPTION
-  tikv ci upgrade go version from 1.13 to 1.16.4, only for branch master
-  tikv test use agent pod with memory volume