### PR TITLE
ci: add some test cases to mysql-test whitelist

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_mysql_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_mysql_test.groovy
@@ -37,6 +37,35 @@ CI_RUN_PART_TEST_CASES = """
     ctype_gbk date_formats invisible_indexes nth type_varchar variables
     """
 
+if (ghprbTargetBranch in ["release-5.3", "release-5.4"]) {
+    CI_RUN_PART_TEST_CASES = """
+        with_non_recursive window_min_max temp_table mariadb_cte_recursive
+        mariadb_cte_nonrecursive json_functions gcol_view gcol_supported_sql_funcs
+        expression_index date_time_ddl show timestamp_insert
+        infoschema datetime_insert alias
+        alter_table alter_table_PK auto_increment
+        bigint bool builtin charset comment_table
+        composite_index concurrent_ddl count_distinct
+        count_distinct2 create_database create_index
+        create_table datetime_update daylight_saving_time
+        ddl_i18n_utf8 decimal do drop echo exec_selection
+        field_length func_concat gcol_alter_table
+        gcol_blocked_sql_funcs gcol_dependenies_on_vcol
+        gcol_ins_upd gcol_non_stored_columns gcol_partition gcol_select
+        grant_dynamic groupby having in index index_merge2
+        index_merge_delete insert insert_select issue_11208 issue_165
+        issue_20571 issue_207 issue_227 issue_266 issue_294 join json
+        like math mysql_replace operator orderby partition_bug18198
+        partition_hash partition_innodb partition_list partition_range
+        precedence prepare qualified regexp replace select_qualified
+        single_delete_update sqllogic str_quoted sub_query sub_query_more
+        time timestamp_update tpcc transaction_isolation_func type
+        type_binary type_uint union update update_stmt variable
+        with_recursive with_recursive_bugs xd
+        index_merge_sqlgen_exprs index_merge_sqlgen_exprs_orandor_1_no_out_trans index_merge1
+        """
+}
+
 // remove test: temp_table
 if (ghprbTargetBranch in ["release-5.2"]) {
     CI_RUN_PART_TEST_CASES = """

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_mysql_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_mysql_test.groovy
@@ -34,6 +34,7 @@ CI_RUN_PART_TEST_CASES = """
     type_binary type_uint union update update_stmt variable 
     with_recursive with_recursive_bugs xd
     index_merge_sqlgen_exprs index_merge_sqlgen_exprs_orandor_1_no_out_trans index_merge1
+    ctype_gbk date_formats invisible_indexes nth type_varchar variables
     """
 
 // remove test: temp_table


### PR DESCRIPTION
We added some test cases to mysql-test and should enable them in CI.

ref
https://github.com/pingcap/tidb-test/pull/1369
https://github.com/pingcap/tidb-test/pull/1345
https://github.com/pingcap/tidb-test/pull/1327
https://github.com/pingcap/tidb-test/pull/1444
https://github.com/pingcap/tidb-test/pull/1445
https://github.com/pingcap/tidb-test/pull/1335