### PR TITLE
fix(tiflow): fix ut get wrong repo dir

### DIFF
--- a/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -43,7 +43,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${BUILD_TAG}") {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)
@@ -76,8 +76,12 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')    
                         }
                         steps {
+                            sh """
+                            rm -rf .git .gitignore
+                            ls -alh
+                            """
                             dir('tiflow') {
-                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}") {
+                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${BUILD_TAG}") {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
                                     """

--- a/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
@@ -43,7 +43,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${BUILD_TAG}") {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)
@@ -76,8 +76,12 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')    
                         }
                         steps {
+                            sh """
+                            rm -rf .git .gitignore
+                            ls -alh
+                            """
                             dir('tiflow') {
-                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}") {
+                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${BUILD_TAG}") {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
                                     """


### PR DESCRIPTION
run `make unit_test_in_verify_ci ` will encounter error below: 
"""
=== Failed

=== FAIL: pkg/tcpserver TestTCPServerTLSHTTP1 (0.01s)

    tcp_server_test.go:77: 

        	Error Trace:	/home/jenkins/agent/workspace/pingcap/tiflow/release-7.1/ghpr_verify/tiflow/pkg/tcpserver/tcp_server_test.go:77

        	Error:      	Received unexpected error:

        	            	[CDC:ErrToTLSConfigFailed]generate tls config failed: could not read ca certificate: open /home/jenkins/agent/workspace/pingcap/tiflow/release-7.1/ghpr_verify/tests/integration_tests/_certificates/ca.pem: no such file or directory

        	            	github.com/pingcap/errors.AddStack

        	            		/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20221009092201-b66cddb77c32/errors.go:174

        	            	github.com/pingcap/errors.(*Error).GenWithStackByArgs

        	            		/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20221009092201-b66cddb77c32/normalize.go:164

        	            	github.com/pingcap/tiflow/pkg/errors.WrapError

        	            		/home/jenkins/agent/workspace/pingcap/tiflow/release-7.1/ghpr_verify/tiflow/pkg/errors/helper.go:34

        	            	github.com/pingcap/tiflow/pkg/security.(*Credential).ToTLSConfigWithVerify

        	            		/home/jenkins/agent/workspace/pingcap/tiflow/release-7.1/ghpr_verify/tiflow/pkg/security/credential.go:75

        	            	github.com/pingcap/tiflow/pkg/tcpserver.wrapTLSListener

        	            		/home/jenkins/agent/workspace/pingcap/tiflow/release-7.1/ghpr_verify/tiflow/pkg/tcpserver/tcp_server.go:165

        	            	github.com/pingcap/tiflow/pkg/tcpserver.NewTCPServer

        	            		/home/jenkins/agent/workspace/pingcap/tiflow/release-7.1/ghpr_verify/tiflow/pkg/tcpserver/tcp_server.go:82

        	            	github.com/pingcap/tiflow/pkg/tcpserver.TestTCPServerTLSHTTP1

        	            		/home/jenkins/agent/workspace/pingcap/tiflow/release-7.1/ghpr_verify/tiflow/pkg/tcpserver/tcp_server_test.go:76

        	            	testing.tRunner

        	            		/usr/local/go/src/testing/testing.go:1576

        	            	runtime.goexit

        	            		/usr/local/go/src/runtime/asm_amd64.s:1598

        	Test:       	TestTCPServerTLSHTTP1



"""