### PR TITLE
ticdc: remove nfs go module cache

### DIFF
--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
@@ -371,17 +371,12 @@ catchError {
                                     image: "${POD_GO_IMAGE}", ttyEnabled: true,
                                     resourceRequestCpu: '2000m', resourceRequestMemory: '12Gi',
                                     command: '/bin/sh -c', args: 'cat',
-                                    envVars: [containerEnvVar(key: 'GOMODCACHE', value: '/nfs/cache/mod'),
-                                                containerEnvVar(key: 'GOPATH', value: '/go')],
+                                    envVars: [containerEnvVar(key: 'GOPATH', value: '/go')],
                             ),
                     ],
                     volumes: [
                             nfsVolume(mountPath: '/home/jenkins/agent/ci-cached-code-daily', serverAddress: '172.16.5.22',
                                     serverPath: '/mnt/ci.pingcap.net-nfs/git', readOnly: false),
-                            nfsVolume(mountPath: '/nfs/cache', serverAddress: '172.16.5.22',
-                                    serverPath: '/mnt/ci.pingcap.net-nfs', readOnly: false),
-                            nfsVolume(mountPath: '/go/pkg', serverAddress: '172.16.5.22',
-                                    serverPath: '/mnt/ci.pingcap.net-nfs/gopath/pkg', readOnly: false),
                             emptyDirVolume(mountPath: '/tmp', memory: true),
                             emptyDirVolume(mountPath: '/home/jenkins', memory: true)
                     ],


### PR DESCRIPTION
The nfs service is not stable enough and can affect Pipeline tasks