### PR TITLE
fix(tikv): fix download url error

### DIFF
--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_test.groovy
@@ -549,7 +549,17 @@ stage('Test') {
                                 fi
                             fi
                             for i in `cat test-chunk-${chunk_suffix} | cut -d ' ' -f 1 | sort -u`; do
-                                curl -o \$i ${FILE_SERVER_URL}/download/tikv_test/${ghprbActualCommit}/\$i --create-dirs;
+                                # 判断字符串是否以 / 开头
+                                if [ "\${i:0:1}" = "/" ]; then
+                                    # 如果以 / 开头，去掉第一个字符（即 /）
+                                    new_string="\${i:1}"
+                                else
+                                    new_string="\$i"
+                                fi
+
+                                echo "Original string: \$i"
+                                echo "New string: \$new_string"
+                                curl -o \$i ${FILE_SERVER_URL}/download/tikv_test/${ghprbActualCommit}/\$new_string --create-dirs;
                                 chmod +x \$i;
                             done
                             CI=1 LOG_FILE=target/my_test.log RUST_TEST_THREADS=1 RUST_BACKTRACE=1 ./test-chunk-${chunk_suffix} 2>&1 | tee tests.out


### PR DESCRIPTION
Fix the uncorrect tikv test cache file url: remove redundant slash on url.

Test pass  https://ci.pingcap.net/blue/organizations/jenkins/tikv_ghpr_test/detail/tikv_ghpr_test/35484/pipeline/88/