### PR TITLE
feat(jobs): using `BUILD_URL` to set git status

### DIFF
--- a/jobs/pingcap/tidb-engine-ext/latest/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb-engine-ext/latest/ghpr_unit_test.groovy
@@ -55,7 +55,7 @@ pipelineJob('pingcap/tidb-engine-ext/ghpr_unit_test') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext('pull-unit-test')
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus('')
                             triggeredStatus('')
                             addTestResults(false)

--- a/jobs/pingcap/tidb/latest/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_build.groovy
@@ -55,7 +55,7 @@ pipelineJob('pingcap/tidb/ghpr_build') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/build")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/latest/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_check.groovy
@@ -53,7 +53,7 @@ pipelineJob('pingcap/tidb/ghpr_check') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/check_dev")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_check2.groovy
@@ -55,7 +55,7 @@ pipelineJob('pingcap/tidb/ghpr_check2') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/check_dev_2")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -55,7 +55,7 @@ pipelineJob('pingcap/tidb/ghpr_mysql_test') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/mysql-test")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -55,7 +55,7 @@ pipelineJob('pingcap/tidb/ghpr_unit_test') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext('idc-jenkins-ci-tidb/unit-test')
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus('')
                             triggeredStatus('')
                             addTestResults(false)

--- a/jobs/pingcap/tidb/release-6.2/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_build.groovy
@@ -53,7 +53,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_build') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/build")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/release-6.2/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_check.groovy
@@ -51,7 +51,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_check') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/check_dev")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -53,7 +53,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_check2') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/check_dev_2")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -53,7 +53,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_mysql_test') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/mysql-test")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
@@ -53,7 +53,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_unit_test') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext('idc-jenkins-ci-tidb/unit-test')
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus('')
                             triggeredStatus('')
                             addTestResults(false)

--- a/jobs/pingcap/tidb/release-6.3/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_build.groovy
@@ -53,7 +53,7 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_build') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/build")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/release-6.3/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_check.groovy
@@ -51,7 +51,7 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_check') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/check_dev")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -53,7 +53,7 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_check2') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/check_dev_2")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
@@ -53,7 +53,7 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_mysql_test') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/mysql-test")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)

--- a/jobs/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
@@ -53,7 +53,7 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_unit_test') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext('idc-jenkins-ci-tidb/unit-test')
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus('')
                             triggeredStatus('')
                             addTestResults(false)

--- a/staging/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/staging/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -54,7 +54,7 @@ pipelineJob('pingcap/tidb/ghpr_mysql_test') {
                         ghprbCancelBuildsOnUpdate { overrideGlobal(true) }
                         ghprbSimpleStatus {
                             commitStatusContext("idc-jenkins-ci-tidb/mysql-test")
-                            statusUrl('${RUN_DISPLAY_URL}')
+                            statusUrl('${BUILD_URL}')
                             startedStatus("")
                             triggeredStatus("")
                             addTestResults(false)


### PR DESCRIPTION
why:
- build url is faster than run display url.
- identified problems list in build page, some error can not display in blue ocean.