### PR TITLE
feat: integrate django test cases into ci pipeline

### DIFF
--- a/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
@@ -106,7 +106,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {0
+                            dir('tidb') {
                                 cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/merged_integration_django_test/rev-${BUILD_TAG}") {
                                     sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'  
                                     sh label: 'tikv-server', script: 'ls bin/tikv-server && chmod +x bin/tikv-server && ./bin/tikv-server -V'

--- a/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
@@ -1,0 +1,161 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master and latest release branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_integration_django_test.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'python'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+        // parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 5, unit: 'MINUTES') }
+            steps {
+                dir("tidb") {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+                dir("tidb-test") {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb-test/rev-${REFS.base_sha}", restoreKeys: ['git/pingcap/tidb-test/rev-']) {
+                        retry(2) {
+                            script {
+                                component.checkout('git@github.com:pingcap/tidb-test.git', 'tidb-test', REFS.base_ref, "", GIT_CREDENTIALS_ID)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir('tidb') {
+                    cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/merged_integration_jdbc_test/rev-${BUILD_TAG}") {
+                        container("python") {
+                            sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
+                            sh label: 'download binary', script: """
+                            chmod +x ${WORKSPACE}/scripts/pingcap/tidb-test/*.sh
+                            ${WORKSPACE}/scripts/pingcap/tidb-test/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            mv third_bin/* bin/
+                            ls -alh bin/
+                            """
+                        }
+                    }
+                }
+                dir('tidb-test') {
+                    cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                        sh 'touch ws-${BUILD_TAG}'
+                    }
+                }
+            }
+        }
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_PARAMS'
+                        values 'django_test/django-orm-test ./test.sh'
+                    }
+                    axis {
+                        name 'TEST_STORE'
+                        values "tikv"
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        yamlFile POD_TEMPLATE_FILE
+                        defaultContainer 'python'
+                    }
+                } 
+                stages {
+                    stage("Test") {
+                        options { timeout(time: 40, unit: 'MINUTES') }
+                        steps {
+                            dir('tidb') {
+                                cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/merged_integration_jdbc_test/rev-${BUILD_TAG}") {
+                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'  
+                                    sh label: 'tikv-server', script: 'ls bin/tikv-server && chmod +x bin/tikv-server && ./bin/tikv-server -V'
+                                    sh label: 'pd-server', script: 'ls bin/pd-server && chmod +x bin/pd-server && ./bin/pd-server -V'  
+                                }
+                            }
+                            dir('tidb-test') {
+                                cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                    sh """
+                                        mkdir -p bin
+                                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                                        ls -alh bin/
+                                    """
+                                    container("java") {
+                                        sh label: "test_params=${TEST_PARAMS} ", script: """
+                                            #!/usr/bin/env bash
+                                            params_array=(\${TEST_PARAMS})
+                                            TEST_DIR=\${params_array[0]}
+                                            TEST_SCRIPT=\${params_array[1]}
+                                            echo "TEST_DIR=\${TEST_DIR}"
+                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+
+                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                                bash ${WORKSPACE}/scripts/pingcap/tidb-test/start_tikv.sh
+                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                                export TIKV_PATH="127.0.0.1:2379"
+                                                export TIDB_TEST_STORE_NAME="tikv"
+                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                            else
+                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                                export TIDB_TEST_STORE_NAME="unistore"
+                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                            fi
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        post{
+                            failure {
+                                script {
+                                    println "Test failed, archive the log"
+                                }
+                            }
+                        }
+                    }
+                }
+            }        
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
@@ -92,7 +92,7 @@ pipeline {
                     }
                     axis {
                         name 'TEST_STORE'
-                        values "tikv"
+                        values "unistore"
                     }
                 }
                 agent{
@@ -120,7 +120,7 @@ pipeline {
                                         cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                                         ls -alh bin/
                                     """
-                                    container("java") {
+                                    container("python") {
                                         sh label: "test_params=${TEST_PARAMS} ", script: """
                                             #!/usr/bin/env bash
                                             params_array=(\${TEST_PARAMS})

--- a/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
@@ -64,7 +64,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/merged_integration_jdbc_test/rev-${BUILD_TAG}") {
+                    cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/merged_integration_django_test/rev-${BUILD_TAG}") {
                         container("python") {
                             sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
                             sh label: 'download binary', script: """
@@ -106,8 +106,8 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {
-                                cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/merged_integration_jdbc_test/rev-${BUILD_TAG}") {
+                            dir('tidb') {0
+                                cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/merged_integration_django_test/rev-${BUILD_TAG}") {
                                     sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'  
                                     sh label: 'tikv-server', script: 'ls bin/tikv-server && chmod +x bin/tikv-server && ./bin/tikv-server -V'
                                     sh label: 'pd-server', script: 'ls bin/pd-server && chmod +x bin/pd-server && ./bin/pd-server -V'  

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_django_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_django_test.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: python
+      image: "hub.pingcap.net/temp/django-tidb-test:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
+        limits:
+          memory: 16Gi
+          cpu: "6"
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64


### PR DESCRIPTION
This PR will add Django unit test cases based on Django-TiDB to the TiDB CI pipeline, the tests should run after every PR merged into TiDB repo.

related PR: https://github.com/pingcap/tidb-test/pull/2151