### PR TITLE
fix(tidb): make mergeci more stable

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_e2e_tests.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_e2e_tests.groovy
@@ -157,11 +157,13 @@ try {
                                     pd_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/\${pd_sha1}/centos7/pd-server.tar.gz"
 
 
-                                    while ! curl --output /dev/null --silent --head --fail \${tikv_url}; do sleep 1; done
-                                    curl \${tikv_url} | tar xz bin
+                                    while ! curl --output /dev/null --silent --head --fail \${tikv_url}; do sleep 10; done
+                                    wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${tikv_url}
+                                    tar -xvz bin/ -f tikv-server.tar.gz && rm -rf tikv-server.tar.gz
 
-                                    while ! curl --output /dev/null --silent --head --fail \${pd_url}; do sleep 1; done
-                                    curl \${pd_url} | tar xz bin
+                                    while ! curl --output /dev/null --silent --head --fail \${pd_url}; do sleep 10; done
+                                    wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${pd_url}
+                                    tar -xvz bin/ -f pd-server.tar.gz && rm -rf pd-server.tar.gz 
                                     ls -lhrt ./bin
                                     make
                                     ls -lhrt ./bin

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_campatibility_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_campatibility_test.groovy
@@ -212,20 +212,25 @@ try {
                         timeout(10) {
                             sh """
                             while ! curl --output /dev/null --silent --head --fail ${tikv_url}; do sleep 15; done
-                            curl ${tikv_url} | tar xz
+                            wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  ${tikv_url}
+                            tar -xvz bin/ -f tikv-server.tar.gz && rm -rf tikv-server.tar.gz
 
                             while ! curl --output /dev/null --silent --head --fail ${pd_url}; do sleep 15; done
-                            curl ${pd_url} | tar xz
+                            wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  ${pd_url}
+                            tar -xvz bin/ -f pd-server.tar.gz && rm -rf pd-server.tar.gz
 
                             mkdir -p ./tidb-old-src
                             echo ${tidb_old_url}
                             echo ${tidb_old_refs}
                             while ! curl --output /dev/null --silent --head --fail ${tidb_old_url}; do sleep 15; done
-                            curl ${tidb_old_url} | tar xz -C ./tidb-old-src
+                            wget -O old-tidb-server.tar.gz -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  ${tidb_old_url}
+                            tar -xz -C ./tidb-old-src -f old-tidb-server.tar.gz && rm -rf old-tidb-server.tar.gz
 
                             mkdir -p ./tidb-src
                             while ! curl --output /dev/null --silent --head --fail ${tidb_done_url}; do sleep 1; done
-                            curl ${tidb_url} | tar xz -C ./tidb-src
+                            wget -O tidb-server.tar.gz -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  ${tidb_url}
+                            tar -xz -C ./tidb-src -f tidb-server.tar.gz && rm -rf tidb-server.tar.gz
+
 
                             mv tidb-old-src/bin/tidb-server bin/tidb-server-old
                             mv tidb-src/bin/tidb-server ./bin/tidb-server

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_common_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_common_test.groovy
@@ -434,10 +434,10 @@ try {
 	                            pd_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/\${pd_sha1}/centos7/pd-server.tar.gz"
 	
 	                            while ! curl --output /dev/null --silent --head --fail \${tikv_url}; do sleep 15; done
-	                            curl \${tikv_url} | tar xz
+	                            curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail  \${tikv_url} | tar xz
 	
 	                            while ! curl --output /dev/null --silent --head --fail \${pd_url}; do sleep 15; done
-	                            curl \${pd_url} | tar xz
+	                            curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail \${pd_url} | tar xz
 	
 	                            mkdir -p ./tidb-src
 	                            while ! curl --output /dev/null --silent --head --fail ${tidb_done_url}; do sleep 15; done

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_common_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_common_test.groovy
@@ -345,14 +345,17 @@ try {
 	
 	
 	                            while ! curl --output /dev/null --silent --head --fail \${tikv_url}; do sleep 1; done
-	                            curl \${tikv_url} | tar xz bin
+                                wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${tikv_url}
+                                tar -xvz bin/ -f tikv-server.tar.gz && rm -rf tikv-server.tar.gz
 	
 	                            while ! curl --output /dev/null --silent --head --fail \${pd_url}; do sleep 1; done
-	                            curl \${pd_url} | tar xz bin
+                                wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 \${pd_url}
+                                tar -xvz bin/ -f pd-server.tar.gz && rm -rf pd-server.tar.gz 
 	
 	                            mkdir -p ./tidb-src
 	                            while ! curl --output /dev/null --silent --head --fail ${tidb_done_url}; do sleep 1; done
-	                            curl ${tidb_url} | tar xz -C ./tidb-src
+                                wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 ${tidb_url} 
+                                tar -xz -C ./tidb-src -f tidb-server.tar.gz
 	                            ln -s \$(pwd)/tidb-src "${ws}/go/src/github.com/pingcap/tidb"
 	
 	                            mv tidb-src/bin/tidb-server ./bin/tidb-server
@@ -434,14 +437,17 @@ try {
 	                            pd_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/\${pd_sha1}/centos7/pd-server.tar.gz"
 	
 	                            while ! curl --output /dev/null --silent --head --fail \${tikv_url}; do sleep 15; done
-	                            curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail  \${tikv_url} | tar xz
+                                wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${tikv_url}
+	                            tar -xvz bin/ -f tikv-server.tar.gz && rm -rf tikv-server.tar.gz
 	
 	                            while ! curl --output /dev/null --silent --head --fail \${pd_url}; do sleep 15; done
-	                            curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail \${pd_url} | tar xz
+                                wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${pd_url}
+	                            tar -xvz bin/ -f pd-server.tar.gz && rm -rf pd-server.tar.gz 
 	
 	                            mkdir -p ./tidb-src
 	                            while ! curl --output /dev/null --silent --head --fail ${tidb_done_url}; do sleep 15; done
-	                            curl ${tidb_url} | tar xz -C ./tidb-src
+	                            wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 ${tidb_url} 
+                                tar -xz -C ./tidb-src -f tidb-server.tar.gz
 	                            ln -s \$(pwd)/tidb-src "${ws}/go/src/github.com/pingcap/tidb"
 	
 	                            mv tidb-src/bin/tidb-server ./bin/tidb-server

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_ddl_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_ddl_test.groovy
@@ -260,17 +260,17 @@ try {
                             pd_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/\${pd_sha1}/centos7/pd-server.tar.gz"
 
                             while ! curl --output /dev/null --silent --head --fail \${tidb_test_url}; do sleep 10; done
-                            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 \${tidb_test_url}
+                            wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 \${tidb_test_url}
                             tar -xvz  -f tidb-test.tar.gz
 
                             cd ${test_dir}
 
                             while ! curl --output /dev/null --silent --head --fail \${tikv_url}; do sleep 10; done
-                            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${tikv_url}
+                            wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${tikv_url}
                             tar -xvz bin/ -f tikv-server.tar.gz && rm -rf tikv-server.tar.gz
 
                             while ! curl --output /dev/null --silent --head --fail \${pd_url}; do sleep 10; done
-                            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${pd_url}
+                            wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${pd_url}
                             tar -xvz bin/ -f pd-server.tar.gz && rm -rf pd-server.tar.gz 
 
                             mkdir -p ${dir}/../tidb/

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_ddl_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_ddl_test.groovy
@@ -260,15 +260,15 @@ try {
                             pd_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/\${pd_sha1}/centos7/pd-server.tar.gz"
 
                             while ! curl --output /dev/null --silent --head --fail \${tidb_test_url}; do sleep 10; done
-                            curl \${tidb_test_url} | tar xz
+                            curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail  \${tidb_test_url} | tar xz
 
                             cd ${test_dir}
 
                             while ! curl --output /dev/null --silent --head --fail \${tikv_url}; do sleep 10; done
-                            curl \${tikv_url} | tar xz
+                            curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail  \${tikv_url} | tar xz
 
                             while ! curl --output /dev/null --silent --head --fail \${pd_url}; do sleep 10; done
-                            curl \${pd_url} | tar xz
+                            curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail  \${pd_url} | tar xz
 
                             mkdir -p ${dir}/../tidb/
                             curl \${tidb_tar_url} | tar -xf - -C ${dir}/../

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_ddl_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_integration_ddl_test.groovy
@@ -260,15 +260,18 @@ try {
                             pd_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/\${pd_sha1}/centos7/pd-server.tar.gz"
 
                             while ! curl --output /dev/null --silent --head --fail \${tidb_test_url}; do sleep 10; done
-                            curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail  \${tidb_test_url} | tar xz
+                            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 \${tidb_test_url}
+                            tar -xvz  -f tidb-test.tar.gz
 
                             cd ${test_dir}
 
                             while ! curl --output /dev/null --silent --head --fail \${tikv_url}; do sleep 10; done
-                            curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail  \${tikv_url} | tar xz
+                            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${tikv_url}
+                            tar -xvz bin/ -f tikv-server.tar.gz && rm -rf tikv-server.tar.gz
 
                             while ! curl --output /dev/null --silent --head --fail \${pd_url}; do sleep 10; done
-                            curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail  \${pd_url} | tar xz
+                            wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0  \${pd_url}
+                            tar -xvz bin/ -f pd-server.tar.gz && rm -rf pd-server.tar.gz 
 
                             mkdir -p ${dir}/../tidb/
                             curl \${tidb_tar_url} | tar -xf - -C ${dir}/../

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_sqllogic_test_1.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_sqllogic_test_1.groovy
@@ -72,7 +72,7 @@ def run_with_pod(Closure body) {
                     containerTemplate(
                             name: 'golang', alwaysPullImage: false,
                             image: "${POD_GO_IMAGE}", ttyEnabled: true,
-                            resourceRequestCpu: '2000m', resourceRequestMemory: '4Gi',
+                            resourceRequestCpu: '4000m', resourceRequestMemory: '4Gi',
                             command: '/bin/sh -c', args: 'cat',
                             envVars: [containerEnvVar(key: 'GOPATH', value: '/go')],  
                     )

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_sqllogic_test_2.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_sqllogic_test_2.groovy
@@ -73,7 +73,7 @@ def run_with_pod(Closure body) {
                     containerTemplate(
                             name: 'golang', alwaysPullImage: false,
                             image: "${POD_GO_IMAGE}", ttyEnabled: true,
-                            resourceRequestCpu: '2000m', resourceRequestMemory: '4Gi',
+                            resourceRequestCpu: '4000m', resourceRequestMemory: '4Gi',
                             command: '/bin/sh -c', args: 'cat',
                             envVars: [containerEnvVar(key: 'GOPATH', value: '/go')],  
                     )


### PR DESCRIPTION
* add retry to download file, avoid errors caused by interrupted downloads
* increase request CPU for sqllogic test, avoid 5000 timeout error

replay test link
1. https://ci.pingcap.net/blue/organizations/jenkins/tidb_ghpr_integration_common_test/detail/tidb_ghpr_integration_common_test/13558/pipeline/176/
2. https://ci.pingcap.net/blue/organizations/jenkins/tidb_ghpr_integration_ddl_test/detail/tidb_ghpr_integration_ddl_test/12060/pipeline/
3. https://ci.pingcap.net/blue/organizations/jenkins/tidb_ghpr_integration_campatibility_test/detail/tidb_ghpr_integration_campatibility_test/12695/pipeline/