### PR TITLE
chore(tidb/br): only run pull-br it before merge

### DIFF
--- a/prow-jobs/pingcap-tidb-release-7.3-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-release-7.3-presubmits.yaml
@@ -52,6 +52,7 @@ presubmits:
       context: pull-br-integration-test
       always_run: false
       run_if_changed: "^br/.*$"
+      run_before_merge: true
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-br-integration-test(?: .*?)?$"
       rerun_command: "/test pull-br-integration-test"


### PR DESCRIPTION
Only run pull-br-integration-test brfore merge other then trigger when push every new commit. This integration test consumes a lot of resources and does not need to be automatically triggered every time.