### PR TITLE
fix(build): only build dm for version v5.3.0+

### DIFF
--- a/jenkins/pipelines/cd/optimization-libs.groovy
+++ b/jenkins/pipelines/cd/optimization-libs.groovy
@@ -230,7 +230,13 @@ def parallel_enterprise_docker(arch, if_release, if_multi_arch) {
         build_enterprise_image("tiflash", TIFLASH_HASH, arch, if_release, if_multi_arch)
     }
 
-    retagProducts = ["tidb-lightning", "tidb-binlog", "ticdc", "br", "dumpling", "ng-monitoring", "dm", "tidb-monitor-initializer"]
+    retagProducts = ["tidb-lightning", "tidb-binlog", "ticdc", "br", "dumpling", "tidb-monitor-initializer"]
+    if (RELEASE_TAG >= "v5.3.0") {
+        // build ng-monitoring only for v5.3.0+
+        // build dm only for v5.3.0+
+        retagProducts.add("ng-monitoring")
+        retagProducts.add("dm")
+    }
     for (item in retagProducts) {
         def product = item
         builds["Push ${product} Docker"] = {

--- a/jenkins/pipelines/cd/pre-release-community-docker.groovy
+++ b/jenkins/pipelines/cd/pre-release-community-docker.groovy
@@ -411,7 +411,13 @@ def release_docker(releaseRepos, builds, arch) {
 
 
 def manifest_multiarch_image() {
-    def imageNames = ["dumpling", "br", "ticdc", "tidb-binlog", "tiflash", "tidb", "tikv", "pd", "tidb-monitor-initializer", "dm", "tidb-lightning", "ng-monitoring"]
+    def imageNames = ["dumpling", "br", "ticdc", "tidb-binlog", "tiflash", "tidb", "tikv", "pd", "tidb-monitor-initializer", "tidb-lightning"]
+    if (RELEASE_TAG >= "v5.3.0") {
+        // build ng-monitoring only for v5.3.0+
+        // build dm only for v5.3.0+
+        imageNames.add("ng-monitoring")
+        imageNames.add("dm")
+    }
     def manifest_multiarch_builds = [:]
     for (imageName in imageNames) {
         def image = imageName

--- a/jenkins/pipelines/cd/pre-release-community-docker.groovy
+++ b/jenkins/pipelines/cd/pre-release-community-docker.groovy
@@ -439,10 +439,12 @@ def manifest_multiarch_image() {
 stage("release") {
     node("${GO_BUILD_SLAVE}") {
         container("golang") {
-            releaseRepos = ["dumpling", "br", "ticdc", "tidb-binlog", "tiflash", "tidb", "tikv", "pd", "monitoring", "dm"]
+            releaseRepos = ["dumpling", "br", "ticdc", "tidb-binlog", "tiflash", "tidb", "tikv", "pd", "monitoring"]
             if (RELEASE_TAG >= "v5.3.0") {
                 // build ng-monitoring only for v5.3.0+
+                // build dm only for v5.3.0+
                 releaseRepos.add("ng-monitoring")
+                releaseRepos.add("dm")
             }
             builds = [:]
             release_docker(releaseRepos, builds, "amd64")
@@ -468,7 +470,13 @@ if (NEED_MULTIARCH) {
                 manifest_multiarch_image()
             }
             stage("sync community image to dockerhub") {
-                def imageNames = ["dumpling", "br", "ticdc", "tidb-binlog", "tiflash", "tidb", "tikv", "pd", "tidb-monitor-initializer", "dm", "tidb-lightning", "ng-monitoring"]
+                def imageNames = ["dumpling", "br", "ticdc", "tidb-binlog", "tiflash", "tidb", "tikv", "pd", "tidb-monitor-initializer", "tidb-lightning"]
+                if (RELEASE_TAG >= "v5.3.0") {
+                    // build ng-monitoring only for v5.3.0+
+                    // build dm only for v5.3.0+
+                    imageNames.add("ng-monitoring")
+                    imageNames.add("dm")
+                }
                 def builds = [:]
                 for (imageName in imageNames) {
                     def image = imageName


### PR DESCRIPTION
dm migrate from pincap/dm into pingcap/tiflow from v5.3.0, so only build dm for version v5.3.0+