### PR TITLE
fix(ci(tiflash)): fix unit-test cache strategy for release-4.0 branch

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-ghpr-unit-tests.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-ghpr-unit-tests.groovy
@@ -261,9 +261,11 @@ run_with_pod {
             dir(repo_path) {
                 sh """
                 mkdir -p /root/.cache
-                source /tests/docker/util.sh
-                export LLVM_PROFILE_FILE="/tiflash/profile/unit-test-%${parallelism}m.profraw"
-                show_env
+                if [[ -f /tests/docker/util.sh ]]; then
+                    source /tests/docker/util.sh
+                    export LLVM_PROFILE_FILE="/tiflash/profile/unit-test-%${parallelism}m.profraw"
+                    show_env
+                fi
                 ENV_VARS_PATH=/tests/docker/_env.sh OUTPUT_XML=true NPROC=${parallelism} /tests/run-gtest.sh
                 """
             }

--- a/jenkins/pipelines/ci/tiflash/tiflash-ghpr-unit-tests.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-ghpr-unit-tests.groovy
@@ -87,7 +87,7 @@ def dispatchRunEnv(toolchain, identifier, Closure body) {
 def existsBuildCache() {
     def status = ""
     try {
-        def api = "https://ci.pingcap.net/job/tiflash-build-common/api/xml?tree=allBuilds[result,number,building,actions[parameters[name,value]]]&xpath=(//allBuild[action[parameter[name=%22TARGET_COMMIT_HASH%22%20and%20value=%22${ghprbActualCommit}%22]%20and%20parameter[name=%22BUILD_TESTS%22%20and%20value=%22true%22]]])[1]"
+        def api = "https://ci.pingcap.net/job/tiflash-build-common/api/xml?tree=allBuilds[result,number,building,actions[parameters[name,value]]]&xpath=(//allBuild[action[parameter[name=%22TARGET_COMMIT_HASH%22%20and%20value=%22${ghprbActualCommit}%22]%20and%20parameter[name=%22ARCHIVE_BUILD_DATA%22%20and%20value=%22true%22]%20and%20parameter[name=%22BUILD_TESTS%22%20and%20value=%22true%22]]])[1]"
         def response = httpRequest api
         def content = response.getContent()
         if (content.contains('<building>false</building>') && content.contains('<result>SUCCESS</result>')) {


### PR DESCRIPTION
Try:

https://ci.pingcap.net/job/tiflash-build-common/api/xml?tree=allBuilds[result,number,building,actions[parameters[name,value]]]&xpath=(//allBuild[action[parameter[name=%22TARGET_COMMIT_HASH%22%20and%20value=%2246e6e48fcdb2dabe6da7aa1ccde4d44732bc2e8d%22]%20and%20parameter[name=%22BUILD_TESTS%22%20and%20value=%22true%22]%20and%20parameter[name=%22ARCHIVE_BUILD_DATA%22%20and%20value=%22true%22]]])[1]