### PR TITLE
feat(tiproxy): add new mysql connector test

### DIFF
--- a/jobs/pingcap/tiproxy/latest/pull_mysql_ connector_test.groovy
+++ b/jobs/pingcap/tiproxy/latest/pull_mysql_ connector_test.groovy
@@ -1,0 +1,39 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/tiproxy/pull_mysql_ connector_test') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tiproxy")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tiproxy/latest/pull_mysql_ connector_test.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_ connector_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_ connector_test.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        requests:
+          memory: 8Gi
+          cpu: "4"
+        limits:
+          memory: 24Gi
+          cpu: "8"
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_connector_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_connector_test.groovy
@@ -1,0 +1,107 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'pingcap/tidb-test'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiproxy/latest/pod-pull_mysql_connector_test.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 45, unit: 'MINUTES')
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    ls -l /dev/null
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 5, unit: 'MINUTES') }
+            steps {
+                dir("tiproxy") {
+                    cache(path: "./", filter: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+                dir("tidb-test") {
+                    cache(path: "./", filter: '**/*', key: "git/pingcap/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb-test/rev-']) {
+                        retry(2) {
+                            script {
+                                component.checkout('git@github.com:pingcap/tidb-test.git', 'tidb-test', "master", REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                            }
+                        }
+                    }
+                }
+                dir("mysql-server") {
+                    cache(path: "./", filter: '**/*', key: "git/xhebox/mysql-server/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/xhebox/mysql-server/rev-']) {
+                        retry(2) {
+                            script {
+                                component.checkout('https://github.com/xhebox/mysql-server.git', 'mysql-server', "8.0", REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir('tiproxy') {
+                    sh label: 'tiproxy', script: 'ls bin/tiproxy || make'
+                }
+                dir('tidb-test') {
+                        sh "touch ws-${BUILD_TAG}"
+                        sh label: 'prepare thirdparty binary', script: """
+                        chmod +x download_binary.sh
+                        ./download_binary.sh --tidb=master
+                        cp ../tiproxy/bin/tiproxy ./bin/
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tiproxy --version
+                        """
+                }
+            }
+        }
+        stage('MySQL Connector Tests') {
+            stage("Test") {
+                steps {
+                    dir('tidb-test') {
+                        sh label: "run test", script: """
+                            #!/usr/bin/env bash
+                            ./bin/tidb-server &
+                            TIDB_PID=\$!
+                            ./mysql_client_test/test.sh -l 127.0.0.1 -p 4000 -t \$PWD/../tiproxy -m \$PWD/../mysql-server -u root
+                            kill \$TIDB_PID || true
+                        """
+                    }
+                }
+            }  
+        }
+    }
+}

--- a/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
@@ -11,3 +11,14 @@ presubmits:
       rerun_command: "/test pull-mysql-test"
       branches:
         - ^main$
+    - name: pingcap/tiproxy/pull_mysql_connector_test
+      agent: jenkins
+      decorate: false # need add this.
+      # skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      always_run: false  # need remove this after the debug is done.
+      context: wip/pull-mysql-connector-test
+      skip_report: false
+      trigger: "(?m)^/test (?:.*? )?pull-mysql-connector-test(?: .*?)?$"
+      rerun_command: "/test pull-mysql-connector-test"
+      branches:
+        - ^main$


### PR DESCRIPTION
Add new pipeline for MySQL Connector Tests.

Note:
* remove `always_run: false` from pingcap-tiproxy-latest-presubmits.yaml after debug test
* change context from `wip/pull-mysql-connector-test` to `pull-mysql-connector-test` after debug test