### PR TITLE
compat w/ jenkins docker

### DIFF
--- a/jenkins/Dockerfile/release/linux-amd64/tiflash
+++ b/jenkins/Dockerfile/release/linux-amd64/tiflash
@@ -3,7 +3,7 @@ FROM hub.pingcap.net/tiflash/centos:7.9.2009-amd64
 USER root
 WORKDIR /root/
 
-ARG INSTALL_MYSQL 0
+ARG INSTALL_MYSQL
 ENV HOME /root/
 ENV TZ Asia/Shanghai
 ENV LD_LIBRARY_PATH /tiflash

--- a/jenkins/Dockerfile/release/linux-amd64/tiflash
+++ b/jenkins/Dockerfile/release/linux-amd64/tiflash
@@ -3,7 +3,7 @@ FROM hub.pingcap.net/tiflash/centos:7.9.2009-amd64
 USER root
 WORKDIR /root/
 
-ARG INSTALL_MYSQL
+ARG INSTALL_MYSQL=0
 ENV HOME /root/
 ENV TZ Asia/Shanghai
 ENV LD_LIBRARY_PATH /tiflash


### PR DESCRIPTION
Docker with older versions does not support default args syntax iwth whitespace.
Signed-off-by: Schrodinger ZHU Yifan <i@zhuyi.fan>