### PR TITLE
fix(pingcap/tidb): merged_build build tidb-server without parallelism

### DIFF
--- a/pipelines/pingcap/tidb/latest/merged_build.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_build.groovy
@@ -84,7 +84,6 @@ pipeline {
                 }
             }
         }
-
         stage("Build tidb-server") {
             steps {
                 dir("tidb") {                                     


### PR DESCRIPTION
Build without parallelism to avoid errors 
```shell
cp bazel-out/k8-fastbuild/bin/tidb-server/tidb-server_/tidb-server ./bin
cp: cannot create regular file './bin/tidb-server': Text file busy
make: *** [bazel_build] Error 1
script returned exit code 2
```