### PR TITLE
Revert "adjust concurrent test number from 8 to 20, reduce integration test time"

### DIFF
--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -1,4 +1,4 @@
-CONCURRENT_NUMBER = 20
+CONCURRENT_NUMBER = 8
 
 def prepare_binaries() {
     stage('Prepare Binaries') {


### PR DESCRIPTION
Reverts PingCAP-QE/ci#347 due to out of index error