### PR TITLE
fix(tiflash): run format check first to avoid git lock error

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
@@ -764,6 +764,9 @@ def buildStage(repo_path, build_dir, install_dir, proxy_cache_ready) {
     stage('Configure Project') {
         cmakeConfigureTiFlash(repo_path, build_dir, install_dir, proxy_cache_ready)
     }
+    stage("Format Check") {
+        clangFormat(repo_path)
+    }
     stage('Build TiFlash') {
         parallel(
             "License check": {
@@ -780,9 +783,6 @@ def buildStage(repo_path, build_dir, install_dir, proxy_cache_ready) {
                         fi
                     """
                 }
-            },
-            "Format Check" : {
-                clangFormat(repo_path)
             },
             "Build TiFlash" : {
                 buildTiFlash(repo_path, build_dir, install_dir)


### PR DESCRIPTION
Run format-check first to avoid git file lock error. Ref https://github.com/PingCAP-QE/ci/issues/2361