### PR TITLE
tikv: hotfix branch use correct image

### DIFF
--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_build.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_build.groovy
@@ -124,12 +124,6 @@ try {
     echo "${e}"
 }
 
-stage("upload status"){
-    node{
-        sh """curl --connect-timeout 2 --max-time 4 -d '{"job":"$JOB_NAME","id":$BUILD_NUMBER}' http://172.16.5.13:36000/api/v1/ci/job/sync || true"""
-    }
-}
-
 stage('Summary') {
     echo "Send slack here ..."
     def duration = ((System.currentTimeMillis() - currentBuild.startTimeInMillis) / 1000 / 60).setScale(2, BigDecimal.ROUND_HALF_UP)

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_test.groovy
@@ -13,6 +13,17 @@ if (params.containsKey("release_test")) {
 def notRun = 1
 def chunk_count = 20
 
+
+// example hotfix branch  release-4.0-20210724 | example release-5.1-hotfix-tiflash-patch1
+// remove suffix "-20210724", only use "release-4.0"
+if (ghprbTargetBranch.startsWith("release-") && ghprbTargetBranch.split("-").size() >= 3 ) {
+    println "tikv hotfix branch: ${ghprbTargetBranch}"
+    def k = ghprbTargetBranch.indexOf("-", ghprbTargetBranch.indexOf("-") + 1)
+    ghprbTargetBranch = ghprbTargetBranch.substring(0, k)
+    println "ci image use  ${ghprbTargetBranch}"
+}
+
+
 try {
 stage("PreCheck") {
     if (!params.force) {

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_test.groovy
@@ -368,13 +368,6 @@ stage('Post-test') {
     }
 }
 
-stage("upload status") {
-    node("master") {
-        println currentBuild.result
-        sh """curl --connect-timeout 2 --max-time 4 -d '{"job":"$JOB_NAME","id":$BUILD_NUMBER}' http://172.16.5.13:36000/api/v1/ci/job/sync || true"""
-    }
-}
-
 if (params.containsKey("triggered_by_upstream_ci")) {
     stage("update commit status") {
         node("master") {


### PR DESCRIPTION
* remove useless job data report api
* hotfix branch test use correct image, example release-4.0-20210724 use image hub.pingcap.net/jenkins/tikv-cached-release-4.0:latest