### PR TITLE
fix(ticdc): fix curl download unstable

### DIFF
--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -72,7 +72,7 @@ def prepare_binaries() {
                     sh """
                     cd go/src/github.com/pingcap/tiflow
                     ls -alh
-                    wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O ticdc_bin.tar.gz ${FILE_SERVER_URL}/download/${cacheBinaryPath}
+                    wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -O ticdc_bin.tar.gz ${FILE_SERVER_URL}/download/${cacheBinaryPath}
                     tar -xvf ticdc_bin.tar.gz
                     chmod +x bin/cdc
                     ./bin/cdc version
@@ -389,36 +389,36 @@ def download_binaries() {
         tiflash_url="${tiflash_url}"
         minio_url="${FILE_SERVER_URL}/download/minio.tar.gz"
 
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 \${tidb_url}
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 \${tidb_url}
         tar -xz -C ./tmp \${tidb_archive_path} -f tidb-server.tar.gz && mv tmp/bin/tidb-server third_bin/
 
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O pd-server.tar.gz  \${pd_url}
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O tikv-server.tar.gz \${tikv_url}
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -O pd-server.tar.gz  \${pd_url}
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -O tikv-server.tar.gz \${tikv_url}
         tar -xz -C ./tmp 'bin/*' -f tikv-server.tar.gz && mv tmp/bin/* third_bin/
         tar -xz -C ./tmp 'bin/*' -f pd-server.tar.gz && mv tmp/bin/* third_bin/
 
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O minio.tar.gz \${minio_url}
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -O minio.tar.gz \${minio_url}
         tar -xz -C third_bin -f ./minio.tar.gz
 
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O  tiflash.tar.gz \${tiflash_url}
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -O  tiflash.tar.gz \${tiflash_url}
         tar -xz -C third_bin -f tiflash.tar.gz
         mv third_bin/tiflash third_bin/_tiflash
         mv third_bin/_tiflash/* third_bin
 
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O third_bin/go-ycsb ${FILE_SERVER_URL}/download/builds/pingcap/go-ycsb/test-br/go-ycsb
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O third_bin/jq ${FILE_SERVER_URL}/download/builds/pingcap/test/jq-1.6/jq-linux64
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -O third_bin/go-ycsb ${FILE_SERVER_URL}/download/builds/pingcap/go-ycsb/test-br/go-ycsb
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -O third_bin/jq ${FILE_SERVER_URL}/download/builds/pingcap/test/jq-1.6/jq-linux64
 
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O etcd.tar.gz ${FILE_SERVER_URL}/download/builds/pingcap/cdc/etcd-v3.4.7-linux-amd64.tar.gz 
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -O etcd.tar.gz ${FILE_SERVER_URL}/download/builds/pingcap/cdc/etcd-v3.4.7-linux-amd64.tar.gz 
         tar -xz -C third_bin  etcd-v3.4.7-linux-amd64/etcdctl  -f etcd.tar.gz
         mv third_bin/etcd-v3.4.7-linux-amd64/etcdctl third_bin/ && rm -rf third_bin/etcd-v3.4.7-linux-amd64
 
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O sync_diff_inspector.tar.gz ${sync_diff_download_url}
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -O sync_diff_inspector.tar.gz ${sync_diff_download_url}
         tar -xz -C third_bin -f sync_diff_inspector.tar.gz
         
         chmod a+x third_bin/*
         rm -rf tmp
 
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O ticdc_bin.tar.gz ${FILE_SERVER_URL}/download/${cacheBinaryPath}
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -O ticdc_bin.tar.gz ${FILE_SERVER_URL}/download/${cacheBinaryPath}
         tar -xvz -C ./ -f ticdc_bin.tar.gz
 
         mv ./third_bin/* ./bin && ls -lh ./bin


### PR DESCRIPTION
To avoid abnormal interruptions during download, use wget instead of curl to download file from fileserver.

tested
1. https://ci2.pingcap.net/blue/organizations/jenkins/cdc_ghpr_integration_test/detail/cdc_ghpr_integration_test/17774/pipeline/173/
2. https://ci2.pingcap.net/blue/organizations/jenkins/cdc_ghpr_kafka_integration_test/detail/cdc_ghpr_kafka_integration_test/16910/pipeline/
3. https://ci2.pingcap.net/blue/organizations/jenkins/cdc_ghpr_kafka_integration_test/detail/cdc_ghpr_kafka_integration_test/16904/pipeline/