### PR TITLE
feat(scripts/pingcap/community): add skip ci words in commit message to avoid unnecessary ci builds

### DIFF
--- a/scripts/pingcap/community/update-prow-owners.ts
+++ b/scripts/pingcap/community/update-prow-owners.ts
@@ -4,7 +4,7 @@ import { dirname } from "https://deno.land/std@0.190.0/path/mod.ts";
 import { Octokit } from "https://esm.sh/octokit@2.0.19";
 
 const headRef = `bot/update-owners-${Date.now()}`;
-const commitMessage = "Update OWNERS file";
+const commitMessage = "[skip ci] Update OWNERS file\n\n\nskip-checks: true";
 const prTitle = "OWNERS: Auto Sync OWNERS files from community membership";
 
 type CommunityMember = string | {


### PR DESCRIPTION
## Why

The pull requests that only make changes on prow `OWNERS` should not trigger CI jobs.

## How

1. Add some CI skip words in head commit of the PR created, this may be worked for Github workflows.
2. Other type CI jobs be implement in another way.

Ref: https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
Signed-off-by: wuhuizuo <wuhuizuo@126.com>