### PR TITLE
update `tiflash-build-common.groovy` to fix ccache process

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
@@ -340,14 +340,16 @@ def fetchCCache(repo_path, target_dir) {
         if (fileExists(ccache_source)) {
             echo "ccache found"
             sh """
+            cd /tmp
             cp ${ccache_source} ccache.tar
             tar -xf ccache.tar
+            cd -
             """
         } else {
             echo "ccache not found"
         }
         sh """
-        ccache -o cache_dir="${target_dir}/.ccache"
+        ccache -o cache_dir="/tmp/.ccache"
         ccache -o max_size=2G
         ccache -o limit_multiple=0.99
         ccache -o hash_dir=false
@@ -789,9 +791,11 @@ def uploadCCache(repo_path, target_dir) {
         def ccache_source = "/home/jenkins/agent/ccache/${ccache_tag}.tar"
         dir(target_dir) {
             sh"""
+            cd /tmp
             rm -rf ccache.tar
             tar -cf ccache.tar .ccache
             cp ccache.tar ${ccache_source}
+            cd -
             """
         }
     } else {


### PR DESCRIPTION
Fix https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/20767/pipeline/

Verified in https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/20776/pipeline