### PR TITLE
Use copr-test related version instead of using latest master

### DIFF
--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_integration-copr-test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_integration-copr-test.groovy
@@ -12,7 +12,7 @@ if (params.containsKey("release_test")) {
 
 def TIDB_BRANCH = ghprbTargetBranch
 def PD_BRANCH = ghprbTargetBranch
-def COPR_TEST_BRANCH = "master"
+def COPR_TEST_BRANCH = ghprbTargetBranch
 
 if (ghprbPullTitle.find("Bump version") != null) {
     currentBuild.result = 'SUCCESS'


### PR DESCRIPTION
Signed-off-by: yibin <huyibin@pingcap.com>
Previously, copr-test doesn't maintain different branches for different TiDB/TiKV releases. However, the copr-test is version sensitive, due to its functions.txt which maintains push-down-function-white-name-list. In release-6.0, TiKV supports new push down function 'mod', which adds a new entry in the white-name-list. But when we test older versions, like TiDB release 5.4 and before, we would encounter not-support error when push down 'mod' to TiKV of related versions.
This PR will ensure that we use correct copr-test branch for test.  