### PR TITLE
tiflash: Only apply lint and format on master branch

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-ghpr-build.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-ghpr-build.groovy
@@ -21,12 +21,10 @@ def need_tests() {
 }
 
 def disable_lint_or_format() {
-        for (i in ['release-4.0', 'release-5.0', 'release-5.1', 'release-5.2']) {
-                if (ghprbTargetBranch.contains(i)) {
-                        return true
-                }
+        if (ghprbTargetBranch == "master") {
+                return false
         }
-        return false
+        return true
 }
 
 def parameters = [


### PR DESCRIPTION
As we upgrade the compiler version, the static lints checks and format could be changed after the compile toolchain is upgraded.
Only apply lints and format check on the master branch.

Changing `TiFlashTestBasic.cpp` in master don't raise any lint errors, but the cherry-pick to release-5.4 raise errors.
https://github.com/pingcap/tiflash/pull/5924