### PR TITLE
Revert "ticdc: use case name in integration step"

### DIFF
--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -172,8 +172,8 @@ def tests(sink_type, node_label) {
             step_cases.add(case_names)
         }
         step_cases.eachWithIndex { case_names, index ->
-            def step_name = case_names.join(" ")
-            test_cases[step_name] = {
+            def step_name = "step_${index}"
+            test_cases["integration test ${step_name}"] = {
                 run_integration_test(step_name, case_names.join(" "))
             }
         }


### PR DESCRIPTION
Reverts PingCAP-QE/ci#419

Coverage step uses hard coded step name, ref:
https://github.com/PingCAP-QE/ci/blob/09643537687a5d956bb3543095595fe51fa739bf/jenkins/pipelines/ci/ticdc/integration_test_common.groovy#L286-L289