### PR TITLE
br: Upload kes

### DIFF
--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -279,7 +279,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                         tikv_download_url = params.getOrDefault("upstream_pr_ci_override_tikv_download_link", tikv_download_url)
                     }
                     sh label: "Download TiKV", script: """
-                    curl ${tikv_download_url} | tar xz bin/tikv-server
+                    curl ${tikv_download_url} | tar xz bin/tikv-server bin/tikv-ctl
                     """
                     // tikv-importer
                     def tikv_importer_sha1 = get_commit_hash("importer", importer)

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -328,6 +328,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                     # minio and s3cmd for testing s3
                     curl ${FILE_SERVER_URL}/download/builds/minio/minio/RELEASE.2020-02-27T00-23-05Z/minio -o bin/minio && chmod 777 bin/minio
                     curl ${FILE_SERVER_URL}/download/builds/minio/minio/RELEASE.2020-02-27T00-23-05Z/mc -o bin/mc && chmod 777 bin/mc
+                    curl ${FILE_SERVER_URL}/download/kes -o bin/kes && chmod 777 bin/kes
                     # fake-gcs-server for testing gcs
                     curl ${FILE_SERVER_URL}/download/builds/fake-gcs-server -o bin/fake-gcs-server && chmod 777 bin/fake-gcs-server
                     # br v4.0.8 for testing gcs incompatible test

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -328,6 +328,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                     # minio and s3cmd for testing s3
                     curl ${FILE_SERVER_URL}/download/builds/minio/minio/RELEASE.2020-02-27T00-23-05Z/minio -o bin/minio && chmod 777 bin/minio
                     curl ${FILE_SERVER_URL}/download/builds/minio/minio/RELEASE.2020-02-27T00-23-05Z/mc -o bin/mc && chmod 777 bin/mc
+                    # download kes server
                     curl ${FILE_SERVER_URL}/download/kes -o bin/kes && chmod 777 bin/kes
                     # fake-gcs-server for testing gcs
                     curl ${FILE_SERVER_URL}/download/builds/fake-gcs-server -o bin/fake-gcs-server && chmod 777 bin/fake-gcs-server


### PR DESCRIPTION
BR TDE test need KMS service, KES binary had been upload to CDN, ci script should be modified to download kes binary.
This pr has been tested in ci debug env.