### PR TITLE
fix: use run_before_merge to control integration test

### DIFF
--- a/jobs/pingcap/tiflow/latest/prow-presubmits.yaml
+++ b/jobs/pingcap/tiflow/latest/prow-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_kafka_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
+      run_before_merge: true
       context: idc-jenkins-ci-ticdc/kafka-integration-test
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
@@ -14,7 +14,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
+      run_before_merge: true
       context: idc-jenkins-ci-ticdc/integration-test
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
@@ -24,7 +24,7 @@ presubmits:
     - name: pingcap/tiflow/pull_dm_compatibility_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
+      run_before_merge: true
       context: idc-jenkins-ci-ticdc/dm-compatibility-test
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
@@ -34,7 +34,7 @@ presubmits:
     - name: pingcap/tiflow/pull_dm_integration_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
+      run_before_merge: true
       context: idc-jenkins-ci-ticdc/dm-integration-test
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
@@ -44,7 +44,7 @@ presubmits:
     - name: pingcap/tiflow/pull_engine_integration_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
+      run_before_merge: true
       context: tiflow/engine-integration-test
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"


### PR DESCRIPTION
Use `run_before_merge` instead of `always`.