### PR TITLE
chore(tiflow): disable trigger old pipeline on release 5.3 & 5.4

### DIFF
--- a/jenkins/jobs/ci2/pingcap/tiflow/dm_ghpr_compatibility_test.groovy
+++ b/jenkins/jobs/ci2/pingcap/tiflow/dm_ghpr_compatibility_test.groovy
@@ -28,6 +28,7 @@ pipelineJob('dm_ghpr_compatibility_test') {
                     }
                     blackListTargetBranches {
                         ghprbBranch { branch('^(release-)?6\\.[1|5]\\d*(\\.\\d+)?(\\-.*)?$') }
+                        ghprbBranch { branch('^(release-)?5\\.[3|4]\\d*(\\.\\d+)?(\\-.*)?$') }
                     }
                     // ignore when only those file changed.(
                     //   multi line regex

--- a/jenkins/jobs/ci2/pingcap/tiflow/dm_ghpr_integration_test.groovy
+++ b/jenkins/jobs/ci2/pingcap/tiflow/dm_ghpr_integration_test.groovy
@@ -28,6 +28,7 @@ pipelineJob('dm_ghpr_integration_test') {
                     }
                     blackListTargetBranches {
                         ghprbBranch { branch('^(release-)?6\\.[1|5]\\d*(\\.\\d+)?(\\-.*)?$') }
+                        ghprbBranch { branch('^(release-)?5\\.[3|4]\\d*(\\.\\d+)?(\\-.*)?$') }
                     }
                     // ignore when only those file changed.(
                     //   multi line regex


### PR DESCRIPTION
Disable trigger old pipeline on release 5.3 & 5.4, those two dm pipeline have been  replaced by a pipeline.