### PR TITLE
chore(pingcap/tiflash): ghpr_build set timeout to 60min

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-ghpr-build.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-ghpr-build.groovy
@@ -75,7 +75,7 @@ def run_with_pod(Closure body) {
     ) {
         node(label) {
             println "debug command:\nkubectl -n ${namespace} exec -ti ${NODE_NAME} bash"
-            body()
+            timeout(unit: 'MINUTES', time: 60) { body() }
         }
     }
 }


### PR DESCRIPTION
Add a timeout limit to prevent pipeline from getting stuck.

tested: https://ci.pingcap.net/view/tiflash/job/tiflash-ghpr-build/20420/