### PR TITLE
chore(tikv/pd): split pd jobs for go1.20

### DIFF
--- a/jobs/tikv/pd/latest/prow-presubmits.yaml
+++ b/jobs/tikv/pd/latest/prow-presubmits.yaml
@@ -1,7 +1,7 @@
 # struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Presubmit
 presubmits:
   tikv/pd:
-    - name: tikv/pd/release-6.5/ghpr_build
+    - name: tikv/pd/ghpr_build
       agent: jenkins
       decorate: false # need add this.
       always_run: true
@@ -9,4 +9,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
       rerun_command: "/test build"
       branches:
-        - ^release-6.[5-9](\.\d+(-\d+)?)?$
+        - ^master$
+        - ^feature[_/].+
+        - ^release-7.[0-9](\.\d+(-\d+)?)?$

--- a/jobs/tikv/pd/release-6.5/aa_folder.groovy
+++ b/jobs/tikv/pd/release-6.5/aa_folder.groovy
@@ -1,0 +1,3 @@
+folder('tikv/pd/release-6.5') {
+    description("Folder for pipelines of tikv/pd repo for v6.5")
+}

--- a/jobs/tikv/pd/release-6.5/ghpr_build.groovy
+++ b/jobs/tikv/pd/release-6.5/ghpr_build.groovy
@@ -1,0 +1,31 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+pipelineJob('tikv/pd/release-6.5/ghpr_build') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/tikv/pd")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/tikv/pd/release-6.5/ghpr_build.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                }
+            }
+        }
+    }
+}

--- a/jobs/tikv/pd/release-6.5/prow-presubmits.yaml
+++ b/jobs/tikv/pd/release-6.5/prow-presubmits.yaml
@@ -1,7 +1,7 @@
 # struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Presubmit
 presubmits:
   tikv/pd:
-    - name: tikv/pd/ghpr_build
+    - name: tikv/pd/release-6.5/ghpr_build
       agent: jenkins
       decorate: false # need add this.
       always_run: true
@@ -9,6 +9,4 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
       rerun_command: "/test build"
       branches:
-        - ^master$
-        - ^feature[_/].+
         - ^release-6.[5-9](\.\d+(-\d+)?)?$

--- a/jobs/tikv/pd/release-6.5/prow-presubmits.yaml
+++ b/jobs/tikv/pd/release-6.5/prow-presubmits.yaml
@@ -1,7 +1,7 @@
 # struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Presubmit
 presubmits:
   tikv/pd:
-    - name: tikv/pd/release-6.5/ghpr_build
+    - name: tikv/pd/ghpr_build
       agent: jenkins
       decorate: false # need add this.
       always_run: true
@@ -9,4 +9,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
       rerun_command: "/test build"
       branches:
+        - ^master$
+        - ^feature[_/].+
         - ^release-6.[5-9](\.\d+(-\d+)?)?$

--- a/pipelines/tikv/pd/release-6.5/ghpr_build.groovy
+++ b/pipelines/tikv/pd/release-6.5/ghpr_build.groovy
@@ -1,0 +1,88 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-pd"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'tikv/pd'
+final POD_TEMPLATE_FILE = 'pipelines/tikv/pd/release-6.5/pod-ghpr_build.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 15, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+        skipDefaultCheckout()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 5, unit: 'MINUTES') }
+            steps {
+                dir("pd") {
+                    cache(path: "./", filter: '**/*', key: "git/tikv/pd/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/tikv/pd/rev-']) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Build') {             
+            steps {
+                dir('pd') {
+                    sh '''
+                        WITH_RACE=1 make && mv bin/pd-server bin/pd-server-race
+                        make
+                    '''
+                }
+            }
+        }
+        stage("Upload") {
+            options {
+                timeout(time: 5, unit: 'MINUTES')
+            }
+            steps {
+                dir('pd') {
+                    sh label: "create pd-server tarball", script: """
+                        rm -rf .git
+                        tar czvf pd-server.tar.gz ./*
+                        echo "pr/${REFS.pulls[0].sha}" > sha1
+                        """
+                    // FIXME(wuhuizuo): filepath is wrong, should renew to tikv/pd
+                    sh label: 'upload to pd dir', script: """
+                        filepath="builds/pingcap/pd/pr/${REFS.pulls[0].sha}/centos7/pd-server.tar.gz"
+                        refspath="refs/pingcap/pd/pr/${REFS.pulls[0].number}/sha1"
+                        curl -F \${filepath}=@pd-server.tar.gz \${FILE_SERVER_URL}/upload
+                        curl -F \${refspath}=@sha1 \${FILE_SERVER_URL}/upload
+                        """
+                }
+            }
+        }
+    }
+}

--- a/pipelines/tikv/pd/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-6.5/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
pd master go version will upgrade to go1.20, so we split pipelines from master.