### PR TITLE
tidb(merge-ci): add tidb_e2e_tests to mergeci

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_integration_test_ci.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_integration_test_ci.groovy
@@ -208,6 +208,13 @@ node("github-status-updater") {
                                 throw new Exception("tidb_ghpr_integration_cdc_test failed")
                             }
                         },
+                        tidb_e2e_tests: {
+                            def result = build(job: "tidb_e2e_tests", parameters: default_params, wait: true, propagate: false)
+                            triggered_job_result << ["name": "tidb_e2e_tests", "type": "tidb-merge-ci-checker" , "result": result]
+                            if (result.getResult() != "SUCCESS") {
+                                throw new Exception("tidb_e2e_tests failed")
+                            }
+                        },
 
                         // TODO : enable this job when tidb unit test more stable
                         // bb7133 is working on it


### PR DESCRIPTION
* tidb_e2e_test has been fixed, currently is stable for tidb master.
https://ci.pingcap.net/blue/organizations/jenkins/tidb_e2e_tests/activity