### PR TITLE
fix(br): default importer use release-5.0

### DIFF
--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -75,7 +75,7 @@ if (getTargetBranch(ghprbTargetBranch)!=""){
 
 
 def TIKV_BRANCH = ghprbTargetBranch
-def TIKV_IMPORTER_BRANCH = ghprbTargetBranch
+def TIKV_IMPORTER_BRANCH = "release-5.0"
 def PD_BRANCH = ghprbTargetBranch
 def TIDB_BRANCH = ghprbTargetBranch
 def BUILD_NUMBER = "${env.BUILD_NUMBER}"


### PR DESCRIPTION
Use the default release-5.0 branch as tikv/importer is no longer being updated.