### PR TITLE
feat: support forked repo

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -368,7 +368,7 @@ def checkoutCode() {
                                                 refspec      : specRef,
                                                 url          : tidb_repo]]]
             }
-            sh "git reset --hard ${TIDB_HASH}"
+            sh 'test -z "$(git status --porcelain)"'
         }
     }
 }

--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -70,7 +70,7 @@ properties([
                 ),
                 string(
                          defaultValue: '',
-                         name: 'FORKED_REPO',
+                         name: 'GITHUB_REPO',
                          trim: true
                 ),
                 booleanParam(
@@ -290,8 +290,8 @@ if (REPO == "tikv" || REPO == "importer" || REPO == "pd") {
 if (REPO == "tiem") {
     repo = "git@github.com:pingcap-inc/${REPO}.git"
 }
-if (FORKED_REPO){
-    repo = "git@github.com:${FORKED_REPO}.git"
+if (GITHUB_REPO){
+    repo = "git@github.com:${GITHUB_REPO}.git"
 }
 specRef = "+refs/heads/*:refs/remotes/origin/*"
 if (params.GIT_PR.length() >= 1) {

--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -38,7 +38,7 @@ pipeline{
         string(name: 'Version', description: 'important, the version for cli --version and profile choosing, eg. v6.5.0')
         choice(name: 'Edition', choices : ["community", "enterprise"])
         string(name: 'PluginGitRef', description: 'the git commit for enterprise plugin, only in enterprise tidb', defaultValue: "master")
-        string(name: 'GithubRepo', description: 'the github repo, eg pingcap/tidb, just ignore unless in forked repo', defaultValue: '')
+        string(name: 'GithubRepo', description: 'the github repo,just ignore unless in forked repo, eg pingcap/tidb', defaultValue: '')
         string(name: 'TiBuildID', description: 'the id of tibuild object, just leave empty if you do not know')
         booleanParam(name: 'IsPushGCR', description: 'whether push gcr')
     }

--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -130,7 +130,7 @@ spec:
                                     string(name: "GIT_HASH", value: GitHash),
                                     string(name: "GIT_PR", value: GitPR),
                                     string(name: "RELEASE_TAG", value: Version),
-                                    string(name: "FORKED_REPO", value: params.GithubRepo),
+                                    string(name: "GITHUB_REPO", value: params.GithubRepo),
                                     [$class: 'BooleanParameterValue', name: 'NEED_SOURCE_CODE', value: false],
                                     [$class: 'BooleanParameterValue', name: 'FORCE_REBUILD', value: true],
                                 ]


### PR DESCRIPTION
Why:
- to support forked repo
- for enterprise-plugin TIDB_HASH can accept repo name before sha1 to accomplish plugin with forked repo