### PR TITLE
*: always use gcc 8

### DIFF
--- a/jenkins/pipelines/cd/multibranch/build_tikv_multi_branch.groovy
+++ b/jenkins/pipelines/cd/multibranch/build_tikv_multi_branch.groovy
@@ -107,11 +107,8 @@ try {
                             rm ~/.gitconfig || true
                             rm -rf bin/*
                             rm -rf /home/jenkins/.target/*
-                            grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
-                            if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
-                                echo using gcc 8
-                                source /opt/rh/devtoolset-8/enable
-                            fi
+                            echo using gcc 8
+                            source /opt/rh/devtoolset-8/enable
                             CARGO_TARGET_DIR=/home/jenkins/.target ROCKSDB_SYS_STATIC=1 make dist_release                            
                             ./bin/tikv-server --version
                             """
@@ -135,11 +132,8 @@ try {
                             sh """
                             rm ~/.gitconfig || true
                             rm -rf bin/*
-                            grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
-                            if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
-                                echo using gcc 8
-                                source /opt/rh/devtoolset-8/enable
-                            fi
+                            echo using gcc 8
+                            source /opt/rh/devtoolset-8/enable
                             CARGO_TARGET_DIR=/home/jenkins/.target ROCKSDB_SYS_STATIC=1 make fail_release
                             mv bin/tikv-server bin/tikv-server-failpoint
                             """                            

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_build.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_build.groovy
@@ -60,11 +60,8 @@ try {
                             rm ~/.gitconfig || true
                             cp -R /home/jenkins/agent/git/tikv/. ./
                             git checkout -f ${ghprbActualCommit}
-                            grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
-                            if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
-                                echo using gcc 8
-                                source /opt/rh/devtoolset-8/enable
-                            fi
+                            echo using gcc 8
+                            source /opt/rh/devtoolset-8/enable
                             CARGO_TARGET_DIR=/home/jenkins/agent/.target ROCKSDB_SYS_STATIC=1 make ${release}
                             # use make release
                             mkdir -p bin

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy
@@ -71,8 +71,8 @@ ARG BUILD_DATE
 RUN cd tikv-src \
         && git fetch origin ${ghBranch}:refs/remotes/origin/${ghBranch} \
         && git checkout origin/${ghBranch} \
-        && grpcio_ver=\\`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2\\` \
-        && if [[ ! "0.8.0" > "\\\$grpcio_ver" ]]; then echo using gcc 8; source /opt/rh/devtoolset-8/enable; fi \
+        && echo using gcc 8 \
+        && source /opt/rh/devtoolset-8/enable \
         && env EXTRA_CARGO_ARGS="--no-run" RUSTFLAGS=-Dwarnings FAIL_POINT=1 ROCKSDB_SYS_SSE=1 RUST_BACKTRACE=1 make dev
 """, "base", args, !params.force_base && now.getDate() != 1)
             
@@ -86,8 +86,8 @@ ARG BUILD_DATE
 RUN cd tikv-src \
         && git fetch origin ${ghBranch}:refs/remotes/origin/${ghBranch} \
         && git checkout origin/${ghBranch} \
-        && grpcio_ver=\\`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2\\` \
-        && if [[ ! "0.8.0" > "\\\$grpcio_ver" ]]; then echo using gcc 8; source /opt/rh/devtoolset-8/enable; fi \
+        && echo using gcc 8 \
+        && source /opt/rh/devtoolset-8/enable \
         && env EXTRA_CARGO_ARGS="--no-run" RUSTFLAGS=-Dwarnings FAIL_POINT=1 ROCKSDB_SYS_SSE=1 RUST_BACKTRACE=1 make dev
 """, "latest", args, false)
         }

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_coverage.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_coverage.groovy
@@ -66,11 +66,8 @@ stage("Cover") {
                 export CARGO_INCREMENTAL=0
                 export RUSTFLAGS="-Zinstrument-coverage"
 
-                grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
-                if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
-                    echo using gcc 8
-                    source /opt/rh/devtoolset-8/enable
-                fi
+                echo using gcc 8
+                source /opt/rh/devtoolset-8/enable
 
                 env RUSTFLAGS="-Zinstrument-coverage" LLVM_PROFILE_FILE="tikv-%p-%m.profraw" FAIL_POINT=1 RUST_TEST_THREADS=1 EXTRA_CARGO_ARGS=--no-fail-fast make test || true
                 """

--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_test.groovy
@@ -101,11 +101,9 @@ stage("Prepare") {
                         export ROCKSDB_SYS_SSE=1
                         export RUST_BACKTRACE=1
                         export LOG_LEVEL=INFO
-                        grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
-                        if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
-                            echo using gcc 8
-                            source /opt/rh/devtoolset-8/enable
-                        fi
+                        echo using gcc 8
+                        source /opt/rh/devtoolset-8/enable
+
                         make clippy || (echo Please fix the clippy error; exit 1)
                     """
 
@@ -166,11 +164,8 @@ stage("Prepare") {
                     export LOG_LEVEL=INFO
                     export CARGO_INCREMENTAL=0
 
-                    grpcio_ver=`grep -A 1 'name = "grpcio"' Cargo.lock | tail -n 1 | cut -d '"' -f 2`
-                    if [[ ! "0.8.0" > "\$grpcio_ver" ]]; then
-                        echo using gcc 8
-                        source /opt/rh/devtoolset-8/enable
-                    fi
+                    echo using gcc 8
+                    source /opt/rh/devtoolset-8/enable
 
                     set -o pipefail
 


### PR DESCRIPTION
We use to check grpcio version and decide to choose what gcc is used.
But now gcc 8 has been used for v5.x for more than almost a year now
without any issues, and the only versions remain using legacy gcc are
v4.0.x.

grpcio 0.10.0 is released, the old check rule doesn't work anymore.
Writing new rules for only one version seems overkilled to me, hence
this PR switches to use gcc 8 all the time