### PR TITLE
tidb(ci): adjust keep days to 30, remove keep nums

### DIFF
--- a/jenkins/jobs/ci/tidb/ghpr_build.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_build.groovy
@@ -1,8 +1,7 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tidb_ghpr_build') {
     logRotator {
-        daysToKeep(180)
-        numToKeep(2000)
+        daysToKeep(30)
     }
     parameters {
         stringParam("ghprbActualCommit")

--- a/jenkins/jobs/ci/tidb/ghpr_check.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_check.groovy
@@ -1,8 +1,7 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tidb_ghpr_check') {
     logRotator {
-        daysToKeep(180)
-        numToKeep(1000)
+        daysToKeep(30)
     }
     parameters {
         stringParam("ghprbActualCommit")

--- a/jenkins/jobs/ci/tidb/ghpr_check2.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_check2.groovy
@@ -1,8 +1,7 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tidb_ghpr_check_2') {
     logRotator {
-        daysToKeep(180)
-        numToKeep(1000)
+        daysToKeep(30)
     }
     parameters {
         stringParam("ghprbActualCommit")

--- a/jenkins/jobs/ci/tidb/ghpr_mysql_test.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_mysql_test.groovy
@@ -1,8 +1,7 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tidb_ghpr_mysql_test') {
     logRotator {
-        daysToKeep(180)
-        numToKeep(1000)
+        daysToKeep(30)
     }
     parameters {
         stringParam("ghprbActualCommit")

--- a/jenkins/jobs/ci/tidb/ghpr_unit_test.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_unit_test.groovy
@@ -1,7 +1,7 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tidb_ghpr_unit_test') {
     logRotator {
-        numToKeep(1500)
+        daysToKeep(30)
     }
     parameters {
         stringParam("ghprbActualCommit")

--- a/jobs/pingcap/tidb/latest/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_build.groovy
@@ -2,8 +2,7 @@
 // For trunk and latest release branches.
 pipelineJob('pingcap/tidb/ghpr_build') {
     logRotator {
-        daysToKeep(180)
-        numToKeep(2000)
+        daysToKeep(30)
     }
     parameters {
         stringParam("ghprbActualCommit")

--- a/jobs/pingcap/tidb/latest/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_check.groovy
@@ -3,8 +3,7 @@
 pipelineJob('pingcap/tidb/ghpr_check') {
     disabled(true)
     logRotator {
-        daysToKeep(180)
-        numToKeep(1500)
+        daysToKeep(30)
     }
     parameters {
         stringParam("ghprbActualCommit")

--- a/jobs/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_check2.groovy
@@ -3,8 +3,7 @@
 pipelineJob('pingcap/tidb/ghpr_check2') {
     disabled(true)
     logRotator {
-        daysToKeep(180)
-        numToKeep(1500)
+        daysToKeep(30)
     }
     parameters {
         stringParam("ghprbActualCommit")

--- a/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -3,8 +3,7 @@
 pipelineJob('pingcap/tidb/ghpr_mysql_test') {
     disabled(true)
     logRotator {
-        daysToKeep(180)
-        numToKeep(1500)
+        daysToKeep(30)
     }
     parameters {
         stringParam("ghprbActualCommit")

--- a/jobs/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -2,7 +2,7 @@
 // For trunk and latest release branches.
 pipelineJob('pingcap/tidb/ghpr_unit_test') {
     logRotator {
-        numToKeep(1500)
+        daysToKeep(30)
     }
     parameters {
         stringParam("ghprbActualCommit")


### PR DESCRIPTION
* currently tidb ci generates 1500 build histories per week, we need to keep history for 1 month.