### PR TITLE
ci: fix wrong pod image

### DIFF
--- a/pipelines/pingcap/tidb-engine-ext/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb-engine-ext/latest/pod-ghpr_unit_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: rust
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base"
+      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
* correct image name : hub.pingcap.net/tiflash/tiflash-llvm-base:latest is not exist