### PR TITLE
chore: use shorter pod hostname for dm it test

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -154,6 +154,7 @@ pipeline {
                 }
                 agent{
                     kubernetes {
+                        label "dm-it-${UUID.randomUUID().toString()}"
                         namespace K8S_NAMESPACE
                         yamlFile POD_TEMPLATE_FILE
                         defaultContainer 'golang'


### PR DESCRIPTION
dm integration test need shorter pod hostname (Less than 60).

test pass: https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftiflow%2Fpull_dm_integration_test/detail/pull_dm_integration_test/126/pipeline