### PR TITLE
fix  bin/tidb-server: Not found in archive issue

### DIFF
--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -13,8 +13,8 @@ GROUP_SIZE = 2
  * pr build is ./bin/tidb-server
  * branch build is bin/tidb-server
  */
-TIDB_ARCHINE_PATH_PR = "./bin/tidb-server"
-TIDB_ARCHINE_PATH_BRANCH = "bin/tidb-server"
+TIDB_ARCHIVE_PATH_PR = "./bin/tidb-server"
+TIDB_ARCHIVE_PATH_BRANCH = "bin/tidb-server"
 
 /**
  * Partition the array.
@@ -173,10 +173,10 @@ def download_binaries() {
 
     // parse tidb branch
     def m1 = ghprbCommentBody =~ /tidb\s*=\s*([^\s\\]+)(\s|\\|$)/
-    def tidb_archive_path = TIDB_ARCHINE_PATH_BRANCH
+    def tidb_archive_path = TIDB_ARCHIVE_PATH_BRANCH
     if (m1) {
         TIDB_BRANCH = "${m1[0][1]}"
-        tidb_archive_path = TIDB_ARCHINE_PATH_PR
+        tidb_archive_path = TIDB_ARCHIVE_PATH_PR
     }
     m1 = null
     println "TIDB_BRANCH=${TIDB_BRANCH}"

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -9,6 +9,14 @@ TOTAL_COUNT = 0
 GROUP_SIZE = 2
 
 /**
+ * the tidb archive is packaged differently on pr than on the branch build,
+ * pr build is ./bin/tidb-server
+ * branch build is bin/tidb-server
+ */
+TIDB_ARCHINE_PATH_PR = "./bin/tidb-server"
+TIDB_ARCHINE_PATH_BRANCH = "bin/tidb-server"
+
+/**
  * Partition the array.
  * @param array
  * @param size
@@ -165,8 +173,10 @@ def download_binaries() {
 
     // parse tidb branch
     def m1 = ghprbCommentBody =~ /tidb\s*=\s*([^\s\\]+)(\s|\\|$)/
+    def tidb_archive_path = TIDB_ARCHINE_PATH_BRANCH
     if (m1) {
         TIDB_BRANCH = "${m1[0][1]}"
+        tidb_archive_path = TIDB_ARCHINE_PATH_PR
     }
     m1 = null
     println "TIDB_BRANCH=${TIDB_BRANCH}"
@@ -204,7 +214,6 @@ def download_binaries() {
         tiflash_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/tiflash/${TIFLASH_BRANCH}/sha1").trim()
     }
     def tidb_url = "${FILE_SERVER_URL}/download/builds/pingcap/tidb/${tidb_sha1}/centos7/tidb-server.tar.gz"
-    def tidb_archive_path = "bin/tidb-server"
     def tikv_url = "${FILE_SERVER_URL}/download/builds/pingcap/tikv/${tikv_sha1}/centos7/tikv-server.tar.gz"
     def pd_url = "${FILE_SERVER_URL}/download/builds/pingcap/pd/${pd_sha1}/centos7/pd-server.tar.gz"
     def tiflash_url = "${FILE_SERVER_URL}/download/builds/pingcap/tiflash/${TIFLASH_BRANCH}/${tiflash_sha1}/centos7/tiflash.tar.gz"


### PR DESCRIPTION
ticdc repo can not run intergration test with tidb PR
command
```
/run-integration-tests /tidb=pr/30008 
```


```

[2021-11-25T06:43:52.238Z] + tidb_url=http://fileserver.pingcap.net/download/builds/pingcap/tidb/pr/b786f429e46104fcbdab1d4880f99812b443036d/centos7/tidb-server.tar.gz

[2021-11-25T06:43:52.238Z] + tidb_archive_path=bin/tidb-server

[2021-11-25T06:43:52.238Z] + tikv_url=http://fileserver.pingcap.net/download/builds/pingcap/tikv/f6ec493e8f0a5af7b4ea5652c7073af81d15d22d/centos7/tikv-server.tar.gz

[2021-11-25T06:43:52.238Z] + pd_url=http://fileserver.pingcap.net/download/builds/pingcap/pd/ca16d8d99e94fd6fab230089df23139381431387/centos7/pd-server.tar.gz

[2021-11-25T06:43:52.238Z] + tiflash_url=http://fileserver.pingcap.net/download/builds/pingcap/tiflash/master/e655a42735301dde42e733a0d3d9dd83a44bf4ae/centos7/tiflash.tar.gz

[2021-11-25T06:43:52.238Z] + minio_url=http://fileserver.pingcap.net/download/minio.tar.gz

[2021-11-25T06:43:52.238Z] + curl http://fileserver.pingcap.net/download/builds/pingcap/tidb/pr/b786f429e46104fcbdab1d4880f99812b443036d/centos7/tidb-server.tar.gz

[2021-11-25T06:43:52.238Z] + tar xz -C ./tmp bin/tidb-server

[2021-11-25T06:43:52.238Z]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current

[2021-11-25T06:43:52.238Z]                                  Dload  Upload   Total   Spent    Left  Speed

[2021-11-25T06:43:55.998Z] 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 20  134M   20 27.1M    0     0  28.3M      0  0:00:04 --:--:--  0:00:04 28.3M
 47  134M   47 64.0M    0     0  32.2M      0  0:00:04  0:00:01  0:00:03 32.2M
 75  134M   75  101M    0     0  34.3M      0  0:00:03  0:00:02  0:00:01 34.3M
100  134M  100  134M    0     0  34.8M      0  0:00:03  0:00:03 --:--:-- 34.8M

[2021-11-25T06:43:55.998Z] tar: bin/tidb-server: Not found in archive
```