### PR TITLE
chore(prow-jobs): comment for why the prow context and job name is not same

### DIFF
--- a/prow-jobs/pingcap-tiflow-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-latest-presubmits.yaml
@@ -13,6 +13,8 @@ presubmits:
       rerun_command: "/test cdc-integration-kafka-test"
       branches:
         - ^master$
+    # TODO: combine other CDC integration tests to a single one, 
+    # Currently we keep the Jenkins job name.
     - name: pingcap/tiflow/pull_cdc_integration_test
       agent: jenkins
       decorate: false # need add this.


### PR DESCRIPTION
for tiflow

Fixes #2111

Signed-off-by: wuhuizuo <wuhuizuo@126.com>