### PR TITLE
fix(jenkins/pipelines/ci/tiflash): reorder the steps in catch block

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-ghpr-integration-tests.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-ghpr-integration-tests.groovy
@@ -42,9 +42,9 @@ def runTest(label, name, path, tidb_branch) {
                                 sh "TAG=${ghprbActualCommit} BRANCH=${tidb_branch} ./run.sh"
                             } catch (e) {
                                 sh "mv log ${name}-log"
-                                archiveArtifacts(artifacts: "${name}-log/**/*.log", allowEmptyArchive: true)
                                 sh "find ${name}-log -name '*.log' | xargs tail -n 500"
                                 sh "docker ps -a"
+                                archiveArtifacts(artifacts: "${name}-log/**/*.log", allowEmptyArchive: true)
                                 throw e
                             }
                         }


### PR DESCRIPTION
Archive will failed, but we need the core log info, so reorder it.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>