### PR TITLE
refactor(pipelines/tikv/pd): simplfy git repo cache keys and checkout peer repos with `component.checkout`

### DIFF
--- a/pipelines/tikv/pd/latest/ghpr_build.groovy
+++ b/pipelines/tikv/pd/latest/ghpr_build.groovy
@@ -43,7 +43,7 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("pd") {
-                    cache(path: "./", filter: '**/*', key: "git/tikv/pd/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/tikv/pd/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)

--- a/pipelines/tikv/pd/release-6.5/ghpr_build.groovy
+++ b/pipelines/tikv/pd/release-6.5/ghpr_build.groovy
@@ -43,7 +43,7 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("pd") {
-                    cache(path: "./", filter: '**/*', key: "git/tikv/pd/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/tikv/pd/rev-']) {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
                                 prow.checkoutRefs(REFS)


### PR DESCRIPTION
Just copy the refactoring to all prow style pipelines
- Ref:  #2113
