### PR TITLE
ticdc: use specific tidb master commit hash for integration tests

### DIFF
--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -329,6 +329,11 @@ def download_binaries() {
 
     println "debug command:\nkubectl -n jenkins-ci exec -ti ${NODE_NAME} bash"
     def tidb_sha1 = sh(returnStdout: true, script: "curl -f ${FILE_SERVER_URL}/download/refs/pingcap/tidb/${TIDB_BRANCH}/sha1").trim()
+    if (ghprbTargetBranch == "master") {
+        // releated to https://github.com/pingcap/tiflow/issues/7409
+        // TODO: remove this after release-6.4 branch created
+        tidb_sha1 = "9743a9a2d2c626acbd7e13d4693cca9c58f329b7"
+    }
     def tikv_sha1 = sh(returnStdout: true, script: "curl -f ${FILE_SERVER_URL}/download/refs/pingcap/tikv/${TIKV_BRANCH}/sha1").trim()
     def pd_sha1 = sh(returnStdout: true, script: "curl -f ${FILE_SERVER_URL}/download/refs/pingcap/pd/${PD_BRANCH}/sha1").trim()
     def tiflash_sha1 = TIFLASH_COMMIT


### PR DESCRIPTION
releated to https://github.com/pingcap/tiflow/issues/7409

tidb pr https://github.com/pingcap/tidb/pull/38243 introduced an incompatible change which may be fixed by https://github.com/pingcap/tiflow/pull/7410.  So we need temporarily lock the tidb version to a commit (master branch)

replay test link
https://ci2.pingcap.net/blue/organizations/jenkins/cdc_ghpr_integration_test/detail/cdc_ghpr_integration_test/16257/pipeline/131/