### PR TITLE
ticdc some improve

### DIFF
--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_downstream_coverage.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_downstream_coverage.groovy
@@ -1,13 +1,4 @@
 
-
-// CI_NAME="jenkins-ci"
-// CI_BUILD_NUMBER=""
-// CI_BUILD_URL=""
-// CI_BRANCH=""
-// CI_PULL_REQUEST=""   // (optional)
-// COVERAGE_FILE = ""
-
-
 properties([
         parameters([
                 string(

--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_downstream_coverage.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_downstream_coverage.groovy
@@ -1,0 +1,108 @@
+
+
+// CI_NAME="jenkins-ci"
+// CI_BUILD_NUMBER=""
+// CI_BUILD_URL=""
+// CI_BRANCH=""
+// CI_PULL_REQUEST=""   // (optional)
+// COVERAGE_FILE = ""
+
+
+properties([
+        parameters([
+                string(
+                        defaultValue: '',
+                        name: 'COVERAGE_FILE',
+                        trim: true
+                ),
+                string(
+                        defaultValue: 'jenkins-ci',
+                        name: 'CI_NAME',
+                        trim: true
+                ),
+                string(
+                        defaultValue: '',
+                        name: 'CI_BUILD_NUMBER',
+                        trim: true
+                ),
+                string(
+                        defaultValue: '',
+                        name: 'CI_BUILD_URL',
+                        trim: true
+                ),
+                string(
+                        defaultValue: '',
+                        name: 'CI_BRANCH',
+                        trim: true
+                ),
+                string(
+                        defaultValue: '',
+                        name: 'CI_PULL_REQUEST',
+                        trim: true
+                ),
+        ]),
+])
+
+
+def run_with_pod(Closure body) {
+    def label = "cdc_ghpr_downstream_coverage-${BUILD_NUMBER}"
+    def cloud = "kubernetes"
+    def namespace = "jenkins-ci2"
+    def pod_go_docker_image = 'hub.pingcap.net/jenkins/centos7_golang-1.16:latest'
+    def jnlp_docker_image = "jenkins/inbound-agent:4.3-4"
+    podTemplate(label: label,
+            cloud: cloud,
+            namespace: namespace,
+            idleMinutes: 0,
+            containers: [
+                    containerTemplate(
+                            name: 'golang', alwaysPullImage: true,
+                            image: "${pod_go_docker_image}", ttyEnabled: true,
+                            resourceRequestCpu: '2000m', resourceRequestMemory: '4Gi',
+                            command: '/bin/sh -c', args: 'cat',
+                            envVars: [containerEnvVar(key: 'GOPATH', value: '/go')],
+                            
+                    )
+            ],
+            volumes: [
+                            nfsVolume(mountPath: '/home/jenkins/agent/ci-cached-code-daily', serverAddress: '172.16.5.22',
+                                    serverPath: '/mnt/ci.pingcap.net-nfs/git', readOnly: false)
+                    ],
+    ) {
+        node(label) {
+            println "debug command:\nkubectl -n ${namespace} exec -ti ${NODE_NAME} bash"
+            body()
+        }
+    }
+}
+
+run_with_pod {
+    container("golang") {
+        def ws = pwd()
+        sh """
+        curl -O ${COVERAGE_FILE}
+        tar -xvf tiflow_coverage.tar.gz
+        ls -alh
+        """
+        dir("go/src/github.com/pingcap/tiflow") { 
+            withCredentials([string(credentialsId: 'coveralls-token-ticdc', variable: 'COVERALLS_TOKEN')]) {
+                timeout(30) {
+                    sh """
+                    export CI_NAME=${CI_NAME}
+                    export CI_BUILD_NUMBER=${CI_BUILD_NUMBER}
+                    export CI_BUILD_URL=${CI_BUILD_URL}
+                    export CI_BRANCH=${CI_BRANCH}
+                    export CI_PULL_REQUEST=${CI_PULL_REQUEST}
+
+                    rm -rf /tmp/tidb_cdc_test
+                    mkdir -p /tmp/tidb_cdc_test
+                    cp cov_dir/* /tmp/tidb_cdc_test
+                    set +x
+                    BUILD_NUMBER=${BUILD_NUMBER} COVERALLS_TOKEN="${COVERALLS_TOKEN}" GOPATH=${ws}/go:\$GOPATH PATH=${ws}/go/bin:/go/bin:\$PATH JenkinsCI=1 make integration_test_coverage || true
+                    set -x
+                    """
+                }
+            }
+        }
+    }
+}

--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
@@ -237,7 +237,7 @@ catchError {
                 common.tests("mysql", label)
             }
             // If it is triggered upstream, there is no need to collect test coverage.
-            if (!params.containsKey("triggered_by_upstream_pr_ci")) {
+            if (!params.containsKey("triggered_by_upstream_pr_ci") && !params.containsKey("release_test")) {
                 common.coverage()
             }
             currentBuild.result = "SUCCESS"

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -358,13 +358,18 @@ def coverage() {
             // tar the coverage files and upload to file server.
             def tiflowCoverageFile = "test/cdc/ci/integration_test/${ghprbActualCommit}/tiflow_coverage.tar.gz"
             sh """
-            tar -czf tilfow-coverage.tar.gz go/src/github.com/pingcap/tiflow
+            tar -czf tiflow_coverage.tar.gz go/src/github.com/pingcap/tiflow
             curl -F ${tiflowCoverageFile}=@tiflow_coverage.tar.gz http://fileserver.pingcap.net/upload
             """
 
             def params_downstream_coverage_pipeline = [       
                 string(name: "COVERAGE_FILE", value: "${FILE_SERVER_URL}/download/${tiflowCoverageFile}"),
+                string(name: "CI_BUILD_NUMBER", value: "${BUILD_NUMBER}"),
+                string(name: "CI_BUILD_URL", value: "${RUN_DISPLAY_URL}"),
+                string(name: "CI_BRANCH", value: "${ghprbTargetBranch}"),
+                string(name: "CI_PULL_REQUEST", value: "${ghprbPullId}"),
             ]
+            println "params_downstream_coverage_pipeline=${params_downstream_coverage_pipeline}"
             build job: "cdc_ghpr_downstream_coverage",
                 wait: false,
                 parameters: params_downstream_coverage_pipeline

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -392,18 +392,6 @@ def coverage() {
             dir("go/src/github.com/pingcap/tiflow") {
                 container("golang") {
                     archiveArtifacts artifacts: 'cov_dir/*', fingerprint: true
-                    // withCredentials([string(credentialsId: 'coveralls-token-ticdc', variable: 'COVERALLS_TOKEN')]) {
-                    //     timeout(30) {
-                    //         sh '''
-                    //         rm -rf /tmp/tidb_cdc_test
-                    //         mkdir -p /tmp/tidb_cdc_test
-                    //         cp cov_dir/* /tmp/tidb_cdc_test
-                    //         set +x
-                    //         BUILD_NUMBER=${BUILD_NUMBER} CODECOV_TOKEN="${CODECOV_TOKEN}" COVERALLS_TOKEN="${COVERALLS_TOKEN}" GOPATH=${ws}/go:\$GOPATH PATH=${ws}/go/bin:/go/bin:\$PATH JenkinsCI=1 make integration_test_coverage || true
-                    //         set -x
-                    //         '''
-                    //     }
-                    // }
                 }
             }
         }

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -366,7 +366,7 @@ def coverage() {
                 string(name: "COVERAGE_FILE", value: "${FILE_SERVER_URL}/download/${tiflowCoverageFile}"),
             ]
             build job: "cdc_ghpr_downstream_coverage",
-                wait: true,
+                wait: false,
                 parameters: params_downstream_coverage_pipeline
 
             dir("go/src/github.com/pingcap/tiflow") {


### PR DESCRIPTION
* skip binary build if found cache binary in fileserver
* move coverall upload coverage file step to downstream pipeline (parse and upload file currently taken more than 20min, it is suffering)