### PR TITLE
ci: fix tidb-tools branch in binlog ci

### DIFF
--- a/jenkins/pipelines/ci/tidb-binlog/binlog_ghpr_integration.groovy
+++ b/jenkins/pipelines/ci/tidb-binlog/binlog_ghpr_integration.groovy
@@ -41,10 +41,10 @@ if (m3) {
 m3 = null
 println "TIDB_BRANCH=${TIDB_BRANCH}"
 
-// parse tidb branch
+// parse tidb-tools branch
 def m4 = ghprbCommentBody =~ /tidb-tools\s*=\s*([^\s\\]+)(\s|\\|$)/
 if (m4) {
-    TIDB_TOOLS_BRANCH = "${m3[0][1]}"
+    TIDB_TOOLS_BRANCH = "${m4[0][1]}"
 }
 m4 = null
 println "TIDB_TOOLS_BRANCH=${TIDB_TOOLS_BRANCH}"


### PR DESCRIPTION
Fix `/tidb-tools=xxx` doesn't work

```
[2022-08-26T09:54:29.914Z] [Pipeline] Start of Pipeline
[2022-08-26T09:54:29.929Z] [Pipeline] echo
[2022-08-26T09:54:29.932Z] TIKV_BRANCH=release-4.0
[2022-08-26T09:54:29.934Z] [Pipeline] echo
[2022-08-26T09:54:29.935Z] PD_BRANCH=release-4.0
[2022-08-26T09:54:29.937Z] [Pipeline] echo
[2022-08-26T09:54:29.937Z] TIDB_BRANCH=release-4.0
[2022-08-26T09:54:29.941Z] [Pipeline] End of Pipeline
[2022-08-26T09:54:29.946Z] java.lang.NullPointerException: Cannot invoke method getAt() on null object
[2022-08-26T09:54:29.946Z] 	at org.codehaus.groovy.runtime.NullObject.invokeMethod(NullObject.java:91)
```

ref: https://github.com/pingcap/tidb-binlog/pull/1202#issuecomment-1228296628