### PR TITLE
chore(tidb/br): remove run_before_merge on release-7.3

### DIFF
--- a/prow-jobs/pingcap-tidb-release-7.3-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-release-7.3-presubmits.yaml
@@ -52,6 +52,7 @@ presubmits:
       context: pull-br-integration-test
       always_run: false
       run_if_changed: "^br/.*$"
+      optional: true
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-br-integration-test(?: .*?)?$"
       rerun_command: "/test pull-br-integration-test"

--- a/prow-jobs/pingcap-tidb-release-7.3-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-release-7.3-presubmits.yaml
@@ -52,7 +52,6 @@ presubmits:
       context: pull-br-integration-test
       always_run: false
       run_if_changed: "^br/.*$"
-      run_before_merge: true
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-br-integration-test(?: .*?)?$"
       rerun_command: "/test pull-br-integration-test"


### PR DESCRIPTION
There are currently some failed lightning cases in the upstream.  To ensure the smooth merging of other PRs, temporarily remove this configuration.