### PR TITLE
feat(jenkins/pipelines/ci/tiflash): merge license header checking in build-common

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
@@ -672,7 +672,6 @@ def buildTiFlash(repo_path, build_dir, install_dir) {
 }
 
 def clangFormat(repo_path) {
-
     if (!params.ENABLE_FORMAT_CHECK) {
         echo "format check skipped"
         return
@@ -763,13 +762,23 @@ def buildStage(repo_path, build_dir, install_dir, proxy_cache_ready) {
         cmakeConfigureTiFlash(repo_path, build_dir, install_dir, proxy_cache_ready)
     }
     stage('Build TiFlash') {
-        parallel (
+        parallel(
+            "License check": {
+                dir(repo_path) {
+                    sh label: "license header check", script: """
+                        wget -q -O license-eye http://fileserver.pingcap.net/download/cicd/ci-tools/license-eye_v0.4.0
+                        chmod +x license-eye
+                        ./license-eye -c .github/licenserc.yml header check
+                    """
+                }
+            },
             "Format Check" : {
                 clangFormat(repo_path)
             },
             "Build TiFlash" : {
                 buildTiFlash(repo_path, build_dir, install_dir)
-            }
+            },
+            failFast: true
         )
     }
 }


### PR DESCRIPTION
migrate github action workflow
when it's merged, we should modify the repo branch protect rule: delete the required context:
<img width="802" alt="image" src="https://user-images.githubusercontent.com/2574558/215309831-9605f7ce-4992-412c-b41c-6ef2271f0c3e.png">
