### PR TITLE
jenkins/pipeline: fix pod template to not override python script

### DIFF
--- a/jenkins/pipelines/qa_release_test.groovy
+++ b/jenkins/pipelines/qa_release_test.groovy
@@ -35,9 +35,6 @@ catchError {
                         envVars: [containerEnvVar(key: 'GOPATH', value: '/go')]
                     )
             ],
-            volumes: [
-                    emptyDirVolume(mountPath: '/home/jenkins', memory: false)
-                    ],
     ) {
         node(label) {
         stage("Prepare") {


### PR DESCRIPTION
Signed-off-by: lob <pengyu@pingcap.com>

This PR fixes issue introduced by #1048. There is a task.py(i.e. `/home/jenkins/task.py`) in `hub.pingcap.net/qa/ci-toolkit:lates` image, so we must not override the folder.