### PR TITLE
fix(staging/tidb): update pod docker daemon version

### DIFF
--- a/staging/pipelines/pingcap/tidb/latest/merged_tiflash_test.groovy
+++ b/staging/pipelines/pingcap/tidb/latest/merged_tiflash_test.groovy
@@ -116,17 +116,14 @@ pipeline {
                     }
                     dir("build-docker-image") {
                         sh label: 'generate dockerfile', script: """
-printf 'FROM hub.pingcap.net/jenkins/alpine-glibc:tiflash-test \n
-COPY tidb-server /tidb-server \n
-WORKDIR / \n
-EXPOSE 4000 \n
-ENTRYPOINT ["/usr/local/bin/dumb-init", "/tidb-server"] \n' > Dockerfile
-
-                        cat Dockerfile
+                        curl -o tidb.Dockerfile https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/tidb.Dockerfile
+                        cat tidb.Dockerfile
                         cp ../tidb/bin/tidb-server tidb-server
+                        ./tidb-server -V
                         """
                         sh label: 'build tmp tidb image', script: """
-                        docker build -t hub.pingcap.net/qa/tidb:${GIT_BASE_BRANCH} -f Dockerfile .
+                        docker build -t hub.pingcap.net/qa/tidb:${GIT_BASE_BRANCH} -f tidb.Dockerfile .
+                        docker run --rm  hub.pingcap.net/qa/tidb:${GIT_BASE_BRANCH} -V
                         """
                     }
                     dir("tiflash/tests/docker") {

--- a/staging/pipelines/pingcap/tidb/latest/merged_tiflash_test.groovy
+++ b/staging/pipelines/pingcap/tidb/latest/merged_tiflash_test.groovy
@@ -123,7 +123,6 @@ pipeline {
                         """
                         sh label: 'build tmp tidb image', script: """
                         docker build -t hub.pingcap.net/qa/tidb:${GIT_BASE_BRANCH} -f tidb.Dockerfile .
-                        docker run --rm  hub.pingcap.net/qa/tidb:${GIT_BASE_BRANCH} -V
                         """
                     }
                     dir("tiflash/tests/docker") {

--- a/staging/pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml
+++ b/staging/pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml
@@ -15,8 +15,15 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: dockerd
-      image: "docker:18.09.6-dind"
+      image: "docker:20.10.17-dind"
       tty: true
+      env:
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+        - name: DOCKER_REGISTRY_MIRROR
+          value: https://registry-mirror.pingcap.net
       securityContext:
         privileged: true
       resources:


### PR DESCRIPTION
update docker version to fix error  (releated https://github.com/containers/skopeo/issues/1501)
```shell
+ docker run --rm hub.pingcap.net/qa/tidb:master -V
runtime/cgo: pthread_create failed: Operation not permitted
SIGABRT: abort
PC=0x7f188db9342c m=0 sigcode=18446744073709551610

goroutine 0 [idle]:
runtime: g 0: unknown pc 0x7f188db9342c
stack: frame={sp:0x7ffd3d98fdc0, fp:0x0} stack=[0x7ffd3d191340,0x7ffd3d990350)
0x00007ffd3d98fcc0:  0x000000000174bbf9 <runtime.sysMapOS+0x0000000000000039>  0x0000000000000000 
0x00007ffd3d98fcd0:  0x00007f1866779000  0x000000000174bb85 <runtime.sysHugePageOS+0x0000000000000065> 
0x00007ffd3d98fce0:  0x00007f1868a00000  0x0000000000200000 
0x00007ffd3d98fcf0:  0x000000000000000e  0x00007f1800000000 
0x00007ffd3d98fd00:  0x00007ffd3d98fd30  0x0000000003f454bc 
0x00007ffd3d98fd10:  0x00007f186898a000  0x00000000017a6a9e <runtime.callCgoMmap+0x000000000000003e> 
0x00007ffd3d98fd20:  0x00007ffd3d98fd28  0x00007f186898a000 
0x00007ffd3d98fd30:  0x00007ffd3d98fda0  0x0000000003f454bc 
```

tested https://prow-ee.pingcap.net/jenkins/job/pingcap/job/tidb/job/merged_tiflash_test/19/console 