### PR TITLE
chore(pingcap/tidb): bump go version to `v1.21.0`

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_build.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_build.groovy
@@ -56,7 +56,7 @@ GO_IMAGE_MAP = [
     "go1.18": "hub.pingcap.net/jenkins/centos7_golang-1.18:latest",
     "go1.19": "hub.pingcap.net/jenkins/centos7_golang-1.19:latest",
     "release-6.2": "hub.pingcap.net/wangweizhen/tidb_image:20220823",
-    "master": "hub.pingcap.net/wangweizhen/tidb_image:go120620230720",
+    "master": "hub.pingcap.net/wangweizhen/tidb_image:go12120230809",
 ]
 VOLUMES = [
     // TODO use s3 cache instead of nfs

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_check.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_check.groovy
@@ -26,7 +26,7 @@ GO_IMAGE_MAP = [
     "go1.16": "hub.pingcap.net/jenkins/centos7_golang-1.16:latest",
     "go1.18": "hub.pingcap.net/jenkins/centos7_golang-1.18:latest",
     "go1.19": "hub.pingcap.net/jenkins/centos7_golang-1.19:latest",
-    "master": "hub.pingcap.net/wangweizhen/tidb_image:go120620230720",
+    "master": "hub.pingcap.net/wangweizhen/tidb_image:go12120230809",
 ]
 ALWAYS_PULL_IMAGE = true
 RESOURCE_REQUEST_CPU = '4000m'

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
@@ -49,7 +49,7 @@ GO_IMAGE_MAP = [
     "go1.16": "hub.pingcap.net/jenkins/centos7_golang-1.16:latest",
     "go1.18": "hub.pingcap.net/jenkins/centos7_golang-1.18:latest",
     "go1.19": "hub.pingcap.net/jenkins/centos7_golang-1.19:latest",
-    "master": "hub.pingcap.net/wangweizhen/tidb_image:go120620230720",
+    "master": "hub.pingcap.net/wangweizhen/tidb_image:go12120230809",
 ]
 
 def user_bazel(branch) {

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_coverage.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_coverage.groovy
@@ -10,7 +10,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go120620230720"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       tty: true
       resources:
         requests:

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_unit_test.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_unit_test.groovy
@@ -26,7 +26,7 @@ GO_IMAGE_MAP = [
     "go1.18": "hub.pingcap.net/jenkins/centos7_golang-1.18:latest",
     "go1.19": "hub.pingcap.net/jenkins/centos7_golang-1.19:latest",
     "release-6.2": "hub.pingcap.net/wangweizhen/tidb_image:20220823",
-    "master": "hub.pingcap.net/wangweizhen/tidb_image:go120620230720",
+    "master": "hub.pingcap.net/wangweizhen/tidb_image:go12120230809",
 ]
 POD_LABEL_MAP = [
     "go1.13": "tidb-ghpr-unit-test-go1130-${BUILD_NUMBER}",

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go120620230720"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go120620230720"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go120620230720"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2_debug.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2_debug.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12020230220"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -7,7 +7,7 @@ spec:
     - name: golang
       # TODO(wuhuizuo): using standard bazel build image to shrink the image size
       # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go120620230720"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-merged_build.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go120620230720"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
@@ -7,7 +7,7 @@ spec:
     - name: golang
       # TODO(wuhuizuo): using standard bazel build image to shrink the image size
       # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go120620230720"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true

--- a/staging/pipelines/pingcap/tidb/latest/pod-ghpr_build.yaml
+++ b/staging/pipelines/pingcap/tidb/latest/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go120620230720"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true

--- a/staging/pipelines/pingcap/tidb/latest/pod-merged_build.yaml
+++ b/staging/pipelines/pingcap/tidb/latest/pod-merged_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go120620230720"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       tty: true
       securityContext:
         privileged: true

--- a/staging/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
+++ b/staging/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go120620230720"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
Go v1.21.0 was release, we need to upgrade the CI/CD container image to adjust for `pingcap/tidb` repo.