### PR TITLE
tidb verifyci: remove trigger command /merge

### DIFF
--- a/jenkins/jobs/ci/tidb/ghpr_build.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_build.groovy
@@ -16,7 +16,7 @@ pipelineJob('tidb_ghpr_build') {
                     cron('H/5 * * * *')
                     gitHubAuthId('8b25795b-a680-4dce-9904-89ef40d73159')
 
-                    triggerPhrase('.*/(merge|run-(all-tests|build).*)')
+                    triggerPhrase('.*/(run-(all-tests|build).*)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jenkins/jobs/ci/tidb/ghpr_check.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_check.groovy
@@ -16,7 +16,7 @@ pipelineJob('tidb_ghpr_check') {
                     cron('H/5 * * * *')
                     gitHubAuthId('8b25795b-a680-4dce-9904-89ef40d73159')
 
-                    triggerPhrase('^.*/(merge|run-(all-tests|check[-_]dev))\\b')
+                    triggerPhrase('^.*/(run-(all-tests|check[-_]dev))\\b')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jenkins/jobs/ci/tidb/ghpr_check2.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_check2.groovy
@@ -16,7 +16,7 @@ pipelineJob('tidb_ghpr_check_2') {
                     cron('H/5 * * * *')
                     gitHubAuthId('8b25795b-a680-4dce-9904-89ef40d73159')
 
-                    triggerPhrase('.*/(merge|run-(all-tests|check[-_]dev[-_]?2))\\b')
+                    triggerPhrase('.*/(run-(all-tests|check[-_]dev[-_]?2))\\b')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jenkins/jobs/ci/tidb/ghpr_mysql_test.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_mysql_test.groovy
@@ -16,7 +16,7 @@ pipelineJob('tidb_ghpr_mysql_test') {
                     cron('H/5 * * * *')
                     gitHubAuthId('8b25795b-a680-4dce-9904-89ef40d73159')
 
-                    triggerPhrase('.*/(merge|run-(all-tests|mysql-test).*)')
+                    triggerPhrase('.*/(run-(all-tests|mysql-test).*)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jenkins/jobs/ci/tidb/ghpr_unit_test.groovy
+++ b/jenkins/jobs/ci/tidb/ghpr_unit_test.groovy
@@ -16,7 +16,7 @@ pipelineJob('tidb_ghpr_unit_test') {
                     cron('H/5 * * * *')
                     gitHubAuthId('8b25795b-a680-4dce-9904-89ef40d73159')
 
-                    triggerPhrase('.*/(merge|run-(all-tests|unit-test).*)')
+                    triggerPhrase('.*/(run-(all-tests|unit-test).*)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb-engine-ext/latest/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb-engine-ext/latest/ghpr_unit_test.groovy
@@ -17,7 +17,7 @@ pipelineJob('pingcap/tidb-engine-ext/ghpr_unit_test') {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
 
-                    triggerPhrase('.*/(merge|run-(all-tests|unit-test).*)')
+                    triggerPhrase('.*/(run-(all-tests|unit-test).*)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb/latest/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_build.groovy
@@ -17,7 +17,7 @@ pipelineJob('pingcap/tidb/ghpr_build') {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
 
-                    triggerPhrase('.*/(merge|run-(all-tests|build).*)')
+                    triggerPhrase('.*/(run-(all-tests|build).*)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb/latest/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_check.groovy
@@ -17,7 +17,7 @@ pipelineJob('pingcap/tidb/ghpr_check') {
                 ghprbTrigger {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
-                    triggerPhrase('^.*/(merge|run-(all-tests|check[-_]dev))\\b')
+                    triggerPhrase('^.*/(run-(all-tests|check[-_]dev))\\b')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipelineJob('pingcap/tidb/ghpr_check2') {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
 
-                    triggerPhrase('.*/(merge|run-(all-tests|check[-_]dev[-_]?2))\\b')
+                    triggerPhrase('.*/(run-(all-tests|check[-_]dev[-_]?2))\\b')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -18,7 +18,7 @@ pipelineJob('pingcap/tidb/ghpr_mysql_test') {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
 
-                    triggerPhrase('.*/(merge|run-(all-tests|mysql-test).*)')
+                    triggerPhrase('.*/(run-(all-tests|mysql-test).*)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -17,7 +17,7 @@ pipelineJob('pingcap/tidb/ghpr_unit_test') {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
 
-                    triggerPhrase('.*/(merge|run-(all-tests|unit-test).*)')
+                    triggerPhrase('.*/(run-(all-tests|unit-test).*)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb/release-6.2/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_build.groovy
@@ -18,7 +18,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_build') {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
 
-                    triggerPhrase('.*/(merge|run-(all-tests|build).*)')
+                    triggerPhrase('.*/(run-(all-tests|build).*)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb/release-6.2/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_check.groovy
@@ -18,7 +18,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_check') {
                 ghprbTrigger {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
-                    triggerPhrase('^(?=.*/(merge|run-(all-tests|check[-_]dev)))(?!.*/run-check[-_]dev[-_]?2)')
+                    triggerPhrase('^(?=.*/(run-(all-tests|check[-_]dev)))(?!.*/run-check[-_]dev[-_]?2)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_check2') {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
 
-                    triggerPhrase('.*/(merge|run-(all-tests|check[-_]dev[-_]?2))')
+                    triggerPhrase('.*/(run-(all-tests|check[-_]dev[-_]?2))')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -19,7 +19,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_mysql_test') {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
 
-                    triggerPhrase('.*/(merge|run-(all-tests|mysql-test).*)')
+                    triggerPhrase('.*/(run-(all-tests|mysql-test).*)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')

--- a/jobs/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
@@ -17,7 +17,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_unit_test') {
                     cron('H/5 * * * *')
                     gitHubAuthId('') // using the default only one.
 
-                    triggerPhrase('.*/(merge|run-(all-tests|unit-test).*)')
+                    triggerPhrase('.*/(run-(all-tests|unit-test).*)')
                     onlyTriggerPhrase(false)
                     skipBuildPhrase(".*skip-ci.*")
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')


### PR DESCRIPTION
* remove trigger command /merge for all tidb verifyci pipeline
* please use /run-all-tests or /run-your-xxx-test to trigger ci
/merge will not trigger any verifyci pipelines, only used to identify pr into the merge queue