### PR TITLE
refine TiDB's ci for BR merged into TiDB

### DIFF
--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -601,7 +601,7 @@ catchError {
                             little_slow_case_names = []
                             break;
                         default:
-                            def list = sh(script: "ls tests | grep -E 'br_|lightning_'", returnStdout:true).trim()
+                            def list = sh(script: "ls br/tests | grep -E 'br_|lightning_'", returnStdout:true).trim()
                             for (name in list.split("\\n")) {
                                 test_case_names << name
                             }

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -528,10 +528,9 @@ catchError {
                     println "br_cmd: ${build_br_cmd}"
                     def filepath = "builds/pingcap/br/pr/${commit_id}/centos7/br_integration_test.tar.gz"
 
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: git_repo_url]]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '${ghprbActualCommit}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """
-                    git checkout -f ${ghprbActualCommit}
                     git rev-parse HEAD
 
                     go version

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -186,7 +186,7 @@ def boolean isBranchMatched(List<String> branches, String targetBranch) {
     return false
 }
 
-def boolean isBRMergedIntoTiDB(params) {
+def boolean isBRMergedIntoTiDB() {
     return params.getOrDefault("triggered_by_upstream_pr_ci", "Origin") == "tidb-br"
 }
 
@@ -336,7 +336,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                 // tidb
                 // we build tidb-server from local, then put it into br_integration_test.tar.gz
                 // so we can get it from br_integration_test.tar.gz
-                if (!isBRMergedIntoTiDB(params) {
+                if (!isBRMergedIntoTiDB() {
                     scripts_builder.append("(tidb_sha1=\$(curl ${FILE_SERVER_URL}/download/refs/pingcap/tidb/${tidb}/sha1); ")
                             .append("mkdir tidb-source; ")
                     def tidb_download_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb/\${tidb_sha1}/centos7/tidb-server.tar.gz"
@@ -381,7 +381,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                 for (case_name in case_names) {
                     timeout(120) {
                         test_path = "tests"
-                        if (isBRMergedIntoTiDB(params)) {
+                        if (isBRMergedIntoTiDB()) {
                         // in tidb repo
                             test_path = "br/tests"
                         }
@@ -399,7 +399,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
 
                             export GOPATH=\$GOPATH:${ws}/go
                             export PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH
-                            TEST_NAME=${case_name} tests/run.sh
+                            TEST_NAME=${case_name} ${test_path}/run.sh
 
                             # Must move coverage files to the current directory
                             ls /tmp/backup_restore_test

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -538,7 +538,7 @@ catchError {
                     println "ghprbPullId: ${ghprbPullId}"
                     println "specStr: ${specStr}"
 
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '${specStr}', url: git_repo_url]]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """
                     git checkout -f ${ghprbActualCommit}

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -344,7 +344,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                     scripts_builder.append("curl ${tidb_download_url} | tar -xz -C tidb-source; ")
                             .append("cp tidb-source/bin/tidb-server bin/; rm -rf tidb-source;) &\n")
                 } else {
-                    scripts_builder.append("\n\n\n")
+                    scripts_builder.append("\n")
                 }
 
                 // tiflash
@@ -389,20 +389,15 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                           try {
                               sh label: "Running ${case_name}", script: """
 
-                              echo START
                               rm -rf /tmp/backup_restore_test
                               mkdir -p /tmp/backup_restore_test
                               rm -rf cover
                               mkdir cover
 
-                              echo mkdir
-
                               if [[ ! -e tests/${case_name}/run.sh ]]; then
                                   echo ${case_name} not exists, skip.
                                   exit 0
                               fi
-
-                              echo tests
 
                               export GOPATH=\$GOPATH:${ws}/go
                               export PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -336,7 +336,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                 // tidb
                 // we build tidb-server from local, then put it into br_integration_test.tar.gz
                 // so we can get it from br_integration_test.tar.gz
-                if (!isBRMergedIntoTiDB() {
+                if (!isBRMergedIntoTiDB()) {
                     scripts_builder.append("(tidb_sha1=\$(curl ${FILE_SERVER_URL}/download/refs/pingcap/tidb/${tidb}/sha1); ")
                             .append("mkdir tidb-source; ")
                     def tidb_download_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb/\${tidb_sha1}/centos7/tidb-server.tar.gz"

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -333,6 +333,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                 // we build tidb-server from local, then put it into br_integration_test.tar.gz
                 // so we can get it from br_integration_test.tar.gz
                 if (!isBRMergedIntoTiDB()) {
+                    echo "br in tidb"
                     scripts_builder.append("(tidb_sha1=\$(curl ${FILE_SERVER_URL}/download/refs/pingcap/tidb/${tidb}/sha1); ")
                             .append("mkdir tidb-source; ")
                     def tidb_download_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb/\${tidb_sha1}/centos7/tidb-server.tar.gz"
@@ -342,6 +343,8 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
 
                     scripts_builder.append("curl ${tidb_download_url} | tar -xz -C tidb-source; ")
                             .append("cp tidb-source/bin/tidb-server bin/; rm -rf tidb-source;) &\n")
+                } else {
+                    scripts_builder.append("\n\n\n")
                 }
 
                 // tiflash
@@ -377,7 +380,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
             dir("${ws}/go/src/github.com/pingcap/br") {
                 if (isBRMergedIntoTiDB()) {
                     // move tests outside for compatibility
-                    sh label: "Running ${case_name}", script: """
+                    sh label: "Move test outside", script: """
                     mv br/tests/* tests/
                     """
                 }

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -538,9 +538,10 @@ catchError {
                     println "ghprbPullId: ${ghprbPullId}"
                     println "specStr: ${specStr}"
 
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: '${ghprbActualCommit}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '${specStr}', url: git_repo_url]]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '${specStr}', url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """
+                    git checkout -f ${ghprbActualCommit}
                     git rev-parse HEAD
 
                     go version

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -551,6 +551,7 @@ catchError {
                     curl -F ${filepath}=@br_integration_test.tar.gz ${FILE_SERVER_URL}/upload
                     """
 
+                    println "from before: ${from}"
                     // Collect test case names.
                     switch (from) {
                         case "tikv":

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -557,6 +557,8 @@ catchError {
                     git rev-parse HEAD
 
                     go version
+
+                    sleep 1000
                     ${build_br_cmd}
 
                     tar czf br_integration_test.tar.gz * .[!.]*

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -558,7 +558,6 @@ catchError {
 
                     go version
 
-                    sleep 1000
                     ${build_br_cmd}
 
                     tar czf br_integration_test.tar.gz * .[!.]*

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -477,7 +477,7 @@ def fast_checkout_tidb() {
                     sh """
                         rm -rf /home/jenkins/agent/code-archive/tidb.tar.gz
                         rm -rf /home/jenkins/agent/code-archive/tidb
-                        wget -O /home/jenkins/agent/code-archive/tidb.tar.gz  ${FILE_SERVER_URL}/download/source/tidb.tar.gz -q --show-progress
+                        wget -O /home/jenkins/agent/code-archive/tidb.tar.gz  ${FILE_SERVER_URL}/download/source/tidb.tar.gz -q
                         tar -xzf /home/jenkins/agent/code-archive/tidb.tar.gz -C ./ --strip-components=1
                     """
                 }

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -371,7 +371,6 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
 
                 def scripts = scripts_builder.toString()
                 echo scripts
-                sleep 1000
                 sh label: "Download and Go Version", script: scripts
             }
 

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -404,8 +404,6 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
 
                               ls /tmp/backup_restore_test
 
-                              sleep 1000
-
                               TEST_NAME=${case_name} tests/run.sh
 
                               # Must move coverage files to the current directory

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -618,7 +618,12 @@ catchError {
                         default:
                             list_path = "tests"
                             if (isBRMergedIntoTiDB()) {
-                                list_path = "br/tests"
+                                // current gcs test need custom endpoint
+                                // but official client has a bug on custom endpoint
+                                // in origin BR repo: we use replace go.mod to fix this issue.
+                                // but after BR merged into TiDB, we cannot use replace due to plugin check.isBRMergedIntoTiDB
+                                // we should skip these tests until https://github.com/googleapis/google-cloud-go/pull/3509 merged.
+                                list_path = "br/tests | grep -v br_gcs | grep -v lightning_gcs"
                             }
                             def list = sh(script: "ls ${list_path} | grep -E 'br_|lightning_'", returnStdout:true).trim()
                             for (name in list.split("\\n")) {

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -397,15 +397,20 @@ def run_cases(case_names) {
            try {
                sh label: "Running ${case_name}", script: """
 
+               echo START
                rm -rf /tmp/backup_restore_test
                mkdir -p /tmp/backup_restore_test
                rm -rf cover
                mkdir cover
 
+               echo mkdir
+
                if [[ ! -e tests/${case_name}/run.sh ]]; then
                    echo ${case_name} not exists, skip.
                    exit 0
                fi
+
+               echo tests
 
                export GOPATH=\$GOPATH:${ws}/go
                export PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -402,6 +402,10 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                               export GOPATH=\$GOPATH:${ws}/go
                               export PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH
 
+                              ls /tmp/backup_restore_test
+
+                              sleep 1000
+
                               TEST_NAME=${case_name} tests/run.sh
 
                               # Must move coverage files to the current directory

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -520,7 +520,10 @@ catchError {
                             build_br_cmd = "make build_for_br_integration_test && make server"
                             break;
                     }
-                    
+
+                    echo ${git_repo_url}
+                    echo ${build_br_cmd}
+
                     def filepath = "builds/pingcap/br/pr/${commit_id}/centos7/br_integration_test.tar.gz"
 
                     checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: ${git_repo_url}]]]

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -485,6 +485,9 @@ catchError {
                     println "refSpecs: ${refSpecs}"
 
                     def from = params.getOrDefault("triggered_by_upstream_pr_ci", "Origin")
+
+                    println "from: ${from}"
+
                     def git_repo_url = "git@github.com:pingcap/br.git"
                     def build_br_cmd = "make build_for_integration_test"
                     def commit_id = "${ghprbActualCommit}"

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -186,7 +186,7 @@ def boolean isBranchMatched(List<String> branches, String targetBranch) {
     return false
 }
 
-def boolean isBRMergedIntoTiDB(Map<?, ?> params) {
+def boolean isBRMergedIntoTiDB(params) {
     return params.getOrDefault("triggered_by_upstream_pr_ci", "Origin") == "tidb-br"
 }
 

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -536,6 +536,8 @@ catchError {
                         specStr = "+refs/pull/*:refs/remotes/origin/pr/*"
                     }
 
+                    println "ghprbPullId: ${ghprbPullId}"
+
                     checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: '${ghprbActualCommit}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -528,15 +528,15 @@ catchError {
                     println "br_cmd: ${build_br_cmd}"
                     def filepath = "builds/pingcap/br/pr/${commit_id}/centos7/br_integration_test.tar.gz"
 
+                    specStr = "+refs/pull/*:refs/remotes/origin/pr/*"
                     // Use pullID to speed up git fetch
                     // or we will get timeout
                     if (ghprbPullId != null && ghprbPullId != "") {
                         specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
-                    } else {
-                        specStr = "+refs/pull/*:refs/remotes/origin/pr/*"
                     }
 
                     println "ghprbPullId: ${ghprbPullId}"
+                    println "specStr: ${specStr}"
 
                     checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: '${ghprbActualCommit}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
 

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -377,15 +377,15 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                 sh label: "Download and Go Version", script: scripts
             }
 
-            if (isBRMergedIntoTiDB()) {
-                dir("go/src/github.com/pingcap/br/br") {
-                    // run cases in sub module
-                    run_cases(case_names)
+            dir("go/src/github.com/pingcap/br") {
+                if (isBRMergedIntoTiDB()) {
+                    // move tests outside for compatibility
+                    sh label: "Running ${case_name}", script: """
+                    mv br/tests/* tests/
+                    """
                 }
-            } else {
-                dir("go/src/github.com/pingcap/br") {
-                    // run cases in origin module
-                    run_cases(case_names)
+                // run cases in origin module
+                run_cases(case_names)
                 }
             }
         }

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -460,7 +460,7 @@ def fast_checkout_tidb() {
                 timeout(5) {
                     sh """
                         cp -R /nfs/cache/git-test/src-tidb.tar.gz*  ./
-                        mkdir -p go/src/github.com/pingcap/tidb
+                        mkdir -p go/src/github.com/pingcap/br
                         tar -xzf src-tidb.tar.gz -C go/src/github.com/pingcap/br --strip-components=1
                     """
                 }

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -528,7 +528,15 @@ catchError {
                     println "br_cmd: ${build_br_cmd}"
                     def filepath = "builds/pingcap/br/pr/${commit_id}/centos7/br_integration_test.tar.gz"
 
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: '${ghprbActualCommit}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: git_repo_url]]]
+                    // Use pullID to speed up git fetch
+                    // or we will get timeout
+                    if (ghprbPullId != null && ghprbPullId != "") {
+                        specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
+                    } else {
+                        specStr = "+refs/pull/*:refs/remotes/origin/pr/*"
+                    }
+
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: '${ghprbActualCommit}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """
                     git rev-parse HEAD

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -521,9 +521,8 @@ catchError {
                             break;
                     }
 
-                    echo ${git_repo_url}
-                    echo ${build_br_cmd}
-
+                    println "git_repo_url: ${git_repo_url}"
+                    println "br_cmd: ${build_br_cmd}"
                     def filepath = "builds/pingcap/br/pr/${commit_id}/centos7/br_integration_test.tar.gz"
 
                     checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: ${git_repo_url}]]]

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -72,10 +72,6 @@ if (getTargetBranch(ghprbTargetBranch)!=""){
     ghprbTargetBranch = "master"
 }
 
-def specStr = "+refs/pull/*:refs/remotes/origin/pr/*"
-if (ghprbPullId != null && ghprbPullId != "") {
-    specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
-}
 
 def TIKV_BRANCH = ghprbTargetBranch
 def TIKV_IMPORTER_BRANCH = ghprbTargetBranch
@@ -482,6 +478,11 @@ def fast_checkout_tidb() {
                     """
                 }
             }
+            specStr = "+refs/pull/*:refs/remotes/origin/pr/*"
+            if (ghprbPullId != null && ghprbPullId != "") {
+                specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
+            }
+
             try {
                 checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'CloneOption', timeout: 2]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tidb.git']]]
             }   catch (info) {
@@ -582,6 +583,11 @@ catchError {
                         build_br_cmd = "make build_for_br_integration_test && make server"
                     } else {
                         println "checkout br repo"
+                        specStr = "+refs/pull/*:refs/remotes/origin/pr/*"
+                        if (ghprbPullId != null && ghprbPullId != "") {
+                            specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
+                        }
+
                         checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
                     }
 

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -381,9 +381,12 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                 for (case_name in case_names) {
                     timeout(120) {
                         test_path = "tests"
+                        cd_cmd = ""
                         if (isBRMergedIntoTiDB()) {
-                        // in tidb repo
+                            // in tidb repo
                             test_path = "br/tests"
+                            // enter br directory to run test
+                            cd_cmd = "cd br"
                         }
                         try {
                             sh label: "Running ${case_name}", script: """
@@ -399,7 +402,10 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
 
                             export GOPATH=\$GOPATH:${ws}/go
                             export PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH
-                            TEST_NAME=${case_name} ${test_path}/run.sh
+
+                            ${cd_cmd}
+
+                            TEST_NAME=${case_name} tests/run.sh
 
                             # Must move coverage files to the current directory
                             ls /tmp/backup_restore_test

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -186,7 +186,7 @@ def boolean isBranchMatched(List<String> branches, String targetBranch) {
     return false
 }
 
-def boolean isBRMergedIntoTiDB(params) {
+def boolean isBRMergedIntoTiDB(Map<?, ?> params) {
     return params.getOrDefault("triggered_by_upstream_pr_ci", "Origin") == "tidb-br"
 }
 

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -582,24 +582,23 @@ catchError {
                             """
                             }
                         }
+                        if(!fileExists("go/src/github.com/pingcap/br/Makefile")) {
+                            dir("go/src/github.com/pingcap/br") {
+                                sh """
+                                rm -rf /home/jenkins/agent/code-archive/tidb.tar.gz
+                                rm -rf /home/jenkins/agent/code-archive/tidb
+                                wget -O /home/jenkins/agent/code-archive/tidb.tar.gz  ${FILE_SERVER_URL}/download/source/tidb.tar.gz -q
+                                tar -xzf /home/jenkins/agent/code-archive/tidb.tar.gz -C ./ --strip-components=1
+                                """
+                            }
+                        }
                     }
                     specStr = "+refs/pull/*:refs/remotes/origin/pr/*"
                     if (ghprbPullId != null && ghprbPullId != "") {
                         specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
                     }
 
-                    if(!fileExists("go/src/github.com/pingcap/br/Makefile")) {
-                       dir("go/src/github.com/pingcap/br") {
-                       sh """
-                       rm -rf /home/jenkins/agent/code-archive/tidb.tar.gz
-                       rm -rf /home/jenkins/agent/code-archive/tidb
-                       wget -O /home/jenkins/agent/code-archive/tidb.tar.gz  ${FILE_SERVER_URL}/download/source/tidb.tar.gz -q
-                       tar -xzf /home/jenkins/agent/code-archive/tidb.tar.gz -C ./ --strip-components=1
-                       """
-                       }
-                    }
-
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """
                     git checkout -f ${ghprbActualCommit}

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -378,11 +378,15 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
             }
 
             dir("${ws}/go/src/github.com/pingcap/br") {
+                export_cmd = ""
                 if (isBRMergedIntoTiDB()) {
                     // move tests outside for compatibility
                     sh label: "Move test outside", script: """
                     mv br/tests/* tests/
                     """
+                    // lightning_examples test need mv file from examples pkg.
+                    // so we should overwrite the path.
+                    export_cmd = "export EXAMPLES_PATH=br/pkg/lightning/mydump/examples"
                 }
                 for (case_name in case_names) {
                       timeout(120) {
@@ -404,6 +408,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
 
                               ls /tmp/backup_restore_test
 
+                              ${export_cmd}
                               TEST_NAME=${case_name} tests/run.sh
 
                               # Must move coverage files to the current directory

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -213,7 +213,7 @@ def get_commit_hash(prj, branch_or_hash) {
 def run_unit_test() {
     node("${GO_TEST_SLAVE}") {
         container("golang") {
-            println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
+            println "debug command:\nkubectl -n jenkins-tidb exec -ti ${NODE_NAME} bash"
             def ws = pwd()
             deleteDir()
 
@@ -255,7 +255,7 @@ def run_unit_test() {
 def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBranch, tiflashCommit) {
     node("${GO_TEST_SLAVE}") {
         container("golang") {
-            println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
+            println "debug command:\nkubectl -n jenkins-tidb exec -ti ${NODE_NAME} bash"
             def ws = pwd()
             deleteDir()
 
@@ -354,8 +354,6 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                 scripts_builder.append("curl ${FILE_SERVER_URL}/download/builds/pingcap/tiflash/${tiflashBranch}/\${tiflashCommit}/centos7/tiflash.tar.gz | tar xz tiflash; ")
                             .append("mv tiflash/* bin/; rmdir tiflash;) &\n")
 
-                sleep 1000
-
                 // Testing S3 ans GCS.
                 // go-ycsb are manual uploaded for test br
                 // minio and s3cmd for testing s3
@@ -373,6 +371,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
 
                 def scripts = scripts_builder.toString()
                 echo scripts
+                sleep 1000
                 sh label: "Download and Go Version", script: scripts
             }
 
@@ -693,7 +692,7 @@ catchError {
         // Skip upload coverage when the job is initialed by TiDB PRs.
         node("${GO_TEST_SLAVE}") {
             container("golang") {
-                println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
+                println "debug command:\nkubectl -n jenkins-tidb exec -ti ${NODE_NAME} bash"
                 if (params.containsKey("triggered_by_upstream_pr_ci")) {
                     println "skip uploading coverage as it is triggered by upstream PRs"
                 } else {

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -535,9 +535,6 @@ catchError {
                         specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
                     }
 
-                    println "ghprbPullId: ${ghprbPullId}"
-                    println "specStr: ${specStr}"
-
                     checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -386,7 +386,6 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                 }
                 // run cases in origin module
                 run_cases(case_names)
-                }
             }
         }
     }

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -601,7 +601,9 @@ catchError {
                             little_slow_case_names = []
                             break;
                         default:
+                            println "from: ${from}"
                             def list = sh(script: "ls br/tests | grep -E 'br_|lightning_'", returnStdout:true).trim()
+                            println "list: ${list}"
                             for (name in list.split("\\n")) {
                                 test_case_names << name
                             }

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -528,7 +528,7 @@ catchError {
                     println "br_cmd: ${build_br_cmd}"
                     def filepath = "builds/pingcap/br/pr/${commit_id}/centos7/br_integration_test.tar.gz"
 
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '${ghprbActualCommit}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: git_repo_url]]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: '${ghprbActualCommit}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """
                     git rev-parse HEAD

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -598,7 +598,7 @@ catchError {
                         specStr = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
                     }
 
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout'], [$class: 'CloneOption', timeout: 2]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """
                     git checkout -f ${ghprbActualCommit}

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -528,7 +528,7 @@ catchError {
                     println "br_cmd: ${build_br_cmd}"
                     def filepath = "builds/pingcap/br/pr/${commit_id}/centos7/br_integration_test.tar.gz"
 
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: ${git_repo_url}]]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """
                     git checkout -f ${ghprbActualCommit}

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -377,66 +377,68 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                 sh label: "Download and Go Version", script: scripts
             }
 
-            dir("go/src/github.com/pingcap/br") {
-                for (case_name in case_names) {
-                    timeout(120) {
-                        test_path = "tests"
-                        cd_cmd = ""
-                        if (isBRMergedIntoTiDB()) {
-                            // in tidb repo
-                            test_path = "br/tests"
-                            // enter br directory to run test
-                            cd_cmd = "cd br"
-                        }
-                        try {
-                            sh label: "Running ${case_name}", script: """
-                            rm -rf /tmp/backup_restore_test
-                            mkdir -p /tmp/backup_restore_test
-                            rm -rf cover
-                            mkdir cover
-
-                            if [[ ! -e ${test_path}/${case_name}/run.sh ]]; then
-                                echo ${case_name} not exists, skip.
-                                exit 0
-                            fi
-
-                            export GOPATH=\$GOPATH:${ws}/go
-                            export PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH
-
-                            ${cd_cmd}
-
-                            TEST_NAME=${case_name} tests/run.sh
-
-                            # Must move coverage files to the current directory
-                            ls /tmp/backup_restore_test
-                            cp /tmp/backup_restore_test/cov.* cover/ || true
-                            ls cover
-                            """
-                        } catch (Exception e) {
-                            sh "tail -4000 '/tmp/backup_restore_test/pd.log' || true"
-                            sh "tail -40000 '/tmp/backup_restore_test/tikv1.log' || true"
-                            sh "tail -40000 '/tmp/backup_restore_test/tikv2.log' || true"
-                            sh "tail -40000 '/tmp/backup_restore_test/tikv3.log' || true"
-                            sh "tail -40000 '/tmp/backup_restore_test/tikv4.log' || true"
-                            sh "tail -1000 '/tmp/backup_restore_test/tidb.log' || true"
-                            sh "tail -1000 '/tmp/backup_restore_test/tiflash-manager.log' || true"
-                            sh "tail -1000 '/tmp/backup_restore_test/tiflash-stdout.log' || true"
-                            sh "tail -1000 '/tmp/backup_restore_test/tiflash-stderr.log' || true"
-                            sh "tail -1000 '/tmp/backup_restore_test/tiflash-proxy.log' || true"
-                            sh "cat '/tmp/backup_restore_test/importer.log' || true"
-                            sh "find '/tmp/backup_restore_test/' -name \"lightning*log\" -exec echo \">>>>>>>>> {}\" \\; -exec cat {} \\; || true"
-                            sh "echo 'Test failed'"
-                            throw e;
-                        }
-                    }
-                    // stash "cover/**" as we are already in "go/src/github.com/pingcap/br/".
-                    stash includes: "cover/**", name: "integration_test_${case_name}", useDefaultExcludes: false, allowEmpty: true
+            if (isBRMergedIntoTiDB()) {
+                dir("go/src/github.com/pingcap/br/br") {
+                    // run cases in sub module
+                    run_cases(case_names)
+                }
+            } else {
+                dir("go/src/github.com/pingcap/br") {
+                    // run cases in origin module
+                    run_cases(case_names)
                 }
             }
         }
     }
 }
 
+def run_cases(case_names) {
+   for (case_name in case_names) {
+       timeout(120) {
+           try {
+               sh label: "Running ${case_name}", script: """
+
+               rm -rf /tmp/backup_restore_test
+               mkdir -p /tmp/backup_restore_test
+               rm -rf cover
+               mkdir cover
+
+               if [[ ! -e tests/${case_name}/run.sh ]]; then
+                   echo ${case_name} not exists, skip.
+                   exit 0
+               fi
+
+               export GOPATH=\$GOPATH:${ws}/go
+               export PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH
+
+               TEST_NAME=${case_name} tests/run.sh
+
+               # Must move coverage files to the current directory
+               ls /tmp/backup_restore_test
+               cp /tmp/backup_restore_test/cov.* cover/ || true
+               ls cover
+               """
+           } catch (Exception e) {
+               sh "tail -4000 '/tmp/backup_restore_test/pd.log' || true"
+               sh "tail -40000 '/tmp/backup_restore_test/tikv1.log' || true"
+               sh "tail -40000 '/tmp/backup_restore_test/tikv2.log' || true"
+               sh "tail -40000 '/tmp/backup_restore_test/tikv3.log' || true"
+               sh "tail -40000 '/tmp/backup_restore_test/tikv4.log' || true"
+               sh "tail -1000 '/tmp/backup_restore_test/tidb.log' || true"
+               sh "tail -1000 '/tmp/backup_restore_test/tiflash-manager.log' || true"
+               sh "tail -1000 '/tmp/backup_restore_test/tiflash-stdout.log' || true"
+               sh "tail -1000 '/tmp/backup_restore_test/tiflash-stderr.log' || true"
+               sh "tail -1000 '/tmp/backup_restore_test/tiflash-proxy.log' || true"
+               sh "cat '/tmp/backup_restore_test/importer.log' || true"
+               sh "find '/tmp/backup_restore_test/' -name \"lightning*log\" -exec echo \">>>>>>>>> {}\" \\; -exec cat {} \\; || true"
+               sh "echo 'Test failed'"
+               throw e;
+           }
+       }
+       // stash "cover/**" as we are already in "go/src/github.com/pingcap/br/".
+       stash includes: "cover/**", name: "integration_test_${case_name}", useDefaultExcludes: false, allowEmpty: true
+   }
+}
 def make_parallel_jobs(case_names, batch_size, tidb, tikv, pd, cdc, importer, tiflashBranch, tiflashCommit) {
     def batches = []
     case_names.collate(batch_size).each { names ->

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -343,6 +343,8 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                     scripts_builder.append("curl ${tidb_download_url} | tar -xz -C tidb-source; ")
                             .append("cp tidb-source/bin/tidb-server bin/; rm -rf tidb-source;) &\n")
                 }
+
+                sh "sleep 1000"
                 // tiflash
                 if (tiflashCommit == "") {
                     scripts_builder.append("(tiflashCommit=\$(curl ${FILE_SERVER_URL}/download/refs/pingcap/tiflash/${tiflashBranch}/sha1); ")

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -538,7 +538,7 @@ catchError {
                     println "ghprbPullId: ${ghprbPullId}"
                     println "specStr: ${specStr}"
 
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: '${ghprbActualCommit}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: git_repo_url]]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', shallow: true, branches: [[name: '${ghprbActualCommit}']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '${specStr}', url: git_repo_url]]]
 
                     sh label: "Build and Compress testing binaries", script: """
                     git rev-parse HEAD

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -559,7 +559,7 @@ catchError {
                 }
 
                 // Checkout and build testing binaries.
-                dir("go/src/github.com/pingcap/br") {
+                dir("${ws}/go/src/github.com/pingcap/br") {
                     if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
                         deleteDir()
                     }
@@ -577,20 +577,18 @@ catchError {
                             timeout(5) {
                             sh """
                             cp -R /nfs/cache/git-test/src-tidb.tar.gz*  ./
-                            mkdir -p go/src/github.com/pingcap/br
-                            tar -xzf src-tidb.tar.gz -C go/src/github.com/pingcap/br --strip-components=1
+                            mkdir -p ${ws}/go/src/github.com/pingcap/br
+                            tar -xzf src-tidb.tar.gz -C ${ws}/go/src/github.com/pingcap/br --strip-components=1
                             """
                             }
                         }
-                        if(!fileExists("go/src/github.com/pingcap/br/Makefile")) {
-                            dir("go/src/github.com/pingcap/br") {
-                                sh """
-                                rm -rf /home/jenkins/agent/code-archive/tidb.tar.gz
-                                rm -rf /home/jenkins/agent/code-archive/tidb
-                                wget -O /home/jenkins/agent/code-archive/tidb.tar.gz  ${FILE_SERVER_URL}/download/source/tidb.tar.gz -q
-                                tar -xzf /home/jenkins/agent/code-archive/tidb.tar.gz -C ./ --strip-components=1
-                                """
-                            }
+                        if(!fileExists("${ws}/go/src/github.com/pingcap/br/Makefile")) {
+                            sh """
+                            rm -rf /home/jenkins/agent/code-archive/tidb.tar.gz
+                            rm -rf /home/jenkins/agent/code-archive/tidb
+                            wget -O /home/jenkins/agent/code-archive/tidb.tar.gz  ${FILE_SERVER_URL}/download/source/tidb.tar.gz -q
+                            tar -xzf /home/jenkins/agent/code-archive/tidb.tar.gz -C ./ --strip-components=1
+                            """
                         }
                     }
                     specStr = "+refs/pull/*:refs/remotes/origin/pr/*"

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_br_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_br_test.groovy
@@ -52,12 +52,6 @@ catchError {
     }
 }
 
-stage("upload status"){
-    node("master") {
-        sh """curl --connect-timeout 2 --max-time 4 -d '{"job":"$JOB_NAME","id":$BUILD_NUMBER}' http://172.16.5.25:36000/api/v1/ci/job/sync || true"""
-    }
-}
-
 if (params.containsKey("triggered_by_upstream_ci")) {
     stage("update commit status") {
         node("master") {

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_br_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_br_test.groovy
@@ -45,7 +45,7 @@ catchError {
                     default_params.upstream_pr_ci_ghpr_actual_commit = "${ghprbTargetBranch}"
                 }
                 // Trigger BRIE test without waiting its finish.
-                build(job: "br_ghpr_unit_and_integration_test", parameters: default_params, wait: true)
+                build(job: "debug_br_ghpr_unit_and_integration_test", parameters: default_params, wait: true)
             }
             currentBuild.result = "SUCCESS"
         }

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_br_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_br_test.groovy
@@ -14,35 +14,38 @@ def tidb_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb/pr/${ghprbActual
 
 catchError {
     node("${GO_TEST_SLAVE}") {
+        // After BR merged into TiDB, every PR should trigger this test.
         stage('Trigger BRIE Test') {
-            if (ghprbTargetBranch == "master" || ghprbTargetBranch == "release-4.0" || ghprbTargetBranch == "release-5.0") {
-                container("golang") {
-                    println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
-                    // Wait build finish.
-                    timeout(60) {
-                        sh """
-                        while ! curl --output /dev/null --silent --head --fail "${tidb_url}"; do sleep 5; done
-                        """
-                    }
-
-                    def default_params = [
-                            booleanParam(name: 'force', value: true),
-                            string(name: 'triggered_by_upstream_pr_ci', value: "tidb"),
-                            string(name: 'upstream_pr_ci_ghpr_target_branch', value: "${ghprbTargetBranch}"),
-                            // We tests BR on the same branch as TiDB's.
-                            string(name: 'upstream_pr_ci_ghpr_actual_commit', value: "${ghprbTargetBranch}"),
-                            string(name: 'upstream_pr_ci_ghpr_pull_id', value: "${ghprbPullId}"),
-                            string(name: 'upstream_pr_ci_ghpr_pull_title', value: "${ghprbPullTitle}"),
-                            string(name: 'upstream_pr_ci_ghpr_pull_link', value: "${ghprbPullLink}"),
-                            string(name: 'upstream_pr_ci_ghpr_pull_description', value: "${ghprbPullDescription}"),
-                            string(name: 'upstream_pr_ci_override_tidb_download_link', value: "${tidb_url}"),
-                    ]
-
-                    // Trigger BRIE test without waiting its finish.
-                    build(job: "br_ghpr_unit_and_integration_test", parameters: default_params, wait: true)
+            container("golang") {
+                println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
+                // Wait build finish.
+                timeout(60) {
+                    sh """
+                    while ! curl --output /dev/null --silent --head --fail "${tidb_url}"; do sleep 5; done
+                    """
                 }
-            } else {
-                println "skip trigger BRIE tests as this PR targets to ${ghprbTargetBranch}"
+
+                def default_params = [
+                        booleanParam(name: 'force', value: true),
+                        // "Origin" means run every br integration tests.
+                        string(name: 'triggered_by_upstream_pr_ci', value: "Origin"),
+                        string(name: 'upstream_pr_ci_ghpr_target_branch', value: "${ghprbTargetBranch}"),
+                        // We tests BR on the same branch as TiDB's.
+                        string(name: 'upstream_pr_ci_ghpr_actual_commit', value: "${ghprbTargetBranch}"),
+                        string(name: 'upstream_pr_ci_ghpr_pull_id', value: "${ghprbPullId}"),
+                        string(name: 'upstream_pr_ci_ghpr_pull_title', value: "${ghprbPullTitle}"),
+                        string(name: 'upstream_pr_ci_ghpr_pull_link', value: "${ghprbPullLink}"),
+                        string(name: 'upstream_pr_ci_ghpr_pull_description', value: "${ghprbPullDescription}"),
+                        string(name: 'upstream_pr_ci_override_tidb_download_link', value: "${tidb_url}"),
+                ]
+
+                // these three branch don't have br integrated.
+                if (ghprbTargetBranch == "release-4.0" || ghprbTargetBranch == "release-5.0" || ghprbTargetBranch == "release-5.1") {
+                    default_params.triggered_by_upstream_pr_ci = "tidb"
+
+                }
+                // Trigger BRIE test without waiting its finish.
+                build(job: "br_ghpr_unit_and_integration_test", parameters: default_params, wait: true)
             }
             currentBuild.result = "SUCCESS"
         }

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_br_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_br_test.groovy
@@ -27,11 +27,10 @@ catchError {
 
                 def default_params = [
                         booleanParam(name: 'force', value: true),
-                        // "Origin" means run every br integration tests.
-                        string(name: 'triggered_by_upstream_pr_ci', value: "Origin"),
+                        // "tidb-br" run every br integration tests after BR merged into TiDB.
+                        string(name: 'triggered_by_upstream_pr_ci', value: "tidb-br"),
                         string(name: 'upstream_pr_ci_ghpr_target_branch', value: "${ghprbTargetBranch}"),
-                        // We tests BR on the same branch as TiDB's.
-                        string(name: 'upstream_pr_ci_ghpr_actual_commit', value: "${ghprbTargetBranch}"),
+                        string(name: 'upstream_pr_ci_ghpr_actual_commit', value: "${ghprbActualCommit}"),
                         string(name: 'upstream_pr_ci_ghpr_pull_id', value: "${ghprbPullId}"),
                         string(name: 'upstream_pr_ci_ghpr_pull_title', value: "${ghprbPullTitle}"),
                         string(name: 'upstream_pr_ci_ghpr_pull_link', value: "${ghprbPullLink}"),
@@ -42,7 +41,8 @@ catchError {
                 // these three branch don't have br integrated.
                 if (ghprbTargetBranch == "release-4.0" || ghprbTargetBranch == "release-5.0" || ghprbTargetBranch == "release-5.1") {
                     default_params.triggered_by_upstream_pr_ci = "tidb"
-
+                    // We tests BR on the same branch as TiDB's.
+                    default_params.upstream_pr_ci_ghpr_actual_commit = "${ghprbTargetBranch}"
                 }
                 // Trigger BRIE test without waiting its finish.
                 build(job: "br_ghpr_unit_and_integration_test", parameters: default_params, wait: true)


### PR DESCRIPTION
close #353

refine TiDB CI after BR merged into TiDB

1. add `tidb-br` upstream for br_integration_test.
2. skip gcs tests due to https://github.com/googleapis/google-cloud-go/pull/3509
