### PR TITLE
ci: refactor tidb_ghpr_integration_cdc_test pipeline

### DIFF
--- a/scripts/pingcap/tiflow/ticdc_integration_test_download_dependency.sh
+++ b/scripts/pingcap/tiflow/ticdc_integration_test_download_dependency.sh
@@ -10,23 +10,25 @@ pd_branch=$3
 tiflash_branch=$4
 file_server_url=$5
 
-tikv_sha1_url=""
-pd_sha1_url=""
-tiflash_sha1_url=""
+tikv_sha1_url="${file_server_url}/download/refs/pingcap/tikv/${pd_branch}/sha1"
+pd_sha1_url="${file_server_url}/download/refs/pingcap/pd/${tikv_branch}/sha1"
+tiflash_sha1_url="${file_server_url}/download/refs/pingcap/tiflash/${tiflash_branch}/sha1"
 
-pd_sha1=""
-tikv_sha1=""
-tiflash_sha1=""
+pd_sha1=$(curl "$pd_sha1_url")
+tikv_sha1=$(curl "$tikv_sha1_url")
+tiflash_sha1=$(curl "$tiflash_sha1_url")
 
-pd_download_url=""
-tikv_download_url=""
-tiflash_download_url=""
+# download pd / tikv / tiflash binary build from tibuid multibranch pipeline
+pd_download_url="${file_server_url}/download/builds/pingcap/pd/${pd_sha1}/centos7/pd-server.tar.gz"
+tikv_download_url="${file_server_url}/download/builds/pingcap/tikv/${tikv_sha1}/centos7/tikv-server.tar.gz"
+tiflash_download_url="${file_server_url}/download/builds/pingcap/tiflash/${tiflash_branch}/${tiflash_sha1}/centos7/tiflash.tar.gz"
 
-sync_diff_url=""
-minio_url=""
-go_ycsb_url=""
-etcd_url=""
-jq_url=""
+# download some dependencies tool binary from file server
+sync_diff_url="${file_server_url}/download/builds/pingcap/cdc/sync_diff_inspector_hash-00998a9a_linux-amd64.tar.gz"
+minio_url="${file_server_url}/download/minio.tar.gz"
+go_ycsb_url="${file_server_url}/download/builds/pingcap/go-ycsb/test-br/go-ycsb"
+etcd_url="${file_server_url}/download/builds/pingcap/cdc/etcd-v3.4.7-linux-amd64.tar.gz"
+jq_url="${file_server_url}/download/builds/pingcap/test/jq-1.6/jq-linux64"
 
 function download() {
     local url=$1
@@ -41,6 +43,30 @@ function download() {
 }
 
 function main() { 
+    rm -rf third_bin
+    rm -rf tmp
+    mkdir third_bin
+    mkdir tmp
+    download "$pd_download_url" "pd-server.tar.gz" "tmp/pd-server.tar.gz"
+    tar -xz -C third_bin bin/* -f tmp/pd-server.tar.gz && mv third_bin/bin/* third_bin/
+    download "$tikv_download_url" "tikv-server.tar.gz" "tmp/tikv-server.tar.gz"
+    tar -xz -C third_bin bin/tikv-server  -f tmp/tikv-server.tar.gz && mv third_bin/bin/tikv-server third_bin/
+    download "$tiflash_download_url" "tiflash.tar.gz" "tmp/tiflash.tar.gz"
+    tar -xz -C third_bin -f tmp/tiflash.tar.gz
+    mv third_bin/tiflash third_bin/_tiflash
+    mv third_bin/_tiflash/* third_bin && rm -rf third_bin/_tiflash
 
-
+    download "$sync_diff_url" "sync_diff_inspector.tar.gz" "tmp/sync_diff_inspector.tar.gz"
+    tar -xz -C third_bin -f tmp/sync_diff_inspector.tar.gz
+    download "$minio_url" "minio.tar.gz" "tmp/minio.tar.gz"
+    tar -xz -C third_bin -f tmp/minio.tar.gz
+    download "$go_ycsb_url" "go-ycsb" "third_bin/go-ycsb"
+    download "$etcd_url" "etcd.tar.gz" "tmp/etcd.tar.gz"
+    tar -xz -C third_bin  etcd-v3.4.7-linux-amd64/etcdctl  -f tmp/etcd.tar.gz
+    mv third_bin/etcd-v3.4.7-linux-amd64/etcdctl third_bin/ && rm -rf third_bin/etcd-v3.4.7-linux-amd64
+    download "$jq_url" "jq" "third_bin/jq"
+    chmod +x third_bin/*
+    ls -alh third_bin/
 }
+
+main "$@"

--- a/scripts/pingcap/tiflow/ticdc_integration_test_download_dependency.sh
+++ b/scripts/pingcap/tiflow/ticdc_integration_test_download_dependency.sh
@@ -1,0 +1,46 @@
+
+
+#! /usr/bin/env bash
+
+set -eu
+
+target_branch=$1
+tikv_branch=$2
+pd_branch=$3
+tiflash_branch=$4
+file_server_url=$5
+
+tikv_sha1_url=""
+pd_sha1_url=""
+tiflash_sha1_url=""
+
+pd_sha1=""
+tikv_sha1=""
+tiflash_sha1=""
+
+pd_download_url=""
+tikv_download_url=""
+tiflash_download_url=""
+
+sync_diff_url=""
+minio_url=""
+go_ycsb_url=""
+etcd_url=""
+jq_url=""
+
+function download() {
+    local url=$1
+    local file_name=$2
+    local file_path=$3
+    if [[ -f "${file_path}" ]]; then
+        echo "file ${file_name} already exists, skip download"
+        return
+    fi
+    echo "download ${file_name} from ${url}"
+    curl -C - --retry 3 -f -L -o "${file_path}" "${url}"
+}
+
+function main() { 
+
+
+}

--- a/staging/jobs/pingcap/tidb/latest/merged_integration_cdc_test.groovy
+++ b/staging/jobs/pingcap/tidb/latest/merged_integration_cdc_test.groovy
@@ -5,14 +5,14 @@ pipelineJob('pingcap/tidb/tidb_merged_integration_cdc_test') {
     }
     parameters {
         stringParam("ghprbActualCommit")
-        stringParam("ghprbPullId")
+        stringParam("ghprbTargetBranch")
     }
     properties {
         // priority(0) // 0 fast than 1
         githubProjectUrl("https://github.com/pingcap/tidb")
         pipelineTriggers {
             triggers {
-                gigthubPush { }
+                gigthubPush {}
             }
         }
     }
@@ -20,7 +20,7 @@ pipelineJob('pingcap/tidb/tidb_merged_integration_cdc_test') {
     definition {
         cpsScm {
             lightweight(true)
-            scriptPath('jenkins/pipelines/ci/tidb/tidb_merged_integration_cdc_test.groovy')
+            scriptPath('staging/pipelines/pingcap/tidb/latest/tidb_merged_integration_cdc_test.groovy')
             scm {
                 git{
                     remote {

--- a/staging/jobs/pingcap/tidb/latest/merged_integration_cdc_test.groovy
+++ b/staging/jobs/pingcap/tidb/latest/merged_integration_cdc_test.groovy
@@ -1,0 +1,35 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+pipelineJob('pingcap/tidb/tidb_merged_integration_cdc_test') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("ghprbActualCommit")
+        stringParam("ghprbPullId")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tidb")
+        pipelineTriggers {
+            triggers {
+                gigthubPush { }
+            }
+        }
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath('jenkins/pipelines/ci/tidb/tidb_merged_integration_cdc_test.groovy')
+            scm {
+                git{
+                    remote {
+                        url('git@github.com:PingCAP-QE/ci.git')
+                        credentials('github-sre-bot-ssh')
+                    }
+                    branch('main')
+                }
+            }
+        }
+    }
+}

--- a/staging/pipelines/pingcap/tidb/latest/merged_integration_cdc_test.groovy
+++ b/staging/pipelines/pingcap/tidb/latest/merged_integration_cdc_test.groovy
@@ -47,7 +47,7 @@ pipeline {
                         retry(2) {
                             checkout(
                                 changelog: false,
-                                poll: false,
+                                poll: true,
                                 scm: [
                                     $class: 'GitSCM', branches: [[name: ghprbActualCommit]],
                                     doGenerateSubmoduleConfigurations: false,
@@ -55,6 +55,7 @@ pipeline {
                                         [$class: 'PruneStaleBranch'],
                                         [$class: 'CleanBeforeCheckout'],
                                         [$class: 'CloneOption', timeout: 15],
+                                        [$class: 'PreBuildMerge', options: [mergeRemote: 'origin', mergeTarget: 'master']],
                                     ],
                                     submoduleCfg: [],
                                     userRemoteConfigs: [[

--- a/staging/pipelines/pingcap/tidb/latest/merged_integration_cdc_test.groovy
+++ b/staging/pipelines/pingcap/tidb/latest/merged_integration_cdc_test.groovy
@@ -1,0 +1,166 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master and latest release branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final POD_TEMPLATE_FILE = 'staging/pipelines/pingcap/tidb/latest/pod-merged_integration_cdc_test.yaml'
+
+// TODO(wuhuizuo): tidb-test should delivered by docker image.
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 40, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 5, unit: 'MINUTES') }
+            steps {
+                dir("tidb") {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${ghprbActualCommit}", restoreKeys: ['git/pingcap/tidb/rev-']) {
+                        retry(2) {
+                            checkout(
+                                changelog: false,
+                                poll: false,
+                                scm: [
+                                    $class: 'GitSCM', branches: [[name: ghprbActualCommit]],
+                                    doGenerateSubmoduleConfigurations: false,
+                                    extensions: [
+                                        [$class: 'PruneStaleBranch'],
+                                        [$class: 'CleanBeforeCheckout'],
+                                        [$class: 'CloneOption', timeout: 15],
+                                    ],
+                                    submoduleCfg: [],
+                                    userRemoteConfigs: [[
+                                        refspec: "+refs/heads/*:refs/remotes/origin/*",
+                                        url: "https://github.com/${GIT_FULL_REPO_NAME}.git",
+                                    ]],
+                                ]
+                            )
+                        }
+                    }
+                }
+                dir("tiflow") {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${ghprbBranch}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                        retry(2) {
+                            checkout(
+                                changelog: false,
+                                poll: false,
+                                scm: [
+                                    $class: 'GitSCM', branches: [[name: ghprbBranch ]],
+                                    doGenerateSubmoduleConfigurations: false,
+                                    extensions: [
+                                        [$class: 'PruneStaleBranch'],
+                                        [$class: 'CleanBeforeCheckout'],
+                                        [$class: 'CloneOption', timeout: 15],
+                                    ],
+                                    submoduleCfg: [],
+                                    userRemoteConfigs: [[
+                                        refspec: "+refs/heads/*:refs/remotes/origin/*",
+                                        url: "https://github.com/tiflow.git",
+                                    ]],
+                                ]
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir('tidb') {
+                    cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${ghprbActualCommit}") {
+                        // FIXME: https://github.com/pingcap/tidb-test/issues/1987
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -race -o bin/tidb-server ./tidb-server'
+                    }
+                }
+                dir('tiflow') {
+                    sh "git branch && git status"
+                    cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                        sh 'touch ws-${BUILD_TAG}'
+                        sh label: 'prepare cdc binary', script: """
+                        make cdc
+                        make integration_test_build
+                        make kafka_consumer
+                        make check_failpoint_ctl
+                        ls bin/
+                        """
+                        sh ""
+                    }
+                }
+            }
+        }
+        stage('MySQL Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'CASES'
+                        values '1', '2', '3', '4'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        defaultContainer 'golang'
+                        yamlFile POD_TEMPLATE_FILE
+                    }
+                }
+                stages {
+                    stage("Test") {
+                        options { timeout(time: 25, unit: 'MINUTES') }
+                        steps {
+                            dir('tidb') {
+                                cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${ghprbActualCommit}") {
+                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                                }
+                            }
+                            dir('tiflow') {
+                                cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                    dir('mysql_test') {
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server CACHE_ENABLED=${CACHE_ENABLED} ./test.sh -backlist=1 -part=${PART}'
+                                    }
+                                }
+                            }
+                        }
+                        post{
+                            always {
+                                junit(testResults: "**/result.xml")
+                            }
+                            failure {
+                                archiveArtifacts(artifacts: 'mysql-test.out*', allowEmptyArchive: true)
+                            }
+                        }
+                    }
+                }
+            }        
+        }
+    }
+
+}

--- a/staging/pipelines/pingcap/tidb/latest/merged_integration_cdc_test.groovy
+++ b/staging/pipelines/pingcap/tidb/latest/merged_integration_cdc_test.groovy
@@ -5,6 +5,7 @@
 
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final GIT_BRANCH = 'master'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'staging/pipelines/pingcap/tidb/latest/pod-merged_integration_cdc_test.yaml'
 
@@ -43,13 +44,13 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${ghprbActualCommit}", restoreKeys: ['git/pingcap/tidb/rev-']) {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${GIT_BRANCH}", restoreKeys: ['git/pingcap/tidb/rev-']) {
                         retry(2) {
                             checkout(
                                 changelog: false,
                                 poll: true,
                                 scm: [
-                                    $class: 'GitSCM', branches: [[name: ghprbActualCommit]],
+                                    $class: 'GitSCM', branches: [[name: GIT_BRANCH ]],
                                     doGenerateSubmoduleConfigurations: false,
                                     extensions: [
                                         [$class: 'PruneStaleBranch'],
@@ -96,7 +97,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${ghprbActualCommit}") {
+                    cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${GIT_BRANCH}") {
                         // FIXME: https://github.com/pingcap/tidb-test/issues/1987
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -race -o bin/tidb-server ./tidb-server'
                     }
@@ -136,7 +137,7 @@ pipeline {
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
-                                cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${ghprbActualCommit}") {
+                                cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${GIT_BRANCH}") {
                                     sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
                                 }
                             }

--- a/staging/pipelines/pingcap/tidb/latest/pod-merged_integration_cdc_test.yaml
+++ b/staging/pipelines/pingcap/tidb/latest/pod-merged_integration_cdc_test.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 12Gi
+          cpu: "2"
+        limits:
+          memory: 16Gi
+          cpu: "r"
+      env:
+        - name: GOPATH
+          value: /share/.go
+        - name: GOCACHE
+          value: /share/.cache/go-build
+      volumeMounts:
+        - name: gocache
+          mountPath: /share/.cache/go-build
+        - name: gopathcache
+          mountPath: /share/.go
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  volumes:
+    - name: gopathcache
+      persistentVolumeClaim:
+        claimName: gopathcache
+    - name: gocache
+      persistentVolumeClaim:
+        claimName: gocache

--- a/staging/pipelines/pingcap/tidb/latest/pod-merged_integration_cdc_test.yaml
+++ b/staging/pipelines/pingcap/tidb/latest/pod-merged_integration_cdc_test.yaml
@@ -13,7 +13,7 @@ spec:
           cpu: "2"
         limits:
           memory: 16Gi
-          cpu: "r"
+          cpu: "4"
       env:
         - name: GOPATH
           value: /share/.go


### PR DESCRIPTION
The current pipeline has the following problems, making it very difficult to maintain and carefully adjust the pipeline
* Some Groovy handles a lot of test-related logic that has nothing to do with ci orchestration
* One script is compatible with multiple branches
* A lot of versioning logic has been added to the script

A newcomer has difficulty modifying the assembly line on his own, So let's refactor these complex historical pipelines and use cdc's pipeline for a refactoring demonstration.
* Make the pipeline jobdsl
* Make the groovy simple and less
* Different branches maintain different pipelines
* Some dependency logic needs to be migrated from groovy to the shell script

