### PR TITLE
fix(jobs/pingcap/tidb): release-6.1 not use bazel

### DIFF
--- a/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
@@ -85,7 +85,7 @@ pipeline {
                         // upload coverage report to file server
                         retry(3) {
                             sh label: "upload coverage report to ${FILE_SERVER_URL}", script: """
-                                filepath="tipipeline/test/report/\${JOB_NAME}/\${BUILD_NUMBER}/\${ghprbActualCommit}/report.xml"
+                                filepath="tipipeline/test/report/\${JOB_NAME}/\${BUILD_NUMBER}/${REFS.pulls[0].sha}/report.xml"
                                 curl -f -F \${filepath}=@test_coverage/tidb-junit-report.xml \${FILE_SERVER_URL}/upload
                                 echo "coverage download link: \${FILE_SERVER_URL}/download/\${filepath}"
                                 """

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
@@ -71,7 +71,6 @@ pipeline {
                  success {
                     dir("tidb") {
                         sh label: "upload coverage to codecov", script: """
-                        mv coverage.dat test_coverage/coverage.dat
                         wget -q -O codecov ${FILE_SERVER_URL}/download/cicd/tools/codecov-v0.3.2
                         chmod +x codecov
                         ./codecov --dir test_coverage/ --token ${TIDB_CODECOV_TOKEN}
@@ -86,8 +85,8 @@ pipeline {
                         // upload coverage report to file server
                         retry(3) {
                             sh label: "upload coverage report to ${FILE_SERVER_URL}", script: """
-                                filepath="tipipeline/test/report/\${JOB_NAME}/\${BUILD_NUMBER}/${REFS.pulls[0].sha}/report.xml"
-                                curl -f -F \${filepath}=@test_coverage/bazel.xml \${FILE_SERVER_URL}/upload
+                                filepath="tipipeline/test/report/\${JOB_NAME}/\${BUILD_NUMBER}/\${ghprbActualCommit}/report.xml"
+                                curl -f -F \${filepath}=@test_coverage/tidb-junit-report.xml \${FILE_SERVER_URL}/upload
                                 echo "coverage download link: \${FILE_SERVER_URL}/download/\${filepath}"
                                 """
                         }


### PR DESCRIPTION
fix upload file error on release-6.1 ut pipeline