### PR TITLE
feat(pingcap/tidb): fail the CI build when found long time cost test cases

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -55,7 +55,7 @@ pipeline {
         stage('Test') {
             environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
                     sh """
                         sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
                         git diff .
@@ -70,13 +70,19 @@ pipeline {
             }
             post {
                  success {
-                    dir("tidb") {
+                    dir(REFS.repo) {
                         script {
                             prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
                         }
+                        // Fail when found long time test cases.
                     }
                 }
                 always {
+                    dir(REFS.repo) {
+                        junit(testResults: "**/bazel.xml", allowEmptyResults: true)
+                        archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
+                    }
+
                     sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
                     container('deno') {
                         sh label: "Report flaky test case results", script: """
@@ -88,24 +94,29 @@ pipeline {
                         """
                     }
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
-                    dir('tidb') {
-                        // archive test report to Jenkins.
-                        junit(testResults: "**/bazel.xml", allowEmptyResults: true)
-                    }
                 }
             }
         }
     }
     post {
-        // TODO(wuhuizuo): put into container lifecyle preStop hook.
-        always {
-            container('report') {
-                sh """
-                    junitUrl="\${FILE_SERVER_URL}/download/tipipeline/test/report/\${JOB_NAME}/\${BUILD_NUMBER}/${REFS.pulls[0].sha}/report.xml"
-                    bash scripts/plugins/report_job_result.sh ${currentBuild.result} result.json "\${junitUrl}" || true
-                """
+        success {
+            catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+                sh label: 'Fail when long time cost test cases are found', script: '''#! /usr/bin/env bash
+
+                    threshold=144 # unit is second, we should update it monthly.
+
+                    breakCaseListfile="break_longtime_case.txt"
+                    jq -r  ".[] | select(.long_time != null) | .long_time | to_entries[] | select(.value > $threshold) | .key" bazel-go-test-problem-cases.json > $breakCaseListfile
+
+                    if (($(cat $breakCaseListfile | wc -l) > 0)); then
+                        echo "$(tput setaf 1)The execution time of these test cases exceeds the threshold($threshold):$(tput sgr0)"
+                        cat $breakCaseListfile
+                        echo "📌 ref: https://github.com/pingcap/tidb/issues/46820"
+
+                        exit 1
+                    fi
+                '''
             }
-            archiveArtifacts(artifacts: 'result.json', fingerprint: true, allowEmptyArchive: true)
         }
     }
 }

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -64,13 +64,6 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
   volumes:
     - name: gopathcache
       persistentVolumeClaim:


### PR DESCRIPTION
Fixes #2441

- no need the `report` step anymore, also remove the container, we will send the data by cloud events in global CI server.
- currently hardcode the threshold value.
- fail in build when long time case found, contributors should fix it, make it run fast.


Signed-off-by: wuhuizuo <wuhuizuo@126.com>