### PR TITLE
fix(libraries/tipipeline/vars): fix `component.fetchAndExtractArtifact`

### DIFF
--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -77,8 +77,13 @@ def fetchAndExtractArtifact(serverUrl, keyInComment, prTargetBranch, prCommentBo
         fi
         
         artifactUrl="${serverUrl}/download/builds/pingcap/${keyInComment}/\${sha1}/${artifactPath}"
-        echo "📦 artifact url: \${artifactUrl}"
-        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 0 -O - "\${artifactUrl}" | tar xz ${pathInArchive}
+        echo "⬇️📦 artifact url: \${artifactUrl}"
+        saveFile=\$(basename \${artifactUrl})
+        wget -q --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 -c -O \${saveFile} \${artifactUrl}
+        echo "📂 extract ${pathInArchive} from \${saveFile} ..."
+        tar -xzf \${saveFile} ${pathInArchive}
+        rm \${saveFile}
+        echo "✅ extracted ${pathInArchive} from \${saveFile} ."
     """)
 }
 


### PR DESCRIPTION
- use wget continue option with saving file to path.
- limit retry times to 3.
- add tiny info outputs lines.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>