### PR TITLE
fix: add mysql-test pipeline for hotfix branch

### DIFF
--- a/jobs/pingcap/tidb/release-6.1-202211124/aa_folder.groovy
+++ b/jobs/pingcap/tidb/release-6.1-202211124/aa_folder.groovy
@@ -1,0 +1,3 @@
+folder('pingcap/tidb/release-6.1-20221124') {
+    description("Folder for pipelines of pingcap/tidb repo for release-6.1-20221124-v6.1.2")
+}

--- a/jobs/pingcap/tidb/release-6.1-202211124/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.1-202211124/ghpr_mysql_test.groovy
@@ -23,9 +23,6 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_mysql_test') {
                     whitelist('')
                     orgslist('')
                     whiteListTargetBranches {
-                        ghprbBranch { branch('^(release-)?6\\.1(\\.\\d+)?(\\-.*)?$') }
-                    }
-                    blackListTargetBranches {
                         ghprbBranch { branch('^release-6.1-20221124-v6.1.2$') }
                     }
                     // ignore when only those file changed.(
@@ -70,7 +67,7 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_mysql_test') {
     definition {
         cpsScm {
             lightweight(true)
-            scriptPath("pipelines/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy")
+            scriptPath("pipelines/pingcap/tidb/release-6.1-20221124/ghpr_mysql_test.groovy")
             scm {
                 git{
                     remote {

--- a/pipelines/pingcap/tidb/release-6.1-20221124/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1-20221124/ghpr_mysql_test.groovy
@@ -1,0 +1,122 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for release-6.2.x branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1-20221124/pod-ghpr_mysql_test.yaml'
+
+// TODO(wuhuizuo): tidb-test should delivered by docker image.
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 40, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 5, unit: 'MINUTES') }
+            steps {
+                dir("tidb") {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${ghprbActualCommit}", restoreKeys: ['git/pingcap/tidb/rev-']) {
+                        retry(2) {
+                            checkout(
+                                changelog: false,
+                                poll: false,
+                                scm: [
+                                    $class: 'GitSCM', branches: [[name: ghprbActualCommit]],
+                                    doGenerateSubmoduleConfigurations: false,
+                                    extensions: [
+                                        [$class: 'PruneStaleBranch'],
+                                        [$class: 'CleanBeforeCheckout'],
+                                        [$class: 'CloneOption', timeout: 15],
+                                    ],
+                                    submoduleCfg: [],
+                                    userRemoteConfigs: [[
+                                        refspec: "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*",
+                                        url: "https://github.com/${GIT_FULL_REPO_NAME}.git",
+                                    ]],
+                                ]
+                            )
+                        }
+                    }
+                }
+                dir("tidb-test") {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb-test/rev-${ghprbActualCommit}", restoreKeys: ['git/pingcap/tidb-test/rev-']) {
+                        retry(2) {
+                            script {
+                                component.checkout('git@github.com:pingcap/tidb-test.git', 'tidb-test', ghprbTargetBranch, ghprbCommentBody, GIT_CREDENTIALS_ID)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir('tidb') {
+                    cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${ghprbActualCommit}") {
+                        // FIXME: https://github.com/pingcap/tidb-test/issues/1987
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
+                    }
+                }
+                dir('tidb-test') {
+                    sh "git branch && git status"
+                }
+            }
+        }
+        stage('MySQL Tests') {
+            options { timeout(time: 25, unit: 'MINUTES') }
+            steps {
+                dir('tidb-test') {
+                    cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                        sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                        dir('mysql_test') {
+                            sh label: "mysql test", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh'
+                        }
+                    }
+                }
+            }
+            post{
+                failure {
+                    archiveArtifacts(artifacts: 'mysql-test.out*', allowEmptyArchive: true)
+                }
+            }
+     
+        }
+    }
+    post {
+        // TODO(wuhuizuo): put into container lifecyle preStop hook.
+        always {
+            container('report') {
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
+            }
+            archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/release-6.1-20221124/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.1-20221124/pod-ghpr_mysql_test.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.18:latest"
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        requests:
+          memory: 4Gi
+          cpu: "2"
+        limits:
+          memory: 6Gi
+          cpu: "3"
+      env:
+        - name: GOPATH
+          value: /share/.go
+        - name: GOCACHE
+          value: /share/.cache/go-build
+      volumeMounts:
+        - name: gocache
+          mountPath: /share/.cache/go-build
+        - name: gopathcache
+          mountPath: /share/.go
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  volumes:
+    - name: gopathcache
+      persistentVolumeClaim:
+        claimName: gopathcache
+    - name: gocache
+      persistentVolumeClaim:
+        claimName: gocache


### PR DESCRIPTION
hotfix branch release-6.1-20221124-v6.1.2 mysql-test need use go1.18 , create one pipeline for this branch