### PR TITLE
fix(tiflow): not run integrations test automatically

### DIFF
--- a/prow-jobs/pingcap-tiflow-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-latest-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_kafka_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
@@ -15,6 +16,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
@@ -26,6 +28,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_storage_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-storage-test
@@ -37,6 +40,7 @@ presubmits:
     - name: pingcap/tiflow/pull_dm_compatibility_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-compatibility-test
@@ -48,6 +52,7 @@ presubmits:
     - name: pingcap/tiflow/pull_dm_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-integration-test
@@ -59,6 +64,7 @@ presubmits:
     - name: pingcap/tiflow/pull_engine_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-engine-integration-test

--- a/prow-jobs/pingcap-tiflow-release-5.3-presubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-release-5.3-presubmits.yaml
@@ -14,6 +14,7 @@ presubmits:
     - name: pingcap/tiflow/release-5.3/pull_cdc_integration_kafka_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       run_before_merge: true
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-cdc-integration-kafka-test
@@ -25,6 +26,7 @@ presubmits:
     - name: pingcap/tiflow/release-5.3/pull_cdc_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
@@ -36,6 +38,7 @@ presubmits:
     - name: pingcap/tiflow/release-5.3/pull_dm_compatibility_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-compatibility-test
@@ -47,6 +50,7 @@ presubmits:
     - name: pingcap/tiflow/release-5.3/pull_dm_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-integration-test

--- a/prow-jobs/pingcap-tiflow-release-5.4-presubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-release-5.4-presubmits.yaml
@@ -14,6 +14,7 @@ presubmits:
     - name: pingcap/tiflow/release-5.4/pull_cdc_integration_kafka_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       run_before_merge: true
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-cdc-integration-kafka-test
@@ -25,6 +26,7 @@ presubmits:
     - name: pingcap/tiflow/release-5.4/pull_cdc_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
@@ -36,6 +38,7 @@ presubmits:
     - name: pingcap/tiflow/release-5.4/pull_dm_compatibility_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-compatibility-test
@@ -47,6 +50,7 @@ presubmits:
     - name: pingcap/tiflow/release-5.4/pull_dm_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-integration-test

--- a/prow-jobs/pingcap-tiflow-release-6.1-presubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-release-6.1-presubmits.yaml
@@ -14,6 +14,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       run_before_merge: true
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-cdc-integration-kafka-test
@@ -25,6 +26,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.1/pull_cdc_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
@@ -36,6 +38,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.1/pull_dm_compatibility_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-compatibility-test
@@ -47,6 +50,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.1/pull_dm_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-integration-test

--- a/prow-jobs/pingcap-tiflow-release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-release-6.5-presubmits.yaml
@@ -14,6 +14,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
@@ -24,6 +25,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.5/pull_cdc_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
@@ -35,6 +37,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.5/pull_dm_compatibility_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-compatibility-test
@@ -46,6 +49,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.5/pull_dm_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-integration-test

--- a/prow-jobs/pingcap-tiflow-release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-release-7.1-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
@@ -15,6 +16,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.1/pull_cdc_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
@@ -26,6 +28,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-storage-test
@@ -37,6 +40,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.1/pull_dm_compatibility_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-compatibility-test
@@ -48,6 +52,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.1/pull_dm_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-integration-test
@@ -59,6 +64,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.1/pull_engine_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-engine-integration-test

--- a/prow-jobs/pingcap-tiflow-release-7.2-presubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-release-7.2-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
@@ -15,6 +16,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.2/pull_cdc_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
@@ -26,6 +28,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-cdc-integration-storage-test
@@ -37,6 +40,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.2/pull_dm_compatibility_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-compatibility-test
@@ -48,6 +52,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.2/pull_dm_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-dm-integration-test
@@ -59,6 +64,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.2/pull_engine_integration_test
       agent: jenkins
       decorate: false # need add this.
+      always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
       context: pull-engine-integration-test


### PR DESCRIPTION
For integration testing, it supports conditional triggering but does not require automatic triggering.

Refer to  https://docs.prow.k8s.io/docs/jobs/#trigger-types.
<img width="709" alt="image" src="https://github.com/PingCAP-QE/ci/assets/16618216/3634bca0-07c7-4a0b-b0e1-847a47ca41e9">
