### PR TITLE
feat: add image sync to dockerhub pipeline

### DIFF
--- a/jenkins/pipelines/cd/update-all-image-to-latest-on-dockerhub.groovy
+++ b/jenkins/pipelines/cd/update-all-image-to-latest-on-dockerhub.groovy
@@ -1,0 +1,31 @@
+pipeline {
+    agent none
+    parameters {
+        string defaultValue: 'latest', description: '', name: 'version', trim: true
+    }
+    stages {
+        stage('update all image tag to latest') {
+            matrix {
+                axes {
+                    axis {
+                        name 'IMAGE'
+                        values "pingcap/br" , "pingcap/dm" , "pingcap/dumpling" , "pingcap/ng-monitoring" , "pingcap/pd" , "pingcap/ticdc" , "pingcap/tidb" , "pingcap/tidb-binlog" , "pingcap/tidb-lightning" , "pingcap/tidb-monitor-initializer" , "pingcap/tiflash" , "pingcap/tikv" , "pingcap/br-enterprise" , "pingcap/dm-enterprise" , "pingcap/dumpling-enterprise" , "pingcap/ng-monitoring-enterprise" , "pingcap/pd-enterprise" , "pingcap/ticdc-enterprise" , "pingcap/tidb-enterprise" , "pingcap/tidb-binlog-enterprise" , "pingcap/tidb-lightning-enterprise" , "pingcap/tidb-monitor-initializer-enterprise" , "pingcap/tiflash-enterprise" , "pingcap/tikv-enterprise"
+                    }
+                }
+
+                stages {
+                    stage("update tag") {
+                        steps {
+                            echo "sync ${IMAGE}:${params.version} to ${IMAGE}:latest"
+                            build job: 'jenkins-image-syncer',
+                                    parameters: [
+                                            string(name: 'SOURCE_IMAGE', value: "${IMAGE}:${params.version}"),
+                                            string(name: 'TARGET_IMAGE', value: "${IMAGE}:latest")
+                                    ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jenkins/pipelines/cd/update-base-images-on-dockerhub.groovy
+++ b/jenkins/pipelines/cd/update-base-images-on-dockerhub.groovy
@@ -1,0 +1,31 @@
+pipeline {
+    agent none
+    parameters {
+        string defaultValue: 'v1', description: '', name: 'version', trim: true
+    }
+    stages {
+        stage('update base images') {
+            matrix {
+                axes {
+                    axis {
+                        name 'IMAGE'
+                        values 'pingcap-base', 'tidb-base', 'tikv-base', 'tiflash-base', 'pd-base', 'tools-base'
+                    }
+                }
+
+                stages {
+                    stage("update tag") {
+                        steps {
+                            echo "sync hub.pingcap.net/bases/${IMAGE}:${params.version} to pingcap/${IMAGE}:${params.version}"
+                            build job: 'jenkins-image-syncer',
+                                    parameters: [
+                                            string(name: 'SOURCE_IMAGE', value: "hub.pingcap.net/bases/${IMAGE}:${params.version}"),
+                                            string(name: 'TARGET_IMAGE', value: "pingcap/${IMAGE}:${params.version}")
+                                    ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Why:
- update dockerhub image latest tag
- sync base image to dockerhub