### PR TITLE
ci/cd: rename pingcap/ticdc to pingcap/tiflow

### DIFF
--- a/jenkins/pipelines/cd/multibranch/build_cdc_multi_branch.groovy
+++ b/jenkins/pipelines/cd/multibranch/build_cdc_multi_branch.groovy
@@ -19,9 +19,9 @@ if (isNeedGo1160) {
 println "BUILD_NODE_NAME=${GO_BUILD_SLAVE}"
 println "TEST_NODE_NAME=${GO_TEST_SLAVE}"
 
-def BUILD_URL = 'git@github.com:pingcap/ticdc.git'
+def BUILD_URL = 'git@github.com:pingcap/tiflow.git'
 
-def build_path = 'go/src/github.com/pingcap/ticdc'
+def build_path = 'go/src/github.com/pingcap/tiflow'
 def slackcolor = 'good'
 def githash
 def ws
@@ -89,7 +89,7 @@ try {
         stage("Upload") {
             dir(build_path) {
                 def target = "ticdc-${os}-${arch}"
-                def refspath = "refs/pingcap/ticdc/${env.BRANCH_NAME}/sha1"
+                def refspath = "refs/pingcap/tiflow/${env.BRANCH_NAME}/sha1"
                 def filepath = "builds/pingcap/ticdc/${githash}/centos7/${target}.tar.gz"
                 container("golang") {
                     timeout(10) {

--- a/jenkins/pipelines/cd/nightly/build-darwin-amd64-4.0.groovy
+++ b/jenkins/pipelines/cd/nightly/build-darwin-amd64-4.0.groovy
@@ -233,7 +233,7 @@ try {
 
 
         stage("Build cdc") {
-            dir("go/src/github.com/pingcap/ticdc") {
+            dir("go/src/github.com/pingcap/tiflow") {
 
                 def target = "ticdc-${os}-${arch}"
                 def filepath = "builds/pingcap/ticdc/${tag}/${CDC_HASH}/darwin/ticdc-${os}-${arch}.tar.gz"
@@ -243,9 +243,9 @@ try {
                         deleteDir()
                     }
                     if(PRE_RELEASE == "true" || RELEASE_TAG == "nightly") {
-                        checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${CDC_HASH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'CloneOption', timeout: 60], [$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/heads/*:refs/remotes/origin/*', url: 'git@github.com:pingcap/ticdc.git']]]
+                        checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${CDC_HASH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'CloneOption', timeout: 60], [$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/heads/*:refs/remotes/origin/*', url: 'git@github.com:pingcap/tiflow.git']]]
                     } else {
-                        checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${RELEASE_TAG}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'LocalBranch'],[$class: 'CloneOption', noTags: true, timeout: 60]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}", url: 'git@github.com:pingcap/ticdc.git']]]
+                        checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${RELEASE_TAG}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'LocalBranch'],[$class: 'CloneOption', noTags: true, timeout: 60]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}", url: 'git@github.com:pingcap/tiflow.git']]]
                     }
                 }
 

--- a/jenkins/pipelines/cd/nightly/build-darwin-arm64-4.0.groovy
+++ b/jenkins/pipelines/cd/nightly/build-darwin-arm64-4.0.groovy
@@ -264,7 +264,7 @@ try {
 
         if(RELEASE_TAG == "nightly" || RELEASE_TAG >= "v4.0.0") {
             stage("Build cdc") {
-                dir("go/src/github.com/pingcap/ticdc") {
+                dir("go/src/github.com/pingcap/tiflow") {
 
                     def target = "ticdc-${os}-${arch}"
                     def filepath = "builds/pingcap/ticdc/${tag}/${CDC_HASH}/${platform}/ticdc-${os}-${arch}.tar.gz"
@@ -274,9 +274,9 @@ try {
                             deleteDir()
                         }
                         if(PRE_RELEASE == "true" || RELEASE_TAG == "nightly") {
-                            checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${CDC_HASH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'CloneOption', timeout: 60], [$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/heads/*:refs/remotes/origin/*', url: 'git@github.com:pingcap/ticdc.git']]]
+                            checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${CDC_HASH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'CloneOption', timeout: 60], [$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/heads/*:refs/remotes/origin/*', url: 'git@github.com:pingcap/tiflow.git']]]
                         } else {
-                            checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${RELEASE_TAG}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'LocalBranch'],[$class: 'CloneOption', noTags: true, timeout: 60]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}", url: 'git@github.com:pingcap/ticdc.git']]]
+                            checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${RELEASE_TAG}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'LocalBranch'],[$class: 'CloneOption', noTags: true, timeout: 60]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}", url: 'git@github.com:pingcap/tiflow.git']]]
                         }
                     }
 

--- a/jenkins/pipelines/cd/nightly/build-linux-arm64-4.0.groovy
+++ b/jenkins/pipelines/cd/nightly/build-linux-arm64-4.0.groovy
@@ -240,7 +240,7 @@ try {
 
         if(RELEASE_TAG == "nightly" || RELEASE_TAG >= "v4.0.0") {
             stage("Build cdc") {
-                dir("go/src/github.com/pingcap/ticdc") {
+                dir("go/src/github.com/pingcap/tiflow") {
 
                     def target = "ticdc-${os}-${arch}"
                     def filepath = "builds/pingcap/ticdc/${tag}/${CDC_HASH}/centos7/ticdc-${os}-${arch}.tar.gz"
@@ -252,9 +252,9 @@ try {
                         }
 
                         if(PRE_RELEASE == "true" || RELEASE_TAG == "nightly") {
-                            checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${CDC_HASH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'CloneOption', timeout: 60], [$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/heads/*:refs/remotes/origin/*', url: 'git@github.com:pingcap/ticdc.git']]]
+                            checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${CDC_HASH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'CloneOption', timeout: 60], [$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/heads/*:refs/remotes/origin/*', url: 'git@github.com:pingcap/tiflow.git']]]
                         } else {
-                            checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${RELEASE_TAG}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'LocalBranch'],[$class: 'CloneOption', noTags: true, timeout: 60]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}", url: 'git@github.com:pingcap/ticdc.git']]]
+                            checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${RELEASE_TAG}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CheckoutOption', timeout: 30], [$class: 'LocalBranch'],[$class: 'CloneOption', noTags: true, timeout: 60]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}", url: 'git@github.com:pingcap/tiflow.git']]]
                         }
                     }
 

--- a/jenkins/pipelines/cd/nightly/release_cdc_docker_nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/release_cdc_docker_nightly.groovy
@@ -1,4 +1,4 @@
-def BUILD_URL = 'git@github.com:pingcap/ticdc.git'
+def BUILD_URL = 'git@github.com:pingcap/tiflow.git'
 def slackcolor = 'good'
 def githash
 
@@ -30,7 +30,7 @@ try {
       container('delivery') {
         sh "rm -rf ./*"
         stage("Checkout") {
-            dir("go/src/github.com/pingcap/ticdc") {
+            dir("go/src/github.com/pingcap/tiflow") {
                 // deleteDir()
                 git credentialsId: 'github-sre-bot-ssh', url: "${BUILD_URL}", branch: "master"
                 sh "git checkout ${BUILD_TAG}"
@@ -38,7 +38,7 @@ try {
             }
         }
         stage("Build & Upload") {
-          dir("go/src/github.com/pingcap/ticdc") {
+          dir("go/src/github.com/pingcap/tiflow") {
             def wss = pwd()
             def DOCKER_TAG = "${BUILD_TAG}"
             if ( DOCKER_TAG == "master" ) {
@@ -65,13 +65,13 @@ try {
                 cat - >"bin/Dockerfile" <<EOF
 FROM ${buildImage} as builder
 RUN apk add --no-cache git make bash
-WORKDIR /go/src/github.com/pingcap/ticdc
+WORKDIR /go/src/github.com/pingcap/tiflow
 COPY . .
 RUN make
 
 FROM registry-mirror.pingcap.net/library/alpine:3.12
 RUN apk add --no-cache tzdata bash curl socat
-COPY --from=builder /go/src/github.com/pingcap/ticdc/bin/cdc /cdc
+COPY --from=builder /go/src/github.com/pingcap/tiflow/bin/cdc /cdc
 EXPOSE 8300
 CMD [ "/cdc" ]
 EOF

--- a/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
@@ -80,7 +80,7 @@ try {
                 curl -F refs/pingcap/tics/nightly/sha1=@sha1 ${FILE_SERVER_URL}/upload
 
                 echo ${cdc_githash} > sha1
-                curl -F refs/pingcap/ticdc/nightly/sha1=@sha1 ${FILE_SERVER_URL}/upload
+                curl -F refs/pingcap/tiflow/nightly/sha1=@sha1 ${FILE_SERVER_URL}/upload
 
                 echo ${tidb_ctl_githash} > sha1
                 curl -F refs/pingcap/tidb-ctl/nightly/sha1=@sha1 ${FILE_SERVER_URL}/upload

--- a/jenkins/pipelines/cd/optimization-build-tidb-linux-amd.groovy
+++ b/jenkins/pipelines/cd/optimization-build-tidb-linux-amd.groovy
@@ -362,13 +362,13 @@ try {
                 container("golang") {
                     def ws = pwd()
                     deleteDir()
-                    dir("go/src/github.com/pingcap/ticdc") {
+                    dir("go/src/github.com/pingcap/tiflow") {
                         if (sh(returnStatus: true, script: '[ -d .git ] || git rev-parse --git-dir > /dev/null 2>&1') != 0) {
                             deleteDir()
                         }
                         def target = "ticdc-linux-amd64"
                         def filepath = "builds/pingcap/ticdc/optimization/${RELEASE_TAG}/${CDC_HASH}/centos7/ticdc-linux-amd64.tar.gz"
-                        checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${CDC_HASH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/heads/*:refs/remotes/origin/*', url: 'git@github.com:pingcap/ticdc.git']]]
+                        checkout changelog: false, poll: true, scm: [$class: 'GitSCM', branches: [[name: "${CDC_HASH}"]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: '+refs/heads/*:refs/remotes/origin/*', url: 'git@github.com:pingcap/tiflow.git']]]
                         sh """
                             for a in \$(git tag --contains ${CDC_HASH}); do echo \$a && git tag -d \$a;done
                             git tag -f ${RELEASE_TAG} ${CDC_HASH}

--- a/jenkins/pipelines/cd/release-enterprise-docker.groovy
+++ b/jenkins/pipelines/cd/release-enterprise-docker.groovy
@@ -241,7 +241,7 @@ __EOF__
             }
 
             builds["Push cdc Docker"] = {
-                dir("go/src/github.com/pingcap/ticdc") {
+                dir("go/src/github.com/pingcap/tiflow") {
                     // deleteDir()
                     checkout changelog: false,
                             poll: true,
@@ -252,7 +252,7 @@ __EOF__
                                   submoduleCfg: [],
                                   userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh',
                                                        refspec: "+refs/tags/${CDC_TAG}:refs/tags/${CDC_TAG}",
-                                                       url: 'git@github.com:pingcap/ticdc.git']]
+                                                       url: 'git@github.com:pingcap/tiflow.git']]
                             ]
 
                     def DOCKER_TAG = "${RELEASE_TAG}"
@@ -266,13 +266,13 @@ __EOF__
                         cat - >"bin/Dockerfile" <<EOF
 FROM ${buildImage} as builder
 RUN apk add --no-cache git make bash
-WORKDIR /go/src/github.com/pingcap/ticdc
+WORKDIR /go/src/github.com/pingcap/tiflow
 COPY . .
 RUN make
 
 FROM alpine:3.12
 RUN apk add --no-cache tzdata bash curl socat
-COPY --from=builder /go/src/github.com/pingcap/ticdc/bin/cdc /cdc
+COPY --from=builder /go/src/github.com/pingcap/tiflow/bin/cdc /cdc
 EXPOSE 8300
 CMD [ "/cdc" ]
 EOF

--- a/jenkins/pipelines/cd/release_cdc_docker.groovy
+++ b/jenkins/pipelines/cd/release_cdc_docker.groovy
@@ -1,4 +1,4 @@
-def BUILD_URL = 'git@github.com:pingcap/ticdc.git'
+def BUILD_URL = 'git@github.com:pingcap/tiflow.git'
 def slackcolor = 'good'
 def githash
 
@@ -60,7 +60,7 @@ try {
       container('delivery') {
         sh "rm -rf ./*"
         stage("Checkout") {
-            dir("go/src/github.com/pingcap/ticdc") {
+            dir("go/src/github.com/pingcap/tiflow") {
                 // deleteDir()
                 git credentialsId: 'github-sre-bot-ssh', url: "${BUILD_URL}", branch: "master"
                 sh "git checkout ${BUILD_TAG}"
@@ -68,7 +68,7 @@ try {
             }
         }
         stage("Build & Upload") {
-          dir("go/src/github.com/pingcap/ticdc") {
+          dir("go/src/github.com/pingcap/tiflow") {
             def wss = pwd()
             def DOCKER_TAG = "${BUILD_TAG}"
             if ( DOCKER_TAG == "master" ) {
@@ -98,13 +98,13 @@ try {
                 cat - >"bin/Dockerfile" <<EOF
 FROM ${buildImage} as builder
 RUN apk add --no-cache git make bash
-WORKDIR /go/src/github.com/pingcap/ticdc
+WORKDIR /go/src/github.com/pingcap/tiflow
 COPY . .
 RUN make
 
 FROM registry-mirror.pingcap.net/library/alpine:3.12
 RUN apk add --no-cache tzdata bash curl socat
-COPY --from=builder /go/src/github.com/pingcap/ticdc/bin/cdc /cdc
+COPY --from=builder /go/src/github.com/pingcap/tiflow/bin/cdc /cdc
 EXPOSE 8300
 CMD [ "/cdc" ]
 EOF

--- a/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update-test-hotfix.groovy
+++ b/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update-test-hotfix.groovy
@@ -68,7 +68,7 @@ def pack = { version, os, arch ->
     rm -rf tikv-*
 
     wget -qnc https://raw.githubusercontent.com/pingcap/tidb-binlog/${RELEASE_BRANCH}/metrics/grafana/binlog.json || true; \
-    wget -qnc https://raw.githubusercontent.com/pingcap/ticdc/${RELEASE_BRANCH}/metrics/grafana/ticdc.json || true; \
+    wget -qnc https://raw.githubusercontent.com/pingcap/tiflow/${RELEASE_BRANCH}/metrics/grafana/ticdc.json || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/disk_performance.json || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/blackbox_exporter.json || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/node.json || true; \

--- a/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update-test.groovy
+++ b/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update-test.groovy
@@ -67,7 +67,7 @@ def pack = { version, os, arch ->
     rm -rf tikv-*
 
     wget -qnc https://raw.githubusercontent.com/pingcap/tidb-binlog/${tag}/metrics/grafana/binlog.json || true; \
-    wget -qnc https://raw.githubusercontent.com/pingcap/ticdc/${tag}/metrics/grafana/ticdc.json || true; \
+    wget -qnc https://raw.githubusercontent.com/pingcap/tiflow/${tag}/metrics/grafana/ticdc.json || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/disk_performance.json || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/blackbox_exporter.json || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/node.json || true; \

--- a/jenkins/pipelines/cd/tiup/prometheus-tiup-mirrior-update-test-hotfix.groovy
+++ b/jenkins/pipelines/cd/tiup/prometheus-tiup-mirrior-update-test-hotfix.groovy
@@ -106,7 +106,7 @@ def pack = { version, os, arch ->
     wget -qnc https://raw.githubusercontent.com/tikv/tikv/${RELEASE_BRANCH}/metrics/alertmanager/tikv.rules.yml || true; \
     wget -qnc https://raw.githubusercontent.com/tikv/tikv/${RELEASE_BRANCH}/metrics/alertmanager/tikv.accelerate.rules.yml || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/tidb-binlog/${RELEASE_BRANCH}/metrics/alertmanager/binlog.rules.yml || true; \
-    wget -qnc https://raw.githubusercontent.com/pingcap/ticdc/${RELEASE_BRANCH}/metrics/alertmanager/ticdc.rules.yml || true; \
+    wget -qnc https://raw.githubusercontent.com/pingcap/tiflow/${RELEASE_BRANCH}/metrics/alertmanager/ticdc.rules.yml || true; \
     if [ ${HOTFIX_TAG} \\> "v5.2.0" ] || [ ${HOTFIX_TAG} == "v5.2.0" ]; then \
         wget -qnc https://raw.githubusercontent.com/pingcap/tidb/${RELEASE_BRANCH}/br/metrics/alertmanager/lightning.rules.yml || true; \
     else

--- a/jenkins/pipelines/cd/tiup/prometheus-tiup-mirrior-update-test.groovy
+++ b/jenkins/pipelines/cd/tiup/prometheus-tiup-mirrior-update-test.groovy
@@ -106,7 +106,7 @@ def pack = { version, os, arch ->
     wget -qnc https://raw.githubusercontent.com/tikv/tikv/${tag}/metrics/alertmanager/tikv.rules.yml || true; \
     wget -qnc https://raw.githubusercontent.com/tikv/tikv/${tag}/metrics/alertmanager/tikv.accelerate.rules.yml || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/tidb-binlog/${tag}/metrics/alertmanager/binlog.rules.yml || true; \
-    wget -qnc https://raw.githubusercontent.com/pingcap/ticdc/${tag}/metrics/alertmanager/ticdc.rules.yml || true; \
+    wget -qnc https://raw.githubusercontent.com/pingcap/tiflow/${tag}/metrics/alertmanager/ticdc.rules.yml || true; \
     if [ ${RELEASE_TAG} \\> "v5.2.0" ] || [ ${RELEASE_TAG} == "v5.2.0" ]; then \
         wget -qnc https://raw.githubusercontent.com/pingcap/tidb/${tag}/br/metrics/alertmanager/lightning.rules.yml || true; \
     else

--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
@@ -100,13 +100,13 @@ catchError {
             def ws = pwd()
             deleteDir()
 
-            dir("${ws}/go/src/github.com/pingcap/ticdc") {
+            dir("${ws}/go/src/github.com/pingcap/tiflow") {
                 if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
-                    echo "Not a valid git folder: ${ws}/go/src/github.com/pingcap/ticdc"
+                    echo "Not a valid git folder: ${ws}/go/src/github.com/pingcap/tiflow"
                     deleteDir()
                 }
                 try {
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
                 } catch (info) {
                     retry(2) {
                         echo "checkout failed, retry.."
@@ -114,7 +114,7 @@ catchError {
                         if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
                             deleteDir()
                         }
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
                     }
                 }
                 sh "git checkout -f ${ghprbActualCommit}"
@@ -141,7 +141,7 @@ catchError {
 
             }
 
-            stash includes: "go/src/github.com/pingcap/ticdc/**", name: "ticdc", useDefaultExcludes: false
+            stash includes: "go/src/github.com/pingcap/tiflow/**", name: "ticdc", useDefaultExcludes: false
         }
 
         def script_path = "go/src/github.com/pingcap/ci/jenkins/pipelines/ci/ticdc/integration_test_common.groovy"

--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_kafka_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_kafka_integration_test.groovy
@@ -76,13 +76,13 @@ catchError {
                 def ws = pwd()
                 deleteDir()
 
-                dir("${ws}/go/src/github.com/pingcap/ticdc") {
+                dir("${ws}/go/src/github.com/pingcap/tiflow") {
                     if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
-                        echo "Not a valid git folder: ${ws}/go/src/github.com/pingcap/ticdc"
+                        echo "Not a valid git folder: ${ws}/go/src/github.com/pingcap/tiflow"
                         deleteDir()
                     }
                     try {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
                     } catch (info) {
                         retry(2) {
                             echo "checkout failed, retry.."
@@ -90,7 +90,7 @@ catchError {
                             if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
                                 deleteDir()
                             }
-                            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
                         }
                     }
                     sh "git checkout -f ${ghprbActualCommit}"
@@ -117,15 +117,15 @@ catchError {
 
                 }
 
-                stash includes: "go/src/github.com/pingcap/ticdc/**", name: "ticdc", useDefaultExcludes: false
+                stash includes: "go/src/github.com/pingcap/tiflow/**", name: "ticdc", useDefaultExcludes: false
             }
 
             def script_path = "go/src/github.com/pingcap/ci/jenkins/pipelines/ci/ticdc/integration_test_common.groovy"
             def common = load script_path
 
             // HACK! Download jks by injecting RACK_COMMAND
-            // https://git.io/JJZXX -> https://github.com/pingcap/ticdc/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks
-            // https://git.io/JJZXM -> https://github.com/pingcap/ticdc/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks
+            // https://git.io/JJZXX -> https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks
+            // https://git.io/JJZXM -> https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks
             def download_jks = 'curl -sfL https://git.io/JJZXX -o /tmp/kafka.server.keystore.jks && curl -sfL https://git.io/JJZXM -o /tmp/kafka.server.truststore.jks'
 
             catchError {

--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_leak_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_leak_test.groovy
@@ -93,13 +93,13 @@ catchError {
             def ws = pwd()
             deleteDir()
 
-            dir("${ws}/go/src/github.com/pingcap/ticdc") {
+            dir("${ws}/go/src/github.com/pingcap/tiflow") {
                 if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
-                    echo "Not a valid git folder: ${ws}/go/src/github.com/pingcap/ticdc"
+                    echo "Not a valid git folder: ${ws}/go/src/github.com/pingcap/tiflow"
                     deleteDir()
                 }
                 try {
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
                 } catch (info) {
                     retry(2) {
                         echo "checkout failed, retry.."
@@ -107,7 +107,7 @@ catchError {
                         if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
                             deleteDir()
                         }
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
                     }
                 }
                 sh "git checkout -f ${ghprbActualCommit}"
@@ -134,7 +134,7 @@ catchError {
 
             }
 
-            stash includes: "go/src/github.com/pingcap/ticdc/**", name: "ticdc", useDefaultExcludes: false
+            stash includes: "go/src/github.com/pingcap/tiflow/**", name: "ticdc", useDefaultExcludes: false
         }
 
         catchError {
@@ -145,7 +145,7 @@ catchError {
                         deleteDir()
                         unstash 'ticdc'
 
-                        dir("go/src/github.com/pingcap/ticdc") {
+                        dir("go/src/github.com/pingcap/tiflow") {
                             sh """
                                 GOPATH=\$GOPATH:${ws}/go PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH make leak_test
                             """

--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_test.groovy
@@ -92,13 +92,13 @@ catchError {
             def ws = pwd()
             deleteDir()
 
-            dir("${ws}/go/src/github.com/pingcap/ticdc") {
+            dir("${ws}/go/src/github.com/pingcap/tiflow") {
                 if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
-                    echo "Not a valid git folder: ${ws}/go/src/github.com/pingcap/ticdc"
+                    echo "Not a valid git folder: ${ws}/go/src/github.com/pingcap/tiflow"
                     deleteDir()
                 }
                 try {
-                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
                 } catch (info) {
                     retry(2) {
                         echo "checkout failed, retry.."
@@ -106,7 +106,7 @@ catchError {
                         if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
                             deleteDir()
                         }
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
                     }
                 }
                 sh "git checkout -f ${ghprbActualCommit}"
@@ -133,7 +133,7 @@ catchError {
 
             }
 
-            stash includes: "go/src/github.com/pingcap/ticdc/**", name: "ticdc", useDefaultExcludes: false
+            stash includes: "go/src/github.com/pingcap/tiflow/**", name: "ticdc", useDefaultExcludes: false
         }
 
         catchError {
@@ -144,7 +144,7 @@ catchError {
                         deleteDir()
                         unstash 'ticdc'
 
-                        dir("go/src/github.com/pingcap/ticdc") {
+                        dir("go/src/github.com/pingcap/tiflow") {
                             sh """
                                 rm -rf /tmp/tidb_cdc_test
                                 mkdir -p /tmp/tidb_cdc_test
@@ -158,7 +158,7 @@ catchError {
                                 tail /tmp/tidb_cdc_test/cov*
                             """
                         }
-                        stash includes: "go/src/github.com/pingcap/ticdc/cov_dir/**", name: "unit_test", useDefaultExcludes: false
+                        stash includes: "go/src/github.com/pingcap/tiflow/cov_dir/**", name: "unit_test", useDefaultExcludes: false
                     }
                 }
             }
@@ -173,7 +173,7 @@ catchError {
                 unstash 'ticdc'
                 unstash 'unit_test'
 
-                dir("go/src/github.com/pingcap/ticdc") {
+                dir("go/src/github.com/pingcap/tiflow") {
                     container("golang") {
                         archiveArtifacts artifacts: 'cov_dir/*', fingerprint: true
                         withCredentials([string(credentialsId: 'codecov-token-ticdc', variable: 'CODECOV_TOKEN')]) {

--- a/jenkins/pipelines/ci/ticdc/dm_ghpr_compatibility_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/dm_ghpr_compatibility_test.groovy
@@ -80,7 +80,7 @@ catchError {
                         deleteDir()
                     }
                     try {
-                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                        checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
                     } catch (error) {
                         retry(2) {
                             echo "checkout failed, retry.."
@@ -88,12 +88,12 @@ catchError {
                             if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) {
                                 deleteDir()
                             }
-                            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
                         }
                     }
                 }
 
-                dir("go/src/github.com/pingcap/ticdc") {
+                dir("go/src/github.com/pingcap/tiflow") {
                     sh """
                         cp -R /home/jenkins/agent/git/ticdc/. ./
                         
@@ -112,7 +112,7 @@ catchError {
                     """
                 }
 
-                stash includes: "go/src/github.com/pingcap/ticdc/**", name: "ticdc", useDefaultExcludes: false
+                stash includes: "go/src/github.com/pingcap/tiflow/**", name: "ticdc", useDefaultExcludes: false
 
                 def tidb_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/tidb/${TIDB_BRANCH}/sha1").trim()
                 sh "curl ${FILE_SERVER_URL}/download/builds/pingcap/tidb/${tidb_sha1}/centos7/tidb-server.tar.gz | tar xz"
@@ -180,7 +180,7 @@ catchError {
                         deleteDir()
                         unstash "ticdc"
                         unstash "binaries"
-                        dir("go/src/github.com/pingcap/ticdc") {
+                        dir("go/src/github.com/pingcap/tiflow") {
                             try {
                                 sh """
                                 rm -rf /tmp/dm_test
@@ -216,7 +216,7 @@ catchError {
                                 """
                             }
                         }
-                        stash includes: "go/src/github.com/pingcap/ticdc/cov_dir/**", name: "integration-cov-${TEST_CASE}"
+                        stash includes: "go/src/github.com/pingcap/tiflow/cov_dir/**", name: "integration-cov-${TEST_CASE}"
                     }
                 }
             }

--- a/jenkins/pipelines/ci/ticdc/dm_ghpr_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/dm_ghpr_integration_test.groovy
@@ -53,15 +53,15 @@ def checkout_and_stash_dm_code() {
 
             dir('/home/jenkins/agent/git/ticdc') {
                 if (sh(returnStatus: true, script: '[ -d .git ] && [ -f Makefile ] && git rev-parse --git-dir > /dev/null 2>&1') != 0) { deleteDir() }
-                checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/ticdc.git']]]
+                checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: 'master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout']], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', refspec: specStr, url: 'git@github.com:pingcap/tiflow.git']]]
             }
 
-            dir('go/src/github.com/pingcap/ticdc') {
+            dir('go/src/github.com/pingcap/tiflow') {
                 sh """cp -R /home/jenkins/agent/git/ticdc/. ./
                     git checkout -f ${ghprbActualCommit}
                     """
             }
-            stash includes: 'go/src/github.com/pingcap/ticdc/**', name: 'ticdc', useDefaultExcludes: false
+            stash includes: 'go/src/github.com/pingcap/tiflow/**', name: 'ticdc', useDefaultExcludes: false
         }
     }
 }
@@ -72,7 +72,7 @@ def build_dm_bin() {
             deleteDir()
             unstash 'ticdc'
             ws = pwd()
-            dir('go/src/github.com/pingcap/ticdc') {
+            dir('go/src/github.com/pingcap/tiflow') {
                 println "debug command:\nkubectl -n jenkins-tidb exec -ti ${env.NODE_NAME} bash"
 
                 // build it test bin
@@ -96,7 +96,7 @@ def build_dm_bin() {
                 sh 'mv gh-ost bin/'
             }
             dir("${ws}") {
-                stash includes: 'go/src/github.com/pingcap/ticdc/**', name: 'ticdc-with-bin', useDefaultExcludes: false
+                stash includes: 'go/src/github.com/pingcap/tiflow/**', name: 'ticdc-with-bin', useDefaultExcludes: false
             }
         }
     }
@@ -164,7 +164,7 @@ def run_tls_source_it_test(String case_name) {
                 sh "ls /var/lib/mysql"
 
                 unstash 'ticdc-with-bin'
-                dir('go/src/github.com/pingcap/ticdc') {
+                dir('go/src/github.com/pingcap/tiflow') {
                     try {
                         sh"""
                                 rm -rf /tmp/dm_test
@@ -199,7 +199,7 @@ def run_tls_source_it_test(String case_name) {
                         throw e
                     }
                 }
-                stash includes: 'go/src/github.com/pingcap/ticdc/cov_dir/**', name: "integration-cov-${case_name}"
+                stash includes: 'go/src/github.com/pingcap/tiflow/cov_dir/**', name: "integration-cov-${case_name}"
             }
         }
     }
@@ -245,7 +245,7 @@ def run_single_it_test(String case_name) {
                 def ws = pwd()
                 deleteDir()
                 unstash 'ticdc-with-bin'
-                dir('go/src/github.com/pingcap/ticdc') {
+                dir('go/src/github.com/pingcap/tiflow') {
                     try {
                         sh"""
                                 rm -rf /tmp/dm_test
@@ -280,7 +280,7 @@ def run_single_it_test(String case_name) {
                         throw e
                     }
                 }
-                stash includes: 'go/src/github.com/pingcap/ticdc/cov_dir/**', name: "integration-cov-${case_name}"
+                stash includes: 'go/src/github.com/pingcap/tiflow/cov_dir/**', name: "integration-cov-${case_name}"
             }
         }
     }
@@ -331,7 +331,7 @@ def run_make_coverage() {
         } catch (Exception e) {
             println e
         }
-        dir('go/src/github.com/pingcap/ticdc') {
+        dir('go/src/github.com/pingcap/tiflow') {
             container('golang') {
                 timeout(30) {
                     sh """

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -51,7 +51,7 @@ def prepare_binaries() {
                     deleteDir()
                     unstash 'ticdc'
 
-                    dir("go/src/github.com/pingcap/ticdc") {
+                    dir("go/src/github.com/pingcap/tiflow") {
                         sh """
                             GOPATH=\$GOPATH:${ws}/go PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH make cdc
                             GOPATH=\$GOPATH:${ws}/go PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH make integration_test_build
@@ -61,14 +61,14 @@ def prepare_binaries() {
                             curl -F test/cdc/ci/ticdc_bin_${env.BUILD_NUMBER}.tar.gz=@ticdc_bin.tar.gz http://fileserver.pingcap.net/upload
                         """
                     }
-                    dir("go/src/github.com/pingcap/ticdc/tests/integration_tests") {
+                    dir("go/src/github.com/pingcap/tiflow/tests/integration_tests") {
                         def cases_name = sh(
                                 script: 'find . -maxdepth 2 -mindepth 2 -name \'run.sh\' | awk -F/ \'{print $2}\'',
                                 returnStdout: true
                         ).trim().split().join(" ")
                         sh "echo ${cases_name} > CASES"
                     }
-                    stash includes: "go/src/github.com/pingcap/ticdc/tests/integration_tests/CASES", name: "cases_name", useDefaultExcludes: false
+                    stash includes: "go/src/github.com/pingcap/tiflow/tests/integration_tests/CASES", name: "cases_name", useDefaultExcludes: false
                 }
             }
         }
@@ -98,7 +98,7 @@ def tests(sink_type, node_label) {
                     println "work space path:\n${ws}"
                     println "this step will run tests: ${case_names}"
                     unstash 'ticdc'
-                    dir("go/src/github.com/pingcap/ticdc") {
+                    dir("go/src/github.com/pingcap/tiflow") {
                         download_binaries()
                         try {
                             sh """
@@ -130,7 +130,7 @@ def tests(sink_type, node_label) {
                             throw e;
                         }
                     }
-                    stash includes: "go/src/github.com/pingcap/ticdc/cov_dir/**", name: "integration_test_${step_name}", useDefaultExcludes: false
+                    stash includes: "go/src/github.com/pingcap/tiflow/cov_dir/**", name: "integration_test_${step_name}", useDefaultExcludes: false
                 }
             }
         }
@@ -139,7 +139,7 @@ def tests(sink_type, node_label) {
         // Gets the name of each case.
         unstash 'cases_name'
         def cases_name = sh(
-                script: 'cat go/src/github.com/pingcap/ticdc/tests/integration_tests/CASES',
+                script: 'cat go/src/github.com/pingcap/tiflow/tests/integration_tests/CASES',
                 returnStdout: true
         ).trim().split()
 
@@ -290,7 +290,7 @@ def coverage() {
                 unstash item
             }
 
-            dir("go/src/github.com/pingcap/ticdc") {
+            dir("go/src/github.com/pingcap/tiflow") {
                 container("golang") {
                     archiveArtifacts artifacts: 'cov_dir/*', fingerprint: true
                     withCredentials([string(credentialsId: 'coveralls-token-ticdc', variable: 'COVERALLS_TOKEN')]) {

--- a/jenkins/pipelines/qa_release_test.groovy
+++ b/jenkins/pipelines/qa_release_test.groovy
@@ -57,7 +57,7 @@ catchError {
                         sh "inv upload --dst refs/pingcap/br/${release_info.br_commit}/sha1 --content ${release_info.br_commit}"
                     }
                     if (release_info.containsKey("ticdc_commit") && release_info.ticdc_commit != "") {
-                        sh "inv upload --dst refs/pingcap/ticdc/${release_info.ticdc_commit}/sha1 --content ${release_info.ticdc_commit}"
+                        sh "inv upload --dst refs/pingcap/tiflow/${release_info.ticdc_commit}/sha1 --content ${release_info.ticdc_commit}"
                     }
                     for (int i = 0; i < release_info.tidb_old_commits.size(); i++) {
                         sh "inv upload --dst builds/download/refs/pingcap/tidb/${release_info.tidb_old_commits[i]}/sha1 --content ${release_info.tidb_old_commits[i]}"
@@ -84,7 +84,7 @@ catchError {
                         sh "inv upload --dst refs/pingcap/br/${release_info.br_commit}/sha1 --content ${release_info.br_commit}"
                     }
                     if (release_info.containsKey("ticdc_commit") && release_info.ticdc_commit != "") {
-                        sh "inv upload --dst refs/pingcap/ticdc/${release_info.ticdc_commit}/sha1 --content ${release_info.ticdc_commit}"
+                        sh "inv upload --dst refs/pingcap/tiflow/${release_info.ticdc_commit}/sha1 --content ${release_info.ticdc_commit}"
                     }
                     for (int i = 0; i < release_info.tidb_old_commits.size(); i++) {
                         sh "inv upload --dst builds/download/refs/pingcap/tidb/${release_info.tidb_old_commits[i]}/sha1 --content ${release_info.tidb_old_commits[i]}"

--- a/misc_tools/create_branch.sh
+++ b/misc_tools/create_branch.sh
@@ -2,7 +2,7 @@
 base_branch=master
 new_branch=release-5.0
 # Should check if tikv/importer's base branch is master, if not, remove it from repo list and create the tikv/importer's branch by hand
-repo_list="pingcap/tidb pingcap/parser tikv/tikv tikv/pd pingcap/tics pingcap/br pingcap/tidb-binlog pingcap/tidb-tools pingcap/ticdc pingcap/dumpling pingcap/tiflash"
+repo_list="pingcap/tidb pingcap/parser tikv/tikv tikv/pd pingcap/tics pingcap/br pingcap/tidb-binlog pingcap/tidb-tools pingcap/tiflow pingcap/dumpling pingcap/tiflash"
 
 set -x
 for repo in $repo_list;do

--- a/misc_tools/create_tag.py
+++ b/misc_tools/create_tag.py
@@ -62,7 +62,7 @@ repo_list = [
         version=''),
     repo_info(
         repo_name='ticdc',
-        repo_addr='pingcap/ticdc',
+        repo_addr='pingcap/tiflow',
         tag_githash='',
         version=''),
     repo_info(
@@ -96,6 +96,6 @@ def create_git_tag():
 
 if __name__ == '__main__':
     token = sys.argv[1]
-    g = Github(token) # personal token 
+    g = Github(token) # personal token
     get_repo_tags()
     create_git_tag()

--- a/misc_tools/get_hash.sh
+++ b/misc_tools/get_hash.sh
@@ -3,7 +3,7 @@
 
 branch=$1
 
-repo_list="pingcap/tidb tikv/tikv tikv/pd pingcap/tics pingcap/br pingcap/tidb-binlog pingcap/tidb-tools pingcap/ticdc tikv/importer"
+repo_list="pingcap/tidb tikv/tikv tikv/pd pingcap/tics pingcap/br pingcap/tidb-binlog pingcap/tidb-tools pingcap/tiflow tikv/importer"
 
 for repo in $repo_list;do
 sha=$(curl -H "Authorization: token $TOKEN" https://api.github.com/repos/$repo/git/refs/heads/$branch | jq -r '.object.sha')


### PR DESCRIPTION
Part of step-4 in https://github.com/pingcap/ticdc/issues/3749

Change with following scripts

```bash
sed -i "s/github.com\/pingcap\/ticdc/github.com\/pingcap\/tiflow/g" $(find . -type f)
sed -i "s/github.com:pingcap\/ticdc/github.com:pingcap\/tiflow/g" $(find . -type f)
sed -i "s/githubusercontent.com\/pingcap\/ticdc/githubusercontent.com\/pingcap\/tiflow/g" $(find . -type f)
```

Besides several `pingcap/ticdc` are changed to `pingcap/tiflow` manually, since not all `pingcap/ticdc` should be changed.

Unchanged contents include

- fileserver build path
- docker image name