### PR TITLE
feat: add new grafana tiup pipeline

### DIFF
--- a/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update.groovy
+++ b/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update.groovy
@@ -1,0 +1,109 @@
+def fallback=false
+pipeline{
+    parameters{
+        string(name: 'VERSION', defaultValue: '7.5.11', description: 'the grafana version')
+        string(name: 'RELEASE_TAG', defaultValue: 'nightly', description: 'the tidb verison')
+        string(name: 'RELEASE_BRANCH', defaultValue: 'master', description: 'target branch')
+        string(name: 'TIDB_VERSION', defaultValue: '', description: 'tiup package verion')
+        string(name: 'TIUP_MIRRORS', defaultValue: 'http://172.16.5.134:8987', description: 'tiup mirror')
+    }
+    agent {
+        kubernetes {
+            yaml '''
+spec:
+  containers:
+  - name: golang
+    image: hub.pingcap.net/jenkins/centos7_golang-1.20
+    args: ["sleep", "infinity"]
+  - name: tiup
+    image: hub.pingcap.net/jenkins/tiup
+    args: ["sleep", "infinity"]
+'''
+                    defaultContainer 'golang'
+        }
+}
+    stages{
+        stage("pull panel"){
+            environment {
+                GOPROXY = "http://goproxy.pingcap.net,https://proxy.golang.org,direct"
+                TOKEN = credentials('sre-bot-token')
+                TARGET = "${params.RELEASE_BRANCH}"
+            }
+            steps{
+                checkout([$class: 'GitSCM',
+                            branches: [[name: "${params.RELEASE_BRANCH}"]],
+                            extensions: [[$class: 'LocalBranch']],
+                            userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', url: 'git@github.com:pingcap/monitoring.git']]]
+                )
+                script{
+                try{
+                    sh "bash scripts/prepare_dashboards.sh"
+                }catch (Exception e) {
+                    fallback = true
+                    echo "fallback"
+                    def  paramsBuild = [
+                    string(name: "RELEASE_BRANCH", value: "${RELEASE_BRANCH}"),
+                    string(name: "RELEASE_TAG", value: "${RELEASE_TAG}"),
+                    string(name: "ORIGIN_TAG", value: ""),
+                    string(name: "TIDB_VERSION", value: "${TIDB_VERSION}"),
+                    string(name: "TIUP_MIRRORS", value: "${TIUP_MIRRORS}"),
+                    [$class: 'BooleanParameterValue', name: 'ARCH_X86', value: true],
+                    [$class: 'BooleanParameterValue', name: 'ARCH_ARM', value: true],
+                    [$class: 'BooleanParameterValue', name: 'ARCH_MAC', value: true],
+                    [$class: 'BooleanParameterValue', name: 'ARCH_MAC_ARM', value: true],
+                    ]
+                    echo "$paramsBuild"
+                    build job: "grafana-tiup-mirror-update-test",
+                                    wait: true,
+                                    parameters: paramsBuild
+                }
+                }
+            }
+        }
+        stage("prepare tiup"){
+            when {expression {!fallback}}
+            environment { TIUPKEY_JSON = credentials('tiup-prod-key')}
+            steps{
+            container("tiup"){
+                sh 'set +x;curl https://tiup-mirrors.pingcap.com/root.json -o /root/.tiup/bin/root.json; mkdir -p /root/.tiup/keys; cp $TIUPKEY_JSON /root/.tiup/keys/private.json'
+            }
+            } 
+        }
+        stage("multi-arch"){
+            when {expression {!fallback}}
+            environment {
+                TIUP_MIRRORS = "${params.TIUP_MIRRORS}"
+                VERSION="${params.TIDB_VERSION}"
+            }
+            matrix{
+                axes {
+                    axis {
+                        name 'OS'
+                        values 'linux', 'darwin'
+                    }
+                    axis {
+                        name 'ARCH'
+                        values 'amd64', 'arm64'
+                    }
+                }
+                stages{
+                    stage("tiup"){
+                    options { retry(3) }
+                    environment { 
+                        OS="$OS"
+                        ARCH="$ARCH"
+                    }
+                    steps{
+                        container("tiup"){
+                            dir("$OS-$ARCH"){
+                            sh "bash ../scripts/build_tiup_grafana.sh"
+                            sh 'tiup mirror publish grafana ${VERSION} grafana.tar.gz "bin/grafana-server" --arch $ARCH --os $OS --desc="Grafana is the open source analytics & monitoring solution for every database" '
+                            }
+                        }
+                    }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update.groovy
+++ b/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update.groovy
@@ -73,7 +73,6 @@ spec:
             when {expression {!fallback}}
             environment {
                 TIUP_MIRRORS = "${params.TIUP_MIRRORS}"
-                VERSION="${params.TIDB_VERSION}"
             }
             matrix{
                 axes {
@@ -97,7 +96,7 @@ spec:
                         container("tiup"){
                             dir("$OS-$ARCH"){
                             sh "bash ../scripts/build_tiup_grafana.sh"
-                            sh 'tiup mirror publish grafana ${VERSION} grafana.tar.gz "bin/grafana-server" --arch $ARCH --os $OS --desc="Grafana is the open source analytics & monitoring solution for every database" '
+                            sh 'tiup mirror publish grafana ${params.TIDB_VERSION} grafana.tar.gz "bin/grafana-server" --arch $ARCH --os $OS --desc="Grafana is the open source analytics & monitoring solution for every database" '
                             }
                         }
                     }

--- a/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update.groovy
+++ b/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update.groovy
@@ -53,7 +53,7 @@ spec:
                     [$class: 'BooleanParameterValue', name: 'ARCH_MAC_ARM', value: true],
                     ]
                     echo "$paramsBuild"
-                    build job: "grafana-tiup-mirror-update-test",
+                    build job: "grafana-tiup-mirror-update",
                                     wait: true,
                                     parameters: paramsBuild
                 }

--- a/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update.groovy
+++ b/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update.groovy
@@ -36,27 +36,27 @@ spec:
                             userRemoteConfigs: [[credentialsId: 'github-sre-bot-ssh', url: 'git@github.com:pingcap/monitoring.git']]]
                 )
                 script{
-                try{
-                    sh "bash scripts/prepare_dashboards.sh"
-                }catch (Exception e) {
-                    fallback = true
-                    echo "fallback"
-                    def  paramsBuild = [
-                    string(name: "RELEASE_BRANCH", value: "${RELEASE_BRANCH}"),
-                    string(name: "RELEASE_TAG", value: "${RELEASE_TAG}"),
-                    string(name: "ORIGIN_TAG", value: ""),
-                    string(name: "TIDB_VERSION", value: "${TIDB_VERSION}"),
-                    string(name: "TIUP_MIRRORS", value: "${TIUP_MIRRORS}"),
-                    [$class: 'BooleanParameterValue', name: 'ARCH_X86', value: true],
-                    [$class: 'BooleanParameterValue', name: 'ARCH_ARM', value: true],
-                    [$class: 'BooleanParameterValue', name: 'ARCH_MAC', value: true],
-                    [$class: 'BooleanParameterValue', name: 'ARCH_MAC_ARM', value: true],
-                    ]
-                    echo "$paramsBuild"
-                    build job: "grafana-tiup-mirror-update-test",
+                    try{
+                        sh "bash scripts/prepare_dashboards.sh"
+                    }catch (Exception e) {
+                        fallback = true
+                        echo "fallback"
+                        def  paramsBuild = [
+                            string(name: "RELEASE_BRANCH", value: "${RELEASE_BRANCH}"),
+                            string(name: "RELEASE_TAG", value: "${RELEASE_TAG}"),
+                            string(name: "ORIGIN_TAG", value: ""),
+                            string(name: "TIDB_VERSION", value: "${TIDB_VERSION}"),
+                            string(name: "TIUP_MIRRORS", value: "${TIUP_MIRRORS}"),
+                            [$class: 'BooleanParameterValue', name: 'ARCH_X86', value: true],
+                            [$class: 'BooleanParameterValue', name: 'ARCH_ARM', value: true],
+                            [$class: 'BooleanParameterValue', name: 'ARCH_MAC', value: true],
+                            [$class: 'BooleanParameterValue', name: 'ARCH_MAC_ARM', value: true],
+                        ]
+                        echo "$paramsBuild"
+                        build job: "grafana-tiup-mirror-update-test",
                                     wait: true,
                                     parameters: paramsBuild
-                }
+                    }
                 }
             }
         }
@@ -87,19 +87,19 @@ spec:
                 }
                 stages{
                     stage("tiup"){
-                    options { retry(3) }
-                    environment { 
-                        OS="$OS"
-                        ARCH="$ARCH"
-                    }
-                    steps{
-                        container("tiup"){
-                            dir("$OS-$ARCH"){
-                            sh "bash ../scripts/build_tiup_grafana.sh"
-                            sh 'tiup mirror publish grafana ${params.TIDB_VERSION} grafana.tar.gz "bin/grafana-server" --arch $ARCH --os $OS --desc="Grafana is the open source analytics & monitoring solution for every database" '
+                        options { retry(3) }
+                        environment { 
+                            OS="$OS"
+                            ARCH="$ARCH"
+                        }
+                        steps{
+                            container("tiup"){
+                                dir("$OS-$ARCH"){
+                                sh "bash ../scripts/build_tiup_grafana.sh"
+                                sh 'tiup mirror publish grafana ${params.TIDB_VERSION} grafana.tar.gz "bin/grafana-server" --arch $ARCH --os $OS --desc="Grafana is the open source analytics & monitoring solution for every database" '
+                                }
                             }
                         }
-                    }
                     }
                 }
             }

--- a/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update.groovy
+++ b/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update.groovy
@@ -53,7 +53,7 @@ spec:
                     [$class: 'BooleanParameterValue', name: 'ARCH_MAC_ARM', value: true],
                     ]
                     echo "$paramsBuild"
-                    build job: "grafana-tiup-mirror-update",
+                    build job: "grafana-tiup-mirror-update-test",
                                     wait: true,
                                     parameters: paramsBuild
                 }

--- a/jenkins/pipelines/cd/tiup/tiup-mirror-update-test-new.groovy
+++ b/jenkins/pipelines/cd/tiup/tiup-mirror-update-test-new.groovy
@@ -531,7 +531,7 @@ node("build_go1130") {
                 builds["TiUP build grafana"] = {
                     retry(3) {
                         if (TIUP_ENV == "prod") {
-                            build(job: "grafana-tiup-mirror-update-test", wait: true, parameters: paramsGRANFANA)
+                            build(job: "grafana-tiup-mirror-update", wait: true, parameters: paramsGRANFANA)
                         } else {
                             build(job: "grafana-tiup-mirror-update-test-hotfix", wait: true, parameters: paramsGRANFANA)
                         }

--- a/jenkins/pipelines/cd/tiup/tiup-mirror-update-test.groovy
+++ b/jenkins/pipelines/cd/tiup/tiup-mirror-update-test.groovy
@@ -259,7 +259,7 @@ node("build_go1130") {
                 }
                 builds["TiUP build grafana"]={
                     retry(3) {
-                        build(job: "grafana-tiup-mirror-update-test", wait: true, parameters: params1)
+                        build(job: "grafana-tiup-mirror-update", wait: true, parameters: params1)
                     }
                 }
                 builds["TiUP build prometheus"]={

--- a/jenkins/pipelines/cd/tiup/tiup-online-mirror-atom.groovy
+++ b/jenkins/pipelines/cd/tiup/tiup-online-mirror-atom.groovy
@@ -96,7 +96,7 @@ node("build_go1130") {
             }
 
             stage("TiUP build grafana") {
-                build(job: "grafana-tiup-mirror-update-test", wait: true, parameters: params1)
+                build(job: "grafana-tiup-mirror-update", wait: true, parameters: params1)
             }
 
             stage("TiUP build prometheus") {


### PR DESCRIPTION
# Why
- old pipeline embed logic, which is different with that in operator, we need to unify them
- pannel now managed within `monitoring` repo

# How
- use script in `pingcap/monitoring` repo
- when the script not exist in repo, we just fallback to old pipeline , and then cherry-pick build script to that branch. 
- without this fallback, a lot of pipeline would fail immediately, when most branch has been migrated, we can remove fallback