### PR TITLE
fix: go binary does not exists in the django test pipeline

### DIFF
--- a/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
@@ -29,8 +29,6 @@ pipeline {
                 sh label: 'Debug info', script: """
                     printenv
                     echo "-------------------------"
-                    go env
-                    echo "-------------------------"
                     echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
                 """
                 container(name: 'net-tool') {


### PR DESCRIPTION
do not print go env in django test pipeline as it uses a python image