### PR TITLE
BR: use fileserver instead stash, merge shell scripts to speed up, split little slow cases

### DIFF
--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -452,13 +452,14 @@ catchError {
                     println "params: ${paramstring}"
                     println "ghprbPullId: ${ghprbPullId}"
                     println "refSpecs: ${refSpecs}"
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'git@github.com:pingcap/br.git']]]
 
                     def filepath = "builds/pingcap/br/pr/${ghprbActualCommit}/centos7/br_integration_test.tar.gz"
 
                     if (!params.containsKey("triggered_by_upstream_pr_ci")
                      || sh(returnStdout: true, script: """curl --output /dev/null --silent --head -w %{http_code}"\\n" ${FILE_SERVER_URL}/download/${filepath}""") == "404") {
                         
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: 'git@github.com:pingcap/br.git']]]
+
                         sh label: "Build and Compress testing binaries", script: """
                         git checkout -f ${ghprbActualCommit}
                         git rev-parse HEAD

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -293,7 +293,6 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                         def index_end = download_url.indexOf("/", index_begin)
                         commit_id = "pd_" + download_url.substring(index_begin, index_end)
                         break;
-                    default:
 
                 }
                 scripts_builder.append("(curl ${FILE_SERVER_URL}/download/builds/pingcap/br/pr/${commit_id}/centos7/br_integration_test.tar.gz | tar xz;) &\n")
@@ -505,7 +504,6 @@ catchError {
                             def index_end = download_url.indexOf("/", index_begin)
                             commit_id = "pd_" + download_url.substring(index_begin, index_end)
                             break;
-                        default:
 
                     }
                     

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -275,22 +275,22 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                     case "tikv":
                         def download_url = "?/pr/tikv_unkown_commit_id/?"
                         download_url = params.getOrDefault("upstream_pr_ci_override_tikv_download_link", download_url)
-                        def index_begin = download_url.indexOf("pr/")
-                        def index_end = download_url.indexOf("/", index_begin + 3)
+                        def index_begin = download_url.indexOf("pr/") + 3
+                        def index_end = download_url.indexOf("/", index_begin)
                         commit_id = "tikv_" + download_url.substring(index_begin, index_end)
                         break;
                     case "tidb":
                         def download_url = "?/pr/tidb_unkown_commit_id/?"
                         download_url = params.getOrDefault("upstream_pr_ci_override_tidb_download_link", download_url)
-                        def index_begin = download_url.indexOf("pr/")
-                        def index_end = download_url.indexOf("/", index_begin + 3)
+                        def index_begin = download_url.indexOf("pr/") + 3
+                        def index_end = download_url.indexOf("/", index_begin)
                         commit_id = "tidb_" + download_url.substring(index_begin, index_end)
                         break;
                     case "pd":
                         def download_url = "?/pr/pd_unkown_commit_id/?"
                         download_url = params.getOrDefault("upstream_pr_ci_override_pd_download_link", download_url)
-                        def index_begin = download_url.indexOf("pr/")
-                        def index_end = download_url.indexOf("/", index_begin + 3)
+                        def index_begin = download_url.indexOf("pr/") + 3
+                        def index_end = download_url.indexOf("/", index_begin)
                         commit_id = "pd_" + download_url.substring(index_begin, index_end)
                         break;
                     default:
@@ -487,22 +487,22 @@ catchError {
                         case "tikv":
                             def download_url = "?/pr/tikv_unkown_commit_id/?"
                             download_url = params.getOrDefault("upstream_pr_ci_override_tikv_download_link", download_url)
-                            def index_begin = download_url.indexOf("pr/")
-                            def index_end = download_url.indexOf("/", index_begin + 3)
+                            def index_begin = download_url.indexOf("pr/") + 3
+                            def index_end = download_url.indexOf("/", index_begin)
                             commit_id = "tikv_" + download_url.substring(index_begin, index_end)
                             break;
                         case "tidb":
                             def download_url = "?/pr/tidb_unkown_commit_id/?"
                             download_url = params.getOrDefault("upstream_pr_ci_override_tidb_download_link", download_url)
-                            def index_begin = download_url.indexOf("pr/")
-                            def index_end = download_url.indexOf("/", index_begin + 3)
+                            def index_begin = download_url.indexOf("pr/") + 3
+                            def index_end = download_url.indexOf("/", index_begin)
                             commit_id = "tidb_" + download_url.substring(index_begin, index_end)
                             break;
                         case "pd":
                             def download_url = "?/pr/pd_unkown_commit_id/?"
                             download_url = params.getOrDefault("upstream_pr_ci_override_pd_download_link", download_url)
-                            def index_begin = download_url.indexOf("pr/")
-                            def index_end = download_url.indexOf("/", index_begin + 3)
+                            def index_begin = download_url.indexOf("pr/") + 3
+                            def index_end = download_url.indexOf("/", index_begin)
                             commit_id = "pd_" + download_url.substring(index_begin, index_end)
                             break;
                         default:

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -457,7 +457,7 @@ catchError {
                     def filepath = "builds/pingcap/br/pr/${ghprbActualCommit}/centos7/br_integration_test.tar.gz"
 
                     if (!params.containsKey("triggered_by_upstream_pr_ci")
-                     || sh(returnStdout: true, script: """curl --output /dev/null --silent --head -w %{http_code}"\n" ${FILE_SERVER_URL}/download/${filepath}""") == "404") {
+                     || sh(returnStdout: true, script: """curl --output /dev/null --silent --head -w %{http_code}"\\n" ${FILE_SERVER_URL}/download/${filepath}""") == "404") {
                         
                         sh label: "Build and Compress testing binaries", script: """
                         git checkout -f ${ghprbActualCommit}


### PR DESCRIPTION
1. use fileserver instead stash. The compress step cannot be omitted so fileserver only speed up file transfer.
2. merge shell scripts. Each `sh` keyword in groovy will trigger master send `scripts` to slaver, which is a heavy workload. So merge these `download shell scripts` into one `sh` keyword in groovy and parallel downloading will reduce much CI time.
3. split little slow cases. Now it has much parallel nodes to do tests and some nodes finish tests much more quickly. In the best case, all nodes finish tests at the same time. So the PR try to reduce the granularity of way to split tests in order to be  more closer to the best case and reduce the number of nodes besides.