### PR TITLE
revert(jenkins/jobs): not set  excluded regions in tidb build job dsl

### DIFF
--- a/jenkins/jobs/ci/tidb/ghpr_build.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_build.groovy
@@ -28,7 +28,8 @@ pipelineJob('tidb_ghpr_build') {
                     orgslist("pingcap")
                     // ignore when only those file changed.(
                     //   multi line regex
-                    excludedRegions('.*\\.md')
+                    // excludedRegions('.*\\.md')
+                    excludedRegions('') // current the context is required in github branch protection.
 
                     blackListLabels("")
                     whiteListLabels("")


### PR DESCRIPTION
Why: current the context is required in github branch protection.