### PR TITLE
chore(tidb): cache bazel repo cache with pvc

### DIFF
--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -104,6 +104,11 @@ pipeline {
                                 }
 
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
+                                sh """
+                                sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
+                                git diff .
+                                git status
+                                """
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
@@ -13,23 +13,9 @@ spec:
         limits:
           memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
-          name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
+        - mountPath: /share/.cache/bazel-repository-cache
+          name: bazel-repository-cache
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -56,19 +42,9 @@ spec:
           memory: 256Mi
           cpu: 100m
   volumes:
-    - name: gopathcache
+    - name: bazel-repository-cache
       persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
-    - name: bazel-out-merged
-      emptyDir: {}
+        claimName: bazel-repository-cache
     - name: bazel-rc
       secret:
         secretName: bazel
@@ -100,3 +76,7 @@ spec:
                 operator: In
                 values:
                   - amd64
+              - key: ci-nvme-high-performance
+                operator: In
+                values:
+                  - "true"

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
@@ -104,6 +104,11 @@ pipeline {
                                 }
 
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
+                                sh """
+                                sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
+                                git diff .
+                                git status
+                                """
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
@@ -14,17 +14,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
-          name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
+        - mountPath: /share/.cache/bazel-repository-cache
+          name: bazel-repository-cache
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -51,19 +42,9 @@ spec:
           memory: 256Mi
           cpu: 100m
   volumes:
-    - name: gopathcache
+    - name: bazel-repository-cache
       persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
-    - name: bazel-out-merged
-      emptyDir: {}
+        claimName: bazel-repository-cache
     - name: bazel-rc
       secret:
         secretName: bazel
@@ -95,3 +76,7 @@ spec:
                 operator: In
                 values:
                   - amd64
+              - key: ci-nvme-high-performance
+                operator: In
+                values:
+                  - "true"


### PR DESCRIPTION
cache bazel repo cache with pvc avoid downloading a large number of dependency packages from external networks.