### PR TITLE
fix(staging/tidb): fix curl download unstable

### DIFF
--- a/jobs/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('pingcap/tidb/merged_integration_br_test') {
+    disabled(true)
     logRotator {
         daysToKeep(30)
     }

--- a/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
-        timeout(time: 40, unit: 'MINUTES')
+        timeout(time: 60, unit: 'MINUTES')
         // parallelsAlwaysFailFast()
     }
     stages {
@@ -121,7 +121,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 25, unit: 'MINUTES') }
+                        options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${GIT_MERGE_COMMIT}") { 

--- a/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -76,6 +76,12 @@ pipeline {
                     cache(path: "./bin", filter: '**/*', key: "ws/${BUILD_TAG}/br") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
                         sh label: 'build-for-br-integration-test', script: 'make build_for_br_integration_test'
+                        sh label: "download dependency", script: """
+                        chmod +x ../scripts/pingcap/br/*.sh
+                        ${WORKSPACE}/scripts/pingcap/br/integration_test_download_dependency.sh master master master master master http://fileserver.pingcap.net
+                        mv third_bin/* bin/
+                        ls -alh bin/
+                        """
                     }
                 }
             }
@@ -112,7 +118,7 @@ pipeline {
                         defaultContainer 'golang'
                         yamlFile POD_TEMPLATE_FILE
                     }
-                } 
+                }
                 stages {
                     stage("Test") {
                         options { timeout(time: 25, unit: 'MINUTES') }
@@ -121,9 +127,9 @@ pipeline {
                                 cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${GIT_MERGE_COMMIT}") { 
                                     sh """git status && ls -alh""" 
                                     cache(path: "./bin", filter: '**/*', key: "ws/${BUILD_TAG}/br") {
-                                        sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
-                                        sh 'chmod +x ../scripts/pingcap/br/*.sh'
-                                        sh "${WORKSPACE}/scripts/pingcap/br/integration_test_download_dependency.sh master master master master master http://fileserver.pingcap.net"
+                                        sh label: 'tidb-server version', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'  
+                                        sh label: 'tikv-server version', script: 'ls bin/tikv-server && chmod +x bin/tikv-server && ./bin/tikv-server -V'
+                                        sh label: 'pd-server version', script: 'ls bin/pd-server && chmod +x bin/pd-server && ./bin/pd-server -V' 
                                         sh label: "Case ${CASES}", script: """
                                             #!/usr/bin/env bash
                                             mv br/tests/*  tests/
@@ -159,51 +165,5 @@ pipeline {
                 }
             }        
         }
-    }
-    post {
-        always {
-            script {
-                println "build url: ${env.BUILD_URL}"
-                println "build blueocean url: ${env.RUN_DISPLAY_URL}"
-                println "build name: ${env.JOB_NAME}"
-                println "build number: ${env.BUILD_NUMBER}"
-                println "build status: ${currentBuild.currentResult}"
-            } 
-        }
-        // success {
-        //     container('status-updater') {
-        //         sh """
-        //             set +x
-        //             github-status-updater \
-        //                 -action update_state \
-        //                 -token ${GITHUB_TOKEN} \
-        //                 -owner pingcap \
-        //                 -repo tidb \
-        //                 -ref  ${GIT_MERGE_COMMIT} \
-        //                 -state success \
-        //                 -context "${COMMIT_CONTEXT}" \
-        //                 -description "test success" \
-        //                 -url "${env.RUN_DISPLAY_URL}"
-        //         """
-        //     }
-        // }
-
-        // unsuccessful {
-        //     container('status-updater') {
-        //         sh """
-        //             set +x
-        //             github-status-updater \
-        //                 -action update_state \
-        //                 -token ${GITHUB_TOKEN} \
-        //                 -owner pingcap \
-        //                 -repo tidb \
-        //                 -ref  ${GIT_MERGE_COMMIT} \
-        //                 -state failure \
-        //                 -context "${COMMIT_CONTEXT}" \
-        //                 -description "test failed" \
-        //                 -url "${env.RUN_DISPLAY_URL}"
-        //         """
-        //     }
-        // }
     }
 }

--- a/scripts/pingcap/br/integration_test_download_dependency.sh
+++ b/scripts/pingcap/br/integration_test_download_dependency.sh
@@ -60,7 +60,7 @@ function download() {
         return
     fi
     echo "download ${file_name} from ${url}"
-    curl -C - --retry 3 -f -L -o "${file_path}" "${url}"
+    wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O "${file_path}" "${url}"
 }
 
 function main() { 
@@ -71,8 +71,6 @@ function main() {
     download "$pd_download_url" "pd-server.tar.gz" "tmp/pd-server.tar.gz"
     tar -xz -C third_bin 'bin/*' -f tmp/pd-server.tar.gz && mv third_bin/bin/* third_bin/
     download "$tikv_download_url" "tikv-server.tar.gz" "tmp/tikv-server.tar.gz"
-    # tar -xz -C third_bin bin/tikv-server  -f tmp/tikv-server.tar.gz && mv third_bin/bin/tikv-server third_bin/
-    # tar -xz -C third_bin bin/tikv-ctl  -f tmp/tikv-server.tar.gz && mv third_bin/bin/tikv-ctl third_bin/
     tar -xz -C third_bin 'bin/*' -f tmp/tikv-server.tar.gz && mv third_bin/bin/* third_bin/
     download "$tiflash_download_url" "tiflash.tar.gz" "tmp/tiflash.tar.gz"
     tar -xz -C third_bin -f tmp/tiflash.tar.gz

--- a/scripts/pingcap/tidb-test/download_pingcap_artifact.sh
+++ b/scripts/pingcap/tidb-test/download_pingcap_artifact.sh
@@ -58,7 +58,7 @@ function download() {
         return
     fi
     echo "download ${file_name} from ${url}"
-    curl -C - --retry 3 -f -L -o "${file_path}" "${url}"
+    wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O "${file_path}" "${url}"
 }
 
 function main() { 

--- a/scripts/pingcap/tiflow/ticdc_integration_test_download_dependency.sh
+++ b/scripts/pingcap/tiflow/ticdc_integration_test_download_dependency.sh
@@ -39,7 +39,7 @@ function download() {
         return
     fi
     echo "download ${file_name} from ${url}"
-    curl -C - --retry 3 -f -L -o "${file_path}" "${url}"
+    wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O "${file_path}" "${url}"
 }
 
 function main() { 


### PR DESCRIPTION
To avoid abnormal interruptions during download, use `wget` instead of `curl` to download file from fileserver.