### PR TITLE
tikv importer: use release-5.0 branch instead of master as default

### DIFF
--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -86,6 +86,10 @@ def tiflashBranch = TIKV_BRANCH
 def tiflashCommit = ""
 def CDC_BRANCH = ""
 
+if (ghprbTargetBranch == "master")  {
+    TIKV_IMPORTER_BRANCH = "release-5.0"
+}
+
 if (ghprbTargetBranch == "master" || (ghprbTargetBranch.startsWith("release-") && ghprbTargetBranch >= "release-4.0")) {
     CDC_BRANCH = ghprbTargetBranch
 }


### PR DESCRIPTION
fix the failure of Lightning's integration test.