### PR TITLE
fix(tidb): clean possible untrack git files

### DIFF
--- a/pipelines/pingcap/tidb/release-6.1/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_build.groovy
@@ -53,6 +53,17 @@ pipeline {
                                     }
                                 }
                             }
+                            sh label: "check git workspace clean", script: """
+                                git status
+                                git clean -d -f -f
+                                if [[ -z \$(git status -s) ]]
+                                then
+                                    echo "tree is clean"
+                                else
+                                    echo "tree is dirty, please contact ee team to clean up"
+                                    exit
+                                fi
+                            """
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check.groovy
@@ -47,6 +47,17 @@ pipeline {
                             }
                         }
                     }
+                    sh label: "check git workspace clean", script: """
+                        git status
+                        git clean -d -f -f
+                        if [[ -z \$(git status -s) ]]
+                        then
+                            echo "tree is clean"
+                        else
+                            echo "tree is dirty, please contact ee team to clean up"
+                            exit
+                        fi
+                    """
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
@@ -49,6 +49,17 @@ pipeline {
                             }
                         }
                     }
+                    sh label: "check git workspace clean", script: """
+                        git status
+                        git clean -d -f -f
+                        if [[ -z \$(git status -s) ]]
+                        then
+                            echo "tree is clean"
+                        else
+                            echo "tree is dirty, please contact ee team to clean up"
+                            exit
+                        fi
+                    """
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check.groovy
@@ -47,6 +47,17 @@ pipeline {
                             }
                         }
                     }
+                    sh label: "check git workspace clean", script: """
+                        git status
+                        git clean -d -f -f
+                        if [[ -z \$(git status -s) ]]
+                        then
+                            echo "tree is clean"
+                        else
+                            echo "tree is dirty, please contact ee team to clean up"
+                            exit
+                        fi
+                    """
                 }
             }
         }


### PR DESCRIPTION
when restore src code caceh from s3 cache,  we might unexpected code cache contains untrack files like `extension/enterprise/` that only existed on branch master as submodule.

so we need clean this dir to make sure current git tree is clean.