### PR TITLE
chore(pingcap/tidb): reduce the network bandwidth consumption

### DIFF
--- a/jobs/pingcap/tidb/latest/merged_build.groovy
+++ b/jobs/pingcap/tidb/latest/merged_build.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/merged_common_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_common_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_common_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_e2e_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -71,7 +71,19 @@ pipelineJob('pingcap/tidb/merged_integration_br_test') {
             lightweight(true)
             scriptPath('pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy')
             scm {
-                github('PingCAP-QE/ci', 'main')
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
             }
         }
     }

--- a/jobs/pingcap/tidb/latest/merged_integration_cdc_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_cdc_test.groovy
@@ -70,7 +70,19 @@ pipelineJob('pingcap/tidb/merged_integration_cdc_test') {
             lightweight(true)
             scriptPath('pipelines/pingcap/tidb/latest/merged_integration_cdc_test.groovy')
             scm {
-                github('PingCAP-QE/ci', 'main')
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
             }
         }
     }

--- a/jobs/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_integration_common_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_integration_copr_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/merged_integration_ddl_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_ddl_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_integration_ddl_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_integration_jdbc_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_integration_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/merged_sqllogic_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_sqllogic_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_sqllogic_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/merged_tiflash_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_tiflash_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_tiflash_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/merged_unit_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_unit_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/merged_unit_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }


### PR DESCRIPTION
Reduce the network bandwidth consumption of downloading ci.git.
Complate git clone 20M, shallow git clone 6.4M.