### PR TITLE
chore(tiproxy): make some it test ci optional

### DIFF
--- a/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
@@ -5,6 +5,7 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      run_before_merge: true
       context: pull-mysql-test
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(pull-mysql-test|all)(?: .*?)?$"
@@ -30,6 +31,7 @@ presubmits:
       always_run: false
       context: pull-integration-jdbc-test # need change this.
       skip_report: false
+      optional: true
       trigger: "(?m)^/test (?:.*? )?pull-integration-jdbc-test(?: .*?)?$"
       rerun_command: "/test pull-integration-jdbc-test"
       branches:
@@ -63,6 +65,7 @@ presubmits:
       always_run: false  
       context: pull-integration-prisma-test
       skip_report: false
+      optional: true
       trigger: "(?m)^/test (?:.*? )?pull-integration-prisma-test(?: .*?)?$"
       rerun_command: "/test pull-integration-prisma-test"
       branches:
@@ -74,6 +77,7 @@ presubmits:
       always_run: false  
       context: pull-integration-python-orm-test
       skip_report: false
+      optional: true
       trigger: "(?m)^/test (?:.*? )?pull-integration-python-orm-test(?: .*?)?$"
       rerun_command: "/test pull-integration-python-orm-test"
       branches:
@@ -85,6 +89,7 @@ presubmits:
       always_run: false  
       context: pull-integration-sequelize-test
       skip_report: false
+      optional: true
       trigger: "(?m)^/test (?:.*? )?pull-integration-sequelize-test(?: .*?)?$"
       rerun_command: "/test pull-integration-sequelize-test"
       branches:
@@ -96,6 +101,7 @@ presubmits:
       always_run: false  
       context: pull-sqllogic-test
       skip_report: false
+      optional: true
       trigger: "(?m)^/test (?:.*? )?pull-sqllogic-test(?: .*?)?$"
       rerun_command: "/test pull-sqllogic-test"
       branches:

--- a/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
@@ -27,7 +27,6 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_jdbc_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       always_run: false
       context: pull-integration-jdbc-test # need change this.
       skip_report: false
@@ -39,7 +38,6 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_common_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       always_run: false
       context: pull-integration-common-test # need change this.
       skip_report: false
@@ -50,7 +48,6 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_ruby_orm_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       always_run: false  
       context: pull-integration-ruby-orm-test # need change this.
       skip_report: false
@@ -61,7 +58,6 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_prisma_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       always_run: false  
       context: pull-integration-prisma-test
       skip_report: false
@@ -73,7 +69,6 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_python_orm_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       always_run: false  
       context: pull-integration-python-orm-test
       skip_report: false
@@ -85,7 +80,6 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_sequelize_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       always_run: false  
       context: pull-integration-sequelize-test
       skip_report: false
@@ -97,7 +91,6 @@ presubmits:
     - name: pingcap/tiproxy/pull_sqllogic_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       always_run: false  
       context: pull-sqllogic-test
       skip_report: false


### PR DESCRIPTION
Make some integration test  ci status optional to avoid impacting the tide check of whether the PR can be merged.