### PR TITLE
fix(jenkins/pipelines/ci/tiflash): no need add `base -ex` to run the test shell

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-ghpr-integration-tests.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-ghpr-integration-tests.groovy
@@ -39,7 +39,7 @@ def runTest(label, name, path, tidb_branch) {
                         container("docker") {
                             try {
                                 echo "path: ${pwd()}"
-                                sh "TAG=${ghprbActualCommit} BRANCH=${tidb_branch} bash -xe ./run.sh"
+                                sh "TAG=${ghprbActualCommit} BRANCH=${tidb_branch} ./run.sh"
                             } catch (e) {
                                 sh "mv log ${name}-log"
                                 archiveArtifacts(artifacts: "${name}-log/**/*.log", allowEmptyArchive: true)


### PR DESCRIPTION
- in release-6.1+ the script has lines `set -ex` and had the shell shaban line.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>