### PR TITLE
Add TiSpark release pipeline

### DIFF
--- a/jobs/pingcap/tispark/aa_folder.groovy
+++ b/jobs/pingcap/tispark/aa_folder.groovy
@@ -1,0 +1,3 @@
+folder('pingcap/tispark') {
+    description("Folder for pipelines of pingcap/tispark repo")
+}

--- a/jobs/pingcap/tispark/latest/release_master.groovy
+++ b/jobs/pingcap/tispark/latest/release_master.groovy
@@ -1,0 +1,25 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/tispark/release_master') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("ghprbActualCommit")
+        stringParam("ghprbPullId")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tispark")
+    }
+
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tispark/latest/release_master.groovy")
+            scm {
+                github('PingCAP-QE/ci', 'main')
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tispark/latest/pod-release_master.yaml
+++ b/pipelines/pingcap/tispark/latest/pod-release_master.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920221108"
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        requests:
+          memory: 8Gi
+          cpu: "4"
+        limits:
+          memory: 24Gi
+          cpu: "8"
+      # env:
+      #   - name: GOPATH
+      #     value: /share/.go
+      #   - name: GOCACHE
+      #     value: /share/.cache/go-build
+      volumeMounts:
+        - mountPath: /home/jenkins/.tidb/tmp
+          name: bazel-out-merged
+        - name: bazel-out-lower
+          subPath: tidb/go1.19.2
+          mountPath: /bazel-out-lower
+        - name: bazel-out-overlay
+          mountPath: /bazel-out-overlay
+        - name: gocache
+          mountPath: /share/.cache/go-build
+        - name: gopathcache
+          mountPath: /share/.go
+        - name: bazel-rc
+          mountPath: /data/
+          readOnly: true
+        - name: containerinfo
+          mountPath: /etc/containerinfo
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - /data/bazel-prepare-in-container.sh
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  volumes:
+    - name: gopathcache
+      persistentVolumeClaim:
+        claimName: gopathcache
+    - name: gocache
+      persistentVolumeClaim:
+        claimName: gocache
+    - name: bazel-out-lower
+      persistentVolumeClaim:
+        claimName: bazel-out-data
+    - name: bazel-out-overlay
+      emptyDir: {}
+    - name: bazel-out-merged
+      emptyDir: {}
+    - name: bazel-rc
+      secret:
+        secretName: bazel
+    - name: containerinfo
+      downwardAPI:
+        items:
+          - path: cpu_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.cpu
+          - path: cpu_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.cpu
+          - path: mem_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.memory
+          - path: mem_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.memory

--- a/pipelines/pingcap/tispark/latest/release_master.groovy
+++ b/pipelines/pingcap/tispark/latest/release_master.groovy
@@ -1,0 +1,164 @@
+final K8S_NAMESPACE = "jenkins-tispark"
+final GIT_FULL_REPO_NAME = 'pingcap/tispark'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tispark/latest/pod-release_master.yaml'
+
+def get_sha(repo, branch) {
+    sh "curl -C - --retry 3 -fs ${FILE_SERVER_URL}/download/builds/pingcap/ee/get_hash_from_github.py > gethash.py"
+    return sh(returnStdout: true, script: "python gethash.py -repo=${repo} -version=${branch} -s=${FILE_SERVER_URL}").trim()
+}
+
+def test_base(commitName, ghprbActualCommit, ghprbCommentBody) {
+    println commitName + " : " + ghprbCommentBody
+    build(job: "tispark_ghpr_integration_test",
+            parameters: [
+                    string(name: 'triggered_by_upstream_ci', value: "release_master"),
+                    booleanParam(name: 'daily_test', value: false),
+                    string(name: 'ghprbActualCommit', value: ghprbActualCommit),
+                    string(name: 'ghprbCommentBody', value: ghprbCommentBody),
+            ],
+            wait: true, propagate: true)
+}
+
+def release_master() {
+    commitID = get_sha("tispark", "master")
+    version = "master"
+    parallel(
+            test1: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version")
+            },
+
+            test2: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.1")
+            },
+
+            test3: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.2")
+            },
+
+            test4: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.3")
+            },
+    )
+
+    version = "release-6.5"
+    parallel(
+            test1: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version")
+            },
+
+            test2: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.1")
+            },
+
+            test3: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.2")
+            },
+
+            test4: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.3")
+            },
+    )
+
+    version = "release-6.1"
+    parallel(
+            test1: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version")
+            },
+
+            test2: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.1")
+            },
+
+            test3: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.2")
+            },
+
+            test4: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.3")
+            },
+    )
+
+    version = "release-5.4"
+    parallel(
+            test1: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version")
+            },
+
+            test2: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.1")
+            },
+
+            test3: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.2")
+            },
+
+            test4: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.3")
+            }
+    )
+    version = "release-4.0"
+    parallel(
+
+            test1: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version")
+            },
+
+            test2: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.1")
+            },
+
+            test3: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.2")
+            },
+
+            test4: {
+                test_base("master", commitID, "tidb=$version pd=$version tiflash=$version tikv=$version profile=spark-3.3")
+            }
+    )
+    // tiflash test
+    parallel(
+
+            test1: {
+                test_base("master", commitID, "tidb=master pd=master tiflash=master tikv=master test-flash=true")
+            },
+
+
+            test2: {
+                test_base("master", commitID, "tidb=release-6.5 pd=release-6.5 tiflash=release-6.5 tikv=release-6.5 profile=spark-3.3 test-flash=true")
+            },
+
+            test3: {
+                test_base("master", commitID, "tidb=release-6.1 pd=release-6.1 tiflash=release-6.1 tikv=release-6.1 profile=spark-3.2 test-flash=true")
+            },
+
+            test4: {
+                test_base("master", commitID, "tidb=release-5.4 pd=release-5.4 tiflash=release-5.4 tikv=release-5.4 profile=spark-3.1 test-flash=true")
+            },
+
+            test5: {
+                test_base("master", commitID, "tidb=release-4.0 pd=release-4.0 tiflash=release-4.0 tikv=release-4.0 test-flash=true")
+            },
+
+    )
+}
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 600, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stage("Trigger job") {
+        release_master()
+    }
+}


### PR DESCRIPTION
Add TiSpark release pipeline.

follow this guide: https://github.com/PingCAP-QE/ci/issues/1693

This is a pipeline to trigger another pipeline. So, I think it needs not too many resources. Please help me alter the `pod-release_master.yaml` if it waste too many resources