### PR TITLE
chore(pingcap/tidb): tidb mysql-test use go1.20 on master

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
tidb msyql-test on master upgrade go version to 1.20.