### PR TITLE
decoupling pd integration test from pr merge

### DIFF
--- a/jenkins/pipelines/ci/pd/pd_ghpr_build.groovy
+++ b/jenkins/pipelines/ci/pd/pd_ghpr_build.groovy
@@ -78,7 +78,7 @@ try {
             def filepath = "builds/pingcap/pd/pr/${ghprbActualCommit}/centos7/pd-server.tar.gz"
             def refspath = "refs/pingcap/pd/pr/${ghprbPullId}/sha1"
             if (params.containsKey("triggered_by_upstream_ci")) {
-                refspath = "refs/pingcap/tidb/pr/branch-${ghprbTargetBranch}/sha1"
+                refspath = "refs/pingcap/pd/pr/branch-${ghprbTargetBranch}/sha1"
             }
 
             dir("go/src/github.com/pingcap/pd") {

--- a/jenkins/pipelines/ci/pd/pd_ghpr_build.groovy
+++ b/jenkins/pipelines/ci/pd/pd_ghpr_build.groovy
@@ -1,5 +1,21 @@
+echo "release test: ${params.containsKey("release_test")}"
+if (params.containsKey("release_test")) {
+    ghprbTargetBranch = params.getOrDefault("release_test__ghpr_target_branch", params.release_test__release_branch)
+    ghprbCommentBody = params.getOrDefault("release_test__ghpr_comment_body", "")
+    ghprbActualCommit = params.getOrDefault("release_test__ghpr_actual_commit", params.release_test__pd_commit)
+    ghprbPullId = params.getOrDefault("release_test__ghpr_pull_id", "")
+    ghprbPullTitle = params.getOrDefault("release_test__ghpr_pull_title", "")
+    ghprbPullLink = params.getOrDefault("release_test__ghpr_pull_link", "")
+    ghprbPullDescription = params.getOrDefault("release_test__ghpr_pull_description", "")
+}
+
 def slackcolor = 'good'
 def githash
+
+def specStr = "+refs/heads/*:refs/remotes/origin/*"
+if (ghprbPullId != null && ghprbPullId != "") {
+    specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
+}
 
 def boolean isBranchMatched(List<String> branches, String targetBranch) {
     for (String item : branches) {
@@ -38,7 +54,7 @@ try {
                 if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
                     deleteDir()
                 }
-                checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'git@github.com:pingcap/pd.git']]]
+                checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/pd.git']]]
             }
         }
 
@@ -61,6 +77,9 @@ try {
         stage("Upload") {
             def filepath = "builds/pingcap/pd/pr/${ghprbActualCommit}/centos7/pd-server.tar.gz"
             def refspath = "refs/pingcap/pd/pr/${ghprbPullId}/sha1"
+            if (params.containsKey("triggered_by_upstream_ci")) {
+                refspath = "refs/pingcap/tidb/pr/branch-${ghprbTargetBranch}/sha1"
+            }
 
             dir("go/src/github.com/pingcap/pd") {
                 container("golang") {

--- a/jenkins/pipelines/ci/pd/pd_ghpr_integration_br_test.groovy
+++ b/jenkins/pipelines/ci/pd/pd_ghpr_integration_br_test.groovy
@@ -81,7 +81,7 @@ if (params.containsKey("triggered_by_upstream_ci")) {
                 PARAM_STATUS = 'error'
             }
             def default_params = [
-                    string(name: 'TIKV_COMMIT_ID', value: ghprbActualCommit ),
+                    string(name: 'PD_COMMIT_ID', value: ghprbActualCommit ),
                     string(name: 'CONTEXT', value: 'idc-jenkins-ci-pd/integration-br-test'),
                     string(name: 'DESCRIPTION', value: PARAM_DESCRIPTION ),
                     string(name: 'BUILD_URL', value: RUN_DISPLAY_URL ),

--- a/jenkins/pipelines/ci/pd/pd_ghpr_integration_br_test.groovy
+++ b/jenkins/pipelines/ci/pd/pd_ghpr_integration_br_test.groovy
@@ -1,0 +1,53 @@
+def BUILD_NUMBER = "${env.BUILD_NUMBER}"
+def pd_url = "${FILE_SERVER_URL}/download/builds/pingcap/pd/pr/${ghprbActualCommit}/centos7/pd-server.tar.gz"
+
+catchError {
+    node("${GO_TEST_SLAVE}") {
+        stage('Trigger BRIE Test') {
+            if (ghprbTargetBranch == "master" || ghprbTargetBranch == "release-4.0" || ghprbTargetBranch == "release-5.0") {
+                container("golang") {
+                    println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
+                    // Wait build finish.
+                    timeout(60) {
+                        sh """
+                        while ! curl --output /dev/null --silent --head --fail "${pd_url}"; do sleep 5; done
+                        """
+                    }
+
+                    def default_params = [
+                            booleanParam(name: 'force', value: true),
+                            string(name: 'triggered_by_upstream_pr_ci', value: "pd"),
+                            string(name: 'upstream_pr_ci_ghpr_target_branch', value: "${ghprbTargetBranch}"),
+                            // We tests BR on the same branch as PD's.
+                            string(name: 'upstream_pr_ci_ghpr_actual_commit', value: "${ghprbTargetBranch}"),
+                            string(name: 'upstream_pr_ci_ghpr_pull_id', value: "${ghprbPullId}"),
+                            string(name: 'upstream_pr_ci_ghpr_pull_title', value: "${ghprbPullTitle}"),
+                            string(name: 'upstream_pr_ci_ghpr_pull_link', value: "${ghprbPullLink}"),
+                            string(name: 'upstream_pr_ci_ghpr_pull_description', value: "${ghprbPullDescription}"),
+                            string(name: 'upstream_pr_ci_override_pd_download_link', value: "${pd_url}"),
+                    ]
+
+                    // Trigger BRIE test without waiting its finish.
+                    build(job: "br_ghpr_unit_and_integration_test", parameters: default_params, wait: false)
+                }
+            } else {
+                println "skip trigger BRIE tests as this PR targets to ${ghprbTargetBranch}"
+            }
+            currentBuild.result = "SUCCESS"
+        }
+    }
+}
+
+stage('Summary') {
+    def duration = ((System.currentTimeMillis() - currentBuild.startTimeInMillis) / 1000 / 60).setScale(2, BigDecimal.ROUND_HALF_UP)
+    def slackmsg = "[#${ghprbPullId}: ${ghprbPullTitle}]" + "\n" +
+            "${ghprbPullLink}" + "\n" +
+            "${ghprbPullDescription}" + "\n" +
+            "Trigger Integration BRIE Test Result: `${currentBuild.result}`" + "\n" +
+            "Elapsed Time: `${duration} mins` " + "\n" +
+            "${env.RUN_DISPLAY_URL}"
+
+    if (currentBuild.result != "SUCCESS" && currentBuild.result != "ABORTED") {
+        slackSend channel: '#jenkins-ci-migration', color: 'danger', teamDomain: 'pingcap', tokenCredentialId: 'slack-pingcap-token', message: "${slackmsg}"
+    }
+}

--- a/jenkins/pipelines/ci/pd/pd_ghpr_integration_br_test.groovy
+++ b/jenkins/pipelines/ci/pd/pd_ghpr_integration_br_test.groovy
@@ -1,3 +1,14 @@
+echo "release test: ${params.containsKey("release_test")}"
+if (params.containsKey("release_test")) {
+    ghprbTargetBranch = params.getOrDefault("release_test__ghpr_target_branch", params.release_test__release_branch)
+    ghprbCommentBody = params.getOrDefault("release_test__ghpr_comment_body", "")
+    ghprbActualCommit = params.getOrDefault("release_test__ghpr_actual_commit", params.release_test__pd_commit)
+    ghprbPullId = params.getOrDefault("release_test__ghpr_pull_id", "")
+    ghprbPullTitle = params.getOrDefault("release_test__ghpr_pull_title", "")
+    ghprbPullLink = params.getOrDefault("release_test__ghpr_pull_link", "")
+    ghprbPullDescription = params.getOrDefault("release_test__ghpr_pull_description", "")
+}
+
 def BUILD_NUMBER = "${env.BUILD_NUMBER}"
 def pd_url = "${FILE_SERVER_URL}/download/builds/pingcap/pd/pr/${ghprbActualCommit}/centos7/pd-server.tar.gz"
 
@@ -49,5 +60,35 @@ stage('Summary') {
 
     if (currentBuild.result != "SUCCESS" && currentBuild.result != "ABORTED") {
         slackSend channel: '#jenkins-ci-migration', color: 'danger', teamDomain: 'pingcap', tokenCredentialId: 'slack-pingcap-token', message: "${slackmsg}"
+    }
+}
+
+if (params.containsKey("triggered_by_upstream_ci")) {
+    stage("update commit status") {
+        node("master") {
+            if (currentBuild.result == "ABORTED") {
+                PARAM_DESCRIPTION = 'Jenkins job aborted'
+                // Commit state. Possible values are 'pending', 'success', 'error' or 'failure'
+                PARAM_STATUS = 'error'
+            } else if (currentBuild.result == "FAILURE") {
+                PARAM_DESCRIPTION = 'Jenkins job failed'
+                PARAM_STATUS = 'failure'
+            } else if (currentBuild.result == "SUCCESS") {
+                PARAM_DESCRIPTION = 'Jenkins job success'
+                PARAM_STATUS = 'success'
+            } else {
+                PARAM_DESCRIPTION = 'Jenkins job meets something wrong'
+                PARAM_STATUS = 'error'
+            }
+            def default_params = [
+                    string(name: 'TIKV_COMMIT_ID', value: ghprbActualCommit ),
+                    string(name: 'CONTEXT', value: 'idc-jenkins-ci-pd/integration-br-test'),
+                    string(name: 'DESCRIPTION', value: PARAM_DESCRIPTION ),
+                    string(name: 'BUILD_URL', value: RUN_DISPLAY_URL ),
+                    string(name: 'STATUS', value: PARAM_STATUS ),
+            ]
+            echo("default params: ${default_params}")
+            build(job: "pd_update_commit_status", parameters: default_params, wait: true)
+        }
     }
 }

--- a/jenkins/pipelines/ci/pd/pd_ghpr_integration_compatibility_test.groovy
+++ b/jenkins/pipelines/ci/pd/pd_ghpr_integration_compatibility_test.groovy
@@ -245,7 +245,7 @@ finally {
                     PARAM_STATUS = 'error'
                 }
                 def default_params = [
-                        string(name: 'TIKV_COMMIT_ID', value: ghprbActualCommit ),
+                        string(name: 'PD_COMMIT_ID', value: ghprbActualCommit ),
                         string(name: 'CONTEXT', value: 'idc-jenkins-ci-pd/integration-compatibility-test'),
                         string(name: 'DESCRIPTION', value: PARAM_DESCRIPTION ),
                         string(name: 'BUILD_URL', value: RUN_DISPLAY_URL ),

--- a/jenkins/pipelines/ci/pd/pd_ghpr_intergration_common_test.groovy
+++ b/jenkins/pipelines/ci/pd/pd_ghpr_intergration_common_test.groovy
@@ -343,7 +343,7 @@ if (params.containsKey("triggered_by_upstream_ci")) {
                 PARAM_STATUS = 'error'
             }
             def default_params = [
-                    string(name: 'TIKV_COMMIT_ID', value: ghprbActualCommit ),
+                    string(name: 'PD_COMMIT_ID', value: ghprbActualCommit ),
                     string(name: 'CONTEXT', value: 'idc-jenkins-ci-pd/integration-common-test'),
                     string(name: 'DESCRIPTION', value: PARAM_DESCRIPTION ),
                     string(name: 'BUILD_URL', value: RUN_DISPLAY_URL ),

--- a/jenkins/pipelines/ci/pd/pd_ghpr_intergration_common_test.groovy
+++ b/jenkins/pipelines/ci/pd/pd_ghpr_intergration_common_test.groovy
@@ -1,3 +1,4 @@
+echo "release test: ${params.containsKey("release_test")}"
 if (params.containsKey("release_test")) {
     ghprbTargetBranch = params.getOrDefault("release_test__ghpr_target_branch", params.release_test__release_branch)
     ghprbCommentBody = params.getOrDefault("release_test__ghpr_comment_body", "")
@@ -321,5 +322,35 @@ finally {
 stage("upload status"){
     node("master"){
         sh """curl --connect-timeout 2 --max-time 4 -d '{"job":"$JOB_NAME","id":$BUILD_NUMBER}' http://172.16.5.13:36000/api/v1/ci/job/sync || true"""
+    }
+}
+
+if (params.containsKey("triggered_by_upstream_ci")) {
+    stage("update commit status") {
+        node("master") {
+            if (currentBuild.result == "ABORTED") {
+                PARAM_DESCRIPTION = 'Jenkins job aborted'
+                // Commit state. Possible values are 'pending', 'success', 'error' or 'failure'
+                PARAM_STATUS = 'error'
+            } else if (currentBuild.result == "FAILURE") {
+                PARAM_DESCRIPTION = 'Jenkins job failed'
+                PARAM_STATUS = 'failure'
+            } else if (currentBuild.result == "SUCCESS") {
+                PARAM_DESCRIPTION = 'Jenkins job success'
+                PARAM_STATUS = 'success'
+            } else {
+                PARAM_DESCRIPTION = 'Jenkins job meets something wrong'
+                PARAM_STATUS = 'error'
+            }
+            def default_params = [
+                    string(name: 'TIKV_COMMIT_ID', value: ghprbActualCommit ),
+                    string(name: 'CONTEXT', value: 'idc-jenkins-ci-pd/integration-common-test'),
+                    string(name: 'DESCRIPTION', value: PARAM_DESCRIPTION ),
+                    string(name: 'BUILD_URL', value: RUN_DISPLAY_URL ),
+                    string(name: 'STATUS', value: PARAM_STATUS ),
+            ]
+            echo("default params: ${default_params}")
+            build(job: "pd_update_commit_status", parameters: default_params, wait: true)
+        }
     }
 }

--- a/jenkins/pipelines/ci/pd/pd_ghpr_intergration_ddl_test.groovy
+++ b/jenkins/pipelines/ci/pd/pd_ghpr_intergration_ddl_test.groovy
@@ -256,7 +256,7 @@ if (params.containsKey("triggered_by_upstream_ci")) {
                 PARAM_STATUS = 'error'
             }
             def default_params = [
-                    string(name: 'TIKV_COMMIT_ID', value: ghprbActualCommit ),
+                    string(name: 'PD_COMMIT_ID', value: ghprbActualCommit ),
                     string(name: 'CONTEXT', value: 'idc-jenkins-ci-pd/integration-ddl-test'),
                     string(name: 'DESCRIPTION', value: PARAM_DESCRIPTION ),
                     string(name: 'BUILD_URL', value: RUN_DISPLAY_URL ),

--- a/jenkins/pipelines/ci/pd/pd_ghpr_intergration_ddl_test.groovy
+++ b/jenkins/pipelines/ci/pd/pd_ghpr_intergration_ddl_test.groovy
@@ -1,3 +1,4 @@
+echo "release test: ${params.containsKey("release_test")}"
 if (params.containsKey("release_test")) {
     ghprbTargetBranch = params.getOrDefault("release_test__ghpr_target_branch", params.release_test__release_branch)
     ghprbCommentBody = params.getOrDefault("release_test__ghpr_comment_body", "")
@@ -234,5 +235,35 @@ finally {
 stage("upload status"){
     node("master"){
         sh """curl --connect-timeout 2 --max-time 4 -d '{"job":"$JOB_NAME","id":$BUILD_NUMBER}' http://172.16.5.13:36000/api/v1/ci/job/sync || true"""
+    }
+}
+
+if (params.containsKey("triggered_by_upstream_ci")) {
+    stage("update commit status") {
+        node("master") {
+            if (currentBuild.result == "ABORTED") {
+                PARAM_DESCRIPTION = 'Jenkins job aborted'
+                // Commit state. Possible values are 'pending', 'success', 'error' or 'failure'
+                PARAM_STATUS = 'error'
+            } else if (currentBuild.result == "FAILURE") {
+                PARAM_DESCRIPTION = 'Jenkins job failed'
+                PARAM_STATUS = 'failure'
+            } else if (currentBuild.result == "SUCCESS") {
+                PARAM_DESCRIPTION = 'Jenkins job success'
+                PARAM_STATUS = 'success'
+            } else {
+                PARAM_DESCRIPTION = 'Jenkins job meets something wrong'
+                PARAM_STATUS = 'error'
+            }
+            def default_params = [
+                    string(name: 'TIKV_COMMIT_ID', value: ghprbActualCommit ),
+                    string(name: 'CONTEXT', value: 'idc-jenkins-ci-pd/integration-ddl-test'),
+                    string(name: 'DESCRIPTION', value: PARAM_DESCRIPTION ),
+                    string(name: 'BUILD_URL', value: RUN_DISPLAY_URL ),
+                    string(name: 'STATUS', value: PARAM_STATUS ),
+            ]
+            echo("default params: ${default_params}")
+            build(job: "pd_update_commit_status", parameters: default_params, wait: true)
+        }
     }
 }

--- a/jenkins/pipelines/ci/pd/pd_integration_test_ci.groovy
+++ b/jenkins/pipelines/ci/pd/pd_integration_test_ci.groovy
@@ -54,15 +54,15 @@ node("github-status-updater") {
                         pd_ghpr_integration_compatibility_test: {
                             build(job: "pd_ghpr_integration_compatibility_test", parameters: default_params, wait: true)
                         },
-//                        pd_ghpr_intergration_common_test: {
-//                            build(job: "pd_ghpr_intergration_common_test", parameters: default_params, wait: true)
-//                        },
-//                        pd_ghpr_intergration_ddl_test: {
-//                            build(job: "pd_ghpr_intergration_ddl_test", parameters: default_params, wait: true)
-//                        },
-//                        pd_ghpr_integration_br_test: {
-//                            build(job: "pd_ghpr_integration_br_test", parameters: default_params, wait: true)
-//                        },
+                        pd_ghpr_intergration_common_test: {
+                            build(job: "pd_ghpr_intergration_common_test", parameters: default_params, wait: true)
+                        },
+                        pd_ghpr_intergration_ddl_test: {
+                            build(job: "pd_ghpr_intergration_ddl_test", parameters: default_params, wait: true)
+                        },
+                        pd_ghpr_integration_br_test: {
+                            build(job: "pd_ghpr_integration_br_test", parameters: default_params, wait: true)
+                        },
                 )
             }
         }

--- a/jenkins/pipelines/ci/pd/pd_integration_test_ci.groovy
+++ b/jenkins/pipelines/ci/pd/pd_integration_test_ci.groovy
@@ -1,0 +1,119 @@
+node("github-status-updater") {
+    stage("Print env"){
+        // commit id / branch / pusher / commit message
+        def trimPrefix = {
+            it.startsWith('refs/heads/') ? it - 'refs/heads/' : it
+        }
+
+        if ( env.REF != '' ) {
+            echo 'trigger by remote invoke'
+            PD_BRANCH = trimPrefix(ref)
+            def m1 = GEWT_COMMIT_MSG =~ /(?<=\()(.*?)(?=\))/
+            if (m1) {
+                GEWT_PULL_ID = "${m1[0][1]}"
+                GEWT_PULL_ID = GEWT_PULL_ID.substring(1)
+            }
+            m1 = null
+            echo "commit_msg=${GEWT_COMMIT_MSG}"
+            echo "author=${GEWT_AUTHOR}"
+            echo "author_email=${GEWT_AUTHOR_EMAIL}"
+            echo "pull_id=${GEWT_PULL_ID}"
+        } else {
+            echo 'trigger manually'
+            echo "param ref not exist"
+        }
+
+        if ( env.PD_COMMIT_ID == '') {
+            echo "invalid param PD_COMMIT_ID"
+            currentBuild.result = "FAILURE"
+            error('Stopping early… invalid param PD_COMMIT_ID')
+        }
+
+        echo "COMMIT=${PD_COMMIT_ID}"
+        echo "BRANCH=${PD_BRANCH}"
+
+        default_params = [
+                string(name: 'triggered_by_upstream_ci', value: "pd_integration_test_ci"),
+                booleanParam(name: 'release_test', value: true),
+                string(name: 'release_test__release_branch', value: PD_BRANCH),
+                string(name: 'release_test__pd_commit', value: PD_COMMIT_ID),
+        ]
+
+        echo("default params: ${default_params}")
+
+    }
+
+    try {
+        stage("Build") {
+            build(job: "pd_ghpr_build", parameters: default_params, wait: true)
+        }
+        stage("Trigger Test Job") {
+            container("golang") {
+                parallel(
+                        // integration test
+                        pd_ghpr_integration_compatibility_test: {
+                            build(job: "pd_ghpr_integration_compatibility_test", parameters: default_params, wait: true)
+                        },
+/*                      pd_ghpr_intergration_common_test: {
+                            build(job: "pd_ghpr_intergration_common_test", parameters: default_params, wait: true)
+                        },
+                        pd_ghpr_intergration_ddl_test: {
+                            build(job: "pd_ghpr_intergration_ddl_test", parameters: default_params, wait: true)
+                        },
+                        pd_ghpr_integration_br_test: {
+                            build(job: "pd_ghpr_integration_br_test", parameters: default_params, wait: true)
+                        },*/
+                )
+            }
+        }
+
+        currentBuild.result = "SUCCESS"
+    } catch(Exception e) {
+        currentBuild.result = "FAILURE"
+        println "catch_exception Exception"
+        println e
+    } finally {
+        stage("alert") {
+            container("python3") {
+                if ( env.REF != '' ) {
+                    sh """
+                cat > env_param.conf <<EOF
+export BRANCH=${PD_BRANCH}
+export COMMIT_ID=${PD_COMMIT_ID}
+export AUTHOR=${GEWT_AUTHOR}
+export AUTHOR_EMAIL=${GEWT_AUTHOR_EMAIL}
+export PULL_ID=${GEWT_PULL_ID}
+export GITHUB_OWNER=tikv
+export GITHUB_REPO=pd
+EOF
+                """
+                }  else {
+                    sh """
+                cat > env_param.conf <<EOF
+export BRANCH=${PD_BRANCH}
+export COMMIT_ID=${PD_COMMIT_ID}
+export GITHUB_OWNER=tikv
+export GITHUB_REPO=pd
+EOF
+                """
+                }
+                sh "cat env_param.conf"
+                sh "curl -LO ${FILE_SERVER_URL}/download/cicd/scripts/integration_test_ci_alert.py"
+
+                withCredentials([string(credentialsId: 'sre-bot-token', variable: 'GITHUB_API_TOKEN'),
+                                 string(credentialsId: 'feishu-ci-report-integration-test', variable: "FEISHU_ALERT_URL")
+                ]) {
+                    sh '''#!/bin/bash
+                set +x
+                export GITHUB_API_TOKEN=${GITHUB_API_TOKEN}
+                export FEISHU_ALERT_URL=${FEISHU_ALERT_URL}
+                source env_param.conf
+                python3 integration_test_ci_alert.py > alert_feishu.log
+                set -x
+                cat alert_feishu.log
+                '''
+                }
+            }
+        }
+    }
+}

--- a/jenkins/pipelines/ci/pd/pd_integration_test_ci.groovy
+++ b/jenkins/pipelines/ci/pd/pd_integration_test_ci.groovy
@@ -101,7 +101,7 @@ EOF
                 sh "curl -LO ${FILE_SERVER_URL}/download/cicd/scripts/integration_test_ci_alert.py"
 
                 withCredentials([string(credentialsId: 'sre-bot-token', variable: 'GITHUB_API_TOKEN'),
-                                 string(credentialsId: 'debug-feishu-alert-url-integration-test', variable: "FEISHU_ALERT_URL")
+                                 string(credentialsId: 'feishu-ci-report-integration-test', variable: "FEISHU_ALERT_URL")
                 ]) {
                     sh '''#!/bin/bash
                 set +x

--- a/jenkins/pipelines/ci/pd/pd_integration_test_ci.groovy
+++ b/jenkins/pipelines/ci/pd/pd_integration_test_ci.groovy
@@ -54,15 +54,15 @@ node("github-status-updater") {
                         pd_ghpr_integration_compatibility_test: {
                             build(job: "pd_ghpr_integration_compatibility_test", parameters: default_params, wait: true)
                         },
-/*                      pd_ghpr_intergration_common_test: {
-                            build(job: "pd_ghpr_intergration_common_test", parameters: default_params, wait: true)
-                        },
-                        pd_ghpr_intergration_ddl_test: {
-                            build(job: "pd_ghpr_intergration_ddl_test", parameters: default_params, wait: true)
-                        },
-                        pd_ghpr_integration_br_test: {
-                            build(job: "pd_ghpr_integration_br_test", parameters: default_params, wait: true)
-                        },*/
+//                        pd_ghpr_intergration_common_test: {
+//                            build(job: "pd_ghpr_intergration_common_test", parameters: default_params, wait: true)
+//                        },
+//                        pd_ghpr_intergration_ddl_test: {
+//                            build(job: "pd_ghpr_intergration_ddl_test", parameters: default_params, wait: true)
+//                        },
+//                        pd_ghpr_integration_br_test: {
+//                            build(job: "pd_ghpr_integration_br_test", parameters: default_params, wait: true)
+//                        },
                 )
             }
         }
@@ -101,7 +101,7 @@ EOF
                 sh "curl -LO ${FILE_SERVER_URL}/download/cicd/scripts/integration_test_ci_alert.py"
 
                 withCredentials([string(credentialsId: 'sre-bot-token', variable: 'GITHUB_API_TOKEN'),
-                                 string(credentialsId: 'feishu-ci-report-integration-test', variable: "FEISHU_ALERT_URL")
+                                 string(credentialsId: 'debug-feishu-alert-url-integration-test', variable: "FEISHU_ALERT_URL")
                 ]) {
                     sh '''#!/bin/bash
                 set +x

--- a/jenkins/pipelines/ci/pd/pd_update_commit_status.groovy
+++ b/jenkins/pipelines/ci/pd/pd_update_commit_status.groovy
@@ -1,0 +1,58 @@
+properties([
+        parameters([
+                choice(
+                        choices: ['success', 'error', 'failure', 'pending'],
+                        name: 'STATUS'
+                ),
+                string(
+                        defaultValue: '',
+                        name: 'PD_COMMIT_ID',
+                        trim: true
+                ),
+                string(
+                        defaultValue: '',
+                        name: 'CONTEXT',
+                        trim: true
+                ),
+                string(
+                        defaultValue: '',
+                        name: 'DESCRIPTION',
+                        trim: true,
+                ),
+                string(
+                        defaultValue: '',
+                        name: 'BUILD_URL',
+                        trim: true
+                )
+        ])
+])
+
+node("github-status-updater") {
+    stage("Print env") {
+        echo "context = ${CONTEXT}"
+        echo "pd_commit_id = ${PD_COMMIT_ID}"
+        echo "status = ${STATUS}"
+        echo "description = ${DESCRIPTION}"
+        echo "build_url = ${BUILD_URL}"
+    }
+
+    stage("Update commit status") {
+        container("github-status-updater") {
+            withCredentials([string(credentialsId: 'sre-bot-token', variable: 'TOKEN')]) {
+                sh '''
+                set +x
+                github-status-updater \
+                    -action update_state \
+                    -token ${TOKEN} \
+                    -owner tikv \
+                    -repo pd \
+                    -ref  ${PD_COMMIT_ID} \
+                    -state ${STATUS} \
+                    -context "${CONTEXT}" \
+                    -description "${DESCRIPTION}" \
+                    -url "${BUILD_URL}"
+                '''
+            }
+        }
+    }
+}


### PR DESCRIPTION
decoupling pd integration test from pr merge:
* all pd integration test required contexts will be removed when try to merge pr
* trigger all pd integration test after pr merged
* update commit status then send feishu report to group
* /run-integration-tests trigger all integration test ci,  /run-all-tests will not trigger any integration test ci anymore