### PR TITLE
feat: enable mergeci report on some ci

### DIFF
--- a/jobs/pingcap/tidb/latest/prow-postsubmits.yaml
+++ b/jobs/pingcap/tidb/latest/prow-postsubmits.yaml
@@ -6,7 +6,7 @@ postsubmits:
       decorate: false # need add this.
       context: ci/e2e-test
       max_concurrency: 1
-      skip_report: true
+      skip_report: false
       branches:
         - ^master$
     - name: pingcap/tidb/merged_common_test
@@ -38,7 +38,7 @@ postsubmits:
       decorate: false # need add this.
       context: wip-integration-jdbc-test
       max_concurrency: 1
-      skip_report: true
+      skip_report: false
       branches:
         - ^master$
     - name: pingcap/tidb/merged_integration_mysql_test
@@ -54,7 +54,7 @@ postsubmits:
       decorate: false # need add this.
       context: ci/sqllogic-test
       max_concurrency: 1
-      skip_report: true
+      skip_report: false
       branches:
         - ^master$
     - name: pingcap/tidb/merged_integration_copr_test
@@ -62,7 +62,7 @@ postsubmits:
       decorate: false # need add this.
       context: ci/integration-copr-test
       max_concurrency: 1
-      skip_report: true
+      skip_report: false
       branches:
         - ^master$
     - name: pingcap/tidb/merged_tiflash_test

--- a/jobs/pingcap/tidb/latest/prow-postsubmits.yaml
+++ b/jobs/pingcap/tidb/latest/prow-postsubmits.yaml
@@ -36,7 +36,7 @@ postsubmits:
     - name: pingcap/tidb/merged_integration_jdbc_test
       agent: jenkins
       decorate: false # need add this.
-      context: wip-integration-jdbc-test
+      context: ci/integration-jdbc-test
       max_concurrency: 1
       skip_report: false
       branches:


### PR DESCRIPTION
The following MergeCI pipeline has been running stably and the status report is enabled.
* ci/integration-copr-test
* ci/sqllogic-test
* ci/integration-jdbc-test
* ci/e2e-test