### PR TITLE
feat(pipelines/pingcap/tidb): add standalone volume for bazel output

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_build.groovy
@@ -26,10 +26,14 @@ spec:
         - name: GOCACHE
           value: ${ENV_GOCACHE}
       volumeMounts:
+        - mountPath: /home/jenkins/.tidb
+          name: bazel-out
         - mountPath: /data/
           name: bazel
           readOnly: true
   volumes:
+    - name: bazel-out
+      emptyDir: {}
     - name: bazel
       secret:
         secretName: bazel

--- a/pipelines/pingcap/tidb/latest/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check.groovy
@@ -27,10 +27,14 @@ spec:
         - name: GOCACHE
           value: ${ENV_GOCACHE}
       volumeMounts:
+        - mountPath: /home/jenkins/.tidb
+          name: bazel-out
         - mountPath: /data/
           name: bazel
           readOnly: true
   volumes:
+    - name: bazel-out
+      emptyDir: {}
     - name: bazel
       secret:
         secretName: bazel

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -26,10 +26,14 @@ spec:
         - name: GOCACHE
           value: ${ENV_GOCACHE}
       volumeMounts:
+        - mountPath: /home/jenkins/.tidb
+          name: bazel-out
         - mountPath: /data/
           name: bazel
           readOnly: true
   volumes:
+    - name: bazel-out
+      emptyDir: {}
     - name: bazel
       secret:
         secretName: bazel

--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -26,10 +26,14 @@ spec:
         - name: GOCACHE
           value: ${ENV_GOCACHE}
       volumeMounts:
+        - mountPath: /home/jenkins/.tidb
+          name: bazel-out
         - mountPath: /data/
           name: bazel
           readOnly: true
   volumes:
+    - name: bazel-out
+      emptyDir: {}
     - name: bazel
       secret:
         secretName: bazel

--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -28,6 +28,8 @@ spec:
         - name: GOCACHE
           value: ${ENV_GOCACHE}
       volumeMounts:
+        - mountPath: /home/jenkins/.tidb
+          name: bazel-out
         - mountPath: /data/
           name: bazel
           readOnly: true
@@ -44,6 +46,8 @@ spec:
       command: [/bin/sh, -c]
       args: [cat]
   volumes:
+    - name: bazel-out
+      emptyDir: {}
     - name: bazel
       secret:
         secretName: bazel


### PR DESCRIPTION
- mount empty dir volume at /home/jenkins/.tidb