### PR TITLE
Change Base image to pingcap/alpine-glibc:alpine-3.14.3-gcompat for ARM64

### DIFF
--- a/jenkins/Dockerfile/release/linux-arm64/br
+++ b/jenkins/Dockerfile/release/linux-arm64/br
@@ -1,3 +1,3 @@
-FROM centos:8
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 COPY zoneinfo.zip  /usr/local/go/lib/time/zoneinfo.zip
 COPY br /br

--- a/jenkins/Dockerfile/release/linux-arm64/dm
+++ b/jenkins/Dockerfile/release/linux-arm64/dm
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 RUN apk add --no-cache tzdata
 COPY dm-worker /dm-worker
 COPY dm-master /dm-master

--- a/jenkins/Dockerfile/release/linux-arm64/dumpling
+++ b/jenkins/Dockerfile/release/linux-arm64/dumpling
@@ -1,3 +1,3 @@
-FROM centos:8
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 COPY zoneinfo.zip  /usr/local/go/lib/time/zoneinfo.zip
 COPY dumpling /dumpling

--- a/jenkins/Dockerfile/release/linux-arm64/ng-monitoring
+++ b/jenkins/Dockerfile/release/linux-arm64/ng-monitoring
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 COPY zoneinfo.zip  /usr/local/go/lib/time/zoneinfo.zip
 COPY ng-monitoring-server /ng-monitoring-server
 EXPOSE 12020

--- a/jenkins/Dockerfile/release/linux-arm64/pd
+++ b/jenkins/Dockerfile/release/linux-arm64/pd
@@ -1,12 +1,6 @@
-FROM centos:8
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 COPY pd-server /pd-server
 COPY pd-ctl /pd-ctl
 COPY pd-recover /pd-recover
-RUN set -e && \
-    curl -O 'http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm' && \
-    rpm -i 'centos-gpg-keys-8-3.el8.noarch.rpm' && \
-    dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos && \
-    dnf install bind-utils wget -y && \
-    dnf clean all
 EXPOSE 2379 2380
 ENTRYPOINT ["/pd-server"]

--- a/jenkins/Dockerfile/release/linux-arm64/ticdc
+++ b/jenkins/Dockerfile/release/linux-arm64/ticdc
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 RUN apk add --no-cache tzdata bash curl socat
 COPY cdc /cdc
 EXPOSE 8300

--- a/jenkins/Dockerfile/release/linux-arm64/tidb
+++ b/jenkins/Dockerfile/release/linux-arm64/tidb
@@ -1,10 +1,4 @@
-FROM centos:8
-RUN set -e && \
-    curl -O 'http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm' && \
-    rpm -i 'centos-gpg-keys-8-3.el8.noarch.rpm' && \
-    dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos && \
-    dnf install bind-utils curl nmap-ncat -y && \
-    dnf clean all
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 COPY tidb-server /tidb-server
 EXPOSE 4000
 ENTRYPOINT ["/tidb-server"]

--- a/jenkins/Dockerfile/release/linux-arm64/tidb-backup-manager
+++ b/jenkins/Dockerfile/release/linux-arm64/tidb-backup-manager
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 ARG RCLONE_VERSION=v1.51.0
 ARG SHUSH_VERSION=v1.4.0
 ARG TOOLKIT_V40=v4.0.12

--- a/jenkins/Dockerfile/release/linux-arm64/tidb-binlog
+++ b/jenkins/Dockerfile/release/linux-arm64/tidb-binlog
@@ -1,15 +1,9 @@
-FROM centos:8
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 COPY zoneinfo.zip  /usr/local/go/lib/time/zoneinfo.zip
 COPY pump /pump
 COPY drainer /drainer
 COPY reparo /reparo
 COPY binlogctl /binlogctl
-RUN set -e && \
-    curl -O 'http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm' && \
-    rpm -i 'centos-gpg-keys-8-3.el8.noarch.rpm' && \
-    dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos && \
-    dnf install bind-utils wget -y && \
-    dnf clean all
 EXPOSE 4000
 EXPOSE 8249 8250
 CMD ["/pump"]

--- a/jenkins/Dockerfile/release/linux-arm64/tidb-lightning
+++ b/jenkins/Dockerfile/release/linux-arm64/tidb-lightning
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 COPY zoneinfo.zip  /usr/local/go/lib/time/zoneinfo.zip
 COPY tidb-lightning /tidb-lightning
 COPY tidb-lightning-ctl /tidb-lightning-ctl

--- a/jenkins/Dockerfile/release/linux-arm64/tidb-monitor-reloader
+++ b/jenkins/Dockerfile/release/linux-arm64/tidb-monitor-reloader
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 COPY ./build/linux/reload  /bin/reload
 ENTRYPOINT ["/bin/reload"]
 CMD        [ "--watch-path=/etc/prometheus/rules", "--prometheus-url=http://127.0.0.1:9090" ]

--- a/jenkins/Dockerfile/release/linux-arm64/tidb-operator
+++ b/jenkins/Dockerfile/release/linux-arm64/tidb-operator
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.10
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 
 RUN apk add tzdata --no-cache
 ADD bin/tidb-scheduler /usr/local/bin/tidb-scheduler

--- a/jenkins/Dockerfile/release/linux-arm64/tidb-tools
+++ b/jenkins/Dockerfile/release/linux-arm64/tidb-tools
@@ -1,3 +1,3 @@
-FROM centos:8
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 COPY zoneinfo.zip  /usr/local/go/lib/time/zoneinfo.zip
 COPY sync_diff_inspector /sync_diff_inspector

--- a/jenkins/Dockerfile/release/linux-arm64/tikv
+++ b/jenkins/Dockerfile/release/linux-arm64/tikv
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM pingcap/alpine-glibc:alpine-3.14.3-gcompat
 ENV TZ=/etc/localtime
 ENV TZDIR=/usr/share/zoneinfo
 COPY tikv-server /tikv-server


### PR DESCRIPTION
This PR aims to change all base image for ARM64 from `centos:8` to `pingcap/alpine-glibc:alpine-3.14.3-gcompat`.