### PR TITLE
tidb: fix tidb-test branch from pr comment

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_mysql_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_mysql_test.groovy
@@ -173,11 +173,11 @@ try {
                 dir("go/src/github.com/pingcap/tidb-test") {
                     timeout(10) {
                         def TIDB_TEST_BRANCH = ghprbTargetBranch
-                        if (ghprbCommentBody ==~ commentBodyReg) {
+                        if (ghprbCommentBody =~ commentBodyReg) {
                             TIDB_TEST_BRANCH = (ghprbCommentBody =~ commentBodyReg)[0][1]
-                        } else if (ghprbTargetBranch ==~ releaseOrHotfixBranchReg) {
+                        } else if (ghprbTargetBranch =~ releaseOrHotfixBranchReg) {
                             TIDB_TEST_BRANCH = String.format('release-%s', (ghprbTargetBranch =~ releaseOrHotfixBranchReg)[0][2])
-                        } else if (ghprbTargetBranch ==~ featureBranchReg) {
+                        } else if (ghprbTargetBranch =~ featureBranchReg) {
                             TIDB_TEST_BRANCH = trunkBranch
                         }
                         println "TIDB_TEST_BRANCH or PR: ${TIDB_TEST_BRANCH}"

--- a/pipelines/pingcap/tidb/latest/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_build.groovy
@@ -108,9 +108,9 @@ pipeline {
                                 def commentBodyReg = /\bplugin\s*=\s*([^\s\\]+)(\s|\\|$)/
 
                                 def pluginBranch = ghprbTargetBranch
-                                if (ghprbCommentBody ==~ ghprbTargetBranch) {
+                                if (ghprbCommentBody =~ ghprbTargetBranch) {
                                     pluginBranch = (ghprbCommentBody =~ ghprbTargetBranch)[0][1]
-                                } else if (ghprbTargetBranch ==~ releaseOrHotfixBranchReg) {
+                                } else if (ghprbTargetBranch =~ releaseOrHotfixBranchReg) {
                                     pluginBranch = String.format('release-%s', (ghprbTargetBranch =~ releaseOrHotfixBranchReg)[0][2])
                                 }  
 


### PR DESCRIPTION
What: revert: refactor `if` expression with `==~` instead of `=~`
Wny: `==~` is strict mode.