### PR TITLE
chore(br): enable ci context report of pull-br-it-test

### DIFF
--- a/prow-jobs/pingcap-tidb-release-6.1-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-release-6.1-presubmits.yaml
@@ -50,10 +50,10 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_br_integration_test
       agent: jenkins
       decorate: false # need add this.
-      context: wip/pull-br-integration-test # need change this to pull-br-integration-test after test pass.
+      context: pull-br-integration-test
       always_run: false
       optional: true
-      skip_report: true # need change to true after test pass.
+      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-br-integration-test(?: .*?)?$"
       rerun_command: "/test pull-br-integration-test"
       branches:

--- a/prow-jobs/pingcap-tidb-release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-release-6.5-presubmits.yaml
@@ -50,10 +50,10 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_br_integration_test
       agent: jenkins
       decorate: false # need add this.
-      context: wip/pull-br-integration-test # need change this to pull-br-integration-test after test pass.
+      context: pull-br-integration-test
       always_run: false
       optional: true
-      skip_report: true # need change to true after test pass.
+      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-br-integration-test(?: .*?)?$"
       rerun_command: "/test pull-br-integration-test"
       branches:

--- a/prow-jobs/pingcap-tidb-release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-release-7.1-presubmits.yaml
@@ -49,10 +49,10 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_br_integration_test
       agent: jenkins
       decorate: false # need add this.
-      context: wip/pull-br-integration-test # need change this to pull-br-integration-test after test pass.
+      context: pull-br-integration-test
       always_run: false
       optional: true
-      skip_report: true # need change to true after test pass.
+      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-br-integration-test(?: .*?)?$"
       rerun_command: "/test pull-br-integration-test"
       branches:


### PR DESCRIPTION
Enable ci context report of pull-br-integration-test because those pipeline test passed. 

test link
1. https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftidb%2Frelease-7.1%2Fpull_br_integration_test/detail/pull_br_integration_test/6/pipeline/
2. https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftidb%2Frelease-6.5%2Fpull_br_integration_test/detail/pull_br_integration_test/3/pipeline/