### PR TITLE
feat(jobs/pingcap/tidb,jenkins/jobs/ci/tidb): switch trigger to new server for `tidb_ghpr_build`

### DIFF
--- a/jenkins/jobs/ci/tidb/ghpr_build.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_build.groovy
@@ -18,14 +18,19 @@ pipelineJob('tidb_ghpr_build') {
                     cron('H/5 * * * *')
                     gitHubAuthId('8b25795b-a680-4dce-9904-89ef40d73159')
 
-                    // ### prod
                     triggerPhrase('.*/(merge|run-(all-tests|build).*)')
                     onlyTriggerPhrase(false)
-
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')
                     whitelist("ming-relax LiangShang hsqlu yangwenmai qxhy123 mccxj dreamquster MyonKeminta colinback spongedu lzmhhh123 bb7133 dbjoa")
                     orgslist("pingcap")
+                    blackListTargetBranches {
+                        ghprbBranch { 
+                            branch('master')
+                            branch('^feature[_|/].*')
+                            branch('^(release-)?6\\.[2-9]\\d*(\\.\\d+)?(\\-.*)?$')
+                        }
+                    }
                     // ignore when only those file changed.(
                     //   multi line regex
                     // excludedRegions('.*\\.md')
@@ -52,7 +57,7 @@ pipelineJob('tidb_ghpr_build') {
                     extensions {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
-                            commitStatusContext("idc-jenkins-ci-tidb/build") // debug: no block the pr.
+                            commitStatusContext("idc-jenkins-ci-tidb/build")
                             statusUrl('${RUN_DISPLAY_URL}')
                             startedStatus("Jenkins job is running.")
                             triggeredStatus("Jenkins job triggered.")

--- a/jobs/pingcap/tidb/latest/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_build.groovy
@@ -19,31 +19,23 @@ pipelineJob('pingcap/tidb/ghpr_build') {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
 
-                    // ### prod
                     triggerPhrase('.*/(merge|run-(all-tests|build).*)')
                     onlyTriggerPhrase(false)
-
-                    // ### debug
-                    // // triggerPhrase('/gray-debug')
-                    // // onlyTriggerPhrase(true)
-
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')
                     whitelist("ming-relax LiangShang hsqlu yangwenmai qxhy123 mccxj dreamquster MyonKeminta colinback spongedu lzmhhh123 bb7133 dbjoa")
                     orgslist("pingcap")
                     whiteListTargetBranches {
-                        // - master
-                        // - release-6.2
-                        // - release-6.2.0
-                        // - release-6.2-20221212
-                        // - release-6.2.0-20221314                       
-                        // - 6.2-*
-                        // - 6.2.0-*
-                        ghprbBranch { branch('^master|(release-)?6\\.[2-9]\\d*(\\.\\d+)?(\\-.*)?$') }
+                        ghprbBranch { 
+                            branch('master')
+                            branch('^feature[_|/].*')
+                            branch('^(release-)?6\\.[2-9]\\d*(\\.\\d+)?(\\-.*)?$')
+                        }
                     }
                     // ignore when only those file changed.(
                     //   multi line regex
-                    excludedRegions('.*\\.md')
+                    // excludedRegions('.*\\.md')
+                    excludedRegions('') // current the context is required in github branch protection.
 
                     blackListLabels("")
                     whiteListLabels("")
@@ -66,7 +58,7 @@ pipelineJob('pingcap/tidb/ghpr_build') {
                     extensions {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
-                            commitStatusContext("IGNORE-gray-build") // debug: no block the pr.
+                            commitStatusContext("idc-jenkins-ci-tidb/build")
                             statusUrl('${RUN_DISPLAY_URL}')
                             startedStatus("")
                             triggeredStatus("")


### PR DESCRIPTION
to switch target branches:
- master
- feature branches: `feautre_*` or `feature/*`
- release branches for `6.2+`