### PR TITLE
feat(pipelines/pingcap/tidb): fix pipeline `ghpr_check`

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check.groovy
@@ -93,6 +93,10 @@ pipeline {
                 }
             }
         }
+        // can not parallel, it will make `parser/parser.go` regenerating.
+        stage("test_part_parser") {
+            steps { dir('tidb') {sh 'make test_part_parser' } }
+        }
         stage("Checks") {
             parallel {
                 stage('check') {
@@ -103,9 +107,6 @@ pipeline {
                 }
                 stage('explaintest') {
                     steps{ dir('tidb') {sh 'make explaintest' } }
-                }
-                stage("test_part_parser") {
-                    steps { dir('tidb') {sh 'make test_part_parser' } }
                 }
                 stage("gogenerate") {
                     steps { dir('tidb') {sh 'make gogenerate' } }


### PR DESCRIPTION
How: move make task `test_part_parser` outof parallel to avoid conflict of file `parser/parser.go`