### PR TITLE
fix: hotfix branch build plugin by remove date suffix

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_build.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_build.groovy
@@ -13,6 +13,16 @@ def slackcolor = 'good'
 def githash
 
 def PLUGIN_BRANCH = ghprbTargetBranch
+
+// example hotfix branch  release-4.0-20210724 | example release-5.1-hotfix-tiflash-patch1
+// remove suffix "-20210724", only use "release-4.0"
+if (PLUGIN_BRANCH.startsWith("release-") && PLUGIN_BRANCH.split("-").size() >= 3 ) {
+    def k = PLUGIN_BRANCH.indexOf("-", PLUGIN_BRANCH.indexOf("-") + 1)
+    PLUGIN_BRANCH = PLUGIN_BRANCH.substring(0, k)
+    println "tidb hotfix branch: ${ghprbTargetBranch}"
+    println "plugin branch use ${PLUGIN_BRANCH}"
+}
+
 // parse enterprise-plugin branch
 def m1 = ghprbCommentBody =~ /plugin\s*=\s*([^\s\\]+)(\s|\\|$)/
 if (m1) {


### PR DESCRIPTION
* example hotfix branch release-4.0-20210727, build enterprise plugin use branch release-4.0 (remove date suffix because hotfix branch with date not been created  on plugin repo)