### PR TITLE
feat(scripts/ops): add ut duration statics script

### DIFF
--- a/scripts/ops/get-topn-longest-cases.ts
+++ b/scripts/ops/get-topn-longest-cases.ts
@@ -1,0 +1,62 @@
+import * as flags from "https://deno.land/std/flags/mod.ts";
+import * as path from "https://deno.land/std/path/mod.ts";
+import { format } from "https://deno.land/std@0.170.0/path/win32.ts";
+import {
+  Direction,
+  ISortOptions,
+  SortService,
+} from "https://deno.land/x/sort@v1.1.1/mod.ts";
+
+/**
+ * typescript style guide: https://google.github.io/styleguide/tsguide.html
+ */
+
+interface cliParams {
+  buildUrl: string;
+  topN?: number;
+}
+
+async function main({ buildUrl, topN = 10 }: cliParams) {
+  const reportUrl = path.join(buildUrl, "testReport/api/json");
+  const report = await (await fetch(reportUrl)).json();
+  const cases: any[] = [];
+
+  report.suites.forEach((suite: { cases: any[] }) => {
+    suite.cases.forEach(({ className, name, duration }) =>
+      cases.push({ className, name, duration })
+    );
+  });
+
+  const sortOptions: ISortOptions[] = [
+    { fieldName: "duration", direction: Direction.DESCENDING },
+  ];
+
+  const sortedCases = SortService.sort(cases, sortOptions);
+  console.log(`total count: ${sortedCases.length}`);
+  console.log(
+    `P50: <=${sortedCases[Math.floor(sortedCases.length * 0.5)]["duration"]}`,
+  );
+  console.log(
+    `P80: <=${sortedCases[Math.floor(sortedCases.length * 0.2)]["duration"]}`,
+  );
+  console.log(
+    `P90: <=${sortedCases[Math.floor(sortedCases.length * 0.1)]["duration"]}`,
+  );
+  console.log(
+    `P95: <=${sortedCases[Math.floor(sortedCases.length * 0.05)]["duration"]}`,
+  );
+  console.log(
+    `P99: <=${sortedCases[Math.floor(sortedCases.length * 0.01)]["duration"]}`,
+  );
+  console.log("-------------------");
+
+  sortedCases.slice(0, topN).forEach(
+    ({ className, name, duration }) => {
+      console.log(className, name, duration);
+    },
+  );
+}
+
+const cliArgs = flags.parse(Deno.args) as cliParams;
+await main(cliArgs);
+console.log("~~~~~~~~~~~end~~~~~~~~~~~~~~");


### PR DESCRIPTION
## run example

get top100 longest cases in a build
```shell
deno run --allow-all scripts/ops/get-topn-longest-cases.ts --buildUrl=https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/11588 --topN=100
```

output:
```log
total count: 7961
P50: <=2.31
P80: <=5.55
P90: <=29.18
P95: <=40
P99: <=190
-------------------
expression TestDoubleRow2Vec 960
mathutil TestStrLenOfUint64Fast 930
mathutil TestStrLenOfUint64Fast/RandomInput 930
gcworker TestGCWithPendingTxn 860
cpuprofile TestParallelCPUProfiler 830
sessionstates TestVerifyToken 810
streamhelper_test TestRegionIterator/case#2 770
copr TestConsistentHash 730
gcworker TestGCLabelRules 730
tikv TestScanSampleStep 730
expression TestDoubleVec2Row 720
gcworker TestSetServiceSafePoint 700
owner TestCluster 680
streamhelper_test TestIntegration 670
schematracker TestNoNumLimit 660
gcworker TestRunDistGCJobAPI 630
lightning TestHTTPAPIOutsideServerMode 610
restore TestDoChecksumWithTikv 600
stmtstats Test_SetupCloseAggregator 600
server TestPacketIORead 560
restore TestTruncate2 550
expression TestEvalExpr 550
export TestBuildRegionQueriesWithoutPartition 520
export TestListPolicyNames 520
export TestPickupPossibleField 520
export TestSelectTiDBRowID 520
selection TestSelectionWithRandomCase 520
lightning TestGetDeleteTask 510
storage TestSendCreds 510
restore TestTruncate3 490
expression TestVectorizedCastStringAsDecimalWithUnsignedFlagInUnion 450
owner TestSingle 450
statistics TestMergeCMSketch4IncrementalAnalyze 450
restore TestTruncate1 440
streamhelper_test TestRegionIterator/case#4 430
iter_test TestParTrans 430
helper TestHotRegion 420
config_test TestContextCancel 410
executor TestSortSpillDisk 410
statistics TestStatistics/SubTestBuild 410
cophandler TestClosureExecutor 410
config_test TestNormalPushPop 400
lockstore TestMemStore 380
statistics TestDistributedWeightedSampling 360
export TestBuildOrderByClause 350
expression TestMockVecPlusIntParallel 350
lockstore TestReplace 350
restore TestTableRestoreSuite 330
reporter TestCollectAndSendBatch 330
local TestLocalIngestLoop 320
restore TestGetTSWithRetry/PD_leader_switch_successfully 310
restore TestSetSpeedLimit 310
export TestBuildSelectField 310
reporter TestCollectCapacity 310
daemon_test TestDaemon 300
session TestAmendCollectAndGenMutations 300
tikv TestCommitPessimisticLock 290
syncer_test TestSyncerSimple 280
expression TestVectorizedBuiltinRegexpForConstants 280
server TestPacketIOWrite 280
bitmap TestConcurrentBitmapUniqueSetter 280
errormanager TestResolveAllConflictKeys 260
aggfuncs TestMemJsonObjectagg 260
statistics TestStatistics/SubTestIntColumnRanges 230
tikv TestPrimaryKeyOpLock 230
gctuner TestFinalizer 230
expression TestSysDate 220
statistics TestCMSketch 220
statistics TestStatistics/SubTestHistogramProtoConversion 220
tikv TestResolveCommit 220
restore TestTableRestoreSuite/TestSaveStatusCheckpoint 200
restore TestAutoSend 200
trace TestSpan 200
executor TestMergeJoinRequiredRows 200
chunk TestActionBlocked 200
selection TestSelectionWithSerialCase 200
checkpoints TestNormalOperations 190
executor TestJoinExec 190
statistics TestStatistics/SubTestIndexRanges 190
tikv TestCommit 190
expression TestRepeat 180
restore TestCalculateShiftTS 170
infosync TestTopology 170
expression TestColHybird 170
statistics TestWeightedSampling 170
tikv TestDeadlock 170
tikv TestPessimiticTxnTTL 170
node TestRegisterNode 170
aggfuncs TestJsonArrayagg 160
expression TestHashGroupKey 160
tikv TestTxnPrewrite 160
local TestLocalWriterWithSort 150
globalconfigsync_test TestGlobalConfigSyncer 150
tikv TestPessimisticLock 150
restore TestAllocTableRowIDsSingleTableSkipChecksum 140
statistics TestStatistics/SubTestColumnRange 140
statistics TestStatistics/SubTestSketch 140
tikv TestMinCommitTs 140
tikv TestOverwritePessimisitcLock 140
tikv TestPessimisticLockForce 140
```