### PR TITLE
fix(prow-jobs): change job `pull-test-infra-prow-image-build-test` to manually triggered

### DIFF
--- a/prow-jobs/ti-community-infra-test-infra-presubmits.yaml
+++ b/prow-jobs/ti-community-infra-test-infra-presubmits.yaml
@@ -16,7 +16,8 @@ presubmits:
     - name: pull-test-infra-prow-image-build-test
       branches:
         - ^release$
-      run_if_changed: '^(\.ko\.yaml|hack/(ts-rollup|make-rules|prowimagebuilder)|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
+      always_run: false
+      # run_if_changed: '^(\.ko\.yaml|hack/(ts-rollup|make-rules|prowimagebuilder)|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
       decorate: true
       spec:
         containers:


### PR DESCRIPTION
It's a presubmits job of `ti-community-infra/test-infra` repo.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>