### PR TITLE
copr test support specify pr

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_copr_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_copr_test.groovy
@@ -12,10 +12,10 @@ if (params.containsKey("release_test")) {
 }
 
 def TIDB_BRANCH = ghprbTargetBranch
-// def PD_BRANCH = ghprbTargetBranch
 def PD_BRANCH = "master"
-// def COPR_TEST_BRANCH = ghprbTargetBranch
+
 def COPR_TEST_BRANCH = "master"
+def COPR_TEST_PR_ID = ""
 def TIKV_BRANCH = ghprbTargetBranch
 
 def refspecCoprTest = "+refs/heads/*:refs/remotes/origin/*"
@@ -42,10 +42,14 @@ if (m3) {
     COPR_TEST_BRANCH = "${m3[0][1]}"
 }
 m3 = null
+
 if (COPR_TEST_BRANCH.startsWith("pr/")) {
-    refspecCoprTest = "+refs/pull/*:refs/remotes/origin/pr/*"
+    COPR_TEST_PR_ID = COPR_TEST_BRANCH.substring(3)
+    refspecCoprTest = "+refs/pull/${COPR_TEST_PR_ID}/head:refs/remotes/origin/PR-${COPR_TEST_PR_ID}"
+    COPR_TEST_PR_ID = COPR_TEST_BRANCH.substring(3)
 }
 println "COPR_TEST_BRANCH=${COPR_TEST_BRANCH}"
+println "COPR_TEST_PR_ID=${COPR_TEST_PR_ID}"
 
 // def tikv_url = "${FILE_SERVER_URL}/download/builds/pingcap/tikv/pr/${ghprbActualCommit}/centos7/tikv-server.tar.gz"
 def release = "release"
@@ -132,8 +136,14 @@ try {
             dir("copr-test") {
                 println "prepare copr-test"
                 println "corp-test branch: ${COPR_TEST_BRANCH}"
+                println "refspec: ${refspecCoprTest}"
                 timeout(30) {
-                    checkout(changelog: false, poll: false, scm: [
+                    if (COPR_TEST_PR_ID != "") {
+                        checkout([$class: 'GitSCM', branches: [[name: "FETCH_HEAD"]],
+                        extensions: [[$class: 'LocalBranch']],
+                        userRemoteConfigs: [[refspec: refspecCoprTest, url: 'https://github.com/tikv/copr-test.git']]])
+                    } else {
+                        checkout(changelog: false, poll: false, scm: [
                             $class: "GitSCM",
                             branches: [ [ name: COPR_TEST_BRANCH ] ],
                             userRemoteConfigs: [
@@ -146,7 +156,8 @@ try {
                                     [$class: 'PruneStaleBranch'], [$class: 'CleanBeforeCheckout'],
                                     [$class: 'CloneOption', depth: 1, noTags: false, reference: '', shallow: true]
                             ],
-                    ])
+                        ])
+                    }
                 }
             }
             container("golang") {

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_copr_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_copr_test.groovy
@@ -20,6 +20,8 @@ def TIKV_BRANCH = ghprbTargetBranch
 
 def refspecCoprTest = "+refs/heads/*:refs/remotes/origin/*"
 
+println "coment body: ${ghprbCommentBody}"
+
 // parse tikv branch
 def m1 = ghprbCommentBody =~ /tikv\s*=\s*([^\s\\]+)(\s|\\|$)/
 if (m1) {

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_copr_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_copr_test.groovy
@@ -18,6 +18,8 @@ def PD_BRANCH = "master"
 def COPR_TEST_BRANCH = "master"
 def TIKV_BRANCH = ghprbTargetBranch
 
+def refspecCoprTest = "+refs/heads/*:refs/remotes/origin/*"
+
 // parse tikv branch
 def m1 = ghprbCommentBody =~ /tikv\s*=\s*([^\s\\]+)(\s|\\|$)/
 if (m1) {
@@ -40,6 +42,9 @@ if (m3) {
     COPR_TEST_BRANCH = "${m3[0][1]}"
 }
 m3 = null
+if (COPR_TEST_BRANCH.startsWith("pr/")) {
+    refspecCoprTest = "+refs/pull/*:refs/remotes/origin/pr/*"
+}
 println "COPR_TEST_BRANCH=${COPR_TEST_BRANCH}"
 
 // def tikv_url = "${FILE_SERVER_URL}/download/builds/pingcap/tikv/pr/${ghprbActualCommit}/centos7/tikv-server.tar.gz"
@@ -125,6 +130,8 @@ try {
 
         stage('Prepare') {
             dir("copr-test") {
+                println "prepare copr-test"
+                println "corp-test branch: ${COPR_TEST_BRANCH}"
                 timeout(30) {
                     checkout(changelog: false, poll: false, scm: [
                             $class: "GitSCM",
@@ -132,7 +139,7 @@ try {
                             userRemoteConfigs: [
                                     [
                                             url: 'https://github.com/tikv/copr-test.git',
-                                            refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*',
+                                            refspec: refspecCoprTest,
                                     ]
                             ],
                             extensions: [


### PR DESCRIPTION
* support to trigger copr-test in tidb pr, comment /run-integration-copr-test copr-test=pr/xxx
* also support specify copr-test branch, comment  comment /run-integration-copr-test copr-test=branch-name