### PR TITLE
fix: avoid build multi-branch at the same time to avoid github limit

### DIFF
--- a/jenkins/pipelines/cd/nightly/release-all-images-by-branch.groovy
+++ b/jenkins/pipelines/cd/nightly/release-all-images-by-branch.groovy
@@ -33,11 +33,11 @@ properties([
                 H 18 * * * % GIT_BRANCH=release-5.3;FORCE_REBUILD=false;NEED_MULTIARCH=false
                 */
                 parameterizedCron('''
-                H 18 * * * % GIT_BRANCH=release-5.4;FORCE_REBUILD=false;NEED_MULTIARCH=false
-                H 18 * * * % GIT_BRANCH=release-6.1;FORCE_REBUILD=false;NEED_MULTIARCH=true
-                H 18 * * * % GIT_BRANCH=release-6.5;FORCE_REBUILD=false;NEED_MULTIARCH=true
-                H 18 * * * % GIT_BRANCH=release-7.1;FORCE_REBUILD=false;NEED_MULTIARCH=true
-                H 18 * * * % GIT_BRANCH=release-7.2;FORCE_REBUILD=false;NEED_MULTIARCH=true
+                0 18 * * * % GIT_BRANCH=release-5.4;FORCE_REBUILD=false;NEED_MULTIARCH=false
+                10 18 * * * % GIT_BRANCH=release-6.1;FORCE_REBUILD=false;NEED_MULTIARCH=true
+                20 18 * * * % GIT_BRANCH=release-6.5;FORCE_REBUILD=false;NEED_MULTIARCH=true
+                30 18 * * * % GIT_BRANCH=release-7.1;FORCE_REBUILD=false;NEED_MULTIARCH=true
+                40 18 * * * % GIT_BRANCH=release-7.2;FORCE_REBUILD=false;NEED_MULTIARCH=true
                 H 19 * * * % GIT_BRANCH=master;FORCE_REBUILD=false;NEED_MULTIARCH=true
             ''')
         ])


### PR DESCRIPTION
# Why:
- get github sha1 failed when many concurrent builds

# How
- disperse the trigger time