### PR TITLE
ci(tiflow): update make engine script

### DIFF
--- a/jenkins/pipelines/ci/ticdc/engine_ghpr_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/engine_ghpr_integration_test.groovy
@@ -309,7 +309,7 @@ run_with_pod {
                     cd go/src/github.com/pingcap/tiflow
                     git config --global --add safe.directory /home/jenkins/agent/workspace/engine_ghpr_integration_test/go/src/github.com/pingcap/tiflow
                     git log | head
-                    make engine
+                    make tiflow tiflow-demo
                     touch ./bin/tiflow-chaos-case
                     make engine_image_from_local
                     docker tag ${ENGINE_TEST_TAG} hub.pingcap.net/tiflow/engine:${imageTag}


### PR DESCRIPTION
ref: https://github.com/pingcap/tiflow/pull/7377

Tiflow will simplify binaries that are built from `make engine`.

Replace `make engine` with `make tiflow tiflow-demo`