### PR TITLE
feat: add prisma integration test to tidb merged ci

### DIFF
--- a/jobs/pingcap/tidb/latest/merged_integration_prisma_test.groovy
+++ b/jobs/pingcap/tidb/latest/merged_integration_prisma_test.groovy
@@ -1,0 +1,37 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+pipelineJob('pingcap/tidb/merged_integration_prisma_test') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tidb")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath('pipelines/pingcap/tidb/latest/merged_integration_prisma_test.groovy')
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/merged_integration_prisma_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_prisma_test.groovy
@@ -1,0 +1,160 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master and latest release branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-merged_integration_prisma_test.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'nodejs'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        CI = "1"
+    }
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+        // parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 5, unit: 'MINUTES') }
+            steps {
+                dir("tidb") {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+                dir("tidb-test") {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb-test/rev-${REFS.base_sha}", restoreKeys: ['git/pingcap/tidb-test/rev-']) {
+                        retry(2) {
+                            script {
+                                component.checkout('git@github.com:pingcap/tidb-test.git', 'tidb-test', REFS.base_ref, "", GIT_CREDENTIALS_ID)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir('tidb') {
+                    cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/merged_integration_prisma_test/rev-${BUILD_TAG}") {
+                        container("nodejs") {
+                            sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
+                            sh label: 'download binary', script: """
+                            chmod +x ${WORKSPACE}/scripts/pingcap/tidb-test/*.sh
+                            ${WORKSPACE}/scripts/pingcap/tidb-test/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            mv third_bin/* bin/
+                            ls -alh bin/
+                            """
+                        }
+                    }
+                }
+                dir('tidb-test') {
+                    cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                        sh 'touch ws-${BUILD_TAG}'
+                    }
+                }
+            }
+        }
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_PARAMS'
+                        values 'prisma_test ./test.sh'
+                    }
+                    axis {
+                        name 'TEST_STORE'
+                        values "unistore"
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        yamlFile POD_TEMPLATE_FILE
+                        defaultContainer 'nodejs'
+                    }
+                } 
+                stages {
+                    stage("Test") {
+                        options { timeout(time: 40, unit: 'MINUTES') }
+                        steps {
+                            dir('tidb') {
+                                cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/merged_integration_prisma_test/rev-${BUILD_TAG}") {
+                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'  
+                                    sh label: 'tikv-server', script: 'ls bin/tikv-server && chmod +x bin/tikv-server && ./bin/tikv-server -V'
+                                    sh label: 'pd-server', script: 'ls bin/pd-server && chmod +x bin/pd-server && ./bin/pd-server -V'  
+                                }
+                            }
+                            dir('tidb-test') {
+                                cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                    sh """
+                                        mkdir -p bin
+                                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                                        ls -alh bin/
+                                    """
+                                    container("nodejs") {
+                                        sh label: "test_params=${TEST_PARAMS} ", script: """
+                                            #!/bin/bash
+                                            set -- \${TEST_PARAMS}
+                                            TEST_DIR=\$1
+                                            TEST_SCRIPT=\$2
+                                            echo "TEST_DIR=\${TEST_DIR}"
+                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+
+                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                                bash ${WORKSPACE}/scripts/pingcap/tidb-test/start_tikv.sh
+                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                                export TIKV_PATH="127.0.0.1:2379"
+                                                export TIDB_TEST_STORE_NAME="tikv"
+                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                            else
+                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                                export TIDB_TEST_STORE_NAME="unistore"
+                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                            fi
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        post{
+                            failure {
+                                script {
+                                    println "Test failed, archive the log"
+                                }
+                            }
+                        }
+                    }
+                }
+            }        
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/merged_integration_prisma_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_prisma_test.groovy
@@ -13,7 +13,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yamlFile POD_TEMPLATE_FILE
-            defaultContainer 'nodejs'
+            defaultContainer 'golang'
         }
     }
     environment {
@@ -64,7 +64,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/merged_integration_prisma_test/rev-${BUILD_TAG}") {
-                        container("nodejs") {
+                        container("golang") {
                             sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
                             sh label: 'download binary', script: """
                             chmod +x ${WORKSPACE}/scripts/pingcap/tidb-test/*.sh
@@ -91,7 +91,7 @@ pipeline {
                     }
                     axis {
                         name 'TEST_STORE'
-                        values "unistore"
+                        values "tikv"
                     }
                 }
                 agent{

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_prisma_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_prisma_test.yaml
@@ -4,8 +4,8 @@ spec:
   securityContext:
     fsGroup: 1000
   containers:
-    - name: nodejs
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_nodejs-16.x:latest"
+    - name: golang
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
       tty: true
       resources:
         requests:
@@ -14,6 +14,16 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
+    - name: nodejs
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_nodejs-16.x:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 8Gi
+          cpu: "4"
+        limits:
+          memory: 8Gi
+          cpu: "4"
     - name: net-tool
       image: wbitt/network-multitool
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_prisma_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_prisma_test.yaml
@@ -4,7 +4,7 @@ spec:
   securityContext:
     fsGroup: 1000
   containers:
-    - name: python
+    - name: nodejs
       image: "hub.pingcap.net/jenkins/centos7_golang-1.16_nodejs-16.x:latest"
       tty: true
       resources:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_prisma_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_prisma_test.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: python
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_nodejs-16.x:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
+        limits:
+          memory: 16Gi
+          cpu: "6"
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
@@ -108,3 +108,11 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
+    - name: pingcap/tidb/merged_integration_prisma_test
+      agent: jenkins
+      decorate: false # need add this.
+      context: wip/integration-prisma-test
+      max_concurrency: 1
+      skip_report: true
+      branches:
+        - ^master$


### PR DESCRIPTION
This PR will add Prisma integration testes to TiDB merged CI pipeline. After this PR be merged, the Prisma integration testes will be execute after every PR be merged in TiDB repo.

Related PR: https://github.com/pingcap/tidb-test/pull/2163

Notice: The `skip_report` option of the trigger is set to `true`, which means skip report the test status on Github checks status. After verifying the test working on the prod, `skip_report` option will be set to `false`.