### PR TITLE
feat(prow-jobs): migrate in job files from configs repo

### DIFF
--- a/prow-jobs/kustomization.yaml
+++ b/prow-jobs/kustomization.yaml
@@ -28,5 +28,11 @@ configMapGenerator:
       - pingcap-tiflow-release-6.1-presubmits.yaml
       - pingcap-tiflow-release-6.2-presubmits.yaml
       - pingcap-tiflow-release-7.1-presubmits.yaml
+      - ti-community-infra-configs-periodics.yaml
+      - ti-community-infra-configs-postsubmits.yaml
+      - ti-community-infra-configs-presubmits.yaml
+      - ti-community-infra-periodics.yaml
+      - ti-community-infra-test-infra-postsubmits.yaml
+      - ti-community-infra-test-infra-presubmits.yaml
       - tikv-pd-latest-presubmits.yaml
       - tikv-pd-release-6.5-presubmits.yaml

--- a/prow-jobs/ti-community-infra-configs-periodics.yaml
+++ b/prow-jobs/ti-community-infra-configs-periodics.yaml
@@ -1,0 +1,27 @@
+periodics:
+  - name: periodic-configs-autobump
+    # Run at minute 5 past every hour from 13 through 20 on every Saturday (At UTC+8 timezone).
+    cron: "05 5-12 * * 6"
+    always_run: true
+    decorate: true
+    extra_refs:
+      # Check out the repo containing the config and deployment files for your Prow instance.
+      - org: ti-community-infra
+        repo: configs
+        base_ref: main
+    max_concurrency: 1
+    spec:
+      containers:
+        - image: ticommunityinfra/generic-autobumper:v20221227-9bc8171e1d
+          command:
+            - /ko-app/generic-autobumper
+          args:
+            - --config=prow/autobump-config/configs-prow-component-autobump-config.yaml
+          volumeMounts:
+            - name: github-token
+              mountPath: /etc/github
+              readOnly: true
+      volumes:
+        - name: github-token
+          secret:
+            secretName: github-token

--- a/prow-jobs/ti-community-infra-configs-postsubmits.yaml
+++ b/prow-jobs/ti-community-infra-configs-postsubmits.yaml
@@ -1,0 +1,83 @@
+postsubmits:
+  ti-community-infra/configs:
+    - name: post-configs-update-orgs
+      decorate: true
+      run_if_changed: "orgs/"
+      branches:
+        - ^main$
+      max_concurrency: 1
+      spec:
+        containers:
+          - image: golang:1.18
+            command:
+              - scripts/peribolos.sh
+            args:
+              - --config-path=orgs/config.yaml
+              - --github-token-path=/etc/github/token
+              - --github-endpoint=http://prow-ghproxy.apps
+              - --github-endpoint=https://api.github.com
+              - --min-admins=2
+              - --fix-org
+              - --fix-org-members
+              - --fix-teams
+              - --fix-team-members
+              - --fix-team-repos
+              - --tokens=1200
+              - --confirm
+            volumeMounts:
+              - name: github-token
+                mountPath: /etc/github
+                readOnly: true
+        volumes:
+          - name: github-token
+            secret:
+              secretName: github-token
+    - name: post-configs-deploy-prow
+      run_if_changed: "prow/cluster"
+      decorate: true
+      branches:
+        - ^main$
+      max_concurrency: 1
+      spec:
+        containers:
+          - image: google/cloud-sdk:319.0.0
+            command:
+              - scripts/deploy.sh
+            args:
+              - --confirm
+              - --config=trusted
+            env:
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /creds/service-account.json
+            volumeMounts:
+              - name: creds
+                mountPath: /creds
+        volumes:
+          - name: creds
+            secret:
+              secretName: deployer-credentials
+      annotations:
+        description: deploys the configured version of prow by running scripts/deploy.sh
+    - name: post-configs-label-sync
+      decorate: true
+      run_if_changed: "prow/config/labels.yaml"
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - image: ticommunityinfra/label_sync:v20221227-9bc8171e1d
+            command:
+              - /ko-app/label_sync
+            args:
+              - --config=prow/config/labels.yaml
+              - --confirm=true
+              - --only=ti-community-infra/tichi,ti-community-infra/configs,ti-community-infra/ti-community-bot,ti-community-infra/rfcs,pingcap/community,pingcap/docs,pingcap/docs-cn,pingcap/docs-tidb-operator,pingcap/tidb,pingcap/tiflow,pingcap/tiflash,tikv/community,tikv/pd,chaos-mesh/website
+              - --token=/etc/github/token
+            volumeMounts:
+              - name: github-token
+                mountPath: /etc/github
+                readOnly: true
+        volumes:
+          - name: github-token
+            secret:
+              secretName: github-token

--- a/prow-jobs/ti-community-infra-configs-presubmits.yaml
+++ b/prow-jobs/ti-community-infra-configs-presubmits.yaml
@@ -1,0 +1,70 @@
+presubmits:
+  ti-community-infra/configs:
+    - name: pull-configs-validate-prow-yaml
+      decorate: true
+      run_if_changed: "prow/"
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - image: ticommunityinfra/checkconfig:v20221227-b4eaee6696
+            command:
+              - /ko-app/checkconfig
+            args:
+              - --plugin-config=prow/config/plugins.yaml
+              - --config-path=prow/config/config.yaml
+              - --job-config-path=prow/jobs
+    - name: pull-configs-validate-external-plugin-yaml
+      decorate: true
+      run_if_changed: "prow/config/external_plugins_config.yaml"
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - image: ticommunityinfra/tichi-check-external-plugin-config:v2.0.4
+            command:
+              - check-external-plugin-config
+            args:
+              - --external-plugin-config-path=prow/config/external_plugins_config.yaml
+    - name: pull-configs-validate-labels-yaml
+      decorate: true
+      run_if_changed: "prow/config/labels.*"
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - image: golang:1.18
+            command:
+              - scripts/verify-labels.sh
+    - name: pull-configs-validate-orgs
+      decorate: true
+      run_if_changed: orgs/
+      branches:
+        - ^main$
+      max_concurrency: 1
+      spec:
+        containers:
+          - image: golang:1.18
+            command:
+              - scripts/peribolos.sh
+            args:
+              - --config-path=orgs/config.yaml
+              - --github-token-path=/etc/github/token
+              - --github-endpoint=http://prow-ghproxy.apps
+              - --github-endpoint=https://api.github.com
+              - --min-admins=2
+              - --fix-org
+              - --fix-org-members
+              - --fix-teams
+              - --fix-team-members
+              - --fix-team-repos
+              - --tokens=1200
+              - --confirm=false
+            volumeMounts:
+              - name: github-token
+                mountPath: /etc/github
+                readOnly: true
+        volumes:
+          - name: github-token
+            secret:
+              secretName: github-token

--- a/prow-jobs/ti-community-infra-periodics.yaml
+++ b/prow-jobs/ti-community-infra-periodics.yaml
@@ -1,0 +1,66 @@
+periodics:
+  - name: periodic-ti-community-infra-rotten
+    interval: 1h
+    decorate: true
+    annotations:
+      description: Adds lifecycle/rotten to stale issues after 30d of inactivity
+    spec:
+      containers:
+        - image: ticommunityinfra/commenter:v20221227-9bc8171e1d
+          command:
+            - /ko-app/commenter
+          args:
+            - --query=org:ti-community-infra -label:lifecycle/frozen label:lifecycle/stale -label:lifecycle/rotten
+            - --updated=720h
+            - --token=/etc/github/token
+            - |-
+              --comment=Stale issues rot after 30d of inactivity.
+              Mark the issue as fresh with `/remove-lifecycle rotten`.
+              Rotten issues close after an additional 30d of inactivity.
+              If this issue is safe to close now please do so with `/close`.
+              Send feedback to [sig-community-infra](https://slack.tidb.io/invite?team=tidb-community&channel=sig-community-infra) or [Mini256](https://github.com/Mini256).
+              /lifecycle rotten
+            - --template
+            - --ceiling=10
+            - --confirm
+          volumeMounts:
+            - name: github-token
+              mountPath: /etc/github
+              readOnly: true
+      volumes:
+        - name: github-token
+          secret:
+            secretName: github-token
+
+  - name: periodic-ti-community-infra-stale
+    interval: 1h
+    decorate: true
+    annotations:
+      description: Adds lifecycle/stale to issues after 90d of inactivity
+    spec:
+      containers:
+        - image: ticommunityinfra/commenter:v20221227-9bc8171e1d
+          command:
+            - /ko-app/commenter
+          args:
+            - --query=org:ti-community-infra -label:lifecycle/frozen -label:lifecycle/stale -label:lifecycle/rotten
+            - --updated=2160h
+            - --token=/etc/github/token
+            - |-
+              --comment=Issues go stale after 90d of inactivity.
+              Mark the issue as fresh with `/remove-lifecycle stale`.
+              Stale issues rot after an additional 30d of inactivity and eventually close.
+              If this issue is safe to close now please do so with `/close`.
+              Send feedback to [sig-community-infra](https://slack.tidb.io/invite?team=tidb-community&channel=sig-community-infra) or [wuhuizuo](https://github.com/wuhuizuo).
+              /lifecycle stale
+            - --template
+            - --ceiling=10
+            - --confirm
+          volumeMounts:
+            - name: github-token
+              mountPath: /etc/github
+              readOnly: true
+      volumes:
+        - name: github-token
+          secret:
+            secretName: github-token

--- a/prow-jobs/ti-community-infra-test-infra-postsubmits.yaml
+++ b/prow-jobs/ti-community-infra-test-infra-postsubmits.yaml
@@ -1,0 +1,35 @@
+postsubmits:
+  ti-community-infra/test-infra:
+    - name: post-test-infra-push-prow-images
+      # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
+      run_if_changed: '^(\.ko\.yaml|hack/(make-rules|prowimagebuilder)|gencred|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
+      decorate: true
+      branches:
+        - ^release$
+      max_concurrency: 1
+      spec:
+        serviceAccountName: pusher
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230222-b5208facd4-test-infra
+            command:
+              - runner.sh
+            args:
+              - make
+              - -C
+              - prow
+              - push-images
+              - REGISTRY=ticommunityinfra
+            env:
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "4"
+      annotations:
+        description:
+          builds and pushes all prow on each commit by running make -C prow
+          push-images
+      rerun_auth_config:
+        github_users:
+          - wuhuizuo

--- a/prow-jobs/ti-community-infra-test-infra-presubmits.yaml
+++ b/prow-jobs/ti-community-infra-test-infra-presubmits.yaml
@@ -1,0 +1,62 @@
+presubmits:
+  ti-community-infra/test-infra:
+    - name: pull-test-infra-unit-test
+      branches:
+        - ^release$
+      always_run: true
+      decorate: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221223-736a4da5ba-test-infra
+            command:
+              - runner.sh
+            args:
+              - make
+              - go-unit
+    - name: pull-test-infra-prow-image-build-test
+      branches:
+        - ^release$
+      run_if_changed: '^(\.ko\.yaml|hack/(ts-rollup|make-rules|prowimagebuilder)|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
+      decorate: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221223-736a4da5ba-test-infra
+            command:
+              - runner.sh
+            args:
+              - make
+              - -C
+              - prow
+              - build-images
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                # This job is very CPU intensive as building prow images in
+                # parallel
+                cpu: "4"
+    - name: pull-test-infra-verify-lint
+      branches:
+        - ^release$
+      always_run: true
+      decorate: true
+      spec:
+        containers:
+          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20221223-736a4da5ba-test-infra
+            command:
+              - runner.sh
+            args:
+              - make
+              - verify
+            env:
+              - name: VERIFY_ESLINT
+                value: "false"
+              - name: VERIFY_PYLINT
+                value: "false"
+              - name: VERIFY_TS_ROLLUP
+                value: "false"
+              - name: VERIFY_BOILERPLATE
+                value: "false"
+              - name: VERIFY_YAMLLINT
+                value: "false"


### PR DESCRIPTION
I have tested with command:
```shell
flux build kustomization prow-post-ci-jobs --path prow-jobs/ --kustomization-file ../ee-ops/apps/gcp/prow/post/ci-jobs.yaml -n apps
```