### PR TITLE
chore: tikv cache image add release-7.0

### DIFF
--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy
@@ -107,6 +107,7 @@ RUN cd tikv-src \
         }
         
         build_branch("master")
+        build_branch("release-7.0")
         build_branch("release-6.6")
         build_branch("release-6.5")
         build_branch("release-6.1")


### PR DESCRIPTION
tikv cache image add release-7.0