### PR TITLE
add resource request in dm ci

### DIFF
--- a/jenkins/pipelines/ci/ticdc/dm_ghpr_compatibility_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/dm_ghpr_compatibility_test.groovy
@@ -142,7 +142,7 @@ catchError {
         podTemplate(label: label,
                 nodeSelector: 'role_type=slave',
                 containers: [
-                        containerTemplate(name: 'golang',alwaysPullImage: false, image: "${POD_GO_DOCKER_IMAGE}", ttyEnabled: true,
+                        containerTemplate(name: 'golang',alwaysPullImage: true, image: "${POD_GO_DOCKER_IMAGE}", ttyEnabled: true,
                                 resourceRequestCpu: '2000m', resourceRequestMemory: '4Gi',
                                 command: 'cat'),
                         containerTemplate(

--- a/jenkins/pipelines/ci/ticdc/dm_ghpr_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/dm_ghpr_integration_test.groovy
@@ -110,12 +110,13 @@ def run_tls_source_it_test(String case_name) {
             namespace: 'jenkins-tidb',
             containers: [
                     containerTemplate(
-                            name: 'golang', alwaysPullImage: false,
+                            name: 'golang', alwaysPullImage: true,
                             image: "${POD_GO_DOCKER_IMAGE}", ttyEnabled: true,
-                            resourceRequestCpu: '2000m', resourceRequestMemory: '4Gi',
+                            resourceRequestCpu: '4000m', resourceRequestMemory: '4Gi',
+                            resourceLimitCpu: '12000m', resourceLimitMemory: "12Gi",
                             command: 'cat'),
                     containerTemplate(
-                            name: 'mysql1', alwaysPullImage: false,
+                            name: 'mysql1', alwaysPullImage: true,
                             image: 'hub.pingcap.net/jenkins/mysql:5.7',ttyEnabled: true,
                             resourceRequestCpu: '1000m', resourceRequestMemory: '1Gi',
                             envVars: [
@@ -212,12 +213,13 @@ def run_single_it_test(String case_name) {
             namespace: 'jenkins-tidb',
             containers: [
                     containerTemplate(
-                            name: 'golang', alwaysPullImage: false,
+                            name: 'golang', alwaysPullImage: true,
                             image: "${POD_GO_DOCKER_IMAGE}", ttyEnabled: true,
-                            resourceRequestCpu: '2000m', resourceRequestMemory: '4Gi',
+                            resourceRequestCpu: '4000m', resourceRequestMemory: '4Gi',
+                            resourceLimitCpu: '12000m', resourceLimitMemory: "12Gi",
                             command: 'cat'),
                     containerTemplate(
-                            name: 'mysql1', alwaysPullImage: false,
+                            name: 'mysql1', alwaysPullImage: true,
                             image: 'hub.pingcap.net/jenkins/mysql:5.7',ttyEnabled: true,
                             resourceRequestCpu: '1000m', resourceRequestMemory: '1Gi',
                             envVars: [


### PR DESCRIPTION
when running dm-it test, pod use almost 4G memory, so i add some resources request/limit config in pod template

see the metrics here

![截屏2021-11-11 下午6 36 22](https://user-images.githubusercontent.com/24697284/141389142-07decbeb-218a-4b18-b00d-3d7bd3efc61b.png)

btw, because all dm-ci was moved into ticdc folder, i just delete the whole dm folder