### PR TITLE
fix: remove useless archive

### DIFF
--- a/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
@@ -80,12 +80,6 @@ pipeline {
                 }
             }
             post {
-                unsuccessful {
-                    dir('tidb') {
-                        archiveArtifacts(artifacts: '**/core.*', allowEmptyArchive: true)
-                        archiveArtifacts(artifacts: '**/*.test.bin', allowEmptyArchive: true)
-                    }
-                }
                 always {
                     dir('tidb') {
                         // archive test report to Jenkins.


### PR DESCRIPTION
remove useless archive to avoid wasting disk space