### PR TITLE
fix(tiflow): to set LD_LIBRARY_PATH

### DIFF
--- a/pipelines/pingcap/tiflow/release-5.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-5.3/pull_cdc_integration_kafka_test.groovy
@@ -89,6 +89,7 @@ pipeline {
                             make check_third_party_binary
                             cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
                             ls -alh ./bin
+                            export LD_LIBRARY_PATH=\$(pwd)/bin:\$LD_LIBRARY_PATH
                             ./bin/tidb-server -V
                             ./bin/pd-server -V
                             ./bin/tikv-server -V

--- a/pipelines/pingcap/tiflow/release-5.3/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-5.3/pull_cdc_integration_test.groovy
@@ -89,6 +89,7 @@ pipeline {
                             make check_third_party_binary
                             cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
                             ls -alh ./bin
+                            export LD_LIBRARY_PATH=\$(pwd)/bin:\$LD_LIBRARY_PATH
                             ./bin/tidb-server -V
                             ./bin/pd-server -V
                             ./bin/tikv-server -V


### PR DESCRIPTION
set LD_LIBRARY_PATH to fix errors when run `tiflash --version`

```
 error while loading shared libraries: libtiflash_proxy.so: cannot open shared object file: No such file or directory
```