### PR TITLE
Add TiDB-Operator related Dockerfile and Jenkins pipeline.

### DIFF
--- a/jenkins/Dockerfile/release/tidb-backup-manager-arm64
+++ b/jenkins/Dockerfile/release/tidb-backup-manager-arm64
@@ -1,0 +1,30 @@
+FROM arm64v8/alpine:3.10
+ARG RCLONE_VERSION=v1.51.0
+ARG SHUSH_VERSION=v1.4.0
+ARG TOOLKIT_V40=v4.0.12
+RUN apk update && apk add ca-certificates
+
+RUN wget -nv https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-arm64.zip \
+  && unzip rclone-${RCLONE_VERSION}-linux-arm64.zip \
+  && mv rclone-${RCLONE_VERSION}-linux-arm64/rclone /usr/local/bin \
+  && chmod 755 /usr/local/bin/rclone \
+  && rm -rf rclone-${RCLONE_VERSION}-linux-arm64.zip rclone-${RCLONE_VERSION}-linux-arm64
+
+RUN wget -nv https://github.com/realestate-com-au/shush/releases/download/${SHUSH_VERSION}/shush_linux_arm64 \
+  && mv shush_linux_arm64 /usr/local/bin/shush \
+  && chmod 755 /usr/local/bin/shush
+
+RUN \
+  wget -nv https://download.pingcap.org/tidb-toolkit-${TOOLKIT_V40}-linux-arm64.tar.gz \
+  && tar -xzf tidb-toolkit-${TOOLKIT_V40}-linux-arm64.tar.gz \
+  && mv tidb-toolkit-${TOOLKIT_V40}-linux-arm64/bin/tidb-lightning /tidb-lightning \
+  && mv tidb-toolkit-${TOOLKIT_V40}-linux-arm64/bin/tidb-lightning-ctl /tidb-lightning-ctl \
+  && mv tidb-toolkit-${TOOLKIT_V40}-linux-arm64/bin/dumpling /dumpling \
+  && chmod 755 /dumpling /tidb-lightning /tidb-lightning-ctl \
+  && rm -rf tidb-toolkit-${TOOLKIT_V40}-linux-arm64.tar.gz \
+  && rm -rf tidb-toolkit-${TOOLKIT_V40}-linux-arm64
+
+COPY bin/tidb-backup-manager /tidb-backup-manager
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/jenkins/Dockerfile/release/tidb-backup-manager-arm64
+++ b/jenkins/Dockerfile/release/tidb-backup-manager-arm64
@@ -1,8 +1,8 @@
-FROM arm64v8/alpine:3.10
+FROM centos:8
 ARG RCLONE_VERSION=v1.51.0
 ARG SHUSH_VERSION=v1.4.0
 ARG TOOLKIT_V40=v4.0.12
-RUN apk update && apk add ca-certificates
+RUN yum makecache && yum install ca-certificates wget unzip -y
 
 RUN wget -nv https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-arm64.zip \
   && unzip rclone-${RCLONE_VERSION}-linux-arm64.zip \

--- a/jenkins/Dockerfile/release/tidb-operator-arm64
+++ b/jenkins/Dockerfile/release/tidb-operator-arm64
@@ -1,0 +1,7 @@
+FROM arm64v8/alpine:3.10
+
+RUN apk add tzdata --no-cache
+ADD bin/tidb-scheduler /usr/local/bin/tidb-scheduler
+ADD bin/tidb-discovery /usr/local/bin/tidb-discovery
+ADD bin/tidb-controller-manager /usr/local/bin/tidb-controller-manager
+ADD bin/tidb-admission-webhook /usr/local/bin/tidb-admission-webhook

--- a/jenkins/pipelines/cd/build-operator-arm-image.groovy
+++ b/jenkins/pipelines/cd/build-operator-arm-image.groovy
@@ -1,0 +1,29 @@
+def baseUrl = "https://raw.githubusercontent.com/PingCAP-QE/ci/operator-arm64/jenkins/Dockerfile/release/"
+
+node("arm_image") {
+    stage("Prepare & build binary") {
+        deleteDir()
+        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: TIDB_OPERATOR_TAG]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'CloneOption', timeout: 2]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/heads/*:refs/remotes/origin/*', url: 'git@github.com:pingcap/tidb-operator.git']]]
+        sh """
+        export GOARCH=arm64
+        make
+        """
+    }
+    stage("Build Docker image") {
+        operatorDockerfilePath = baseUrl + "tidb-operator-arm64"
+        backupManagerDockerfilePath = baseUrl + "tidb-backup-manager-arm64"
+        docker.withRegistry("", "dockerhub") {
+            sh """
+            cd images/tidb-operator && wget ${operatorDockerfilePath} -O Dockerfile
+            docker build . -t pingcap/tidb-operator-arm64:${TIDB_OPERATOR_TAG}
+            docker push pingcap/tidb-operator-arm64:${TIDB_OPERATOR_TAG}
+            """
+
+            sh """
+            cd images/tidb-backup-manager && wget ${backupManagerDockerfilePath} -O Dockerfile
+            docker build . -t pingcap/tidb-backup-manager-arm64:${TIDB_OPERATOR_TAG}
+            docker push pingcap/tidb-backup-manager-arm64:${TIDB_OPERATOR_TAG}
+            """
+        }
+    }
+}

--- a/jenkins/pipelines/cd/build-operator-arm-image.groovy
+++ b/jenkins/pipelines/cd/build-operator-arm-image.groovy
@@ -25,5 +25,13 @@ node("arm_image") {
             docker push pingcap/tidb-backup-manager-arm64:${TIDB_OPERATOR_TAG}
             """
         }
+        docker.withRegistry("https://uhub.service.ucloud.cn", "ucloud-registry") {
+            sh """
+            docker tag pingcap/tidb-operator-arm64:${TIDB_OPERATOR_TAG} uhub.service.ucloud.cn/pingcap/tidb-operator-arm64:${TIDB_OPERATOR_TAG}
+            docker tag pingcap/tidb-backup-manager-arm64:${TIDB_OPERATOR_TAG} uhub.service.ucloud.cn/pingcap/tidb-backup-manager-arm64:${TIDB_OPERATOR_TAG}
+            docker push uhub.service.ucloud.cn/pingcap/tidb-operator-arm64:${TIDB_OPERATOR_TAG}
+            docker push uhub.service.ucloud.cn/pingcap/tidb-backup-manager-arm64:${TIDB_OPERATOR_TAG}
+            """
+        }
     }
 }

--- a/jenkins/pipelines/cd/build-operator-arm-image.groovy
+++ b/jenkins/pipelines/cd/build-operator-arm-image.groovy
@@ -1,4 +1,4 @@
-def baseUrl = "https://raw.githubusercontent.com/PingCAP-QE/ci/operator-arm64/jenkins/Dockerfile/release/"
+def baseUrl = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/"
 
 node("arm_image") {
     stage("Prepare & build binary") {


### PR DESCRIPTION
This PR will:
* Add TiDB-Operator related Dockerfile and Jenkins pipeline.
* tidb-backup-manager-arm64 Dockerfile is switched to `centos:8` to avoid libc related problems.

Before Merge, we should:
1. Change `baseUrl` in `jenkins/pipelines/cd/build-operator-arm-image.groovy` to use the right branch(instead of `operator-arm64`).
2. Make sure those images are working.