### PR TITLE
tiflash: fix trigger tiflash-build-common error

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-ghpr-unit-tests.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-ghpr-unit-tests.groovy
@@ -170,7 +170,7 @@ run_with_pod {
                 propagate: false,
                 parameters: parameters
             )
-            if (built.getResult() != 'SUCCESS') {
+            if (task.getResult() != 'SUCCESS') {
                 error "Build failed, see: https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/${task.number}/pipeline"
             } else {
                 echo "Built at: https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/${task.number}/pipeline"


### PR DESCRIPTION
* fix trigger downstream pipeline with error 
```shell
Cannot invoke method getResult() on null object
```