### PR TITLE
fix(pipelines/pingcap/tidb/latest): support set peer repos in PR title

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_build.groovy
@@ -62,7 +62,7 @@ pipeline {
                             cache(path: "./", filter: '**/*', key: "git/pingcap/enterprise-plugin/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/enterprise-plugin/rev-']) {
                                 retry(2) {
                                     script {
-                                        component.checkout('git@github.com:pingcap/enterprise-plugin.git', 'plugin', REFS.base_ref, '', GIT_CREDENTIALS_ID)
+                                        component.checkout('git@github.com:pingcap/enterprise-plugin.git', 'plugin', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -56,7 +56,7 @@ pipeline {
                     cache(path: "./", filter: '**/*', key: "git/pingcap/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb-test/rev-']) {
                         retry(2) {
                             script {
-                                component.checkout('git@github.com:pingcap/tidb-test.git', 'tidb-test', REFS.base_ref, '', GIT_CREDENTIALS_ID)
+                                component.checkout('git@github.com:pingcap/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
                             }
                         }
                     }


### PR DESCRIPTION
current jobs of tidb repo are Prow job style

before refactored, we can trigger them with comment, such as `/run-mysql-test tidb-test=pr/1234`
now, we should append ` | tidb-test=pr/1234` in PR title, and then comment with `/retest`, then the bot will rerun the failed jobs with the PR codes of `/pulls/1234` of `tidb-test` repo.
examples:
- `<scope>: the PR main title | tidb-test=pr/1234`
- `<scope>: the PR main title | plugin=pr/456`