### PR TITLE
Disable tikv-client unit test in TiSpark integration_test

### DIFF
--- a/jenkins/pipelines/ci/tispark/integration_test.groovy
+++ b/jenkins/pipelines/ci/tispark/integration_test.groovy
@@ -262,24 +262,25 @@ podTemplate(name: label, label: label, cloud: "kubernetes-ng", instanceCap: 12, 
                 }
             }
 
-            groovy.lang.Closure run_tikvclient_test = { chunk_suffix ->
-            withCredentials([string(credentialsId: 'codecov-token-tispark', variable: 'CODECOV_TOKEN')]) { 
-                dir("go/src/github.com/pingcap/tispark") {      
-                        sh """
-                            rm -rf /maven/.m2/repository/*
-                            rm -rf /maven/.m2/settings.xml
-                            rm -rf ~/.m2/settings.xml
-                            archive_url=http://fileserver.pingcap.net/download/builds/pingcap/tispark/cache/tispark-m2-cache-latest.tar.gz
-                            if [ ! "\$(ls -A /maven/.m2/repository)" ]; then curl -sL \$archive_url | tar -zx -C /maven || true; fi
-                        """
-                        sh """
-                            export MAVEN_OPTS="-Xmx6G -XX:MaxMetaspaceSize=1024M"
-                            mvn test ${MVN_PROFILE} -am -pl tikv-client
-                        """
-                        sh 'curl -s https://codecov.io/bash | bash -s'
-                    }
-                }      
-            }
+// Disable tikv client unit test
+//            groovy.lang.Closure run_tikvclient_test = { chunk_suffix ->
+//            withCredentials([string(credentialsId: 'codecov-token-tispark', variable: 'CODECOV_TOKEN')]) {
+//                dir("go/src/github.com/pingcap/tispark") {
+//                        sh """
+//                            rm -rf /maven/.m2/repository/*
+//                            rm -rf /maven/.m2/settings.xml
+//                            rm -rf ~/.m2/settings.xml
+//                            archive_url=http://fileserver.pingcap.net/download/builds/pingcap/tispark/cache/tispark-m2-cache-latest.tar.gz
+//                            if [ ! "\$(ls -A /maven/.m2/repository)" ]; then curl -sL \$archive_url | tar -zx -C /maven || true; fi
+//                        """
+//                        sh """
+//                            export MAVEN_OPTS="-Xmx6G -XX:MaxMetaspaceSize=1024M"
+//                            mvn test ${MVN_PROFILE} -am -pl tikv-client
+//                        """
+//                        sh 'curl -s https://codecov.io/bash | bash -s'
+//                    }
+//                }
+//            }
 
             groovy.lang.Closure run_intergration_test = { chunk_suffix, run_test ->
                 node(label) {
@@ -378,7 +379,9 @@ podTemplate(name: label, label: label, cloud: "kubernetes-ng", instanceCap: 12, 
                 int x = i
                 tests["Integration test = $i"] = {run_intergration_test(x, run_tispark_test)}
             }
-            tests["Integration tikv-client test"] = {run_intergration_test(0, run_tikvclient_test)}
+
+// Disable tikv client unit test
+//            tests["Integration tikv-client test"] = {run_intergration_test(0, run_tikvclient_test)}
 
             parallel tests
         }

--- a/jenkins/pipelines/ci/tispark/integration_test.groovy
+++ b/jenkins/pipelines/ci/tispark/integration_test.groovy
@@ -262,25 +262,24 @@ podTemplate(name: label, label: label, cloud: "kubernetes-ng", instanceCap: 12, 
                 }
             }
 
-// Disable tikv client unit test
-//            groovy.lang.Closure run_tikvclient_test = { chunk_suffix ->
-//            withCredentials([string(credentialsId: 'codecov-token-tispark', variable: 'CODECOV_TOKEN')]) {
-//                dir("go/src/github.com/pingcap/tispark") {
-//                        sh """
-//                            rm -rf /maven/.m2/repository/*
-//                            rm -rf /maven/.m2/settings.xml
-//                            rm -rf ~/.m2/settings.xml
-//                            archive_url=http://fileserver.pingcap.net/download/builds/pingcap/tispark/cache/tispark-m2-cache-latest.tar.gz
-//                            if [ ! "\$(ls -A /maven/.m2/repository)" ]; then curl -sL \$archive_url | tar -zx -C /maven || true; fi
-//                        """
-//                        sh """
-//                            export MAVEN_OPTS="-Xmx6G -XX:MaxMetaspaceSize=1024M"
-//                            mvn test ${MVN_PROFILE} -am -pl tikv-client
-//                        """
-//                        sh 'curl -s https://codecov.io/bash | bash -s'
-//                    }
-//                }
-//            }
+            groovy.lang.Closure run_tikvclient_test = { chunk_suffix ->
+            withCredentials([string(credentialsId: 'codecov-token-tispark', variable: 'CODECOV_TOKEN')]) {
+                dir("go/src/github.com/pingcap/tispark") {
+                        sh """
+                            rm -rf /maven/.m2/repository/*
+                            rm -rf /maven/.m2/settings.xml
+                            rm -rf ~/.m2/settings.xml
+                            archive_url=http://fileserver.pingcap.net/download/builds/pingcap/tispark/cache/tispark-m2-cache-latest.tar.gz
+                            if [ ! "\$(ls -A /maven/.m2/repository)" ]; then curl -sL \$archive_url | tar -zx -C /maven || true; fi
+                        """
+                        sh """
+                            export MAVEN_OPTS="-Xmx6G -XX:MaxMetaspaceSize=1024M"
+                            mvn test ${MVN_PROFILE} -am -pl tikv-client -Dtest=**/txn/*,**/PDClientTest.java
+                        """
+                        sh 'curl -s https://codecov.io/bash | bash -s'
+                    }
+                }
+            }
 
             groovy.lang.Closure run_intergration_test = { chunk_suffix, run_test ->
                 node(label) {
@@ -379,9 +378,7 @@ podTemplate(name: label, label: label, cloud: "kubernetes-ng", instanceCap: 12, 
                 int x = i
                 tests["Integration test = $i"] = {run_intergration_test(x, run_tispark_test)}
             }
-
-// Disable tikv client unit test
-//            tests["Integration tikv-client test"] = {run_intergration_test(0, run_tikvclient_test)}
+            tests["Integration tikv-client test"] = {run_intergration_test(0, run_tikvclient_test)}
 
             parallel tests
         }


### PR DESCRIPTION
**What**: Disable tikv-client unit test in TiSpark integration_test.

**Why**: Because tikv-client unit test has been already done in GitHub Action, we need not add it to the integration test again.