### PR TITLE
cdc: ignore upload coverage error

### DIFF
--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -300,7 +300,7 @@ def coverage() {
                             mkdir -p /tmp/tidb_cdc_test
                             cp cov_dir/* /tmp/tidb_cdc_test
                             set +x
-                            BUILD_NUMBER=${BUILD_NUMBER} CODECOV_TOKEN="${CODECOV_TOKEN}" COVERALLS_TOKEN="${COVERALLS_TOKEN}" GOPATH=${ws}/go:\$GOPATH PATH=${ws}/go/bin:/go/bin:\$PATH JenkinsCI=1 make integration_test_coverage
+                            BUILD_NUMBER=${BUILD_NUMBER} CODECOV_TOKEN="${CODECOV_TOKEN}" COVERALLS_TOKEN="${COVERALLS_TOKEN}" GOPATH=${ws}/go:\$GOPATH PATH=${ws}/go/bin:/go/bin:\$PATH JenkinsCI=1 make integration_test_coverage || true
                             set -x
                             '''
                         }


### PR DESCRIPTION
Ignore upload coverage error so that we don't need to rerun tests.