### PR TITLE
ticdc: use another k8s cluster run test

### DIFF
--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
@@ -135,7 +135,7 @@ catchError {
                                 containerTemplate(
                                         name: 'golang', alwaysPullImage: true,
                                         image: "${POD_GO_DOCKER_IMAGE}", ttyEnabled: true,
-                                        resourceRequestCpu: '2000m', resourceRequestMemory: '4Gi',
+                                        resourceRequestCpu: '4000m', resourceRequestMemory: '8Gi',
                                         resourceLimitCpu: '30000m', resourceLimitMemory: "20Gi",
                                         command: '/bin/sh -c', args: 'cat',
                                         envVars: [containerEnvVar(key: 'GOMODCACHE', value: '/nfs/cache/mod'),


### PR DESCRIPTION
* use a new k8s cluster to run test
* a more detailed monitor dashboard is available on this new cluster