### PR TITLE
Revert "chore(pingcap/tiflow): set goproxy to proxy.golang.org"

### DIFF
--- a/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -93,7 +93,6 @@ pipeline {
                             dir('tiflow') {
                                 cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${ghprbActualCommit}") {
                                     sh label: "${TEST_CMD}", script: """
-                                        unset GOPROXY && go env -w GOPROXY="https://proxy.golang.org,direct"
                                         make ${TEST_CMD}
                                     """
                                 }


### PR DESCRIPTION
Reverts PingCAP-QE/ci#1698