### PR TITLE
fix: hotfix will fail if it contains special features

### DIFF
--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -104,6 +104,9 @@ spec:
                     ImageForGcr = "gcr.io/pingcap-public/dbaas/$Product:$Version-$BUILD_NUMBER-dev"
                     if (params.IsHotfix.toBoolean()){
                         Image = "hub.pingcap.net/qa/$Product:$Version-$BUILD_NUMBER"
+                        if (params.Features != ""){
+                            error "hotfix artifact but with extra features"
+                        }
                         ImageForGcr = "gcr.io/pingcap-public/dbaas/$Product:$Version"
                         BinPathDict["amd64"] = "builds/hotfix/$Product/$Version/$BUILD_NUMBER/$Product-patch-linux-amd64.tar.gz"
                         BinPathDict["arm64"] = "builds/hotfix/$Product/$Version/$BUILD_NUMBER/$Product-patch-linux-arm64.tar.gz"


### PR DESCRIPTION
## Why:
- someone just give failpoint image as hotfix to customer

## How:
- just fail to avoid this situation before I have better solution