### PR TITLE
chore(tiflow): split to 16 group to decrease ci time

### DIFF
--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
@@ -126,7 +126,8 @@ pipeline {
                 axes {
                     axis {
                         name 'TEST_GROUP'
-                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08', 'G09'
+                        values 'G0', 'G1', 'G2', 'G3', 'G4', 'G5', 'G6',  'G7', 'G8', 'G9', 'G10', 'G11', 'G12', 'G13', 
+                            'G14', 'G15'
                     }
                 }
                 agent{
@@ -162,6 +163,7 @@ pipeline {
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
                                         chmod +x ../scripts/pingcap/tiflow/release-6.1/cdc_run_group.sh
                                         cp ../scripts/pingcap/tiflow/release-6.1/cdc_run_group.sh tests/integration_tests/
+                                        ln -s ${WORKSPACE}/tiflow/bin ${WORKSPACE}/tiflow/tests/bin
                                         ./tests/integration_tests/cdc_run_group.sh kafka ${TEST_GROUP}
                                     """
                                 }

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
@@ -126,7 +126,8 @@ pipeline {
                 axes {
                     axis {
                         name 'TEST_GROUP'
-                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08', 'G09'
+                        values 'G0', 'G1', 'G2', 'G3', 'G4', 'G5', 'G6',  'G7', 'G8', 'G9', 'G10', 'G11', 'G12', 'G13', 
+                            'G14', 'G15'
                     }
                 }
                 agent{
@@ -148,6 +149,7 @@ pipeline {
                                 cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                        ln -s ${WORKSPACE}/tiflow/bin ${WORKSPACE}/tiflow/tests/bin
                                         chmod +x ../scripts/pingcap/tiflow/release-6.1/cdc_run_group.sh
                                         cp ../scripts/pingcap/tiflow/release-6.1/cdc_run_group.sh tests/integration_tests/
                                         ./tests/integration_tests/cdc_run_group.sh mysql ${TEST_GROUP}

--- a/scripts/pingcap/tiflow/release-6.1/cdc_run_group.sh
+++ b/scripts/pingcap/tiflow/release-6.1/cdc_run_group.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# This script split the integration tests into 10 groups to support parallel group tests execution.
+# This script split the integration tests into 16 groups to support parallel group tests execution.
 # all the integration tests are located in tests/integration_tests directory. only the directories
 # containing run.sh will be considered as integration tests. the script will print the total # # # number
 
 # usage: ./cdc_run_group.sh G0  to run the integration tests in group 0
-# current supported groups are G0, G1, G2, G3, G4, G5, G6, G7, G8, G9
+# current supported groups are G0, G1, G2, G3, G4, G5, G6, G7, G8, G9, 'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
 
 
 set -eo pipefail
@@ -24,14 +24,14 @@ IFS=$'\n' directories=($(sort <<<"${directories[*]}"))
 unset IFS
 
 # Print the total number of directories
-echo "Total number of directories: ${#directories[@]}"
+echo "Total number of valid directories: ${#directories[@]}"
 
 # Step 2 & 3
-split_length=$((${#directories[@]}/10))
-remainder=$((${#directories[@]}%10))
+split_length=$((${#directories[@]}/16))
+remainder=$((${#directories[@]}%16))
 
 grouped_directories=()
-for ((i=0; i<10; i++)); do
+for ((i=0; i<16; i++)); do
     start_index=$((i*split_length))
     if [[ $i -lt $remainder ]]; then
         start_index=$((start_index+i))
@@ -62,7 +62,7 @@ group_index="${test_group:1}"
 test_names=${grouped_directories[${group_index}]}
 if [[ -n $test_names ]]; then
     echo ""
-    echo "Running tests: $test_names"
+    echo "Running tests in group${group_index}: $test_names"
     echo "Sink type: $sink_type"
 	"${CUR}"/run.sh "${sink_type}" "${test_names}"
 fi


### PR DESCRIPTION
split cdc tests to 16 group to speed up the execution of CI.