### PR TITLE
chore(pingcap/tidb): master use go1.20, split release-6.6

### DIFF
--- a/jobs/pingcap/tidb/release-6.6/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.6/ghpr_build.groovy
@@ -1,0 +1,31 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+pipelineJob('pingcap/tidb/release-6.6/ghpr_build') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tidb")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tidb/latest/ghpr_build.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/tidb/release-6.6/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.6/ghpr_check.groovy
@@ -1,0 +1,30 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+pipelineJob('pingcap/tidb/release-6.6/ghpr_check') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tidb")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tidb/release-6.6/ghpr_check.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/tidb/release-6.6/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.6/ghpr_check2.groovy
@@ -1,0 +1,30 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+pipelineJob('pingcap/tidb/release-6.6/ghpr_check2') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tidb")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
@@ -1,0 +1,30 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+pipelineJob('pingcap/tidb/release-6.6/ghpr_mysql_test') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tidb")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/tidb/release-6.6/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.6/ghpr_unit_test.groovy
@@ -1,0 +1,30 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+pipelineJob('pingcap/tidb/release-6.6/ghpr_unit_test') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tidb")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tidb/release-6.6/ghpr_unit_test.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/tidb/release-6.6/prow-presubmits.yaml
+++ b/jobs/pingcap/tidb/release-6.6/prow-presubmits.yaml
@@ -1,7 +1,7 @@
 # struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Presubmit
 presubmits:
   pingcap/tidb:
-    - name: pingcap/tidb/ghpr_build
+    - name: pingcap/tidb/release-6.6/ghpr_build
       agent: jenkins
       decorate: false # need add this.
       always_run: true
@@ -9,10 +9,8 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
       rerun_command: "/test build"
       branches:
-        - ^master$
-        - ^release-7\.[0-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
-        - ^feature[_/].+
-    - name: pingcap/tidb/ghpr_check
+        - ^release-6\.[6-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
+    - name: pingcap/tidb/release-6.6/ghpr_check
       agent: jenkins
       decorate: false # need add this.
       always_run: true
@@ -20,10 +18,8 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?check-dev(?: .*?)?$"
       rerun_command: "/test check-dev"
       branches:
-        - ^master$
-        - ^release-7\.[0-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
-        - ^feature[_/].+
-    - name: pingcap/tidb/ghpr_check2
+        - ^release-6\.[6-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
+    - name: pingcap/tidb/release-6.6/ghpr_check2
       agent: jenkins
       decorate: false # need add this.
       always_run: true
@@ -31,10 +27,8 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?check-dev2(?: .*?)?$"
       rerun_command: "/test check-dev2"
       branches:
-        - ^master$
-        - ^release-7\.[0-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
-        - ^feature[_/].+
-    - name: pingcap/tidb/ghpr_mysql_test
+        - ^release-6\.[6-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
+    - name: pingcap/tidb/release-6.6/ghpr_mysql_test
       agent: jenkins
       decorate: false # need add this.
       always_run: true
@@ -42,10 +36,8 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?mysql-test(?: .*?)?$"
       rerun_command: "/test mysql-test"
       branches:
-        - ^master$
-        - ^release-7\.[0-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
-        - ^feature[_/].+
-    - name: pingcap/tidb/ghpr_unit_test
+        - ^release-6\.[6-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
+    - name: pingcap/tidb/release-6.6/ghpr_unit_test
       agent: jenkins
       decorate: false # need add this.
       always_run: true
@@ -53,6 +45,4 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?unit-test(?: .*?)?$"
       rerun_command: "/test unit-test"
       branches:
-        - ^master$
-        - ^release-7\.[0-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
-        - ^feature[_/].+
+        - ^release-6\.[6-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_build.groovy
@@ -1,0 +1,159 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.6/pod-ghpr_build.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    ls -l /dev/null
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            // FIXME(wuhuizuo): catch AbortException and set the job abort status
+            // REF: https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/GitSCM.java#L1161
+            parallel {   
+                stage('tidb') {
+                    steps {
+                        dir('tidb') {
+                            cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
+                                retry(2) {
+                                    script {
+                                        prow.checkoutRefs(REFS)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                stage("enterprise-plugin") {
+                    steps {
+                        dir("enterprise-plugin") {
+                            cache(path: "./", filter: '**/*', key: "git/pingcap/enterprise-plugin/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/enterprise-plugin/rev-']) {
+                                retry(2) {
+                                    script {
+                                        component.checkout('git@github.com:pingcap/enterprise-plugin.git', 'plugin', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("Build tidb-server and plugin"){
+            parallel {
+                stage("Build tidb-server") {
+                    stages {
+                        stage("Build"){
+                            steps {
+                                dir("tidb") {                                     
+                                    sh "make bazel_build"
+                                }
+                            }
+                            post {       
+                                // TODO: statics and report logic should not put in pipelines.
+                                // Instead should only send a cloud event to a external service.
+                                always {
+                                    dir("tidb") {
+                                        archiveArtifacts(
+                                            artifacts: 'importer.log,tidb-server-check.log',
+                                            allowEmptyArchive: true,
+                                        )
+                                    }            
+                                }
+                            }
+                        }
+                        stage("Upload") {
+                            options {
+                                timeout(time: 5, unit: 'MINUTES')
+                            }
+                            steps {
+                                dir("tidb") {
+                                    sh label: "create tidb-server tarball", script: """
+                                        rm -rf .git
+                                        tar czvf tidb-server.tar.gz ./*
+                                        echo "pr/${REFS.pulls[0].sha}" > sha1
+                                        echo "done" > done
+                                        """
+                                    sh label: 'upload to tidb dir', script: """
+                                        filepath="builds/${GIT_FULL_REPO_NAME}/pr/${REFS.pulls[0].sha}/centos7/tidb-server.tar.gz"
+                                        donepath="builds/${GIT_FULL_REPO_NAME}/pr/${REFS.pulls[0].sha}/centos7/done"
+                                        refspath="refs/${GIT_FULL_REPO_NAME}/pr/${REFS.pulls[0].number}/sha1"
+                                        curl -F \${filepath}=@tidb-server.tar.gz \${FILE_SERVER_URL}/upload
+                                        curl -F \${donepath}=@done \${FILE_SERVER_URL}/upload
+                                        curl -F \${refspath}=@sha1 \${FILE_SERVER_URL}/upload
+                                        """
+                                    sh label: 'upload to tidb-checker dir', script: """
+                                        filepath="builds/pingcap/tidb-check/pr/${REFS.pulls[0].sha}/centos7/tidb-server.tar.gz"
+                                        donepath="builds/pingcap/tidb-check/pr/${REFS.pulls[0].sha}/centos7/done"
+                                        curl -F \${filepath}=@tidb-server.tar.gz \${FILE_SERVER_URL}/upload
+                                        curl -F \${donepath}=@done \${FILE_SERVER_URL}/upload                                    
+                                        """
+                                }
+                            }
+                        }
+                    }
+                }
+                stage("Build plugins") {
+                    steps {
+                        timeout(time: 15, unit: 'MINUTES') {
+                            sh label: 'build pluginpkg tool', script: 'cd tidb/cmd/pluginpkg && go build'
+                        }
+                        dir('enterprise-plugin/whitelist') {
+                            sh label: 'build plugin whitelist', script: '''
+                                GO111MODULE=on go mod tidy
+                                ../../tidb/cmd/pluginpkg/pluginpkg -pkg-dir . -out-dir .
+                                '''
+                        }
+                        dir('enterprise-plugin/audit') {
+                            sh label: 'build plugin: audit', script: '''
+                                GO111MODULE=on go mod tidy
+                                ../../tidb/cmd/pluginpkg/pluginpkg -pkg-dir . -out-dir .
+                                '''
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        // TODO(wuhuizuo): put into container lifecyle preStop hook.
+        always {
+            container('report') {
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
+            }
+            archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_check.groovy
@@ -1,0 +1,71 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.6/pod-ghpr_check.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    ls -l /dev/null
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            // FIXME(wuhuizuo): catch AbortException and set the job abort status
+            // REF: https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/GitSCM.java#L1161
+            steps {
+                dir('tidb') {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("Checks") {
+            // !!! concurrent go builds will encounter conflicts probabilistically.
+            steps {
+                dir('tidb') {
+                    sh script: 'make gogenerate check explaintest'
+                }
+            }
+        }
+    }
+    post {
+        // TODO(wuhuizuo): put into container lifecyle preStop hook.
+        always {
+            container('report') {                
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
+            }
+            archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
@@ -1,0 +1,138 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            // FIXME(wuhuizuo): catch AbortException and set the job abort status
+            // REF: https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/GitSCM.java#L1161
+            steps {
+                dir('tidb') {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("Prepare") {
+            steps {
+                dir('tidb') {
+                    cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                    }
+                    script {
+                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')
+                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'pd', REFS.base_ref, REFS.pulls[0].title, 'centos7/pd-server.tar.gz', 'bin')
+                    }
+                    // cache it for other pods
+                    cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}") {
+                        sh """
+                            mv bin/tidb-server bin/explain_test_tidb-server
+                            touch rev-${REFS.pulls[0].sha}
+                        """
+                    }
+                }
+            }
+        }
+        stage('Checks') {
+            matrix {
+                axes {
+                    axis {
+                        name 'SCRIPT_AND_ARGS'
+                        values(
+                            'explaintest.sh y', 
+                            'explaintest.sh n', 
+                            'run_real_tikv_tests.sh bazel_brietest', 
+                            'run_real_tikv_tests.sh bazel_pessimistictest', 
+                            'run_real_tikv_tests.sh bazel_sessiontest', 
+                            'run_real_tikv_tests.sh bazel_statisticstest',
+                            'run_real_tikv_tests.sh bazel_txntest',
+                            'run_real_tikv_tests.sh bazel_addindextest',
+                        )
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        defaultContainer 'golang'
+                        yamlFile POD_TEMPLATE_FILE
+                    }
+                }
+                stages {                    
+                    stage('Test')  {
+                        options { timeout(time: 30, unit: 'MINUTES') }
+                        steps {
+                            dir('tidb') {
+                                cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}") {
+                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
+                                }
+
+                                sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
+                                sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
+                            }
+                        }
+                        post {
+                            failure {
+                                dir("checks-collation-enabled") {
+                                    archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        success {
+            // Upload check flag to fileserver
+            sh "echo done > done && curl -F ci_check/${JOB_NAME}/${REFS.pulls[0].sha}=@done ${FILE_SERVER_URL}/upload"
+        }
+
+        // TODO(wuhuizuo): put into container lifecyle preStop hook.
+        always {
+            container('report') {                
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
+            }
+            archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
@@ -1,0 +1,136 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.6/pod-ghpr_mysql_test.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+// TODO(wuhuizuo): tidb-test should delivered by docker image.
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 40, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir("tidb") {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+                dir("tidb-test") {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb-test/rev-']) {
+                        retry(2) {
+                            script {
+                                component.checkout('git@github.com:pingcap/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir('tidb') {
+                    cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                        // FIXME: https://github.com/pingcap/tidb-test/issues/1987
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -race -o bin/tidb-server ./tidb-server'
+                    }
+                }
+                dir('tidb-test') {
+                    sh "git branch && git status"
+                    cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                        sh 'touch ws-${BUILD_TAG}'
+                    }
+                }
+            }
+        }
+        stage('MySQL Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'PART'
+                        values '1', '2', '3', '4'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        defaultContainer 'golang'
+                        yamlFile POD_TEMPLATE_FILE
+                    }
+                }
+                stages {
+                    stage("Test") {
+                        options { timeout(time: 25, unit: 'MINUTES') }
+                        steps {
+                            dir('tidb') {
+                                cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                                }
+                            }
+                            dir('tidb-test') {
+                                cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                    dir('mysql_test') {
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
+                                    }
+                                }
+                            }
+                        }
+                        post{
+                            always {
+                                junit(testResults: "**/result.xml")
+                            }
+                            failure {
+                                archiveArtifacts(artifacts: 'mysql-test.out*', allowEmptyArchive: true)
+                            }
+                        }
+                    }
+                }
+            }        
+        }
+    }
+    post {
+        // TODO(wuhuizuo): put into container lifecyle preStop hook.
+        always {
+            container('report') {
+                sh "bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json || true"
+            }
+            archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_unit_test.groovy
@@ -1,0 +1,94 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.6/pod-ghpr_unit_test.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 90, unit: 'MINUTES')
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    ls -l /dev/null
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            // FIXME(wuhuizuo): catch AbortException and set the job abort status
+            // REF: https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/GitSCM.java#L1161
+            steps {
+                dir('tidb') {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Test') {
+            environment { TIDB_CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir('tidb') {
+                    sh './build/jenkins_unit_test.sh' 
+                }
+            }
+            post {
+                 success {
+                    dir("tidb") {
+                        sh label: "upload coverage to codecov", script: """
+                        mv coverage.dat test_coverage/coverage.dat
+                        wget -q -O codecov ${FILE_SERVER_URL}/download/cicd/tools/codecov-v0.3.2
+                        chmod +x codecov
+                        ./codecov --dir test_coverage/ --token ${TIDB_CODECOV_TOKEN} --pr ${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --branch origin/pr/${REFS.pulls[0].number}
+                        """
+                    }
+                }
+                always {
+                    dir('tidb') {
+                        // archive test report to Jenkins.
+                        junit(testResults: "**/bazel.xml", allowEmptyResults: true)
+                    }
+                }
+            }
+        }
+    }
+    post {
+        // TODO(wuhuizuo): put into container lifecyle preStop hook.
+        always {
+            container('report') {
+                sh """
+                    junitUrl="\${FILE_SERVER_URL}/download/tipipeline/test/report/\${JOB_NAME}/\${BUILD_NUMBER}/${REFS.pulls[0].sha}/report.xml"
+                    bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json "\${junitUrl}" || true
+                """
+            }
+            archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_build.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920230207"
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        limits:
+          memory: 24Gi
+          cpu: "8"
+      # env:
+      #   - name: GOPATH
+      #     value: /share/.go
+      #   - name: GOCACHE
+      #     value: /share/.cache/go-build
+      volumeMounts:
+        - mountPath: /home/jenkins/.tidb/tmp
+          name: bazel-out-merged
+        - name: bazel-out-lower
+          subPath: tidb/go1.19.2
+          mountPath: /bazel-out-lower
+        - name: bazel-out-overlay
+          mountPath: /bazel-out-overlay
+        - name: gocache
+          mountPath: /share/.cache/go-build
+        - name: gopathcache
+          mountPath: /share/.go
+        - name: bazel-rc
+          mountPath: /data/
+          readOnly: true
+        - name: containerinfo
+          mountPath: /etc/containerinfo
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - /data/bazel-prepare-in-container.sh
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  volumes:
+    - name: gopathcache
+      persistentVolumeClaim:
+        claimName: gopathcache
+    - name: gocache
+      persistentVolumeClaim:
+        claimName: gocache
+    - name: bazel-out-lower
+      persistentVolumeClaim:
+        claimName: bazel-out-data
+    - name: bazel-out-overlay
+      emptyDir: {}
+    - name: bazel-out-merged
+      emptyDir: {}
+    - name: bazel-rc
+      secret:
+        secretName: bazel
+    - name: containerinfo
+      downwardAPI:
+        items:
+          - path: cpu_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.cpu
+          - path: cpu_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.cpu
+          - path: mem_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.memory
+          - path: mem_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.memory

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920230207"
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        requests:
+          memory: 8Gi
+          cpu: "8"
+        limits:
+          memory: 32Gi
+          cpu: "8"
+      # env:
+      #   - name: GOPATH
+      #     value: /share/.go
+      #   - name: GOCACHE
+      #     value: /share/.cache/go-build
+      volumeMounts:
+        - mountPath: /home/jenkins/.tidb/tmp
+          name: bazel-out-merged
+        - name: bazel-out-lower
+          subPath: tidb/go1.19.2
+          mountPath: /bazel-out-lower
+        - name: bazel-out-overlay
+          mountPath: /bazel-out-overlay
+        - name: gocache
+          mountPath: /share/.cache/go-build
+        - name: gopathcache
+          mountPath: /share/.go
+        - name: bazel-rc
+          mountPath: /data/
+          readOnly: true
+        - name: containerinfo
+          mountPath: /etc/containerinfo
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - /data/bazel-prepare-in-container.sh
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  volumes:
+    - name: gopathcache
+      persistentVolumeClaim:
+        claimName: gopathcache
+    - name: gocache
+      persistentVolumeClaim:
+        claimName: gocache
+    - name: bazel-out-lower
+      persistentVolumeClaim:
+        claimName: bazel-out-data
+    - name: bazel-out-overlay
+      emptyDir: {}
+    - name: bazel-out-merged
+      emptyDir: {}
+    - name: bazel-rc
+      secret:
+        secretName: bazel
+    - name: containerinfo
+      downwardAPI:
+        items:
+          - path: cpu_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.cpu
+          - path: cpu_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.cpu
+          - path: mem_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.memory
+          - path: mem_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.memory

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920230207"
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        limits:
+          memory: 32Gi
+          cpu: "8"
+      # env:
+      #   - name: GOPATH
+      #     value: /share/.go
+      #   - name: GOCACHE
+      #     value: /share/.cache/go-build
+      volumeMounts:
+        - mountPath: /home/jenkins/.tidb/tmp
+          name: bazel-out-merged
+        - name: bazel-out-lower
+          subPath: tidb/go1.19.2
+          mountPath: /bazel-out-lower
+        - name: bazel-out-overlay
+          mountPath: /bazel-out-overlay
+        - name: gocache
+          mountPath: /share/.cache/go-build
+        - name: gopathcache
+          mountPath: /share/.go
+        - name: bazel-rc
+          mountPath: /data/
+          readOnly: true
+        - name: containerinfo
+          mountPath: /etc/containerinfo
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - /data/bazel-prepare-in-container.sh
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  volumes:
+    - name: gopathcache
+      persistentVolumeClaim:
+        claimName: gopathcache
+    - name: gocache
+      persistentVolumeClaim:
+        claimName: gocache
+    - name: bazel-out-lower
+      persistentVolumeClaim:
+        claimName: bazel-out-data
+    - name: bazel-out-overlay
+      emptyDir: {}
+    - name: bazel-out-merged
+      emptyDir: {}
+    - name: bazel-rc
+      secret:
+        secretName: bazel
+    - name: containerinfo
+      downwardAPI:
+        items:
+          - path: cpu_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.cpu
+          - path: cpu_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.cpu
+          - path: mem_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.memory
+          - path: mem_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.memory

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_mysql_test.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 4Gi
+          cpu: "2"
+        limits:
+          memory: 6Gi
+          cpu: "3"
+      # env:
+      #   - name: GOPATH
+      #     value: /share/.go
+      #   - name: GOCACHE
+      #     value: /share/.cache/go-build
+      volumeMounts:
+        - name: gocache
+          mountPath: /share/.cache/go-build
+        - name: gopathcache
+          mountPath: /share/.go
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  volumes:
+    - name: gopathcache
+      persistentVolumeClaim:
+        claimName: gopathcache
+    - name: gocache
+      persistentVolumeClaim:
+        claimName: gocache

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_unit_test.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      # TODO(wuhuizuo): using standard bazel build image to shrink the image size
+      # and keep image simple,so no need to refresh image to update basic bazel out data.
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920230207"
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        requests:
+          memory: 8Gi
+          cpu: "4"
+      # env:
+      #   - name: GOPATH
+      #     value: /share/.go
+      #   - name: GOCACHE
+      #     value: /share/.cache/go-build
+      volumeMounts:
+        - mountPath: /home/jenkins/.tidb/tmp
+          name: bazel-out-merged
+        - name: bazel-out-lower
+          subPath: tidb/go1.19.2
+          mountPath: /bazel-out-lower
+        - name: bazel-out-overlay
+          mountPath: /bazel-out-overlay
+        - name: gocache
+          mountPath: /share/.cache/go-build
+        - name: gopathcache
+          mountPath: /share/.go
+        - name: bazel-rc
+          mountPath: /data/
+          readOnly: true
+        - name: containerinfo
+          mountPath: /etc/containerinfo
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - /data/bazel-prepare-in-container.sh
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  volumes:
+    - name: gopathcache
+      persistentVolumeClaim:
+        claimName: gopathcache
+    - name: gocache
+      persistentVolumeClaim:
+        claimName: gocache
+    - name: bazel-out-lower
+      persistentVolumeClaim:
+        claimName: bazel-out-data
+    - name: bazel-out-overlay
+      emptyDir: {}
+    - name: bazel-out-merged
+      emptyDir: {}
+    - name: bazel-rc
+      secret:
+        secretName: bazel
+    - name: containerinfo
+      downwardAPI:
+        items:
+          - path: cpu_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.cpu
+          - path: cpu_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.cpu
+          - path: mem_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.memory
+          - path: mem_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.memory


### PR DESCRIPTION
tidb ci on master upgrade go version go go1.20, so we splite pipelines for release-6.6.