### PR TITLE
tidb mergeci: tics test failed on ksyun due to cpu num logic

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_tics_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_tics_test.groovy
@@ -45,7 +45,7 @@ metadata:
 
 def run(label, Closure body) {
     podTemplate(name: label, label: label, 
-        cloud: "kubernetes-ksyun", 
+        cloud: "kubernetes-ng", 
         yaml: podYAML,
         yamlMergeStrategy: merge(),
         namespace: "jenkins-tidb-mergeci", instanceCap: 20,


### PR DESCRIPTION
* tics test fail due to cpu nums diff between node and pod, so we adjust cluster back to original