### PR TITLE
refactor(pipelines/pingcap/tiflow): simplfy git repo cache keys

### DIFF
--- a/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -43,7 +43,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)
@@ -77,7 +77,7 @@ pipeline {
                         }
                         steps {
                             dir('tiflow') {
-                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}") {
+                                cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
                                     """

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -65,7 +65,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -65,7 +65,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -65,7 +65,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,

--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -67,7 +67,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -67,7 +67,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,

--- a/pipelines/pingcap/tiflow/latest/pull_engine_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_engine_integration_test.groovy
@@ -69,7 +69,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,
@@ -142,7 +142,7 @@ pipeline {
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
-                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}") {
+                                cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     container("golang") {
                                         sh label: "prepare", script: """
                                             git rev-parse HEAD

--- a/pipelines/pingcap/tiflow/release-5.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-5.3/ghpr_verify.groovy
@@ -42,7 +42,7 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)
@@ -76,7 +76,7 @@ pipeline {
                         }
                         steps {
                             dir('tiflow') {
-                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}") {
+                                cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
                                     """

--- a/pipelines/pingcap/tiflow/release-6.0/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.0/ghpr_verify.groovy
@@ -42,7 +42,7 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)
@@ -76,7 +76,7 @@ pipeline {
                         }
                         steps {
                             dir('tiflow') {
-                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}") {
+                                cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
                                     """

--- a/pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy
@@ -43,7 +43,7 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)
@@ -77,7 +77,7 @@ pipeline {
                         }
                         steps {
                             dir('tiflow') {
-                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}") {
+                                cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
                                     """

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
@@ -65,7 +65,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
@@ -65,7 +65,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
@@ -68,7 +68,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_integration_test.groovy
@@ -67,7 +67,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)

--- a/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
@@ -42,7 +42,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)
@@ -76,7 +76,7 @@ pipeline {
                         }
                         steps {
                             dir('tiflow') {
-                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}") {
+                                cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
                                     """

--- a/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
@@ -43,7 +43,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)
@@ -77,7 +77,7 @@ pipeline {
                         }
                         steps {
                             dir('tiflow') {
-                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}") {
+                                cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
                                     """

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -65,7 +65,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -65,7 +65,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
@@ -65,7 +65,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -67,7 +67,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
@@ -67,7 +67,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,

--- a/pipelines/pingcap/tiflow/release-7.1/pull_engine_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_engine_integration_test.groovy
@@ -69,7 +69,7 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiflow/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             checkout(
                                 changelog: false,
@@ -142,7 +142,7 @@ pipeline {
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
-                                cache(path: "./", filter: '**/*', key: "git/pingcap/tiflow/rev-${REFS.pulls[0].sha}") {
+                                cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     container("golang") {
                                         sh label: "prepare", script: """
                                             git rev-parse HEAD


### PR DESCRIPTION
more extracting for multi PRs cases.

It's already used in tidb's pipelines.