### PR TITLE
adjust concurrent test number from 8 to 20, reduce integration test time

### DIFF
--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -1,4 +1,4 @@
-CONCURRENT_NUMBER = 8
+CONCURRENT_NUMBER = 20
 
 def prepare_binaries() {
     stage('Prepare Binaries') {


### PR DESCRIPTION
* To reduece ticdc integration test time, adjust concurrent test number from 8 to 20