### PR TITLE
cdc debug image fail

### DIFF
--- a/jenkins/Dockerfile/release/debug-image/ticdc
+++ b/jenkins/Dockerfile/release/debug-image/ticdc
@@ -1,5 +1,5 @@
 FROM centos:centos7.9.2009
-RUN yum install tzdata bash curl socat
+RUN yum install -y tzdata bash curl socat
 COPY cdc /cdc
 EXPOSE 8300
 CMD [ "/cdc" ]


### PR DESCRIPTION
```
[2022-01-13T09:19:32.842Z] Installing for dependencies:

[2022-01-13T09:19:32.842Z]  tcp_wrappers-libs      x86_64      7.6-77.el7               base          66 k

[2022-01-13T09:19:32.842Z] Updating for dependencies:

[2022-01-13T09:19:32.842Z]  libcurl                x86_64      7.29.0-59.el7_9.1        updates      223 k

[2022-01-13T09:19:32.842Z] 

[2022-01-13T09:19:32.842Z] Transaction Summary

[2022-01-13T09:19:32.842Z] ================================================================================

[2022-01-13T09:19:32.842Z] Install  1 Package  (+1 Dependent package)

[2022-01-13T09:19:32.842Z] Upgrade  3 Packages (+1 Dependent package)

[2022-01-13T09:19:32.842Z] 

[2022-01-13T09:19:32.842Z] Total download size: 2.3 M

[2022-01-13T09:19:32.842Z] Is this ok [y/d/N]: Exiting on user command

[2022-01-13T09:19:32.842Z] Your transaction was saved, rerun it with:

[2022-01-13T09:19:32.842Z]  yum load-transaction /tmp/yum_save_tx.2022-01-13.09-19.3Pmuum.yumtx

[2022-01-13T09:19:32.842Z] The command '/bin/sh -c yum install tzdata bash curl socat' returned a non-zero code: 1
```