### PR TITLE
Remove the deprecated target page_ctl

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
@@ -134,7 +134,7 @@ def getBuildTarget() {
     }
 
     if (params.BUILD_PAGE_TOOLS) {
-        targets = "page_ctl page_stress_testing ${targets}"
+        targets = "page_stress_testing ${targets}"
     }
 
     if (!targets) {


### PR DESCRIPTION
After https://github.com/pingcap/tiflash/pull/5003, the target `page_ctl` is deprecated, need to remove it from CI.