### PR TITLE
ci: fix tidb-tools sha1 branch

### DIFF
--- a/jenkins/pipelines/ci/tidb-binlog/binlog_ghpr_integration.groovy
+++ b/jenkins/pipelines/ci/tidb-binlog/binlog_ghpr_integration.groovy
@@ -166,7 +166,7 @@ try {
                 sh "curl -C - --retry 3 ${FILE_SERVER_URL}/download/builds/pingcap/tidb/${tidb_sha1}/centos7/tidb-server.tar.gz | tar xz"
 
                 dir("go/src/github.com/pingcap/tidb-tools") {
-                    def tidb_tools_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/tidb-tools/master/sha1").trim()
+                    def tidb_tools_sha1 = sh(returnStdout: true, script: "curl ${FILE_SERVER_URL}/download/refs/pingcap/tidb-tools/${TIDB_TOOLS_BRANCH}/sha1").trim()
                     def tidb_tools_file = "${FILE_SERVER_URL}/download/builds/pingcap/tidb-tools/${tidb_tools_sha1}/centos7/tidb-tools.tar.gz"
                     sh """
                     curl ${tidb_tools_file} | tar xz


### PR DESCRIPTION
Use `${TIDB_TOOLS_BRANCH}` variable instead of `master`