### PR TITLE
tiflash: improve error notice and fix idents

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
@@ -264,18 +264,17 @@ def checkoutStage(repo_path, checkout_target) {
         dir(repo_path) {
             def cache_path = "/home/jenkins/agent/ci-cached-code-daily/src-tics.tar.gz"
             if (fileExists(cache_path)) {
-                println "get code from nfs to reduce clone time"
-                sh """
-                set +x
+                sh label: "Get code from nfs to reduce clone time", script: """
                 cp -R ${cache_path}  ./
                 tar -xzf ${cache_path} --strip-components=1
                 rm -f src-tics.tar.gz
                 chown -R 1000:1000 ./
-                set -x
                 """
             }
             checkoutTiFlash(checkout_target, true)
         }
+        sh label: "Print build information", script: """
+        set +x
         echo "Target Branch: ${params.TARGET_BRANCH}"
         echo "Target Pull Request: ${params.TARGET_PULL_REQUEST}"
         echo "Commit Hash: ${params.TARGET_COMMIT_HASH}"
@@ -290,7 +289,8 @@ def checkoutStage(repo_path, checkout_target) {
         echo "Proxy Cache Refresh: ${params.UPDATE_PROXY_CACHE}"
         echo "Format Check: ${params.ENABLE_FORMAT_CHECK}"
         echo "Static Analysis: ${params.ENABLE_STATIC_ANALYSIS}"
-
+        set -x
+        """
     }
 }
 

--- a/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
@@ -489,15 +489,15 @@ def prepareStage(repo_path) {
                     mkdir -p ~/.cargo/registry
                     mkdir -p ~/.cargo/git
                     mkdir -p /home/jenkins/agent/rust/registry/cache
-                    mkdir -p /home/jenkins/agent/rust/registry/index 
+                    mkdir -p /home/jenkins/agent/rust/registry/index
                     mkdir -p /home/jenkins/agent/rust/git/db
                     mkdir -p /home/jenkins/agent/rust/git/checkouts
-                    
+
                     rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                    rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index 
+                    rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
                     rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
                     rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-                    
+
                     rm -rf ~/.rustup/tmp
                     rm -rf ~/.rustup/toolchains
                     mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
@@ -506,7 +506,7 @@ def prepareStage(repo_path) {
                     ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
 
                     """
-                }                
+                }
             }
         )
     }
@@ -518,7 +518,7 @@ def buildClusterManage(repo_path, install_dir) {
         echo "cluster_manager is deprecated"
     } else {
         sh "cd ${repo_path}/cluster_manage && sh release.sh"
-        sh "mkdir -p ${install_dir} && cp -rf ${repo_path}/cluster_manage/dist/flash_cluster_manager ${install_dir}/flash_cluster_manager"        
+        sh "mkdir -p ${install_dir} && cp -rf ${repo_path}/cluster_manage/dist/flash_cluster_manager ${install_dir}/flash_cluster_manager"
     }
 }
 
@@ -661,7 +661,7 @@ def buildTiFlash(repo_path, build_dir, install_dir) {
         sh """
         ccache -s
         ls -lha ${install_dir}
-        """        
+        """
     }
 }
 
@@ -882,7 +882,7 @@ def run_with_pod(Closure body) {
                         image: "hub.pingcap.net/jenkins/centos7_golang-1.18.5:latest", ttyEnabled: true,
                         resourceRequestCpu: '200m', resourceRequestMemory: '1Gi',
                         command: '/bin/sh -c', args: 'cat',
-                        envVars: [containerEnvVar(key: 'GOPATH', value: '/go')]     
+                        envVars: [containerEnvVar(key: 'GOPATH', value: '/go')]
                     )
             ],
             volumes: [

--- a/jenkins/pipelines/ci/tiflash/tiflash-cache-update-multibranch.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-cache-update-multibranch.groovy
@@ -1,18 +1,22 @@
 def coverage() {
-    if (env.BRANCH_NAME.contains("release-5.2") 
+    if (env.BRANCH_NAME.contains("release-5.2")
      || env.BRANCH_NAME.contains("release-5.1")
-     || env.BRANCH_NAME.contains("release-5.0") 
-     || env.BRANCH_NAME.contains("release-4.0") 
+     || env.BRANCH_NAME.contains("release-5.0")
+     || env.BRANCH_NAME.contains("release-4.0")
      || env.BRANCH_NAME.contains("release-3.0")) {
         return false
     }
-    return true
+
+    // The coverage is not useful for each PR for now, as there is no diff information
+    // and it is just hard for the author to know how good the coverage is.
+    // Let's disable it for the moment, until we can provide more effective data.
+    return false
 }
 
 def page_tools() {
     if (env.BRANCH_NAME.contains("release-5.1")
-     || env.BRANCH_NAME.contains("release-5.0") 
-     || env.BRANCH_NAME.contains("release-4.0") 
+     || env.BRANCH_NAME.contains("release-5.0")
+     || env.BRANCH_NAME.contains("release-4.0")
      || env.BRANCH_NAME.contains("release-3.0")) {
         return false
     }

--- a/jenkins/pipelines/ci/tiflash/tiflash-ghpr-build.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-ghpr-build.groovy
@@ -12,43 +12,43 @@
 // ])
 
 def need_tests() {
-        for (i in ['release-4.0']) {
-                if (ghprbTargetBranch.contains(i)) {
-                        return true
-                }
+    for (i in ['release-4.0']) {
+        if (ghprbTargetBranch.contains(i)) {
+            return true
         }
-        return false
+    }
+    return false
 }
 
 def disable_lint_or_format() {
-        if (ghprbTargetBranch == "master") {
-                return false
-        }
-        return true
+    if (ghprbTargetBranch == "master") {
+        return false
+    }
+    return true
 }
 
 def parameters = [
-        string(name: "ARCH", value: "amd64"),
-        string(name: "OS", value: "linux"),
-        string(name: "CMAKE_BUILD_TYPE", value: "Debug"),
-        string(name: "TARGET_BRANCH", value: ghprbTargetBranch),
-        string(name: "TARGET_PULL_REQUEST", value: ghprbPullId),
-        string(name: "TARGET_COMMIT_HASH", value: ghprbActualCommit),
-        [$class: 'BooleanParameterValue', name: 'BUILD_TIFLASH', value: true],
-        [$class: 'BooleanParameterValue', name: 'BUILD_PAGE_TOOLS', value: false],
-        [$class: 'BooleanParameterValue', name: 'BUILD_TESTS', value: need_tests()],
-        [$class: 'BooleanParameterValue', name: 'ENABLE_CCACHE', value: true],
-        [$class: 'BooleanParameterValue', name: 'ENABLE_PROXY_CACHE', value: true],
-        [$class: 'BooleanParameterValue', name: 'UPDATE_CCACHE', value: false],
-        [$class: 'BooleanParameterValue', name: 'UPDATE_PROXY_CACHE', value: false],
-        [$class: 'BooleanParameterValue', name: 'ENABLE_STATIC_ANALYSIS', value: !disable_lint_or_format()],
-        [$class: 'BooleanParameterValue', name: 'ENABLE_FORMAT_CHECK', value: !disable_lint_or_format()],
-        [$class: 'BooleanParameterValue', name: 'ENABLE_COVERAGE', value: false],
-        [$class: 'BooleanParameterValue', name: 'PUSH_MESSAGE', value: false],
-        [$class: 'BooleanParameterValue', name: 'DEBUG_WITHOUT_DEBUG_INFO', value: true],
-        [$class: 'BooleanParameterValue', name: 'ARCHIVE_ARTIFACTS', value: true],
-        [$class: 'BooleanParameterValue', name: 'ENABLE_FAILPOINTS', value: true],
-    ]
+    string(name: "ARCH", value: "amd64"),
+    string(name: "OS", value: "linux"),
+    string(name: "CMAKE_BUILD_TYPE", value: "Debug"),
+    string(name: "TARGET_BRANCH", value: ghprbTargetBranch),
+    string(name: "TARGET_PULL_REQUEST", value: ghprbPullId),
+    string(name: "TARGET_COMMIT_HASH", value: ghprbActualCommit),
+    [$class: 'BooleanParameterValue', name: 'BUILD_TIFLASH', value: true],
+    [$class: 'BooleanParameterValue', name: 'BUILD_PAGE_TOOLS', value: false],
+    [$class: 'BooleanParameterValue', name: 'BUILD_TESTS', value: need_tests()],
+    [$class: 'BooleanParameterValue', name: 'ENABLE_CCACHE', value: true],
+    [$class: 'BooleanParameterValue', name: 'ENABLE_PROXY_CACHE', value: true],
+    [$class: 'BooleanParameterValue', name: 'UPDATE_CCACHE', value: false],
+    [$class: 'BooleanParameterValue', name: 'UPDATE_PROXY_CACHE', value: false],
+    [$class: 'BooleanParameterValue', name: 'ENABLE_STATIC_ANALYSIS', value: !disable_lint_or_format()],
+    [$class: 'BooleanParameterValue', name: 'ENABLE_FORMAT_CHECK', value: !disable_lint_or_format()],
+    [$class: 'BooleanParameterValue', name: 'ENABLE_COVERAGE', value: false],
+    [$class: 'BooleanParameterValue', name: 'PUSH_MESSAGE', value: false],
+    [$class: 'BooleanParameterValue', name: 'DEBUG_WITHOUT_DEBUG_INFO', value: true],
+    [$class: 'BooleanParameterValue', name: 'ARCHIVE_ARTIFACTS', value: true],
+    [$class: 'BooleanParameterValue', name: 'ENABLE_FAILPOINTS', value: true],
+]
 
 
 def run_with_pod(Closure body) {
@@ -56,22 +56,22 @@ def run_with_pod(Closure body) {
     def cloud = "kubernetes-ng"
     def namespace = "jenkins-tiflash"
     podTemplate(label: label,
-            cloud: cloud,
-            namespace: namespace,
-            idleMinutes: 0,
-            containers: [
-                    containerTemplate(
-                        name: 'golang', alwaysPullImage: true,
-                        image: "hub.pingcap.net/jenkins/centos7_golang-1.18.5:latest", ttyEnabled: true,
-                        resourceRequestCpu: '200m', resourceRequestMemory: '1Gi',
-                        command: '/bin/sh -c', args: 'cat',
-                        envVars: [containerEnvVar(key: 'GOPATH', value: '/go')]     
-                    )
-            ],
+        cloud: cloud,
+        namespace: namespace,
+        idleMinutes: 0,
+        containers: [
+            containerTemplate(
+                name: 'golang', alwaysPullImage: true,
+                image: "hub.pingcap.net/jenkins/centos7_golang-1.18.5:latest", ttyEnabled: true,
+                resourceRequestCpu: '200m', resourceRequestMemory: '1Gi',
+                command: '/bin/sh -c', args: 'cat',
+                envVars: [containerEnvVar(key: 'GOPATH', value: '/go')]
+            )
+        ],
             volumes: [
-                    emptyDirVolume(mountPath: '/tmp', memory: false),
-                    emptyDirVolume(mountPath: '/home/jenkins', memory: false)
-                    ],
+            emptyDirVolume(mountPath: '/tmp', memory: false),
+            emptyDirVolume(mountPath: '/home/jenkins', memory: false)
+        ],
     ) {
         node(label) {
             println "debug command:\nkubectl -n ${namespace} exec -ti ${NODE_NAME} bash"
@@ -86,51 +86,52 @@ def taskFinishTime = System.currentTimeMillis()
 resultDownloadPath = ""
 
 try {
-run_with_pod {
+    run_with_pod {
         stage('Build') {
-                def built = build(
-                                job: "tiflash-build-common",
-                                wait: true,
-                                propagate: false,
-                                parameters: parameters
-                        )
-                echo "built at: https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/${built.number}/pipeline"
-                if (built.getResult() != 'SUCCESS') {
-                        error "build failed"
-                }
+            def built = build(
+                job: "tiflash-build-common",
+                wait: true,
+                propagate: false,
+                parameters: parameters
+            )
+            if (built.getResult() != 'SUCCESS') {
+                error "Build failed, see: https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/${built.number}/pipeline"
+            } else {
+                echo "Built at: https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/${built.number}/pipeline"
+            }
         }
-}
-        currentBuild.result = "SUCCESS"
+    }
+    currentBuild.result = "SUCCESS"
 } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {
     currentBuild.result = "ABORTED"
     echo "${e}"
 } catch (Exception e) {
     currentBuild.result = "FAILURE"
     echo "${e}"
-} finally { 
+} finally {
     stage("upload-pipeline-data") {
         taskFinishTime = System.currentTimeMillis()
         build job: 'upload-pipelinerun-data',
-            wait: false,
-            parameters: [
-                    [$class: 'StringParameterValue', name: 'PIPELINE_NAME', value: "${JOB_NAME}"],
-                    [$class: 'StringParameterValue', name: 'PIPELINE_RUN_URL', value: "${RUN_DISPLAY_URL}"],
-                    [$class: 'StringParameterValue', name: 'REPO', value: "pingcap/tiflash"],
-                    [$class: 'StringParameterValue', name: 'COMMIT_ID', value: ghprbActualCommit],
-                    [$class: 'StringParameterValue', name: 'TARGET_BRANCH', value: ghprbTargetBranch],
-                    [$class: 'StringParameterValue', name: 'JUNIT_REPORT_URL', value: resultDownloadPath],
-                    [$class: 'StringParameterValue', name: 'PULL_REQUEST', value: ghprbPullId],
-                    [$class: 'StringParameterValue', name: 'PULL_REQUEST_AUTHOR', value: params.getOrDefault("ghprbPullAuthorLogin", "default")],
-                    [$class: 'StringParameterValue', name: 'JOB_TRIGGER', value: params.getOrDefault("ghprbPullAuthorLogin", "default")],
-                    [$class: 'StringParameterValue', name: 'TRIGGER_COMMENT_BODY', value: params.getOrDefault("ghprbCommentBody", "default")],
-                    [$class: 'StringParameterValue', name: 'JOB_RESULT_SUMMARY', value: ""],
-                    [$class: 'StringParameterValue', name: 'JOB_START_TIME', value: "${taskStartTimeInMillis}"],
-                    [$class: 'StringParameterValue', name: 'JOB_END_TIME', value: "${taskFinishTime}"],
-                    [$class: 'StringParameterValue', name: 'POD_READY_TIME', value: ""],
-                    [$class: 'StringParameterValue', name: 'CPU_REQUEST', value: "2000m"],
-                    [$class: 'StringParameterValue', name: 'MEMORY_REQUEST', value: "8Gi"],
-                    [$class: 'StringParameterValue', name: 'JOB_STATE', value: currentBuild.result],
-                    [$class: 'StringParameterValue', name: 'JENKINS_BUILD_NUMBER', value: "${BUILD_NUMBER}"],
+        wait: false,
+        parameters: [
+            [$class: 'StringParameterValue', name: 'PIPELINE_NAME', value: "${JOB_NAME}"],
+            [$class: 'StringParameterValue', name: 'PIPELINE_RUN_URL', value: "${RUN_DISPLAY_URL}"],
+            [$class: 'StringParameterValue', name: 'REPO', value: "pingcap/tiflash"],
+            [$class: 'StringParameterValue', name: 'COMMIT_ID', value: ghprbActualCommit],
+            [$class: 'StringParameterValue', name: 'TARGET_BRANCH', value: ghprbTargetBranch],
+            [$class: 'StringParameterValue', name: 'JUNIT_REPORT_URL', value: resultDownloadPath],
+            [$class: 'StringParameterValue', name: 'PULL_REQUEST', value: ghprbPullId],
+            [$class: 'StringParameterValue', name: 'PULL_REQUEST_AUTHOR', value: params.getOrDefault("ghprbPullAuthorLogin", "default")],
+            [$class: 'StringParameterValue', name: 'JOB_TRIGGER', value: params.getOrDefault("ghprbPullAuthorLogin", "default")],
+            [$class: 'StringParameterValue', name: 'TRIGGER_COMMENT_BODY', value: params.getOrDefault("ghprbCommentBody", "default")],
+            [$class: 'StringParameterValue', name: 'JOB_RESULT_SUMMARY', value: ""],
+            [$class: 'StringParameterValue', name: 'JOB_START_TIME', value: "${taskStartTimeInMillis}"],
+            [$class: 'StringParameterValue', name: 'JOB_END_TIME', value: "${taskFinishTime}"],
+            [$class: 'StringParameterValue', name: 'POD_READY_TIME', value: ""],
+            [$class: 'StringParameterValue', name: 'CPU_REQUEST', value: "2000m"],
+            [$class: 'StringParameterValue', name: 'MEMORY_REQUEST', value: "8Gi"],
+            [$class: 'StringParameterValue', name: 'JOB_STATE', value: currentBuild.result],
+            [$class: 'StringParameterValue', name: 'JENKINS_BUILD_NUMBER', value: "${BUILD_NUMBER}"],
         ]
     }
 }

--- a/jenkins/pipelines/ci/tiflash/tiflash-ghpr-unit-tests.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-ghpr-unit-tests.groovy
@@ -168,9 +168,10 @@ run_with_pod {
                 propagate: false,
                 parameters: parameters
             )
-            echo "built at: https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/${task.number}/pipeline"
-            if (task.getResult() != 'SUCCESS') {
-                error "build failed"
+            if (built.getResult() != 'SUCCESS') {
+                error "Build failed, see: https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/${task.number}/pipeline"
+            } else {
+                echo "Built at: https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/${task.number}/pipeline"
             }
             built = task.number
         } else {

--- a/jenkins/pipelines/ci/tiflash/tiflash-ghpr-unit-tests.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-ghpr-unit-tests.groovy
@@ -16,6 +16,7 @@ def coverage() {
     // Let's disable it for the moment, until we can provide more effective data.
     return false
 }
+
 def page_tools() {
     if (ghprbTargetBranch.contains("release-5.1")
      || ghprbTargetBranch.contains("release-5.0")
@@ -25,6 +26,7 @@ def page_tools() {
     }
     return true
 }
+
 def IDENTIFIER = "tiflash-ut-${ghprbTargetBranch}-${ghprbPullId}-${BUILD_NUMBER}"
 def parameters = [
     string(name: "ARCH", value: "amd64"),


### PR DESCRIPTION
1. When build failed, will show a link pointing the build URL inline. Sometimes BlueOcean does not show the Trigger Build, and this could be helpful.
2. Fixed idents for some scripts. (If you want to view diff, please diff without whitespace)
3. Disable coverage in the unit test phase, as currently it does not work well. We can enable it later when the efficiency can be improved by running it in the post PR stage and providing more detailed coverages.
4. Adjusted unit test CPU request from 10c to 12c, since our test concurrency is set to 12. Also changed the limit from 20c to 12c, because 12c should be enough. (this limit change may be reverted later, if we really incur some problems)