### PR TITLE
chore(pingcap/tiflow): set goproxy to proxy.golang.org 

### DIFF
--- a/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -93,6 +93,7 @@ pipeline {
                             dir('tiflow') {
                                 cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${ghprbActualCommit}") {
                                     sh label: "${TEST_CMD}", script: """
+                                        unset GOPROXY && go env -w GOPROXY="https://proxy.golang.org,direct"
                                         make ${TEST_CMD}
                                     """
                                 }

--- a/pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy
@@ -93,6 +93,7 @@ pipeline {
                             dir('tiflow') {
                                 cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${ghprbActualCommit}") {
                                     sh label: "${TEST_CMD}", script: """
+                                        unset GOPROXY && go env -w GOPROXY="https://proxy.golang.org,direct"
                                         make ${TEST_CMD}
                                     """
                                 }


### PR DESCRIPTION
Explicitly set the variable GOPROXY to avoid checksum errors. This error can be caused by the introduction of the upstream goproxy.io.

Revert this after internal goproxy back to normal.