### PR TITLE
chore: tidb pipelines on master use go1.20

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_cdc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_cdc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_ddl_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
merged pipeline on tidb master upgrade to go1.20.1.