### PR TITLE
ci: skip ticdc integration tests if matching engine dir

### DIFF
--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
@@ -210,15 +210,15 @@ def pattern_match_all_files(pattern, files_list) {
 
 if (ghprbPullId != null && ghprbPullId != "" && !params.containsKey("triggered_by_upstream_pr_ci")) {
     def pr_diff_files = list_pr_diff_files()
-    def pattern = /^dm\/.*$/
+    def pattern = /(^dm\/|^engine\/).*$/
     // if all diff files start with dm/, skip cdc integration test
     def matched = pattern_match_all_files(pattern, pr_diff_files)
     if (matched) {
-        echo "matched, all diff files full path start with dm/, current pr is dm's pr(not related to ticdc), skip cdc integration test"
+        echo "matched, all diff files full path start with dm/ or engine/, current pr is dm/engine's pr(not related to ticdc), skip cdc integration test"
         currentBuild.result = 'SUCCESS'
         return 0
     } else {
-        echo "not matched, some diff files not start with dm/, need run the cdc integration test"
+        echo "not matched, some diff files not start with dm/ or engine/, need run the cdc integration test"
     }
 }
 

--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_kafka_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_kafka_integration_test.groovy
@@ -184,15 +184,15 @@ def pattern_match_all_files(pattern, files_list) {
 
 if (ghprbPullId != null && ghprbPullId != "" && !params.containsKey("triggered_by_upstream_pr_ci")) {
     def pr_diff_files = list_pr_diff_files()
-    def pattern = /^dm\/.*$/
+    def pattern = /(^dm\/|^engine\/).*$/
     // if all diff files start with dm/, skip cdc integration test
     def matched = pattern_match_all_files(pattern, pr_diff_files)
     if (matched) {
-        echo "matched, all diff files full path start with dm/, current pr is dm's pr(not related to ticdc), skip cdc integration test"
+        echo "matched, all diff files full path start with dm/ or engine/, current pr is dm/engine's pr(not related to ticdc), skip cdc integration test"
         currentBuild.result = 'SUCCESS'
         return 0
     } else {
-        echo "not matched, some diff files not start with dm/, need run the cdc integration test"
+        echo "not matched, some diff files not start with dm/ or engine/, need run the cdc integration test"
     }
 }
 


### PR DESCRIPTION
ref: task-5 in https://github.com/pingcap/tiflow/issues/5352

Skip ticdc integration test/kafka integration test if only changes engine code.