### PR TITLE
using bazel_importintotest to replace loaddatatest

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -85,7 +85,7 @@ pipeline {
                             'run_real_tikv_tests.sh bazel_statisticstest',
                             'run_real_tikv_tests.sh bazel_txntest',
                             'run_real_tikv_tests.sh bazel_addindextest',
-                            'run_real_tikv_tests.sh bazel_loaddatatest',
+                            'run_real_tikv_tests.sh bazel_importintotest',
                         )
                     }
                 }


### PR DESCRIPTION
see https://github.com/pingcap/tidb/pull/44602, we plan to rename bazel_loaddatatest to bazel_importintotest to avoid mixing with load data