### PR TITLE
ci: disable merged cdc test pipeline

### DIFF
--- a/jobs/pingcap/tidb/latest/merged_integration_cdc_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_cdc_test.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('pingcap/tidb/merged_integration_cdc_test') {
+    disabled(true)
     logRotator {
         daysToKeep(30)
     }


### PR DESCRIPTION
disable merged cdc test pipeline, this pipelines not finished yet.