### PR TITLE
chore: reduce the network bandwidth consumption

### DIFF
--- a/jobs/pingcap/tidb-engine-ext/latest/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb-engine-ext/latest/ghpr_unit_test.groovy
@@ -74,10 +74,16 @@ pipelineJob('pingcap/tidb-engine-ext/ghpr_unit_test') {
             scm {
                 git{
                     remote {
-                        url('git@github.com:PingCAP-QE/ci.git')
-                        credentials('github-sre-bot-ssh')
+                        url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-engine-ext/release-6.1/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb-engine-ext/release-6.1/ghpr_unit_test.groovy
@@ -74,10 +74,16 @@ pipelineJob('pingcap/tidb-engine-ext/release-6.1/ghpr_unit_test') {
             scm {
                 git{
                     remote {
-                        url('git@github.com:PingCAP-QE/ci.git')
-                        credentials('github-sre-bot-ssh')
+                        url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/latest/ghpr_build.groovy
+++ b/jobs/pingcap/tidb-test/latest/ghpr_build.groovy
@@ -25,6 +25,13 @@ pipelineJob('pingcap/tidb-test/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/latest/ghpr_integration_jdbc_test.groovy
+++ b/jobs/pingcap/tidb-test/latest/ghpr_integration_jdbc_test.groovy
@@ -25,6 +25,13 @@ pipelineJob('pingcap/tidb-test/ghpr_integration_jdbc_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/latest/ghpr_integration_mysql_test.groovy
+++ b/jobs/pingcap/tidb-test/latest/ghpr_integration_mysql_test.groovy
@@ -25,6 +25,13 @@ pipelineJob('pingcap/tidb-test/ghpr_integration_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/release-6.0/ghpr_build.groovy
+++ b/jobs/pingcap/tidb-test/release-6.0/ghpr_build.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb-test/release-6.0/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/jobs/pingcap/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb-test/release-6.0/ghpr_integration_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/release-6.0/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb-test/release-6.0/ghpr_mysql_test.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb-test/release-6.0/ghpr_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/release-6.1/ghpr_build.groovy
+++ b/jobs/pingcap/tidb-test/release-6.1/ghpr_build.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb-test/release-6.1/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/release-6.1/ghpr_integration_mysql_test.groovy
+++ b/jobs/pingcap/tidb-test/release-6.1/ghpr_integration_mysql_test.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb-test/release-6.1/ghpr_integration_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/release-6.1/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb-test/release-6.1/ghpr_mysql_test.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb-test/release-6.1/ghpr_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/release-6.2/ghpr_build.groovy
+++ b/jobs/pingcap/tidb-test/release-6.2/ghpr_build.groovy
@@ -25,6 +25,13 @@ pipelineJob('pingcap/tidb-test/release-6.2/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/jobs/pingcap/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -25,6 +25,13 @@ pipelineJob('pingcap/tidb-test/release-6.2/ghpr_integration_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb-test/release-6.2/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb-test/release-6.2/ghpr_mysql_test.groovy
@@ -25,6 +25,13 @@ pipelineJob('pingcap/tidb-test/release-6.2/ghpr_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_build.groovy
@@ -25,6 +25,13 @@ pipelineJob('pingcap/tidb/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_check.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb/ghpr_check') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_check2.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb/ghpr_check2') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb/ghpr_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb/ghpr_unit_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.1/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.1/ghpr_build.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.1/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.1/ghpr_check.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_check') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.1/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.1/ghpr_check2.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_check2') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.1/ghpr_unit_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.2/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_build.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.2/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_check.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_check') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_check2') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.2/ghpr_unit_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.3/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_build.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.3/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_check.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_check') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_check2') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.3/ghpr_unit_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.4/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.4/ghpr_build.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.4/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.4/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.4/ghpr_check.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.4/ghpr_check') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.4/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.4/ghpr_check2.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.4/ghpr_check2') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.4/ghpr_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.4/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.4/ghpr_unit_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.4/ghpr_unit_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.5/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.5/ghpr_build.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb/release-6.5/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.5/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.5/ghpr_check.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.5/ghpr_check') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.5/ghpr_check2') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.5/ghpr_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.5/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.5/ghpr_unit_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.5/ghpr_unit_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.6/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/release-6.6/ghpr_build.groovy
@@ -24,6 +24,13 @@ pipelineJob('pingcap/tidb/release-6.6/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.6/ghpr_check.groovy
+++ b/jobs/pingcap/tidb/release-6.6/ghpr_check.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.6/ghpr_check') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.6/ghpr_check2.groovy
+++ b/jobs/pingcap/tidb/release-6.6/ghpr_check2.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.6/ghpr_check2') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
+++ b/jobs/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.6/ghpr_mysql_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tidb/release-6.6/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/release-6.6/ghpr_unit_test.groovy
@@ -23,6 +23,13 @@ pipelineJob('pingcap/tidb/release-6.6/ghpr_unit_test') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/jobs/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -72,7 +72,19 @@ pipelineJob('pingcap/tiflow/ghpr_verify') {
             lightweight(true)
             scriptPath("pipelines/pingcap/tiflow/latest/ghpr_verify.groovy")
             scm {
-                github('PingCAP-QE/ci', 'main')
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
             }
         }
     }

--- a/jobs/pingcap/tiflow/release-5.3/ghpr_verify.groovy
+++ b/jobs/pingcap/tiflow/release-5.3/ghpr_verify.groovy
@@ -69,7 +69,19 @@ pipelineJob('pingcap/tiflow/release-5.3/ghpr_verify') {
             lightweight(true)
             scriptPath("pipelines/pingcap/tiflow/release-5.3/ghpr_verify.groovy")
             scm {
-                github('PingCAP-QE/ci', 'main')
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
             }
         }
     }

--- a/jobs/pingcap/tiflow/release-6.0/ghpr_verify.groovy
+++ b/jobs/pingcap/tiflow/release-6.0/ghpr_verify.groovy
@@ -69,7 +69,19 @@ pipelineJob('pingcap/tiflow/release-6.0/ghpr_verify') {
             lightweight(true)
             scriptPath("pipelines/pingcap/tiflow/release-6.0/ghpr_verify.groovy")
             scm {
-                github('PingCAP-QE/ci', 'main')
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
             }
         }
     }

--- a/jobs/pingcap/tiflow/release-6.1/ghpr_verify.groovy
+++ b/jobs/pingcap/tiflow/release-6.1/ghpr_verify.groovy
@@ -69,7 +69,19 @@ pipelineJob('pingcap/tiflow/release-6.1/ghpr_verify') {
             lightweight(true)
             scriptPath("pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy")
             scm {
-                github('PingCAP-QE/ci', 'main')
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
             }
         }
     }

--- a/jobs/pingcap/tiflow/release-6.2/ghpr_verify.groovy
+++ b/jobs/pingcap/tiflow/release-6.2/ghpr_verify.groovy
@@ -69,7 +69,19 @@ pipelineJob('pingcap/tiflow/release-6.2/ghpr_verify') {
             lightweight(true)
             scriptPath("pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy")
             scm {
-                github('PingCAP-QE/ci', 'main')
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
             }
         }
     }

--- a/jobs/ti-community-infra/test-prod/prow_debug.groovy
+++ b/jobs/ti-community-infra/test-prod/prow_debug.groovy
@@ -26,6 +26,13 @@ pipelineJob('ti-community-infra/test-prod/prow_debug') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/tikv/migration/latest/pull_integration_test.groovy
+++ b/jobs/tikv/migration/latest/pull_integration_test.groovy
@@ -70,7 +70,19 @@ pipelineJob('tikv/migration/pull_integration_test') {
             lightweight(true)
             scriptPath("pipelines/tikv/migration/latest/pull_integration_test.groovy")
             scm {
-                github('PingCAP-QE/ci', 'main')
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
             }
         }
     }

--- a/jobs/tikv/migration/latest/pull_unit_test.groovy
+++ b/jobs/tikv/migration/latest/pull_unit_test.groovy
@@ -70,7 +70,19 @@ pipelineJob('tikv/migration/pull_unit_test') {
             lightweight(true)
             scriptPath("pipelines/tikv/migration/latest/pull_unit_test.groovy")
             scm {
-                github('PingCAP-QE/ci', 'main')
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
             }
         }
     }

--- a/jobs/tikv/pd/latest/ghpr_build.groovy
+++ b/jobs/tikv/pd/latest/ghpr_build.groovy
@@ -25,6 +25,13 @@ pipelineJob('tikv/pd/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }

--- a/jobs/tikv/pd/release-6.5/ghpr_build.groovy
+++ b/jobs/tikv/pd/release-6.5/ghpr_build.groovy
@@ -24,6 +24,13 @@ pipelineJob('tikv/pd/release-6.5/ghpr_build') {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
                     branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
                 }
             }
         }


### PR DESCRIPTION
Reduce the network bandwidth consumption of downloading ci.git.
* complate git clone will consume 20M.
* shallow git clone will consume 6.4M.