### PR TITLE
fix: add GOPROXY for tiflow docker build

### DIFF
--- a/jenkins/pipelines/cd/tiflow-docker.groovy
+++ b/jenkins/pipelines/cd/tiflow-docker.groovy
@@ -6,7 +6,7 @@ metadata:
   namespace: jenkins-cd
 spec:
   containers:
-  - name: dockerd
+  - name: docker
     image: docker:dind
     args: ["--registry-mirror=https://registry-mirror.pingcap.net"]
     env:
@@ -24,12 +24,6 @@ spec:
         command: ["docker", "info"]
       initialDelaySeconds: 10
       failureThreshold: 6
-  - name: docker
-    image: docker
-    command: ["sleep", "infinity"]
-    env:
-    - name: DOCKER_HOST
-      value: tcp://localhost:2375
 '''
 
 def GitHash = ''


### PR DESCRIPTION
# WHY
build tiflow usually report connection reset when connectting to goproxy
# How
Add GOPROXY in Dockerfile
Signed-off-by: lijie <lijie@pingcap.com>