### PR TITLE
fix(tidb): correct ci on old branch release-5.4

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_check.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_check.groovy
@@ -207,7 +207,7 @@ try {
                 }
             }
         }
-        tests["integrationtest"] = {
+        tests["explaintest"] = {
             run_with_pod {
                 deleteDir()
                 unstash 'tidb'
@@ -216,7 +216,7 @@ try {
                         sh """
                         go version
                         make checklist
-                        make integrationtest
+                        make explaintest
                         """
                     }
                 }

--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_check_2.groovy
@@ -65,6 +65,8 @@ def taskFinishTime = System.currentTimeMillis()
 resultDownloadPath = ""
 ciErrorCode = 0
 
+ALWAYS_PULL_IMAGE = true
+
 def run_with_pod(Closure body) {
     def label = "${JOB_NAME}-${BUILD_NUMBER}"
     def cloud = "kubernetes-ksyun"
@@ -154,7 +156,7 @@ try {
                                 }
                             sh "git checkout -f ${ghprbActualCommit}"
                             sh """
-                            GO111MODULE=on go build -o bin/integration_test_tidb-server github.com/pingcap/tidb/tidb-server
+                            GO111MODULE=on go build -o bin/explain_test_tidb-server github.com/pingcap/tidb/tidb-server
                             """
                         }
                     }
@@ -326,10 +328,10 @@ try {
                                     bin/pd-server -name=pd3 --data-dir=pd3 --client-urls=http://127.0.0.1:2399 --peer-urls=http://127.0.0.1:2398 -force-new-cluster &> pd3.log &
                                     bin/tikv-server --pd=127.0.0.1:2399 -s tikv3 --addr=0.0.0.0:20190 --advertise-addr=127.0.0.1:20190 --advertise-status-addr=127.0.0.1:20185 -C tikv.toml -f  tikv3.log &
 
-                                    # GO111MODULE=on go build -o bin/integration_test_tidb-server github.com/pingcap/tidb/tidb-server
+                                    # GO111MODULE=on go build -o bin/explain_test_tidb-server github.com/pingcap/tidb/tidb-server
                                     ls -alh ./bin/
 
-                                    export TIDB_SERVER_PATH=${ws}/bin/integration_test_tidb-server
+                                    export TIDB_SERVER_PATH=${ws}/bin/explain_test_tidb-server
                                     export TIKV_PATH=127.0.0.1:2379
                                     export TIDB_TEST_STORE_NAME="tikv"
                                     chmod +x tests/integrationtest/run-tests.sh
@@ -391,10 +393,10 @@ try {
                                     bin/pd-server -name=pd3 --data-dir=pd3 --client-urls=http://127.0.0.1:2399 --peer-urls=http://127.0.0.1:2398 -force-new-cluster &> pd3.log &
                                     bin/tikv-server --pd=127.0.0.1:2399 -s tikv3 --addr=0.0.0.0:20190 --advertise-addr=127.0.0.1:20190 --advertise-status-addr=127.0.0.1:20185 -C tikv.toml -f  tikv3.log &
 
-                                    # GO111MODULE=on go build -o bin/integration_test_tidb-server github.com/pingcap/tidb/tidb-server
+                                    # GO111MODULE=on go build -o bin/explain_test_tidb-server github.com/pingcap/tidb/tidb-server
                                     ls -alh ./bin/
 
-                                    export TIDB_SERVER_PATH=${ws}/bin/integration_test_tidb-server
+                                    export TIDB_SERVER_PATH=${ws}/bin/explain_test_tidb-server
                                     export TIKV_PATH=127.0.0.1:2379
                                     export TIDB_TEST_STORE_NAME="tikv"
                                     chmod +x tests/integrationtest/run-tests.sh


### PR DESCRIPTION
revert related changes  from https://github.com/PingCAP-QE/ci/pull/2410 to fix ci on branch release-5.4