### PR TITLE
jenkins/ci/tidb: increase check_2 timeout for gotest

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
@@ -170,8 +170,8 @@ def test_suites = { suites,option ->
                         cd session
                         export log_level=error
                         # export GOPROXY=http://goproxy.pingcap.net
-                        GOPATH=${ws}/go go test -with-tikv -pd-addrs=127.0.0.1:2379,127.0.0.1:2389,127.0.0.1:2399 -timeout 10m -vet=off ${option} '${suites}'
-                        #go test -with-tikv -pd-addrs=127.0.0.1:2379 -timeout 10m -vet=off
+                        GOPATH=${ws}/go go test -with-tikv -pd-addrs=127.0.0.1:2379,127.0.0.1:2389,127.0.0.1:2399 -timeout 20m -vet=off ${option} '${suites}'
+                        #go test -with-tikv -pd-addrs=127.0.0.1:2379 -timeout 20m -vet=off
                         """
                     }
                 }catch (Exception e){

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
@@ -143,7 +143,7 @@ def test_suites = { suites,option ->
         deleteDir()
         unstash 'tidb'
         container("golang") {
-            timeout(720) {
+            timeout(1320) {
                 ws = pwd()
                 def tikv_refs = "${FILE_SERVER_URL}/download/refs/pingcap/tikv/${TIKV_BRANCH}/sha1"
                 def tikv_sha1 = sh(returnStdout: true, script: "curl ${tikv_refs}").trim()


### PR DESCRIPTION
[This PR](https://github.com/pingcap/tidb/pull/30692) makes the test run in serial. We should increase the timeout for the go test.