### PR TITLE
chore: disable trigger mysql-test on master branch

### DIFF
--- a/jenkins/jobs/ci/tidb-test/tidb_test_ghpr_mysql_test.groovy
+++ b/jenkins/jobs/ci/tidb-test/tidb_test_ghpr_mysql_test.groovy
@@ -45,6 +45,9 @@ pipelineJob('tidb_test_ghpr_mysql_test') {
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')
                     whitelist('')
                     orgslist('pingcap')
+                    blackListTargetBranches {
+                        ghprbBranch { branch('master') }
+                    }
                     // ignore when only those file changed.(
                     //   multi line regex
                     // excludedRegions('.*\\.md')


### PR DESCRIPTION
Mysql-test ci on master has been refactored to prow style on ksyun, so we disable trigger this on idc jenkins.