### PR TITLE
refactor(jobs, pipelines): prefer to getting refs from params

### DIFF
--- a/jobs/pingcap-qe/ci/self_test.groovy
+++ b/jobs/pingcap-qe/ci/self_test.groovy
@@ -7,7 +7,7 @@ pipelineJob('pingcap-qe/ci/self_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("JOB_SPEC")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         githubProjectUrl("https://github.com/PingCAP-QE/ci")

--- a/jobs/pingcap/tidb/latest/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_build.groovy
@@ -5,9 +5,10 @@ pipelineJob('pingcap/tidb/ghpr_build') {
         daysToKeep(30)
     }
     parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_check.groovy
@@ -7,7 +7,7 @@ pipelineJob('pingcap/tidb/ghpr_check') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_check2.groovy
@@ -7,7 +7,7 @@ pipelineJob('pingcap/tidb/ghpr_check2') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -7,7 +7,7 @@ pipelineJob('pingcap/tidb/ghpr_mysql_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -7,7 +7,7 @@ pipelineJob('pingcap/tidb/ghpr_unit_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/merged_common_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_common_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/merged_common_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/merged_e2e_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/merged_integration_common_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/merged_integration_copr_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/merged_integration_ddl_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_ddl_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/merged_integration_ddl_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/merged_integration_jdbc_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/merged_integration_mysql_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/merged_sqllogic_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_sqllogic_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/merged_sqllogic_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/latest/merged_tiflash_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_tiflash_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/merged_tiflash_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.1/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.1/ghpr_build.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_build') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.1/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.1/ghpr_check.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_check') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.1/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.1/ghpr_check2.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_check2') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_mysql_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_unit_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.2/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_build.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_build') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.2/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_check.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_check') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_check2') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_mysql_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_unit_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.3/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_build.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_build') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.3/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_check.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_check') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_check2') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_mysql_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_unit_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.4/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.4/ghpr_build.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.4/ghpr_build') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.4/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.4/ghpr_check.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.4/ghpr_check') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.4/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.4/ghpr_check2.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.4/ghpr_check2') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.4/ghpr_mysql_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/pingcap/tidb/release-6.4/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.4/ghpr_unit_test.groovy
@@ -6,7 +6,7 @@ pipelineJob('pingcap/tidb/release-6.4/ghpr_unit_test') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/ti-community-infra/test-prod/prow_debug.groovy
+++ b/jobs/ti-community-infra/test-prod/prow_debug.groovy
@@ -8,7 +8,7 @@ pipelineJob('ti-community-infra/test-prod/prow_debug') {
         // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("JOB_SPEC")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/jobs/tikv/pd/latest/ghpr_build.groovy
+++ b/jobs/tikv/pd/latest/ghpr_build.groovy
@@ -5,9 +5,10 @@ pipelineJob('tikv/pd/ghpr_build') {
         daysToKeep(30)
     }
     parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
-        stringParam("PROW_DECK_URL", "https://prow.tidb.net")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -42,7 +42,7 @@ def checkoutRefs(refs, timeout=5, credentialsId='') {
     final branches = [[name: refs.base_sha]]
 
     // for pull requests.
-    if (refs.pulls.size() > 0) {
+    if (refs.pulls && refs.pulls.size() > 0) {
         // +refs/pull/${pullId}/*:refs/remotes/origin/pr/${pullId}/*
         final remotePullRefSpecs = refs.pulls.collect { 
             "+refs/pull/${it.number}/head:refs/remotes/origin/pr/${it.number}/head" }

--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -31,6 +31,23 @@ def getJobRefs(prowDeckUrl, prowJobId) {
     return getJobSpec(prowDeckUrl, prowJobId).refs
 }
 
+// checkout pull requests pre-merged commit
+def checkoutPr(prowDeckUrl, prowJobId, timeout=5, credentialsId='') {
+    final refs = getJobRefs(prowDeckUrl, prowJobId)
+    assert refs.pulls.size() > 0
+
+    checkoutRefs(refs, timeout, credentialsId)
+}
+
+// checkout base refs, can use it to checkout the pushed codes.
+def checkoutBase(prowDeckUrl, prowJobId, timeout=5, credentialsId='') {
+    final refs = getJobRefs(prowDeckUrl, prowJobId)
+    // ignore `.pulls` field.
+    refs.pulls = []
+
+    checkoutRefs(refs, timeout, credentialsId)
+}
+
 def checkoutRefs(refs, timeout=5, credentialsId='') {
     final remoteUrl = "https://github.com/${refs.org}/${refs.repo}.git"
     final remoteRefSpec = "+refs/heads/${refs.base_ref}:refs/remotes/origin/${refs.base_ref}"

--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -31,23 +31,6 @@ def getJobRefs(prowDeckUrl, prowJobId) {
     return getJobSpec(prowDeckUrl, prowJobId).refs
 }
 
-// checkout pull requests pre-merged commit
-def checkoutPr(prowDeckUrl, prowJobId, timeout=5, credentialsId='') {
-    final refs = getJobRefs(prowDeckUrl, prowJobId)
-    assert refs.pulls.size() > 0
-
-    checkoutRefs(refs, timeout, credentialsId)
-}
-
-// checkout base refs, can use it to checkout the pushed codes.
-def checkoutBase(prowDeckUrl, prowJobId, timeout=5, credentialsId='') {
-    final refs = getJobRefs(prowDeckUrl, prowJobId)
-    // ignore `.pulls` field.
-    refs.pulls = []
-
-    checkoutRefs(refs, timeout, credentialsId)
-}
-
 def checkoutRefs(refs, timeout=5, credentialsId='') {
     final remoteUrl = "https://github.com/${refs.org}/${refs.repo}.git"
     final remoteRefSpec = "+refs/heads/${refs.base_ref}:refs/remotes/origin/${refs.base_ref}"

--- a/pipelines/pingcap/tidb/latest/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_build.groovy
@@ -6,7 +6,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_build.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -7,7 +7,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 // TODO(wuhuizuo): tidb-test should delivered by docker image.
 pipeline {

--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/merged_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_common_test.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -5,7 +5,7 @@
 
 final K8S_NAMESPACE = "jenkins-tidb"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/merged_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_ddl_test.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_integration_ddl_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/latest/merged_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_tiflash_test.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_build.groovy
@@ -6,7 +6,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-ghpr_build.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-ghpr_check.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-ghpr_check2.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy
@@ -6,7 +6,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-ghpr_mysql_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 // TODO(wuhuizuo): tidb-test should delivered by docker image.
 pipeline {

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-ghpr_unit_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_build.groovy
@@ -5,8 +5,8 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
-final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_build.yaml'final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_build.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_check.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_check2.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -6,7 +6,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_mysql_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 // TODO(wuhuizuo): tidb-test should delivered by docker image.
 pipeline {

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_unit_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_build.groovy
@@ -6,7 +6,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.3/pod-ghpr_build.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.3/pod-ghpr_check.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.3/pod-ghpr_check2.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
@@ -6,7 +6,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.3/pod-ghpr_mysql_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 // TODO(wuhuizuo): tidb-test should delivered by docker image.
 pipeline {

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.3/pod-ghpr_unit_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_build.groovy
@@ -6,7 +6,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.4/pod-ghpr_build.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_check.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.4/pod-ghpr_check.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.4/pod-ghpr_check2.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
@@ -6,7 +6,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.4/pod-ghpr_mysql_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 // TODO(wuhuizuo): tidb-test should delivered by docker image.
 pipeline {

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_unit_test.groovy
@@ -5,7 +5,7 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.4/pod-ghpr_unit_test.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/pipelines/ti-community-infra/test-prod/prow_debug.groovy
+++ b/pipelines/ti-community-infra/test-prod/prow_debug.groovy
@@ -3,7 +3,6 @@
 // should triggerd for master and latest release branches
 @Library('tipipeline') _
 final POD_TEMPLATE_FILE = 'pipelines/ti-community-infra/test-prod/pod-prow_debug.yaml'
-final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {
@@ -23,11 +22,11 @@ pipeline {
             }
         }
         stage('Checkout') {
-            when { expression { return params.PROW_JOB_ID } }
+            when { expression { return params.JOB_SPEC } }
             steps {
                 dir('test') {
                     script {
-                        prow.checkoutRefs(REFS)
+                        prow.checkoutRefs(readJSON(text: params.JOB_SPEC).refs)
                     }
                     sh "pwd && ls -l"
                 }

--- a/pipelines/tikv/pd/latest/ghpr_build.groovy
+++ b/pipelines/tikv/pd/latest/ghpr_build.groovy
@@ -6,7 +6,7 @@ final K8S_NAMESPACE = "jenkins-pd"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'tikv/pd'
 final POD_TEMPLATE_FILE = 'pipelines/tikv/pd/latest/pod-ghpr_build.yaml'
-final REFS = prow.getJobRefs(params.PROW_DECK_URL, params.PROW_JOB_ID)
+final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
     agent {

--- a/staging/jobs/pingcap-qe/ee-ops/prow_debug.groovy
+++ b/staging/jobs/pingcap-qe/ee-ops/prow_debug.groovy
@@ -7,6 +7,7 @@ pipelineJob('pingcap-qe/ee-ops/prow_debug') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/staging/jobs/prow_debug.groovy
+++ b/staging/jobs/prow_debug.groovy
@@ -7,6 +7,7 @@ pipelineJob('prow_debug') {
     parameters {
         stringParam("BUILD_ID")
         stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
     }
     properties {
         // priority(0) // 0 fast than 1

--- a/staging/pipelines/pingcap-qe/ee-ops/prow_debug.groovy
+++ b/staging/pipelines/pingcap-qe/ee-ops/prow_debug.groovy
@@ -10,9 +10,6 @@ pipeline {
             yamlFile POD_TEMPLATE_FILE
         }
     }
-    environment {
-        PROW_DECK_URL = 'http://prow-deck.apps.svc'
-    }
     options { skipDefaultCheckout() }
     stages {
         stage('Debug info') {
@@ -26,11 +23,11 @@ pipeline {
             }
         }
         stage('Checkout') {
-            when { expression { return params.PROW_JOB_ID } }
+            when { expression { return params.JOB_SPEC } }
             steps {
                 dir('test') {
                     script {
-                        prow.checkoutPr(env.PROW_DECK_URL, params.PROW_JOB_ID)
+                        prow.checkoutRefs(readJSON(text: params.JOB_SPEC).refs)
                     }
                     sh "pwd && ls -l"
                 }


### PR DESCRIPTION
parse refs from job params `JOB_SPEC` which would be given by Prow.

Base on: https://github.com/PingCAP-QE/ci/pull/1715

Increased changes:
- Prefer to get refs from params instead of fetching from prow.