### PR TITLE
make integration test fail fast Optional

### DIFF
--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -797,6 +797,9 @@ try {
 
         println test_cases
         test_cases.failFast = true
+        if (params.containsKey("ENABLE_FAIL_FAST") && params.get("ENABLE_FAIL_FAST") == "false") {
+            test_cases.failFast = false
+        }
         parallel test_cases
     }
 

--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -800,6 +800,7 @@ try {
         if (params.containsKey("ENABLE_FAIL_FAST") && params.get("ENABLE_FAIL_FAST") == "false") {
             test_cases.failFast = false
         }
+        println "failFast: ${test_cases.failFast}"
         parallel test_cases
     }
 

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -164,17 +164,20 @@ def tests(sink_type, node_label) {
                         dir("go/src/github.com/pingcap/tiflow") {
                             download_binaries()
                             try {
-                                sh """
-                                    s3cmd --version
-                                    rm -rf /tmp/tidb_cdc_test
-                                    mkdir -p /tmp/tidb_cdc_test
-                                    echo "${env.KAFKA_VERSION}" > /tmp/tidb_cdc_test/KAFKA_VERSION
-                                    GOPATH=\$GOPATH:${ws}/go PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH make integration_test_${sink_type} CASE="${case_names}"
-                                    rm -rf cov_dir
-                                    mkdir -p cov_dir
-                                    ls /tmp/tidb_cdc_test
-                                    cp /tmp/tidb_cdc_test/cov*out cov_dir || touch cov_dir/dummy_file_${step_name}
-                                """
+                                timeout(time: 60, unit: 'MINUTES') { 
+                                    sh """
+                                        s3cmd --version
+                                        rm -rf /tmp/tidb_cdc_test
+                                        mkdir -p /tmp/tidb_cdc_test
+                                        echo "${env.KAFKA_VERSION}" > /tmp/tidb_cdc_test/KAFKA_VERSION
+                                        GOPATH=\$GOPATH:${ws}/go PATH=\$GOPATH/bin:${ws}/go/bin:\$PATH make integration_test_${sink_type} CASE="${case_names}"
+                                        rm -rf cov_dir
+                                        mkdir -p cov_dir
+                                        ls /tmp/tidb_cdc_test
+                                        cp /tmp/tidb_cdc_test/cov*out cov_dir || touch cov_dir/dummy_file_${step_name}
+                                    """
+                                }
+
                                 // cyclic tests do not run on kafka sink, so there is no cov* file.
                                 sh """
                                 tail /tmp/tidb_cdc_test/cov* || true

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -127,6 +127,9 @@ def tests(sink_type, node_label) {
             def test_cases = [:]
             // Set to fail fast.
             test_cases.failFast = true
+            if (params.containsKey("ENABLE_FAIL_FAST") && params.get("ENABLE_FAIL_FAST") == "false") {
+                test_cases.failFast = false
+            }
 
             // Start running integration tests.
             def run_integration_test = { step_name, case_names ->

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -130,6 +130,7 @@ def tests(sink_type, node_label) {
             if (params.containsKey("ENABLE_FAIL_FAST") && params.get("ENABLE_FAIL_FAST") == "false") {
                 test_cases.failFast = false
             }
+            println "failFast: ${test_cases.failFast}"
 
             // Start running integration tests.
             def run_integration_test = { step_name, case_names ->

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_br_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_br_test.groovy
@@ -110,6 +110,7 @@ if (params.containsKey("triggered_by_upstream_ci") && params.get("triggered_by_u
                 PARAM_STATUS = 'error'
             }
             def default_params = [
+                    booleanParam(name: 'ENABLE_FAIL_FAST', value: false),
                     string(name: 'TIDB_COMMIT_ID', value: ghprbActualCommit ),
                     string(name: 'CONTEXT', value: 'idc-jenkins-ci-tidb/integration-br-test'),
                     string(name: 'DESCRIPTION', value: PARAM_DESCRIPTION ),

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_cdc_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_cdc_test.groovy
@@ -37,6 +37,7 @@ node("${GO_TEST_SLAVE}") {
                     println "tidb binary url: ${tidb_url}"
                     def default_params = [
                             booleanParam(name: 'force', value: true),
+                            booleanParam(name: 'ENABLE_FAIL_FAST', value: false),
                             string(name: 'triggered_by_upstream_pr_ci', value: "tidb"),
                             string(name: 'upstream_pr_ci_ghpr_target_branch', value: "${ghprbTargetBranch}"),
                             // We use the latest commit build binary which cached in file server to run test.


### PR DESCRIPTION
* daily ci or merge ci trigger br/cdc integration test, we want get all test case results