### PR TITLE
fix: array is not support by bash in python image

### DIFF
--- a/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_django_test.groovy
@@ -120,10 +120,10 @@ pipeline {
                                     """
                                     container("python") {
                                         sh label: "test_params=${TEST_PARAMS} ", script: """
-                                            #!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
+                                            #!/bin/bash
+                                            set -- \${TEST_PARAMS}
+                                            TEST_DIR=\$1
+                                            TEST_SCRIPT=\$2
                                             echo "TEST_DIR=\${TEST_DIR}"
                                             echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 


### PR DESCRIPTION
error log: https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftidb%2Fmerged_integration_django_test/detail/merged_integration_django_test/19/pipeline/