### PR TITLE
fix: use wget instead of curl

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -317,7 +317,7 @@ def checkoutCode() {
             println "get code from fileserver to reduce clone time"
             println "codeCacheInFileserverUrl=${codeCacheInFileserverUrl}"
             sh """
-            curl -O -C - --retry 5 --retry-delay 6 --retry-max-time 60 ${codeCacheInFileserverUrl}
+            wget -c --tries 3 --no-verbose ${codeCacheInFileserverUrl}
             tar -xzf src-${REPO}.tar.gz --strip-components=1
             rm -f src-${REPO}.tar.gz
             rm -rf ./*


### PR DESCRIPTION
## Why
- curl fileserver often fail with: curl: (18) transfer closed with 557466155 bytes remaining to read