### PR TITLE
fix(gitee/pipelines/pingcap_enterprise):  add git ssh key in go build containers

### DIFF
--- a/libraries/tipipeline/vars/git.groovy
+++ b/libraries/tipipeline/vars/git.groovy
@@ -1,7 +1,7 @@
 // Set SSH authentication for git clone or other operations.
 def setSshKey(String credentialsId, String gitHost = 'github.com') {
     withCredentials([sshUserPrivateKey(credentialsId: credentialsId, keyFileVariable: 'SSH_KEY')]) {
-        sh label: 'Set git ssh key' script: """
+        sh label: 'Set git ssh key', script: """
             [ -d ~/.ssh ] || mkdir ~/.ssh && chmod 0700 ~/.ssh
             echo "\$SSH_KEY" > ~/.ssh/id_rsa
             chmod 400 ~/.ssh/id_rsa


### PR DESCRIPTION
why: some repo's script will using git to clone or update, but we only set it in default container.
Signed-off-by: wuhuizuo <wuhuizuo@126.com>