### PR TITLE
feat(scripts/plugins): extract flaky tests from bazel output

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -77,7 +77,7 @@ pipeline {
                 }
                 failure {
                     sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
-                    archiveArtifacts(artifacts: 'bazel-*.log', fingerprint: false, allowEmptyArchive: true)
+                    archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
                 }
                 always {
                     dir('tidb') {

--- a/scripts/plugins/analyze-go-test-from-bazel-output.sh
+++ b/scripts/plugins/analyze-go-test-from-bazel-output.sh
@@ -3,7 +3,7 @@
 # parse bazel go test case index log
 # param $1 file path
 function parse_bazel_go_test_index_log() {
-    indexReg="((===|---) (RUN|PASS|FAIL))|-- Test timed out at|FLAKY|(====================( Test output for //|=+))"
+    indexReg="((===|---) (RUN|PASS|FAIL))|-- Test timed out at|(====================( Test output for //|=+))"
     local logPath="$1"
     grep --color -nE "$indexReg" "$logPath" >bazel-go-test-index.log
 }
@@ -33,6 +33,62 @@ function parse_bazel_target_output_log() {
     done
 }
 
+function parse_bazel_go_test_new_flaky_cases() {
+    local logPath="$1"
+    local resultFile="$2"
+
+    echo '{}' >"$resultFile"
+    [ -f "bazel-go-test-index.log" ] || parse_bazel_go_test_index_log "$logPath"
+
+    # extract bazel flaky summary info
+    grep -E 'FLAKY:|^\s*/.*/shard_[0-9]+_of_[0-9]+/test_attempts/attempt_[0-9]+.log\b' "$logPath" >bazel-flaky-summaries.log
+
+    # extract bazel flaky targets
+    local indexes=($(grep -n FLAKY bazel-flaky-summaries.log | grep -Eo "^[0-9]+"))
+    local p=0
+    while [ $p -lt "${#indexes[@]}" ]; do
+        local target
+        local targetShardOutputLineNum
+
+        ###### extract target name ###############
+
+        ###### extract shard flag in target ##########
+        local e
+        if [ $((p + 1)) -eq "${#indexes[@]}" ]; then
+            e='$'
+        else
+            e=$((${indexes[${p+1}]} - 1))
+        fi
+        local ts="${indexes[${p}]}"
+        local s=$((ts + 1))
+        target=$(sed -n "${ts},${ts}p" bazel-flaky-summaries.log | grep -Eo "\b//[-_:/a-zA-Z0-9]+\b")
+
+        ###### find the new flaky cases #######
+        for targetShardFlag in $(sed -n "${s},${e}p" bazel-flaky-summaries.log | grep -Eo "shard_[0-9]+_of_[0-9]+"); do
+            targetShardOutputLineNum=$(grep -E "^[0-9]+:=+ Test output for $target \(${targetShardFlag//_/ }\):" bazel-go-test-index.log | grep -Eo "^[0-9]+")
+            local newFlakyCases=($(
+                sed -nE "/^${targetShardOutputLineNum}:/,/^[0-9]+:={80}/p" bazel-go-test-index.log |
+                    grep -E "=== RUN|--- PASS" |
+                    grep -Eo "\bTest\w+" | sort | uniq -c |
+                    grep "^\s*1\b" |
+                    grep -Eo "\bTest\w+"
+            ))
+
+            ##### add into result json file.
+            local caseJqArray
+            caseJqArray=$(printf ',"%s"' "${newFlakyCases[@]}")
+            caseJqArray=${caseJqArray:1}
+            # WIP
+            jq ".\"$target\" += {\"new\": [${caseJqArray}]}" "$resultFile" >"$resultFile".new
+            mv "$resultFile".new "$resultFile"
+        done
+
+        p=$((p + 1))
+    done
+
+    exit 0
+}
+
 # param $1 file path or url
 function main() {
     local logPath="$1"
@@ -47,6 +103,7 @@ function main() {
 
     parse_bazel_go_test_index_log "$logPath"
     parse_bazel_target_output_log "$logPath"
+    parse_bazel_go_test_new_flaky_cases "$logPath" bazel-go-test-flaky-cases.json
 }
 
 main "$@"

--- a/scripts/plugins/analyze-go-test-from-bazel-output.sh
+++ b/scripts/plugins/analyze-go-test-from-bazel-output.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 
+DEFAULT_GO_TEST_INDEX_FILE="bazel-go-test-index.log"
+DEFAILT_GO_TEST_PROBLEM_CASES_JSONFILE="bazel-go-test-problem-cases.json"
+BAZEL_TARGET_OUTPUT_FILE_PREFIX="bazel-target-output"
+BAZEL_FLAKY_SUMMARY_FILE="bazel-flaky-summaries.log"
+
 # parse bazel go test case index log
 # param $1 file path
 function parse_bazel_go_test_index_log() {
     indexReg="((===|---) (RUN|PASS|FAIL))|-- Test timed out at|(====================( Test output for //|=+))"
     local logPath="$1"
-    grep --color -nE "$indexReg" "$logPath" >bazel-go-test-index.log
+    grep --color -nE "$indexReg" "$logPath" >"$DEFAULT_GO_TEST_INDEX_FILE"
 }
 
 function parse_bazel_target_output_log() {
@@ -14,7 +19,7 @@ function parse_bazel_target_output_log() {
     local indexes=($(grep -nE "====================( Test output for //|=+)" ${logPath} | grep -oE "^[0-9]+"))
     local p=0
     while [ $((2 * p)) -lt "${#indexes[@]}" ]; do
-        saveFlag="bazel-target-output-L${indexes[$((2 * p))]}-${indexes[$((2 * p + 1))]}"
+        saveFlag="$BAZEL_TARGET_OUTPUT_FILE_PREFIX-L${indexes[$((2 * p))]}-${indexes[$((2 * p + 1))]}"
         sed -n "${indexes[$((2 * p))]},${indexes[$((2 * p + 1))]}p" "${logPath}" >"$saveFlag.log"
         local append=""
 
@@ -29,6 +34,7 @@ function parse_bazel_target_output_log() {
         if [ "$append" != "" ]; then
             mv "$saveFlag.log" "$saveFlag${append}.log"
         fi
+
         p=$((p + 1))
     done
 }
@@ -37,14 +43,13 @@ function parse_bazel_go_test_new_flaky_cases() {
     local logPath="$1"
     local resultFile="$2"
 
-    echo '{}' >"$resultFile"
-    [ -f "bazel-go-test-index.log" ] || parse_bazel_go_test_index_log "$logPath"
+    [ -f "$DEFAULT_GO_TEST_INDEX_FILE" ] || parse_bazel_go_test_index_log "$logPath"
 
     # extract bazel flaky summary info
-    grep -E 'FLAKY:|^\s*/.*/shard_[0-9]+_of_[0-9]+/test_attempts/attempt_[0-9]+.log\b' "$logPath" >bazel-flaky-summaries.log
+    grep -E 'FLAKY:|^\s*/.*/shard_[0-9]+_of_[0-9]+/test_attempts/attempt_[0-9]+.log\b' "$logPath" >"$BAZEL_FLAKY_SUMMARY_FILE"
 
     # extract bazel flaky targets
-    local indexes=($(grep -n FLAKY bazel-flaky-summaries.log | grep -Eo "^[0-9]+"))
+    local indexes=($(grep -n FLAKY "$BAZEL_FLAKY_SUMMARY_FILE" | grep -Eo "^[0-9]+"))
     local p=0
     while [ $p -lt "${#indexes[@]}" ]; do
         local target
@@ -65,28 +70,58 @@ function parse_bazel_go_test_new_flaky_cases() {
 
         ###### find the new flaky cases #######
         for targetShardFlag in $(sed -n "${s},${e}p" bazel-flaky-summaries.log | grep -Eo "shard_[0-9]+_of_[0-9]+"); do
-            targetShardOutputLineNum=$(grep -E "^[0-9]+:=+ Test output for $target \(${targetShardFlag//_/ }\):" bazel-go-test-index.log | grep -Eo "^[0-9]+")
-            local newFlakyCases=($(
-                sed -nE "/^${targetShardOutputLineNum}:/,/^[0-9]+:={80}/p" bazel-go-test-index.log |
-                    grep -E "=== RUN|--- PASS" |
-                    grep -Eo "\bTest\w+" | sort | uniq -c |
-                    grep "^\s*1\b" |
-                    grep -Eo "\bTest\w+"
-            ))
+            targetShardOutputLineNum=$(grep -E "^[0-9]+:=+ Test output for $target \(${targetShardFlag//_/ }\):" "$DEFAULT_GO_TEST_INDEX_FILE" | grep -Eo "^[0-9]+")
+            for n in $targetShardOutputLineNum; do
+                local newFlakyCases=($(
+                    sed -nE "/^${n}:/,/^[0-9]+:={80}/p" "$DEFAULT_GO_TEST_INDEX_FILE" |
+                        grep -E "=== RUN|--- PASS" |
+                        grep -Eo "\bTest\w+" | sort | uniq -c |
+                        grep "^\s*1\b" |
+                        grep -Eo "\bTest\w+"
+                ))
+                if [ "${#newFlakyCases[@]}" -gt 0 ]; then
+                    ##### add into result json file.
+                    local caseJqArray
+                    caseJqArray=$(printf ',"%s"' "${newFlakyCases[@]}")
+                    caseJqArray=${caseJqArray:1}
 
-            ##### add into result json file.
-            local caseJqArray
-            caseJqArray=$(printf ',"%s"' "${newFlakyCases[@]}")
-            caseJqArray=${caseJqArray:1}
-            # WIP
-            jq ".\"$target\" += {\"new\": [${caseJqArray}]}" "$resultFile" >"$resultFile".new
-            mv "$resultFile".new "$resultFile"
+                    jq ".\"$target\".new_flaky |= (. + [${caseJqArray}] | unique)" \
+                        "$resultFile" >"$resultFile".new && mv "$resultFile".new "$resultFile"
+                fi
+            done
         done
 
         p=$((p + 1))
     done
+}
 
-    exit 0
+function parse_bazel_go_test_long_cases() {
+    local logPath="$1"
+    local resultFile="$2"
+
+    [ -f "$DEFAULT_GO_TEST_INDEX_FILE" ] || parse_bazel_go_test_index_log "$logPath"
+
+    for f in $BAZEL_TARGET_OUTPUT_FILE_PREFIX-*.timeout.log; do
+        local target
+        [[ -e "$f" ]] || break
+
+        target=$(head -n1 "$f" | grep -Eo "//[-_:/a-zA-Z0-9]+\b")
+
+        # add test cases with time cost value -1(means timed out).
+        grep -E "=== RUN|--- PASS:" "$f" | grep -Eo "\bTest\w+" | sort | uniq |
+            while read c; do
+                jq "$(printf '.["%s"].long_time.%s |= -1' "$target" $c)" \
+                    "$resultFile" >"$resultFile".new && mv "$resultFile".new "$resultFile"
+            done
+
+        # update the timecost of passed test cases.
+        grep -E "\-\-\- PASS:" "$f" | grep -Eo '\bTest\w+(\s+\([0-9.]+s\))' | sed -E 's/[\(\)]//g;s/s$//g' |
+            while read rec; do
+                echo "$rec"
+                jq "$(printf '.["%s"].long_time.%s |= if (. and . >= 0) then . else %s end' "$target" $rec)" \
+                    "$resultFile" >"$resultFile".new && mv "$resultFile".new "$resultFile"
+            done
+    done
 }
 
 # param $1 file path or url
@@ -103,7 +138,16 @@ function main() {
 
     parse_bazel_go_test_index_log "$logPath"
     parse_bazel_target_output_log "$logPath"
-    parse_bazel_go_test_new_flaky_cases "$logPath" bazel-go-test-flaky-cases.json
+
+    echo "{}" >"$DEFAILT_GO_TEST_PROBLEM_CASES_JSONFILE"
+    parse_bazel_go_test_new_flaky_cases "$logPath" "$DEFAILT_GO_TEST_PROBLEM_CASES_JSONFILE"
+    parse_bazel_go_test_long_cases "$logPath" "$DEFAILT_GO_TEST_PROBLEM_CASES_JSONFILE"
+
+    echo "Output files:"
+    ls $DEFAILT_GO_TEST_PROBLEM_CASES_JSONFILE \
+        $DEFAULT_GO_TEST_INDEX_FILE \
+        $BAZEL_FLAKY_SUMMARY_FILE \
+        $BAZEL_TARGET_OUTPUT_FILE_PREFIX-*.log || true
 }
 
 main "$@"

--- a/scripts/plugins/report_job_result.sh
+++ b/scripts/plugins/report_job_result.sh
@@ -1,4 +1,3 @@
-
 #! /usr/bin/env bash
 
 #### Notable: should run in python container with image: hub.pingcap.net/jenkins/python3-requests:latest ###
@@ -27,7 +26,7 @@ function gen() {
     local taskStartTime=$(date "+%s%3N" -d "$(stat /proc/1 | grep 'Modify: ' | sed 's/Modify: //')")
     local taskEndTime=$(date '+%s%3N')
 
-    cat <<EOF > "${savePath}"
+    cat <<EOF >"${savePath}"
 {
     "pipeline_name": "${JOB_NAME}",
     "pipeline_run_url": "${RUN_DISPLAY_URL}",
@@ -53,10 +52,10 @@ function gen() {
 EOF
 }
 
-# function 
+# function report
 # param $1: json file path
 function report() {
-    local jsonPath="$1"    
+    local jsonPath="$1"
     local fileServerUrl="${FILE_SERVER_URL:=http://fileserver.pingcap.net}"
     echo $fileServerUrl
     wget "${fileServerUrl}/download/rd-atom-agent/agent_upload_verifyci_metadata.py"


### PR DESCRIPTION
output a new file: `bazel-go-test-problem-cases.json`

```json
{
  "//ddl/tiflashtest:tiflashtest_test": {
    "new_flaky": [
      "TestTiFlashProgressCache",
      "TestTiFlashTruncatePartition"
    ]
  },
  "//executor:executor_test": {
    "new_flaky": [
      "TestStaleReadNoExtraTSORequest"
    ]
  },
  "//ddl:ddl_test": {
    "new_flaky": [
      "TestCancel"
    ],
    "long_time": {
      "TestCancel": -1
    }
  },
  "//session:session_test": {
    "new_flaky": [
      "TestClusteredIndexSplitAndAddIndex2",
      "TestClusteredIndexSyntax",
      "TestCommitWhenSchemaChanged",
      "TestDeleteExecChunk",
      "TestGlobalAndLocalTxn",
      "TestIndexLookUpReaderChunk",
      "TestIndexMergeUpgradeFrom400To540",
      "TestIndexUsageSyncLease",
      "TestInitializeSQLFile",
      "TestPartitionTable",
      "TestPrefixClusteredIndexAddIndexAndRecover",
      "TestRetrySchemaChange",
      "TestRetrySchemaChangeForEmptyChange",
      "TestTiDBCostModelUpgradeFrom610To650",
      "TestUpgradeVersion74",
      "TestValidationRecursion"
    ],
    "long_time": {
      "TestGlobalAndLocalTxn": -1,
      "TestInitializeSQLFile": -1,
      "TestIndexUsageSyncLease": -1,
      "TestStmtSummary": 194.32,
      "TestCommitWhenSchemaChanged": -1,
      "TestUpdateDuplicateBindInfo": 234.78,
      "TestUpgradeToVer85": 190.92,
      "TestValidationRecursion": -1,
      "TestTiDBCostModelUpgradeFrom610To650": -1,
      "TestForIssue23387": 169.53,
      "TestInsertExecChunk": 127.39,
      "TestRetrySchemaChangeForEmptyChange": -1,
      "TestUpgradeClusteredIndexDefaultValue": 240.66,
      "TestAnalyzeVersionUpgradeFrom300To500": 276.21,
      "TestDeleteExecChunk": -1,
      "TestIssue17979_2": 274.67,
      "TestPrefixClusteredIndexAddIndexAndRecover": -1,
      "TestRetrySchemaChange": -1,
      "TestUpgradeVersion66": 241.09,
      "TestIndexLookUpReaderChunk": -1,
      "TestIndexMergeUpgradeFrom300To540": 271.79,
      "TestClusteredIndexSplitAndAddIndex2": -1,
      "TestUpgrade": 295.71,
      "TestClusteredIndexSyntax": -1,
      "TestIssue17979_1": 262.03,
      "TestIssue20900_2": 224.99,
      "TestPartitionTable": -1,
      "TestIndexMergeUpgradeFrom400To540": -1,
      "TestUpgradeVersion74": -1
    }
  }
}

```

- `-1` means the test not finished, and timed out the last one.