### PR TITLE
feat: add lib checkout to only pull current pr

### DIFF
--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -70,7 +70,6 @@ def checkoutV2(gitUrl, keyInComment, prTargetBranch, prCommentBody, credentialsI
         pluginSpec += " +refs/pull/$prId/head:refs/remotes/origin/pr/$prId/head"
         componentBranch = "origin/${componentBranch}/head"
     }
-    println(componentBranch)
     println(gitUrl)
     println(pluginSpec)
 


### PR DESCRIPTION
Only checkout code of the current PR instead of all PRs, reducing unnecessary consumption of download bandwidth.

Add a checkoutV2 method to avoid unexpected errors affecting all related pipelines.When running for a period of time without any unexpected situations, replace the existing logic that uses checkout.

Notice: please clean lib cache in do jenkins after pr merged.