### PR TITLE
fix(pipelines/pingcap/tidb): fix report steps

### DIFF
--- a/jenkins/pipelines/nightly/tidb/tidb_nightly_unit_test.groovy
+++ b/jenkins/pipelines/nightly/tidb/tidb_nightly_unit_test.groovy
@@ -159,7 +159,7 @@ try {
                             grep  "\${package_base}/expression/" packages.list >> packages.list.short
                             echo  "\${package_base}/expression" > packages_race_12
                             grep "\${package_base}/planner/core" packages.list.short > packages_race_6
-                            grep "\${package_base}/store/tikv" packages.list.short > packages_race_5 | true #store/tikv is removed from master
+                            grep "\${package_base}/store/tikv" packages.list.short > packages_race_5 || true #store/tikv is removed from master
                             grep "\${package_base}/server" packages.list.short > packages_race_4
 
                             cat packages.list.short | grep -v "\${package_base}/planner/core" | grep -v "\${package_base}/store/tikv" | grep -v "\${package_base}/server" > packages.list.short.1

--- a/jenkins/pipelines/utf-ci/utf-go-test.groovy
+++ b/jenkins/pipelines/utf-ci/utf-go-test.groovy
@@ -5,7 +5,7 @@ def main(image, targetName) {
             if (params.MANIFEST) {
                 writeFile(file: params.MANIFEST_FILE, text: params.MANIFEST)
             } else {
-                sh("cp /*.libsonnet ./ | true")
+                sh("cp /*.libsonnet ./ || true")
                 sh("cp /*.jsonnet ./")
             }
 

--- a/pipelines/pingcap/tidb/latest/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_build.groovy
@@ -169,7 +169,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/latest/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check.groovy
@@ -95,7 +95,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {                
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -176,7 +176,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {                
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -143,7 +143,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -102,7 +102,7 @@ pipeline {
             container('report') {
                 sh """
                     junitUrl="\${FILE_SERVER_URL}/download/tipipeline/test/report/\${JOB_NAME}/\${BUILD_NUMBER}/\${ghprbActualCommit}/report.xml"
-                    bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json "\${junitUrl}" | true
+                    bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json "\${junitUrl}" || true
                 """
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_build.groovy
@@ -170,7 +170,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check.groovy
@@ -96,7 +96,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {                
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -177,7 +177,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {                
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -144,7 +144,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
@@ -103,7 +103,7 @@ pipeline {
             container('report') {
                 sh """
                     junitUrl="\${FILE_SERVER_URL}/download/tipipeline/test/report/\${JOB_NAME}/\${BUILD_NUMBER}/\${ghprbActualCommit}/report.xml"
-                    bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json "\${junitUrl}" | true
+                    bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json "\${junitUrl}" || true
                 """
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_build.groovy
@@ -169,7 +169,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check.groovy
@@ -95,7 +95,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {                
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -176,7 +176,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {                
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
@@ -143,7 +143,7 @@ pipeline {
         // TODO(wuhuizuo): put into container lifecyle preStop hook.
         always {
             container('report') {
-                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json | true"
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
@@ -102,7 +102,7 @@ pipeline {
             container('report') {
                 sh """
                     junitUrl="\${FILE_SERVER_URL}/download/tipipeline/test/report/\${JOB_NAME}/\${BUILD_NUMBER}/\${ghprbActualCommit}/report.xml"
-                    bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json "\${junitUrl}" | true
+                    bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json "\${junitUrl}" || true
                 """
             }
             archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)


### PR DESCRIPTION
why: should perfer to `|| true` rather than `| true`