### PR TITLE
feat(pipelines): add affinity to job pods

### DIFF
--- a/pipelines/pingcap-inc/enterprise-extensions/latest/pod-pr-verify.yaml
+++ b/pipelines/pingcap-inc/enterprise-extensions/latest/pod-pr-verify.yaml
@@ -28,7 +28,7 @@ spec:
           mountPath: /data/
           readOnly: true
         - name: containerinfo
-          mountPath: /etc/containerinfo          
+          mountPath: /etc/containerinfo
       lifecycle:
         postStart:
           exec:
@@ -64,3 +64,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-engine-ext/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb-engine-ext/latest/pod-ghpr_unit_test.yaml
@@ -35,3 +35,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-engine-ext/release-6.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb-engine-ext/release-6.1/pod-ghpr_unit_test.yaml
@@ -35,3 +35,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/latest/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb-test/latest/pod-ghpr_build.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/latest/pod-ghpr_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb-test/latest/pod-ghpr_integration_common_test.yaml
@@ -28,4 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
-
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/latest/pod-ghpr_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb-test/latest/pod-ghpr_integration_jdbc_test.yaml
@@ -38,4 +38,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
-
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/latest/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb-test/latest/pod-ghpr_integration_mysql_test.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/latest/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb-test/latest/pod-ghpr_mysql_test.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/release-6.0/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb-test/release-6.0/pod-ghpr_build.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/release-6.0/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb-test/release-6.0/pod-ghpr_integration_mysql_test.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/release-6.0/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb-test/release-6.0/pod-ghpr_mysql_test.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/release-6.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb-test/release-6.1/pod-ghpr_build.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/release-6.1/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb-test/release-6.1/pod-ghpr_integration_mysql_test.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/release-6.1/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb-test/release-6.1/pod-ghpr_mysql_test.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/release-6.2/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb-test/release-6.2/pod-ghpr_build.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/release-6.2/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb-test/release-6.2/pod-ghpr_integration_mysql_test.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb-test/release-6.2/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb-test/release-6.2/pod-ghpr_mysql_test.yaml
@@ -30,3 +30,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-canary-scan-security.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-canary-scan-security.yaml
@@ -18,3 +18,12 @@ spec:
             secretKeyRef:
               key: token
               name: security-server-api-token
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_build.yaml
@@ -91,3 +91,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -91,3 +91,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -113,3 +113,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_build.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_build.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
@@ -38,4 +38,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
-
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
@@ -28,4 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
-
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
@@ -35,3 +35,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_cdc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_cdc_test.yaml
@@ -35,3 +35,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
@@ -28,4 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
-
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
@@ -35,3 +35,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_ddl_test.yaml
@@ -28,4 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
-
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
@@ -38,4 +38,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
-
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
@@ -28,4 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
-
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
@@ -28,4 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
-
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml
@@ -69,3 +69,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
@@ -96,3 +96,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml
@@ -28,4 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
-
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_build.yaml
@@ -47,3 +47,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check.yaml
@@ -47,3 +47,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check2.yaml
@@ -47,3 +47,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_mysql_test.yaml
@@ -47,3 +47,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_unit_test.yaml
@@ -47,3 +47,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_build.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check2.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_mysql_test.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_unit_test.yaml
@@ -96,3 +96,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_build.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check2.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_mysql_test.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_unit_test.yaml
@@ -96,3 +96,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_build.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check2.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_mysql_test.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_unit_test.yaml
@@ -96,3 +96,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
@@ -91,3 +91,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
@@ -91,3 +91,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_mysql_test.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
@@ -113,3 +113,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_build.yaml
@@ -91,3 +91,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check.yaml
@@ -94,3 +94,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml
@@ -91,3 +91,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_mysql_test.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_unit_test.yaml
@@ -93,3 +93,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_build.yaml
@@ -86,3 +86,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_check.yaml
@@ -89,3 +89,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_check2.yaml
@@ -86,3 +86,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_mysql_test.yaml
@@ -40,3 +40,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_unit_test.yaml
@@ -108,3 +108,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_build.yaml
@@ -86,3 +86,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check.yaml
@@ -89,3 +89,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
@@ -86,3 +86,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_mysql_test.yaml
@@ -40,3 +40,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
@@ -108,3 +108,12 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
@@ -4,122 +4,129 @@ spec:
   securityContext:
     fsGroup: 1000
   containers:
-  - image: wurstmeister/zookeeper
-    imagePullPolicy: IfNotPresent
-    name: zookeeper
-    resources:
-      requests:
-        cpu: 200m
-        memory: 4Gi
-      limits:
-        cpu: 2000m
-        memory: 4Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - args:
-    - cat
-    image: hub.pingcap.net/jenkins/golang-tini:1.20
-    imagePullPolicy: Always
-    name: golang
-    resources:
-      requests:
-        cpu: "2"
-        memory: 12Gi
-      limits:
-        cpu: "4"
-        memory: 16Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - env:
-    - name: KAFKA_CREATE_TOPICS
-      value: big-message-test:1:1
-    - name: KAFKA_BROKER_ID
-      value: "1"
-    - name: KAFKA_SSL_KEYSTORE_PASSWORD
-      value: test1234
-    - name: KAFKA_ZOOKEEPER_CONNECT
-      value: localhost:2181
-    - name: KAFKA_MESSAGE_MAX_BYTES
-      value: "11534336"
-    - name: KAFKA_REPLICA_FETCH_MAX_BYTES
-      value: "11534336"
-    - name: KAFKA_ADVERTISED_LISTENERS
-      value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
-    - name: ZK
-      value: zk
-    - name: KAFKA_SSL_KEYSTORE_LOCATION
-      value: /tmp/kafka.server.keystore.jks
-    - name: KAFKA_SSL_KEY_PASSWORD
-      value: test1234
-    - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
-      value: test1234
-    - name: KAFKA_LISTENERS
-      value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
-    - name: KAFKA_SSL_TRUSTSTORE_LOCATION
-      value: /tmp/kafka.server.truststore.jks
-    - name: RACK_COMMAND
-      value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks
-        -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks
-        -o /tmp/kafka.server.truststore.jks
-    image: wurstmeister/kafka:2.12-2.4.1
-    imagePullPolicy: IfNotPresent
-    name: kafka
-    resources:
-      requests:
-        cpu: 200m
-        memory: 4Gi
-      limits:
-        cpu: 2000m
-        memory: 4Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - env:
-    - name: KAFKA_SERVER
-      value: 127.0.0.1:9092
-    - name: ZOOKEEPER_SERVER
-      value: 127.0.0.1:2181
-    - name: DOWNSTREAM_DB_HOST
-      value: 127.0.0.1
-    - name: USE_FLAT_MESSAGE
-      value: "true"
-    - name: DOWNSTREAM_DB_PORT
-      value: "3306"
-    - name: DB_NAME
-      value: test
-    image: rustinliu/ticdc-canal-json-adapter:latest
-    imagePullPolicy: IfNotPresent
-    name: canal-adapter
-    # TODO: add resource limit
-    # can't add resource limit now, because canal-adapter will OOM
-    # issue: https://github.com/PingCAP-QE/ci/issues/1893
-    resources:
-      requests:
-        cpu: 200m
-        memory: 4Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - name: net-tool
-    image: wbitt/network-multitool
-    tty: true
-    resources:
-      limits:
-        memory: 128Mi
-        cpu: 100m
-  - name: report
-    image: hub.pingcap.net/jenkins/python3-requests:latest
-    tty: true
-    resources:
-      limits:
-        memory: 256Mi
-        cpu: 100m
+    - image: wurstmeister/zookeeper
+      imagePullPolicy: IfNotPresent
+      name: zookeeper
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
+        limits:
+          cpu: 2000m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - args:
+        - cat
+      image: hub.pingcap.net/jenkins/golang-tini:1.20
+      imagePullPolicy: Always
+      name: golang
+      resources:
+        requests:
+          cpu: "2"
+          memory: 12Gi
+        limits:
+          cpu: "4"
+          memory: 16Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - env:
+        - name: KAFKA_CREATE_TOPICS
+          value: big-message-test:1:1
+        - name: KAFKA_BROKER_ID
+          value: "1"
+        - name: KAFKA_SSL_KEYSTORE_PASSWORD
+          value: test1234
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: localhost:2181
+        - name: KAFKA_MESSAGE_MAX_BYTES
+          value: "11534336"
+        - name: KAFKA_REPLICA_FETCH_MAX_BYTES
+          value: "11534336"
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
+        - name: ZK
+          value: zk
+        - name: KAFKA_SSL_KEYSTORE_LOCATION
+          value: /tmp/kafka.server.keystore.jks
+        - name: KAFKA_SSL_KEY_PASSWORD
+          value: test1234
+        - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+          value: test1234
+        - name: KAFKA_LISTENERS
+          value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
+        - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+          value: /tmp/kafka.server.truststore.jks
+        - name: RACK_COMMAND
+          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+      image: wurstmeister/kafka:2.12-2.4.1
+      imagePullPolicy: IfNotPresent
+      name: kafka
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
+        limits:
+          cpu: 2000m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - env:
+        - name: KAFKA_SERVER
+          value: 127.0.0.1:9092
+        - name: ZOOKEEPER_SERVER
+          value: 127.0.0.1:2181
+        - name: DOWNSTREAM_DB_HOST
+          value: 127.0.0.1
+        - name: USE_FLAT_MESSAGE
+          value: "true"
+        - name: DOWNSTREAM_DB_PORT
+          value: "3306"
+        - name: DB_NAME
+          value: test
+      image: rustinliu/ticdc-canal-json-adapter:latest
+      imagePullPolicy: IfNotPresent
+      name: canal-adapter
+      # TODO: add resource limit
+      # can't add resource limit now, because canal-adapter will OOM
+      # issue: https://github.com/PingCAP-QE/ci/issues/1893
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
   volumes:
-  - emptyDir: {}
-    name: volume-0
+    - emptyDir: {}
+      name: volume-0
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml
@@ -28,3 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
@@ -28,3 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml
@@ -66,3 +66,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
@@ -66,3 +66,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/latest/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_engine_integration_test.yaml
@@ -12,10 +12,10 @@ spec:
           memory: 8Gi
           cpu: "4"
       volumeMounts:
-      - name: volume-tmp
-        mountPath: /tmp
-      - name: volume-docker
-        mountPath: /var/lib/docker
+        - name: volume-tmp
+          mountPath: /tmp
+        - name: volume-docker
+          mountPath: /var/lib/docker
     - name: dockerd
       image: "docker:20.10.17-dind"
       securityContext:
@@ -33,10 +33,10 @@ spec:
           memory: 16Gi
           cpu: "6"
       volumeMounts:
-      - name: volume-docker
-        mountPath: /var/lib/docker
-      - name: volume-tmp
-        mountPath: /tmp
+        - name: volume-docker
+          mountPath: /var/lib/docker
+        - name: volume-tmp
+          mountPath: /tmp
     - name: docker
       image: 'hub.pingcap.net/tiflow/dind:alpine-docker-go1.20'
       tty: true
@@ -53,10 +53,10 @@ spec:
           memory: 16Gi
           cpu: "6"
       volumeMounts:
-      - name: volume-docker
-        mountPath: /var/lib/docker
-      - name: volume-tmp
-        mountPath: /tmp
+        - name: volume-docker
+          mountPath: /var/lib/docker
+        - name: volume-tmp
+          mountPath: /tmp
     - name: net-tool
       image: wbitt/network-multitool
       tty: true
@@ -76,3 +76,12 @@ spec:
       emptyDir: {}
     - name: "volume-tmp"
       emptyDir: {}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-5.3/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-5.3/pod-ghpr_verify.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-6.0/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.0/pod-ghpr_verify.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-6.1/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.1/pod-ghpr_verify.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-6.1/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.1/pod-pull_cdc_integration_kafka_test.yaml
@@ -4,122 +4,129 @@ spec:
   securityContext:
     fsGroup: 1000
   containers:
-  - image: wurstmeister/zookeeper
-    imagePullPolicy: IfNotPresent
-    name: zookeeper
-    resources:
-      requests:
-        cpu: 200m
-        memory: 4Gi
-      limits:
-        cpu: 2000m
-        memory: 4Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - args:
-    - cat
-    image: hub.pingcap.net/jenkins/golang-tini:1.19
-    imagePullPolicy: Always
-    name: golang
-    resources:
-      requests:
-        cpu: "2"
-        memory: 12Gi
-      limits:
-        cpu: "4"
-        memory: 16Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - env:
-    - name: KAFKA_CREATE_TOPICS
-      value: big-message-test:1:1
-    - name: KAFKA_BROKER_ID
-      value: "1"
-    - name: KAFKA_SSL_KEYSTORE_PASSWORD
-      value: test1234
-    - name: KAFKA_ZOOKEEPER_CONNECT
-      value: localhost:2181
-    - name: KAFKA_MESSAGE_MAX_BYTES
-      value: "11534336"
-    - name: KAFKA_REPLICA_FETCH_MAX_BYTES
-      value: "11534336"
-    - name: KAFKA_ADVERTISED_LISTENERS
-      value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
-    - name: ZK
-      value: zk
-    - name: KAFKA_SSL_KEYSTORE_LOCATION
-      value: /tmp/kafka.server.keystore.jks
-    - name: KAFKA_SSL_KEY_PASSWORD
-      value: test1234
-    - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
-      value: test1234
-    - name: KAFKA_LISTENERS
-      value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
-    - name: KAFKA_SSL_TRUSTSTORE_LOCATION
-      value: /tmp/kafka.server.truststore.jks
-    - name: RACK_COMMAND
-      value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks
-        -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks
-        -o /tmp/kafka.server.truststore.jks
-    image: wurstmeister/kafka:2.12-2.4.1
-    imagePullPolicy: IfNotPresent
-    name: kafka
-    resources:
-      requests:
-        cpu: 200m
-        memory: 4Gi
-      limits:
-        cpu: 2000m
-        memory: 4Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - env:
-    - name: KAFKA_SERVER
-      value: 127.0.0.1:9092
-    - name: ZOOKEEPER_SERVER
-      value: 127.0.0.1:2181
-    - name: DOWNSTREAM_DB_HOST
-      value: 127.0.0.1
-    - name: USE_FLAT_MESSAGE
-      value: "true"
-    - name: DOWNSTREAM_DB_PORT
-      value: "3306"
-    - name: DB_NAME
-      value: test
-    image: rustinliu/ticdc-canal-json-adapter:latest
-    imagePullPolicy: IfNotPresent
-    name: canal-adapter
-    # TODO: add resource limit
-    # can't add resource limit now, because canal-adapter will OOM
-    # issue: https://github.com/PingCAP-QE/ci/issues/1893
-    resources:
-      requests:
-        cpu: 200m
-        memory: 4Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - name: net-tool
-    image: wbitt/network-multitool
-    tty: true
-    resources:
-      limits:
-        memory: 128Mi
-        cpu: 100m
-  - name: report
-    image: hub.pingcap.net/jenkins/python3-requests:latest
-    tty: true
-    resources:
-      limits:
-        memory: 256Mi
-        cpu: 100m
+    - image: wurstmeister/zookeeper
+      imagePullPolicy: IfNotPresent
+      name: zookeeper
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
+        limits:
+          cpu: 2000m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - args:
+        - cat
+      image: hub.pingcap.net/jenkins/golang-tini:1.19
+      imagePullPolicy: Always
+      name: golang
+      resources:
+        requests:
+          cpu: "2"
+          memory: 12Gi
+        limits:
+          cpu: "4"
+          memory: 16Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - env:
+        - name: KAFKA_CREATE_TOPICS
+          value: big-message-test:1:1
+        - name: KAFKA_BROKER_ID
+          value: "1"
+        - name: KAFKA_SSL_KEYSTORE_PASSWORD
+          value: test1234
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: localhost:2181
+        - name: KAFKA_MESSAGE_MAX_BYTES
+          value: "11534336"
+        - name: KAFKA_REPLICA_FETCH_MAX_BYTES
+          value: "11534336"
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
+        - name: ZK
+          value: zk
+        - name: KAFKA_SSL_KEYSTORE_LOCATION
+          value: /tmp/kafka.server.keystore.jks
+        - name: KAFKA_SSL_KEY_PASSWORD
+          value: test1234
+        - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+          value: test1234
+        - name: KAFKA_LISTENERS
+          value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
+        - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+          value: /tmp/kafka.server.truststore.jks
+        - name: RACK_COMMAND
+          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+      image: wurstmeister/kafka:2.12-2.4.1
+      imagePullPolicy: IfNotPresent
+      name: kafka
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
+        limits:
+          cpu: 2000m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - env:
+        - name: KAFKA_SERVER
+          value: 127.0.0.1:9092
+        - name: ZOOKEEPER_SERVER
+          value: 127.0.0.1:2181
+        - name: DOWNSTREAM_DB_HOST
+          value: 127.0.0.1
+        - name: USE_FLAT_MESSAGE
+          value: "true"
+        - name: DOWNSTREAM_DB_PORT
+          value: "3306"
+        - name: DB_NAME
+          value: test
+      image: rustinliu/ticdc-canal-json-adapter:latest
+      imagePullPolicy: IfNotPresent
+      name: canal-adapter
+      # TODO: add resource limit
+      # can't add resource limit now, because canal-adapter will OOM
+      # issue: https://github.com/PingCAP-QE/ci/issues/1893
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
   volumes:
-  - emptyDir: {}
-    name: volume-0
+    - emptyDir: {}
+      name: volume-0
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-6.1/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.1/pod-pull_cdc_integration_test.yaml
@@ -28,3 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-6.1/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.1/pod-pull_dm_compatibility_test.yaml
@@ -66,3 +66,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-6.1/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.1/pod-pull_dm_integration_test.yaml
@@ -8,7 +8,7 @@ spec:
       image: hub.pingcap.net/jenkins/golang-tini:1.19
       tty: true
       args:
-      - cat
+        - cat
       resources:
         requests:
           memory: 12Gi
@@ -68,3 +68,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-6.2/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.2/pod-ghpr_verify.yaml
@@ -45,3 +45,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-6.5/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-ghpr_verify.yaml
@@ -40,3 +40,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-7.1/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-ghpr_verify.yaml
@@ -40,3 +40,12 @@ spec:
     - name: gocache
       persistentVolumeClaim:
         claimName: gocache
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_kafka_test.yaml
@@ -4,122 +4,129 @@ spec:
   securityContext:
     fsGroup: 1000
   containers:
-  - image: wurstmeister/zookeeper
-    imagePullPolicy: IfNotPresent
-    name: zookeeper
-    resources:
-      requests:
-        cpu: 200m
-        memory: 4Gi
-      limits:
-        cpu: 2000m
-        memory: 4Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - args:
-    - cat
-    image: hub.pingcap.net/wulifu/golang-tini:1.20.2
-    imagePullPolicy: Always
-    name: golang
-    resources:
-      requests:
-        cpu: "2"
-        memory: 12Gi
-      limits:
-        cpu: "4"
-        memory: 16Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - env:
-    - name: KAFKA_CREATE_TOPICS
-      value: big-message-test:1:1
-    - name: KAFKA_BROKER_ID
-      value: "1"
-    - name: KAFKA_SSL_KEYSTORE_PASSWORD
-      value: test1234
-    - name: KAFKA_ZOOKEEPER_CONNECT
-      value: localhost:2181
-    - name: KAFKA_MESSAGE_MAX_BYTES
-      value: "11534336"
-    - name: KAFKA_REPLICA_FETCH_MAX_BYTES
-      value: "11534336"
-    - name: KAFKA_ADVERTISED_LISTENERS
-      value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
-    - name: ZK
-      value: zk
-    - name: KAFKA_SSL_KEYSTORE_LOCATION
-      value: /tmp/kafka.server.keystore.jks
-    - name: KAFKA_SSL_KEY_PASSWORD
-      value: test1234
-    - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
-      value: test1234
-    - name: KAFKA_LISTENERS
-      value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
-    - name: KAFKA_SSL_TRUSTSTORE_LOCATION
-      value: /tmp/kafka.server.truststore.jks
-    - name: RACK_COMMAND
-      value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks
-        -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks
-        -o /tmp/kafka.server.truststore.jks
-    image: wurstmeister/kafka:2.12-2.4.1
-    imagePullPolicy: IfNotPresent
-    name: kafka
-    resources:
-      requests:
-        cpu: 200m
-        memory: 4Gi
-      limits:
-        cpu: 2000m
-        memory: 4Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - env:
-    - name: KAFKA_SERVER
-      value: 127.0.0.1:9092
-    - name: ZOOKEEPER_SERVER
-      value: 127.0.0.1:2181
-    - name: DOWNSTREAM_DB_HOST
-      value: 127.0.0.1
-    - name: USE_FLAT_MESSAGE
-      value: "true"
-    - name: DOWNSTREAM_DB_PORT
-      value: "3306"
-    - name: DB_NAME
-      value: test
-    image: rustinliu/ticdc-canal-json-adapter:latest
-    imagePullPolicy: IfNotPresent
-    name: canal-adapter
-    # TODO: add resource limit
-    # can't add resource limit now, because canal-adapter will OOM
-    # issue: https://github.com/PingCAP-QE/ci/issues/1893
-    resources:
-      requests:
-        cpu: 200m
-        memory: 4Gi
-    tty: true
-    volumeMounts:
-    - mountPath: /tmp
-      name: volume-0
-  - name: net-tool
-    image: wbitt/network-multitool
-    tty: true
-    resources:
-      limits:
-        memory: 128Mi
-        cpu: 100m
-  - name: report
-    image: hub.pingcap.net/jenkins/python3-requests:latest
-    tty: true
-    resources:
-      limits:
-        memory: 256Mi
-        cpu: 100m
+    - image: wurstmeister/zookeeper
+      imagePullPolicy: IfNotPresent
+      name: zookeeper
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
+        limits:
+          cpu: 2000m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - args:
+        - cat
+      image: hub.pingcap.net/wulifu/golang-tini:1.20.2
+      imagePullPolicy: Always
+      name: golang
+      resources:
+        requests:
+          cpu: "2"
+          memory: 12Gi
+        limits:
+          cpu: "4"
+          memory: 16Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - env:
+        - name: KAFKA_CREATE_TOPICS
+          value: big-message-test:1:1
+        - name: KAFKA_BROKER_ID
+          value: "1"
+        - name: KAFKA_SSL_KEYSTORE_PASSWORD
+          value: test1234
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: localhost:2181
+        - name: KAFKA_MESSAGE_MAX_BYTES
+          value: "11534336"
+        - name: KAFKA_REPLICA_FETCH_MAX_BYTES
+          value: "11534336"
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
+        - name: ZK
+          value: zk
+        - name: KAFKA_SSL_KEYSTORE_LOCATION
+          value: /tmp/kafka.server.keystore.jks
+        - name: KAFKA_SSL_KEY_PASSWORD
+          value: test1234
+        - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+          value: test1234
+        - name: KAFKA_LISTENERS
+          value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
+        - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+          value: /tmp/kafka.server.truststore.jks
+        - name: RACK_COMMAND
+          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+      image: wurstmeister/kafka:2.12-2.4.1
+      imagePullPolicy: IfNotPresent
+      name: kafka
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
+        limits:
+          cpu: 2000m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - env:
+        - name: KAFKA_SERVER
+          value: 127.0.0.1:9092
+        - name: ZOOKEEPER_SERVER
+          value: 127.0.0.1:2181
+        - name: DOWNSTREAM_DB_HOST
+          value: 127.0.0.1
+        - name: USE_FLAT_MESSAGE
+          value: "true"
+        - name: DOWNSTREAM_DB_PORT
+          value: "3306"
+        - name: DB_NAME
+          value: test
+      image: rustinliu/ticdc-canal-json-adapter:latest
+      imagePullPolicy: IfNotPresent
+      name: canal-adapter
+      # TODO: add resource limit
+      # can't add resource limit now, because canal-adapter will OOM
+      # issue: https://github.com/PingCAP-QE/ci/issues/1893
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
   volumes:
-  - emptyDir: {}
-    name: volume-0
+    - emptyDir: {}
+      name: volume-0
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_storage_test.yaml
@@ -28,3 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_test.yaml
@@ -28,3 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_compatibility_test.yaml
@@ -66,3 +66,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml
@@ -66,3 +66,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_engine_integration_test.yaml
@@ -12,10 +12,10 @@ spec:
           memory: 8Gi
           cpu: "4"
       volumeMounts:
-      - name: volume-tmp
-        mountPath: /tmp
-      - name: volume-docker
-        mountPath: /var/lib/docker
+        - name: volume-tmp
+          mountPath: /tmp
+        - name: volume-docker
+          mountPath: /var/lib/docker
     - name: dockerd
       image: "docker:20.10.17-dind"
       securityContext:
@@ -33,10 +33,10 @@ spec:
           memory: 16Gi
           cpu: "6"
       volumeMounts:
-      - name: volume-docker
-        mountPath: /var/lib/docker
-      - name: volume-tmp
-        mountPath: /tmp
+        - name: volume-docker
+          mountPath: /var/lib/docker
+        - name: volume-tmp
+          mountPath: /tmp
     - name: docker
       image: 'hub.pingcap.net/tiflow/dind:alpine-docker-go1.20'
       tty: true
@@ -53,10 +53,10 @@ spec:
           memory: 16Gi
           cpu: "6"
       volumeMounts:
-      - name: volume-docker
-        mountPath: /var/lib/docker
-      - name: volume-tmp
-        mountPath: /tmp
+        - name: volume-docker
+          mountPath: /var/lib/docker
+        - name: volume-tmp
+          mountPath: /tmp
     - name: net-tool
       image: wbitt/network-multitool
       tty: true
@@ -76,3 +76,12 @@ spec:
       emptyDir: {}
     - name: "volume-tmp"
       emptyDir: {}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/ti-community-infra/test-prod/pod-prow_debug.yaml
+++ b/pipelines/ti-community-infra/test-prod/pod-prow_debug.yaml
@@ -16,3 +16,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/tikv/migration/latest/pod-pull_integration_test.yaml
+++ b/pipelines/tikv/migration/latest/pod-pull_integration_test.yaml
@@ -28,3 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/tikv/migration/latest/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/migration/latest/pod-pull_unit_test.yaml
@@ -28,3 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/tikv/pd/latest/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/latest/pod-ghpr_build.yaml
@@ -28,3 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
@@ -35,3 +35,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/tikv/pd/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-6.5/pod-ghpr_build.yaml
@@ -28,3 +28,12 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64


### PR DESCRIPTION
Prepare add `arm64` nodes in ci pool:

- limit current jobs run on amd64 nodes.

Changes:

> made by command: `find pipelines -type f -name "pod*.yaml" | xargs -I {}  ~/go/bin/yq -i '.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDurin
gExecution.nodeSelectorTerms = [{"matchExpressions": [{"key": "kubernetes.io/arch", "operator": "In", "values": ["amd64"]}]}]' {}`

- add yaml filed in all pod yaml files:
```yaml
spec:
  // ....
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: kubernetes.io/arch
                operator: In
                values:
                  - amd64
```