### PR TITLE
chore(pipelines/pingcap/tidb/latest): print the coverage files

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -125,6 +125,7 @@ pipeline {
                             }
                             success {
                                 dir("tidb") {
+                                    sh 'ls -alh test_coverage/ || true'
                                     script {
                                         prow.uploadCoverageToCodecov(REFS, 'integration', 'test_coverage/coverage.dat')
                                     }


### PR DESCRIPTION
Currently it has no coverage data collected, let's print them.

Ref: #2171 

Signed-off-by: wuhuizuo <wuhuizuo@126.com>