### PR TITLE
Add centos7_jenkins along with golang images

### DIFF
--- a/jenkins/Dockerfile/centos7_golang-1.13-arm64
+++ b/jenkins/Dockerfile/centos7_golang-1.13-arm64
@@ -1,0 +1,23 @@
+# docker build . -t hub.pingcap.net/jenkins/centos7_golang-1.13-arm64:latest
+FROM hub.pingcap.net/jenkins/centos7_jenkins-arm64
+
+USER root
+WORKDIR /root
+
+ENV GOLANG_VERSION 1.13.7
+ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-arm64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 8717de6c662ada01b7bf318f5025c046b57f8c10cd39a88268bdc171cc7e4eab
+
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+	&& tar -C /usr/local -xzf golang.tar.gz \
+	&& rm golang.tar.gz
+
+RUN mkdir /go && chown jenkins:jenkins /go
+
+ENV GOPATH /go
+ENV GOROOT /usr/local/go
+ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
+
+USER jenkins
+WORKDIR /home/jenkins

--- a/jenkins/Dockerfile/centos7_golang-1.16-arm64
+++ b/jenkins/Dockerfile/centos7_golang-1.16-arm64
@@ -1,0 +1,24 @@
+# docker build . -t hub.pingcap.net/jenkins/centos7_golang-1.16-arm64:latest
+FROM hub.pingcap.net/jenkins/centos7_jenkins-arm64
+
+USER root
+WORKDIR /root
+
+
+ENV GOLANG_VERSION 1.16.4
+ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-arm64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 8b18eb05ddda2652d69ab1b1dd1f40dd731799f43c6a58b512ad01ae5b5bba21
+
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+	&& tar -C /usr/local -xzf golang.tar.gz \
+	&& rm golang.tar.gz
+
+RUN mkdir /go && chown jenkins:jenkins /go
+
+ENV GOPATH /go
+ENV GOROOT /usr/local/go
+ENV PATH $GOPATH/bin:$GOROOT/bin:$PATH
+
+USER jenkins
+WORKDIR /home/jenkins

--- a/jenkins/Dockerfile/centos7_jenkins_arm64
+++ b/jenkins/Dockerfile/centos7_jenkins_arm64
@@ -1,0 +1,40 @@
+# docker build . -t hub.pingcap.net/jenkins/centos7_jenkins-arm64:latest
+FROM hub.pingcap.net/jenkins/centos7-arm64:latest
+
+USER root
+WORKDIR /root
+
+RUN yum makecache \
+	&& yum update -y \
+	&& yum install --nogpgcheck -y tar wget which file unzip python-pip lsof mariadb \
+	&& yum install --nogpgcheck -y make gcc gcc-c++ libstdc++-static pkg-config psmisc \
+	&& yum install --nogpgcheck -y libzstd-devel lz4-devel zlib-devel bzip2-devel snappy-devel libdwarf-devel elfutils-libelf-devel elfutils-devel binutils-devel \
+    && yum install --nogpgcheck -y curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-CPAN perl-devel \
+    && yum groupinstall 'Development Tools' -y \
+	&& yum install --nogpgcheck -y sudo  gdb \
+	&& yum install -y libssl-dev pkg-config cmake zlib1g-dev openssl* glibc* \
+	&& yum clean all
+
+RUN wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.18.0.tar.gz && tar xf git-2.18.0.tar.gz && cd git-2.18.0/ \
+    && make configure \
+    && ./configure --prefix=/usr/local \ 
+    && make all \
+    && make install
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+
+ENV HOME /home/${user}
+RUN groupadd -g ${gid} ${group}
+RUN useradd -c "Jenkins user" -d $HOME -u ${uid} -g ${gid} -m ${user}
+RUN echo '%jenkins ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+ENV TZ Asia/Shanghai
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN mkdir /git && chown ${user}:${group} /git
+
+USER ${user}
+WORKDIR /home/${user}

--- a/jenkins/Dockerfile/jnlp-slave-arm64
+++ b/jenkins/Dockerfile/jnlp-slave-arm64
@@ -1,0 +1,32 @@
+# docker build . -t hub.pingcap.net/jenkins/jnlp-slave-arm64:latest
+FROM arm64v8/openjdk:10.0.1-jre
+
+LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="3.19"
+
+ARG VERSION=3.19
+ARG AGENT_WORKDIR=/home/jenkins/agent
+
+RUN apt-get update \
+  && apt-get install -y curl bash git openssh-client openssl \
+  && curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
+  && chmod 755 /usr/share/jenkins \
+  && chmod 644 /usr/share/jenkins/slave.jar 
+
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+
+ENV HOME /home/${user}
+RUN groupadd -g ${gid} ${group}
+RUN useradd -c "Jenkins user" -d $HOME -u ${uid} -g ${gid} -m ${user}
+RUN echo '%jenkins ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER ${user}
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
+RUN mkdir /home/${user}/.jenkins && mkdir -p ${AGENT_WORKDIR}
+
+VOLUME /home/${user}/.jenkins
+VOLUME ${AGENT_WORKDIR}
+WORKDIR /home/${user}


### PR DESCRIPTION
This PR has added three docker images, names are:
* hub.pingcap.net/jenkins/centos7_golang-1.13-arm64:latest
* hub.pingcap.net/jenkins/centos7_golang-1.16-arm64:latest
* hub.pingcap.net/jenkins/centos7_jenkins-arm64:latest

Those are modified from amd64 Dockerfiles from:
* jenkins/Dockerfile/centos7_golang-1.13
* jenkins/Dockerfile/centos7_golang-1.16
* jenkins/Dockerfile/centos7_jenkins

However, `hub.pingcap.net/jenkins/centos7_jenkins-arm64` has some modifications, as follows:
* Removed `gdb`, `jq` as they does not present on centos7-arm64
* Compiled Git 2.18

Note: `hub.pingcap.net/jenkins/centos7-arm64:latest` is the same as `arm64v8/centos:7`