### PR TITLE
feat(tidb): update go image

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12120230809"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
use go1.21 in image of mysql-test ci.