### PR TITLE
feat(pipelines/pingcap/tidb/latest): make pod in check2 job be a guaranteed pod

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -10,11 +10,8 @@ spec:
         privileged: true
       tty: true
       resources:
-        requests:
-          memory: 8Gi
-          cpu: "6"
         limits:
-          memory: 16Gi
+          memory: 32Gi
           cpu: "8"
       # env:
       #   - name: GOPATH


### PR DESCRIPTION
request == limit = 8 core + 32 GB(from 16GB)

Signed-off-by: wuhuizuo <wuhuizuo@126.com>