### PR TITLE
feat(prow-jobs): Add presubmit jobs for verifying GitOps for prow configMaps and cronJobs

### DIFF
--- a/prow-jobs/pingcap-qe-ci-presubmits.yaml
+++ b/prow-jobs/pingcap-qe-ci-presubmits.yaml
@@ -48,14 +48,3 @@ presubmits:
               limits:
                 memory: 256Mi
                 cpu: 200m
-          - name: xxx
-            image: debian
-            command: [bash, -c]
-            args:
-              - |
-                ls /home/prow/go
-                pwd
-                ls -l
-                ls -l /home/prow/go/src/github.com/
-                ls -l /home/prow/go/src/github.com/PingCAP-QE
-                ls -l /home/prow/go/src/github.com/PingCAP-QE/ee-ops

--- a/prow-jobs/ti-community-infra-configs-presubmits.yaml
+++ b/prow-jobs/ti-community-infra-configs-presubmits.yaml
@@ -2,7 +2,7 @@ presubmits:
   ti-community-infra/configs:
     - name: pull-configs-validate-prow-yaml
       decorate: true
-      run_if_changed: "prow/"
+      run_if_changed: "prow/config/"
       branches:
         - ^main$
       spec:
@@ -68,3 +68,59 @@ presubmits:
           - name: github-token
             secret:
               secretName: github-token
+    - name: pull-verify-gitops-prow-configs
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ee-ops
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ee-ops         
+      run_if_changed: "prow/config/"
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - name: main
+            image: ghcr.io/fluxcd/flux-cli:v2.0.0-rc.4
+            securityContext:
+              runAsUser: 0 # the default user or the image is not root.
+            command: [flux, -n, apps]
+            args:
+              - build
+              - kustomization 
+              - prow-configs
+              - --path=prow
+              - --kustomization-file=../ee-ops/apps/gcp/prow/pre/prow-configs.yaml
+              - --dry-run
+            resources:
+              limits:
+                memory: 256Mi
+                cpu: 200m
+    - name: pull-verify-gitops-prow-cronjobs
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ee-ops
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ee-ops         
+      run_if_changed: "prow/cronjobs/"
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - name: main
+            image: ghcr.io/fluxcd/flux-cli:v2.0.0-rc.4
+            securityContext:
+              runAsUser: 0 # the default user or the image is not root.
+            command: [flux, -n, apps]
+            args:
+              - build
+              - kustomization 
+              - prow-post-cronjobs-community
+              - --path=prow/cronjobs
+              - --kustomization-file=../ee-ops/apps/gcp/prow/post/cronjobs-community.yaml
+              - --dry-run
+            resources:
+              limits:
+                memory: 256Mi
+                cpu: 200m


### PR DESCRIPTION
## Changes

- add presubmit to verify GitOps for configMaps for prow.
- add presubmit to verify GitOps for cronJobs for prow.

Ref: https://github.com/PingCAP-QE/ee-ops/issues/627