### PR TITLE
feat(tiflow): cdc and dm 6.1 use go1.19

### DIFF
--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_integration_test.groovy
@@ -93,7 +93,7 @@ resultDownloadPath = ""
 def selectGoVersion(branchNameOrTag) {
     if (branchNameOrTag.startsWith("v")) {
         println "This is a tag"
-        if (branchNameOrTag >= "v6.3") {
+        if (branchNameOrTag >= "v6.1") {
             println "tag ${branchNameOrTag} use go 1.19"
             return "go1.19"
         }
@@ -135,7 +135,7 @@ def selectGoVersion(branchNameOrTag) {
         }
 
 
-        if (branchNameOrTag.startsWith("release-") && branchNameOrTag >= "release-6.3") {
+        if (branchNameOrTag.startsWith("release-") && branchNameOrTag >= "release-6.1") {
             println("branchNameOrTag: ${branchNameOrTag}  use go1.19")
             return "go1.19"
         }

--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_kafka_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_kafka_integration_test.groovy
@@ -68,7 +68,7 @@ resultDownloadPath = ""
 def selectGoVersion(branchNameOrTag) {
     if (branchNameOrTag.startsWith("v")) {
         println "This is a tag"
-        if (branchNameOrTag >= "v6.3") {
+        if (branchNameOrTag >= "v6.1") {
             println "tag ${branchNameOrTag} use go 1.19"
             return "go1.19"
         }
@@ -110,7 +110,7 @@ def selectGoVersion(branchNameOrTag) {
         }
 
 
-        if (branchNameOrTag.startsWith("release-") && branchNameOrTag >= "release-6.3") {
+        if (branchNameOrTag.startsWith("release-") && branchNameOrTag >= "release-6.1") {
             println("branchNameOrTag: ${branchNameOrTag}  use go1.19")
             return "go1.19"
         }

--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_leak_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_leak_test.groovy
@@ -41,7 +41,7 @@ resultDownloadPath = ""
 
 node("master") {
     deleteDir()
-    def goversion_lib_url = 'https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/pipelines/goversion-select-lib.groovy'
+    def goversion_lib_url = 'https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/pipelines/ci/tidb/goversion-select-lib.groovy'
     sh "curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail ${goversion_lib_url}"
     def goversion_lib = load('goversion-select-lib.groovy')
     GO_VERSION = goversion_lib.selectGoVersion(ghprbTargetBranch)

--- a/jenkins/pipelines/ci/ticdc/cdc_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/cdc_ghpr_test.groovy
@@ -29,7 +29,7 @@ resultDownloadPath = ""
 
 node("master") {
     deleteDir()
-    def goversion_lib_url = 'https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/pipelines/goversion-select-lib.groovy'
+    def goversion_lib_url = 'https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/pipelines/ci/tidb/goversion-select-lib.groovy'
     sh "curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail ${goversion_lib_url}"
     def goversion_lib = load('goversion-select-lib.groovy')
     GO_VERSION = goversion_lib.selectGoVersion(ghprbTargetBranch)

--- a/jenkins/pipelines/ci/ticdc/dm_ghpr_compatibility_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/dm_ghpr_compatibility_test.groovy
@@ -84,7 +84,7 @@ resultDownloadPath = ""
 
 node("master") {
     deleteDir()
-    def goversion_lib_url = 'https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/pipelines/goversion-select-lib.groovy'
+    def goversion_lib_url = 'https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/pipelines/ci/tidb/goversion-select-lib.groovy'
     sh "curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail ${goversion_lib_url}"
     def goversion_lib = load('goversion-select-lib.groovy')
     GO_VERSION = goversion_lib.selectGoVersion(ghprbTargetBranch)

--- a/jenkins/pipelines/ci/ticdc/dm_ghpr_integration_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/dm_ghpr_integration_test.groovy
@@ -105,7 +105,7 @@ POD_NAMESPACE = "jenkins-dm"
 
 node("master") {
     deleteDir()
-    def goversion_lib_url = 'https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/pipelines/goversion-select-lib.groovy'
+    def goversion_lib_url = 'https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/pipelines/ci/tidb/goversion-select-lib.groovy'
     sh "curl -O --retry 3 --retry-delay 5 --retry-connrefused --fail ${goversion_lib_url}"
     def goversion_lib = load('goversion-select-lib.groovy')
     GO_VERSION = goversion_lib.selectGoVersion(ghprbTargetBranch)


### PR DESCRIPTION
branch equals and greater than release-6.1 use go1.19

replay with go1.19 image test link

1. https://ci2.pingcap.net/job/dm_ghpr_compatibility_test/8882/console