### PR TITLE
feat(tiflash): install clang-format-15 if not exist

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
@@ -408,6 +408,12 @@ def resolveDependency(dep_name) {
             chmod +x '/usr/local/bin/clang-format'
             """
         }
+        else if (dep_name == 'clang-format-15') {
+            sh """
+            cp '${dependency_dir}/clang-format-15' '/usr/local/bin/clang-format-15'
+            chmod +x '/usr/local/bin/clang-format-15'
+            """
+        }
         else if (dep_name == 'gcovr') {
             sh """
             cp '${dependency_dir}/gcovr.tar' '/tmp/'
@@ -468,6 +474,11 @@ def prepareStage(repo_path) {
             "Clang-Format" : {
                 if (params.ENABLE_CCACHE) {
                     resolveDependency('clang-format')
+                }
+            },
+            "Clang-Format-15" : {
+                if (params.ENABLE_CCACHE) {
+                    resolveDependency('clang-format-15')
                 }
             },
             "Coverage" : {


### PR DESCRIPTION
 Install clang-format-15 if not exist, releated to https://github.com/pingcap/tiflash/pull/7927/files#diff-a847e281c62ad2738f1616a96cd3174ca1fa5eba8134bf6f5d802a425c92c8b2.

After the change, the CI of the tiflash master branch will prioritize using clang-format-15.