### PR TITLE
Update titan CI to not pass rocksdb dir

### DIFF
--- a/jenkins/pipelines/ci/titan/titan_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/titan/titan_ghpr_test.groovy
@@ -81,9 +81,6 @@ def prepare() {
         dir("titan") {
             deleteDir()
         }
-        dir("rocksdb") {
-            deleteDir()
-        }
         unstash "titan"
     }
 }


### PR DESCRIPTION
Do not pass rocksdb dir by CI, titan itself would download the rocksdb branch corresponding to Titan CMakeList.txt