### PR TITLE
chore: enable django_test report

### DIFF
--- a/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
@@ -103,8 +103,8 @@ postsubmits:
     - name: pingcap/tidb/merged_integration_django_test
       agent: jenkins
       decorate: false # need add this.
-      context: wip/integration-django-test
-      max_concurrency: 2
-      skip_report: true
+      context: ci/integration-django-test
+      max_concurrency: 1
+      skip_report: false
       branches:
         - ^master$


### PR DESCRIPTION
Enable django_test report.
The pipeline has been running smoothly for a while.