### PR TITLE
feat(pipelines/pingcap/tidb/latest): analyze bazel output when failed.

### DIFF
--- a/scripts/plugins/analyze-go-test-from-bazel-output.sh
+++ b/scripts/plugins/analyze-go-test-from-bazel-output.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# parse bazel go test case index log
+# param $1 file path
+function parse_bazel_go_test_index_log() {
+    indexReg="((===|---) (RUN|PASS|FAIL))|-- Test timed out at|FLAKY|(====================( Test output for //|=+))"
+    local logPath="$1"
+    grep --color -nE "$indexReg" "$logPath" >bazel-go-test-index.log
+}
+
+function parse_bazel_target_output_log() {
+    local logPath="$1"
+
+    local indexes=($(grep -nE "====================( Test output for //|=+)" ${logPath} | grep -oE "^\d+"))
+    local p=0
+    while [ $((2 * p)) -lt "${#indexes[@]}" ]; do
+        saveFlag="bazel-target-output-L${indexes[$((2 * p))]}-${indexes[$((2 * p + 1))]}"
+        sed -n "${indexes[$((2 * p))]},${indexes[$((2 * p + 1))]}p" "${logPath}" >"$saveFlag.log"
+        local append=""
+
+        if grep -E "^-- Test timed out at" "$saveFlag.log" >/dev/null; then
+            append="$append.timeout"
+        elif grep -E "^--- FAIL" "$saveFlag.log" >/dev/null; then
+            append="$append.fail"
+        elif grep -E "(---|===) (PASS|FAIL|RUN)" "$saveFlag.log" | grep -oE "\bTest\w+\b" | sort | uniq -c | grep "^\s*1\b" >/dev/null; then
+            append="$append.fatal"
+        fi
+
+        if [ "$append" != "" ]; then
+            mv "$saveFlag.log" "$saveFlag${append}.log"
+        fi
+        p=$((p + 1))
+    done
+}
+
+# param $1 file path or url
+function main() {
+    local logPath="$1"
+
+    if [[ $logPath =~ https?://.* ]]; then
+        echo "Parse from remote url: $logPath"
+        wget -O bazel-output.log "$logPath"
+        logPath="bazel-output.log"
+    else
+        echo "Parse from local file: $logPath"
+    fi
+
+    parse_bazel_go_test_index_log "$logPath"
+    parse_bazel_target_output_log "$logPath"
+}
+
+main "$@"


### PR DESCRIPTION
## Usage
```bash
./scripts/plugins/analyze-go-test-from-bazel-output.sh bazel-test.log
```

## Output files

> Those files also will be archived in CI server.

- `bazel-go-test-index.log` // bazel test sumary index file, you should check it first.
    ```log
    828:==================== Test output for //session:session_test (shard 23 of 50):
    829:=== RUN   TestIndexMergeUpgradeFrom300To540
    3096:--- PASS: TestIndexMergeUpgradeFrom300To540 (206.04s)
    3097:=== RUN   TestValidationRecursion
    4085:-- Test timed out at 2023-03-07 15:37:05 CST --
    4086:================================================================================
    4104:==================== Test output for //session:session_test (shard 24 of 50):
    4105:=== RUN   TestIndexMergeUpgradeFrom400To540
    7413:-- Test timed out at 2023-03-07 15:37:05 CST --
    7414:================================================================================
    7424:==================== Test output for //session:session_test (shard 17 of 50):
    7425:=== RUN   TestUpgradeVersion74
    11110:-- Test timed out at 2023-03-07 15:36:54 CST --
    11111:================================================================================
    11115:[35mFLAKY: [0m//session:session_test (Summary)
    11121:==================== Test output for //session:session_test (shard 26 of 50):
    11122:=== RUN   TestInitializeSQLFile
    14411:-- Test timed out at 2023-03-07 15:37:13 CST --
    14412:================================================================================
    14793:==================== Test output for //ddl:ddl_test (shard 43 of 50):
    14794:=== RUN   TestDropColumns
    15510:--- PASS: TestDropColumns (3.91s)
    15511:=== RUN   TestShowCreateTable
    16453:--- PASS: TestShowCreateTable (4.31s)
    16454:=== RUN   TestParallelTruncateTableAndAddColumns
    17134:--- PASS: TestParallelTruncateTableAndAddColumns (4.53s)
    17135:=== RUN   TestAddColumnTooMany
    17762:--- PASS: TestAddColumnTooMany (5.82s)
    17763:=== RUN   TestEnumDefaultValue
    18409:--- PASS: TestEnumDefaultValue (4.27s)
    18410:=== RUN   TestAddTableWithPartition
    19106:--- PASS: TestAddTableWithPartition (5.53s)
    19107:=== RUN   TestFKOnGeneratedColumns
    21771:--- PASS: TestFKOnGeneratedColumns (25.18s)
    21772:=== RUN   TestParallelDDL
    23134:--- FAIL: TestParallelDDL (7.13s)
    23135:=== RUN   TestGetTasks
    23747:--- PASS: TestGetTasks (4.80s)
    23748:=== RUN   TestMultiSchemaChangeMix
    24528:--- PASS: TestMultiSchemaChangeMix (8.51s)
    24529:=== RUN   TestMultiRegionGetTableEndHandle
    25128:--- PASS: TestMultiRegionGetTableEndHandle (4.84s)
    25129:=== RUN   TestCanceledJobTakeTime
    25748:--- PASS: TestCanceledJobTakeTime (4.52s)
    25755:================================================================================
    25767:[35mFLAKY: [0m//ddl:ddl_test (Summary)
    25907:==================== Test output for //server:server_test (shard 18 of 50):
    25908:=== RUN   TestGetSessionVarsWaitTimeout
    26499:--- PASS: TestGetSessionVarsWaitTimeout (5.31s)
    26500:=== RUN   TestCheckCN
    26501:--- PASS: TestCheckCN (0.00s)
    26502:=== RUN   TestInternalSessionTxnStartTS
    27119:--- FAIL: TestInternalSessionTxnStartTS (5.08s)
    27126:================================================================================
    27128:==================== Test output for //server:server_test (shard 45 of 50):
    27129:=== RUN   TestGetSchemaStorage
    27560:================================================================================
    27598:[35mFLAKY: [0m//server:server_test (Summary)
    28078:==================== Test output for //session:session_test (shard 11 of 50):
    28079:=== RUN   TestBootstrapInitExpensiveQueryHandle
    29769:================================================================================
    29770:==================== Test output for //session:session_test (shard 11 of 50):
    29771:=== RUN   TestBootstrapInitExpensiveQueryHandle
    30289:================================================================================
    30290:==================== Test output for //session:session_test (shard 11 of 50):
    30291:=== RUN   TestBootstrapInitExpensiveQueryHandle
    32379:-- Test timed out at 2023-03-07 16:05:58 CST --
    32380:================================================================================
    ```
- `bazel-target-output-L14793-25755.fail.log` // output of bazel test target that failed with tests.
- `bazel-target-output-L27128-27560.fatal.log` // output of bazel test target that exited with fatal or panic.
- `bazel-target-output-L30290-32380.timeout.log` // output of bazel test target that runned timeout.

