### PR TITLE
feat: tiflow ci enable report

### DIFF
--- a/jobs/pingcap/tiflow/latest/README.md
+++ b/jobs/pingcap/tiflow/latest/README.md
@@ -1,0 +1,18 @@
+CI Jobs
+===
+
+## Run before merged
+
+| Job name                                                     | Description                                   | Trigger comment in PR                    | CI script                                                    | Can be run locally by contributors | Core Instructions to run locally                             | Runner resouce requirement                                   |
+| ------------------------------------------------------------ | --------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------ | ---------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| [pull_cdc_integration_kafka_test](./pull_cdc_integration_kafka_test.groovy) | Run cdc integration test with kafka sink type | `/test cdc-integration-kafka-test`       | [link](/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy) | Yes                                | [Please refer to the document](https://github.com/pingcap/tiflow/tree/master/tests/integration_tests#run-integration-tests-locally) | [link](/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml) |
+| [pull_cdc_integration_test](pull_cdc_integration_test.groovy) | Run cdc integration test with mysql sink type | `/test /test cdc-integration-mysql-test` | [link](/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy) | Yes                                | [Please refer to the document](https://github.com/pingcap/tiflow/tree/master/tests/integration_tests#run-integration-tests-locally) | [link](/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml) |
+| [pull_dm_compatibility_test](pull_dm_compatibility_test.groovy) | Run DM Compatibility Test                     | `/test dm-compatibility-test`            | [link](/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy) | Yes                                | [Please refer to the document](https://github.com/pingcap/tiflow/tree/master/dm/tests#compatibility-test) | [link](/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml) |
+| [pull_dm_integration_test](pull_dm_integration_test.groovy)  | Run DM Integration Test                       | `/test dm-integration-test`              | [link](/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy) | Yes                                | [Please refer to the document](https://github.com/pingcap/tiflow/tree/master/dm/tests#integration-test) | [link](/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml) |
+| [pull_engine_integration_test](pull_engine_integration_test.groovy) | Run Engine  Integration Test                  | `/test engine-integration-test`          | [link](/pipelines/pingcap/tiflow/latest/pull_engine_integration_test.groovy) | Yes                                | [Please refer to the document](https://github.com/pingcap/tiflow/tree/master/engine/test/integration_tests#run-engine-integration-tests) | [link](/pipelines/pingcap/tiflow/latest/pod-pull_engine_integration_test.yaml) |
+
+Others are refactoring, comming soon.
+
+## Run after merged
+
+> Refactoring, coming soon.

--- a/jobs/pingcap/tiflow/latest/prow-presubmits.yaml
+++ b/jobs/pingcap/tiflow/latest/prow-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       always_run: false
       # context: idc-jenkins-ci-ticdc/kafka-integration-test
       context: wip/cdc-integration-kafka-test
-      skip_report: true
+      skip_report: false
       trigger: "(?m)^/test (?:.*? )?cdc-integration-kafka-test(?: .*?)?$"
       rerun_command: "/test cdc-integration-kafka-test"
       branches:
@@ -18,7 +18,7 @@ presubmits:
       always_run: false
       # context: idc-jenkins-ci-ticdc/integration-test
       context: wip/cdc-integration-mysql-test
-      skip_report: true
+      skip_report: false
       trigger: "(?m)^/test (?:.*? )?cdc-integration-mysql-test(?: .*?)?$"
       rerun_command: "/test cdc-integration-mysql-test"
       branches:
@@ -29,7 +29,7 @@ presubmits:
       always_run: false
       # context: idc-jenkins-ci-ticdc/dm-compatibility-test
       context: wip/dm-compatibility-test
-      skip_report: true
+      skip_report: false
       trigger: "(?m)^/test (?:.*? )?dm-compatibility-test(?: .*?)?$"
       rerun_command: "/test dm-compatibility-test"
       branches:
@@ -40,7 +40,7 @@ presubmits:
       always_run: false
       # context: idc-jenkins-ci-ticdc/dm-integration-test
       context: wip/dm-integration-test
-      skip_report: true
+      skip_report: false
       trigger: "(?m)^/test (?:.*? )?dm-integration-test(?: .*?)?$"
       rerun_command: "/test dm-integration-test"
       branches:
@@ -51,7 +51,7 @@ presubmits:
       always_run: false
       # context: idc-jenkins-ci-ticdc/engine-integration-test
       context: wip/engine-integration-test
-      skip_report: true
+      skip_report: false
       trigger: "(?m)^/test (?:.*? )?engine-integration-test(?: .*?)?$"
       rerun_command: "/test engine-integration-test"
       branches:


### PR DESCRIPTION
Enable status reporting for the following pipelines.
* pull_cdc_integration_kafka_test
* pull_cdc_integration_test
* pull_dm_compatibility_test
* pull_dm_integration_test
* pull_engine_integration_test