### PR TITLE
Revert "fix: use CI=1 for tidb make command"

### DIFF
--- a/pipelines/pingcap/tidb/latest/canary-ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/canary-ghpr_unit_test.groovy
@@ -17,7 +17,6 @@ pipeline {
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
-        CI = "1"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_build.groovy
@@ -18,7 +18,6 @@ pipeline {
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
-        CI = "1"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check.groovy
@@ -17,9 +17,6 @@ pipeline {
             defaultContainer 'golang'
         }
     }
-    environment {
-        CI = "1"
-    }
     options {
         timeout(time: 30, unit: 'MINUTES')
         parallelsAlwaysFailFast()

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -22,7 +22,6 @@ pipeline {
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
-        CI = "1"
     }
     stages {
         stage('Debug info') {

--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -18,7 +18,6 @@ pipeline {
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
-        CI = "1"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_build.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_build.groovy
@@ -18,7 +18,6 @@ pipeline {
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
-        CI = "1"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_common_test.groovy
@@ -19,7 +19,6 @@ pipeline {
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
-        CI = "1"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -17,7 +17,6 @@ pipeline {
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
-        CI = "1"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -20,7 +20,6 @@ pipeline {
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
-        CI = "1"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_cdc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_cdc_test.groovy
@@ -20,7 +20,6 @@ pipeline {
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
-        CI = "1"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -19,7 +19,6 @@ pipeline {
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
-        CI = "1"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -19,7 +19,6 @@ pipeline {
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
-        CI = "1"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_ddl_test.groovy
@@ -19,7 +19,6 @@ pipeline {
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
-        CI = "1"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -18,7 +18,6 @@ pipeline {
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
-        CI = "1"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -19,7 +19,6 @@ pipeline {
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
-        CI = "1"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_prisma_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_prisma_test.groovy
@@ -18,7 +18,6 @@ pipeline {
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
-        CI = "1"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
@@ -18,7 +18,6 @@ pipeline {
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
-        CI = "1"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_tiflash_test.groovy
@@ -18,7 +18,6 @@ pipeline {
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
-        CI = "1"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
@@ -19,7 +19,6 @@ pipeline {
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
-        CI = "1"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')


### PR DESCRIPTION
Reverts PingCAP-QE/ci#2167

`CI=true` is  a default environment variable in jenkins. So it is unnecessary to set CI=1.