### PR TITLE
fix: shell syntax var define

### DIFF
--- a/jenkins/pipelines/cd/tidb-operator.groovy
+++ b/jenkins/pipelines/cd/tidb-operator.groovy
@@ -10,7 +10,7 @@ def EnableE2E = false
 final CHART_ITEMS = 'tidb-operator tidb-cluster tidb-backup tidb-drainer tidb-lightning tikv-importer'
 final TOOLS_BUILD_DIR = 'output/tkctl'
 final CHARTS_BUILD_DIR = 'output/chart'
-final K8S_CLUSTER = "kubernetes-ng"
+final K8S_CLUSTER = "kubernetes"
 final K8S_NAMESPACE="jenkins-tidb-operator"
 
 final dindYaml = '''

--- a/jenkins/pipelines/cd/tidb-operator.groovy
+++ b/jenkins/pipelines/cd/tidb-operator.groovy
@@ -122,9 +122,6 @@ pipeline {
                         stage("checkout") {
                             steps {
                                 script {
-                                    sh '''curl -O http://fileserver.pingcap.net/download/tmp/tidb-operator.tar.gz
-                                          tar -xzf tidb-operator.tar.gz
-                                          rm tidb-operator.tar.gz'''
                                     def scmVars = checkout changelog: false, poll: false, scm: [
                                             $class           : 'GitSCM',
                                             branches         : [[name: "${params.GitRef}"]],
@@ -160,7 +157,7 @@ pipeline {
                                                 continue
                                             }
                                             sh """
-                                            TKCTL_CLI_PACKAGE = "tkctl-${OS}-${ARCH}-${ReleaseTag}"
+                                            TKCTL_CLI_PACKAGE="tkctl-${OS}-${ARCH}-${ReleaseTag}"
                                             GOOS=${OS} GOARCH=${ARCH} make cli
                                             tar -czf ${TOOLS_BUILD_DIR}/\${TKCTL_CLI_PACKAGE}.tgz tkctl
                                             sha256sum ${TOOLS_BUILD_DIR}/\${TKCTL_CLI_PACKAGE}.tgz > ${TOOLS_BUILD_DIR}/\${TKCTL_CLI_PACKAGE}.sha256
@@ -399,7 +396,7 @@ pipeline {
                                                 continue
                                             }
                                             sh """
-                                                TKCTL_CLI_PACKAGE = "tkctl-${OS}-${ARCH}-${ReleaseTag}"
+                                                TKCTL_CLI_PACKAGE="tkctl-${OS}-${ARCH}-${ReleaseTag}"
                                                 cd ${TOOLS_BUILD_DIR}
                                                 upload_qiniu.py \${TKCTL_CLI_PACKAGE}.tgz \${TKCTL_CLI_PACKAGE}.tgz
                                                 upload_qiniu.py \${TKCTL_CLI_PACKAGE}.sha256 \${TKCTL_CLI_PACKAGE}.sha256


### PR DESCRIPTION
## Why
```
TKCTL_CLI_PACKAGE = tkctl-linux-amd64-v1.4.0-alpha.3
[2022-11-30T11:04:14.445Z] /home/jenkins/agent/workspace/release-tidb-operator@tmp/durable-c70c2321/script.sh: line 2: TKCTL_CLI_PACKAGE: command not found
```

## How
fix shell script syntax

Signed-off-by: lijie <lijie@pingcap.com>