### PR TITLE
fix: force tikv linux/arm64 use 64k pagesize

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -774,6 +774,10 @@ if [ ${OS} == 'linux' ]; then
     echo using gcc 8
     source /opt/rh/devtoolset-8/enable
 fi;
+# arm linux page sizes vary from 4k to 64k
+if [ ${OS}/${ARCH} == 'linux/arm64' ]; then
+    export JEMALLOC_SYS_WITH_LG_PAGE=16
+fi;
 if [ ${failpoint} == 'true' ]; then
     CARGO_TARGET_DIR=.target ROCKSDB_SYS_STATIC=1 make fail_release
 else

--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -774,7 +774,7 @@ if [ ${OS} == 'linux' ]; then
     echo using gcc 8
     source /opt/rh/devtoolset-8/enable
 fi;
-# arm linux page sizes vary from 4k to 64k
+# compatibility: arm linux page sizes vary from 4k to 64k
 if [ ${OS}/${ARCH} == 'linux/arm64' ]; then
     export JEMALLOC_SYS_WITH_LG_PAGE=16
 fi;


### PR DESCRIPTION
## Why:
- jemalloc in tikv use host pagesize, but 4k page binary can not run 64k kernel
- larger page size is compatible with lower page size: https://github.com/jemalloc/jemalloc/issues/467
- there is no any pitfall if builder is 64k. https://github.com/jemalloc/jemalloc/blob/b71da25b8a12c2c3f0c10b0811d15a61980186e8/configure.ac#L1805

## How:
- force tikv on linux/arm64 use 64k page size

## Tested:
- [x] builder 64k direct built binary can run on 4k machines
- [x] builder 4k with this PR built binary can run on both 4k and 64k machines