### PR TITLE
Revert "fix(pipelines/tikv/pd): using other goproxy to avoid branch version issue"

### DIFF
--- a/pipelines/tikv/pd/latest/ghpr_build.groovy
+++ b/pipelines/tikv/pd/latest/ghpr_build.groovy
@@ -53,12 +53,12 @@ pipeline {
                 }
             }
         }
-        stage('Build') {
+        stage('Build') {             
             steps {
                 dir('pd') {
                     sh '''
-                        GOPROXY="https://proxy.golang.org,direct" WITH_RACE=1 make && mv bin/pd-server bin/pd-server-race
-                        GOPROXY="https://proxy.golang.org,direct" make
+                        WITH_RACE=1 make && mv bin/pd-server bin/pd-server-race
+                        make
                     '''
                 }
             }


### PR DESCRIPTION
Reverts PingCAP-QE/ci#1668

Internal goproxy upstream has been back to normal.