### PR TITLE
feat: add job integration-django-test

### DIFF
--- a/jobs/pingcap/tidb/latest/merged_integration_django_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_django_test.groovy
@@ -1,0 +1,37 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+pipelineJob('pingcap/tidb/merged_integration_django_test') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tidb")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath('pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy')
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
@@ -89,4 +89,11 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-
+    - name: pingcap/tidb/merged_integration_django_test
+      agent: jenkins
+      decorate: false # need add this.
+      context: wip/integration-django-test
+      max_concurrency: 2
+      skip_report: true
+      branches:
+        - ^master$


### PR DESCRIPTION
* Add job integration-django-test to postsubmit jobs on master.
* Currently, the task is in debug mode, so the status update has been disabled.
