### PR TITLE
ticdc: use case name in integration step

### DIFF
--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -172,8 +172,8 @@ def tests(sink_type, node_label) {
             step_cases.add(case_names)
         }
         step_cases.eachWithIndex { case_names, index ->
-            def step_name = "step_${index} " + case_names.join(" ")
-            test_cases["integration test ${step_name}"] = {
+            def step_name = "${index} ${case_names.join(" ")}"
+            test_cases["${step_name}"] = {
                 run_integration_test(step_name, case_names.join(" "))
             }
         }

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -172,7 +172,7 @@ def tests(sink_type, node_label) {
             step_cases.add(case_names)
         }
         step_cases.eachWithIndex { case_names, index ->
-            def step_name = "step_${index}"
+            def step_name = "step_${index}_case_" + case_names.join("_")
             test_cases["integration test ${step_name}"] = {
                 run_integration_test(step_name, case_names.join(" "))
             }

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -173,7 +173,7 @@ def tests(sink_type, node_label) {
         }
         step_cases.eachWithIndex { case_names, index ->
             def step_name = case_names.join(" ")
-            test_cases["${step_name}"] = {
+            test_cases[step_name] = {
                 run_integration_test(step_name, case_names.join(" "))
             }
         }

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -172,7 +172,7 @@ def tests(sink_type, node_label) {
             step_cases.add(case_names)
         }
         step_cases.eachWithIndex { case_names, index ->
-            def step_name = "${index} ${case_names.join(" ")}"
+            def step_name = case_names.join(" ")
             test_cases["${step_name}"] = {
                 run_integration_test(step_name, case_names.join(" "))
             }

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -172,7 +172,7 @@ def tests(sink_type, node_label) {
             step_cases.add(case_names)
         }
         step_cases.eachWithIndex { case_names, index ->
-            def step_name = "step_${index} case " + case_names.join(" ")
+            def step_name = "step_${index} " + case_names.join(" ")
             test_cases["integration test ${step_name}"] = {
                 run_integration_test(step_name, case_names.join(" "))
             }

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -172,7 +172,7 @@ def tests(sink_type, node_label) {
             step_cases.add(case_names)
         }
         step_cases.eachWithIndex { case_names, index ->
-            def step_name = "step_${index}_case_" + case_names.join("_")
+            def step_name = "step_${index} case " + case_names.join(" ")
             test_cases["integration test ${step_name}"] = {
                 run_integration_test(step_name, case_names.join(" "))
             }


### PR DESCRIPTION
Currently integration test stage name is `integration test step_12`, we can't find the running case directly (have to click the stage name and expand details).