### PR TITLE
perf(prow-jobs): update trigger condition for CI jobs of pingcap/tidb release-6.5

### DIFF
--- a/prow-jobs/pingcap-tidb-release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-release-6.5-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_build
       agent: jenkins
       decorate: false # need add this.
-      always_run: true
+      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
       trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
       rerun_command: "/test build"
@@ -14,7 +14,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_check
       agent: jenkins
       decorate: false # need add this.
-      always_run: true
+      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
       trigger: "(?m)^/test (?:.*? )?check-dev(?: .*?)?$"
       rerun_command: "/test check-dev"
@@ -23,7 +23,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_check2
       agent: jenkins
       decorate: false # need add this.
-      always_run: true
+      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
       trigger: "(?m)^/test (?:.*? )?check-dev2(?: .*?)?$"
       rerun_command: "/test check-dev2"
@@ -32,7 +32,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_mysql_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: true
+      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
       trigger: "(?m)^/test (?:.*? )?mysql-test(?: .*?)?$"
       rerun_command: "/test mysql-test"
@@ -41,7 +41,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_unit_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: true
+      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
       trigger: "(?m)^/test (?:.*? )?unit-test(?: .*?)?$"
       rerun_command: "/test unit-test"


### PR DESCRIPTION
update trigger condition for CI jobs of pingcap/tidb release-6.5.

An existing issue with the tide.
Due to the defect of tide, modifying any condition triggering related configurations will retrigger CI for all existing PRs, which may put tremendous pressure on prow and cause issues with the refresh status of prow components.

So, after merging this PR, please continue to observe whether Prow is running normally.