### PR TITLE
feat: add jq and pd-recover according to plan

### DIFF
--- a/jenkins/Dockerfile/release/linux-amd64/pd
+++ b/jenkins/Dockerfile/release/linux-amd64/pd
@@ -1,5 +1,8 @@
 FROM pingcap/alpine-glibc:alpine-3.14.6
+RUN apk add --no-cache \
+    jq
 COPY pd-server /pd-server
 COPY pd-ctl /pd-ctl
+COPY pd-recover /pd-recover
 EXPOSE 2379 2380
 ENTRYPOINT ["/pd-server"]


### PR DESCRIPTION
Why:
- according to the add component plan

How:
- arm64 already has  pd-recover, no need to change
- add jq to amd64 pd image, and for arm64 to base image  because yum is not reliable and slow, refer https://github.com/PingCAP-QE/ci-dockerfile/pull/67.
- if `apk add` is not acceptable for amd64, we will add jq to base image. Because tidb alse use apk add, it seems to be acceptable