### PR TITLE
fix: git commit hash environment variable

### DIFF
--- a/jenkins/pipelines/cd/tidb-operator.groovy
+++ b/jenkins/pipelines/cd/tidb-operator.groovy
@@ -136,7 +136,7 @@ pipeline {
                             }
                         }
                         stage("bin") {
-                            environment { GOPROXY = "https://goproxy.pingcap.net,direct" }
+                            environment {GIT_COMMIT = "$GitHash"; GOPROXY = "https://goproxy.pingcap.net,direct" }
                             steps {
                                 sh """set -eux
                                     go mod download


### PR DESCRIPTION
# Why
tidb-operator commit hash use ci jenkins script commit hash, becuase GIT_COMMIT environment has been pre-set
# How
set environment variable explicitly
Signed-off-by: lijie <lijie@pingcap.com>