### PR TITLE
feat: will upload plugin to proper file-server path for non LTS

### DIFF
--- a/jenkins/pipelines/cd/release-enterprise-plugin.groovy
+++ b/jenkins/pipelines/cd/release-enterprise-plugin.groovy
@@ -9,6 +9,7 @@ pipeline{
     parameters {
         string(name: 'Version', description: 'important, the version for cli --version and profile choosing, eg. v6.5.0')
         string(name: 'Hash', description: 'git hash')
+        booleanParam(name: 'IsLTS', description: 'whether it is a lts version')
     }
     agent {
         kubernetes {
@@ -26,23 +27,30 @@ pipeline{
                     }
                 }
                 stages{
-                stage("upload"){
-                    environment {
-                        QINIU_BUCKET_NAME = 'tidb'
-                        QINIU_ACCESS_KEY = credentials('qn_access_key');
-                        QINIU_SECRET_KEY = credentials('qiniu_secret_key');
+                    stage("upload fileserver"){
+                        steps{
+                            sh """
+                            wget -q http://fileserver.pingcap.net/download/builds/pingcap/enterprise-plugin/optimization/${params.Version}/${params.Hash}/centos7/enterprise-plugin-linux-${arch}-enterprise.tar.gz
+                            wget -q http://fileserver.pingcap.net/download/builds/pingcap/enterprise-plugin/optimization/${params.Version}/${params.Hash}/centos7/enterprise-plugin-linux-${arch}-enterprise.tar.gz.sha256
+                            curl --fail -F release/enterprise-plugin-${params.Version}-linux-${arch}.tar.gz=@enterprise-plugin-linux-${arch}-enterprise.tar.gz http://fileserver.pingcap.net/upload
+                            curl --fail -F release/enterprise-plugin-${params.Version}-linux-${arch}.tar.gz.sha256=@enterprise-plugin-linux-${arch}-enterprise.tar.gz.sha256 http://fileserver.pingcap.net/upload
+                            """
+                        }
                     }
-                    steps{
-                sh """
-                wget -q http://fileserver.pingcap.net/download/builds/pingcap/enterprise-plugin/optimization/${params.Version}/${params.Hash}/centos7/enterprise-plugin-linux-${arch}-enterprise.tar.gz
-                wget -q http://fileserver.pingcap.net/download/builds/pingcap/enterprise-plugin/optimization/${params.Version}/${params.Hash}/centos7/enterprise-plugin-linux-${arch}-enterprise.tar.gz.sha256
-                curl --fail -F release/enterprise-plugin-${params.Version}-linux-${arch}.tar.gz=@enterprise-plugin-linux-${arch}-enterprise.tar.gz http://fileserver.pingcap.net/upload
-                curl --fail -F release/enterprise-plugin-${params.Version}-linux-${arch}.tar.gz.sha256=@enterprise-plugin-linux-${arch}-enterprise.tar.gz.sha256 http://fileserver.pingcap.net/upload
-                upload_qiniu.py enterprise-plugin-linux-${arch}-enterprise.tar.gz enterprise-plugin-${params.Version}-linux-${arch}.tar.gz
-                upload_qiniu.py enterprise-plugin-linux-${arch}-enterprise.tar.gz.sha256 enterprise-plugin-${params.Version}-linux-${arch}.tar.gz.sha256
-                """
+                    stage("upload public"){
+                        when {equals expected:true, actual:params.IsLTS.toBoolean()}
+                        environment {
+                            QINIU_BUCKET_NAME = 'tidb'
+                            QINIU_ACCESS_KEY = credentials('qn_access_key');
+                            QINIU_SECRET_KEY = credentials('qiniu_secret_key');
+                        }
+                        steps{
+                            sh """
+                            upload_qiniu.py enterprise-plugin-linux-${arch}-enterprise.tar.gz enterprise-plugin-${params.Version}-linux-${arch}.tar.gz
+                            upload_qiniu.py enterprise-plugin-linux-${arch}-enterprise.tar.gz.sha256 enterprise-plugin-${params.Version}-linux-${arch}.tar.gz.sha256
+                            """
+                        }
                     }
-                }
                 }
             }
         }


### PR DESCRIPTION
## Why:
old non-LTS internal plugin path is ugly

## How:
add an option to specify whether it is LTS, non LTS will not push to public, but still push to internal