### PR TITLE
chore/migrate plugin repo

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -303,7 +303,7 @@ repo = "git@github.com:pingcap/${REPO}.git"
 if (REPO == "tikv" || REPO == "importer" || REPO == "pd") {
     repo = "git@github.com:tikv/${REPO}.git"
 }
-if (REPO == "tiem") {
+if (REPO == "tiem" || REPO == "enterprise-plugin") {
     repo = "git@github.com:pingcap-inc/${REPO}.git"
 }
 if (GITHUB_REPO){

--- a/tools/gethash/gethash.py
+++ b/tools/gethash/gethash.py
@@ -61,7 +61,7 @@ def get_hash_by_pr_from_github(repo, pr):
 
 
 def get_hash_by_branch_from_fileserver(repo, branch, fileserver):
-    urlstr = "%s/download/refs/pingcap/%s/%s/sha1" %(fileserver, repo, branch)
+    urlstr = fileserver + "/download/refs/pingcap/" + repo + "/" + branch + "/sha1"
     req = urllib2.Request(urlstr)
     response = urllib2.urlopen(req)
     return response.read().decode().strip()

--- a/tools/gethash/gethash.py
+++ b/tools/gethash/gethash.py
@@ -19,7 +19,8 @@ def org_repo_parse(repo):
             "tikv": "tikv",
             "importer": "tikv",
             "pd": "tikv",
-            "TiBigData": "tidb-incubator"
+            "TiBigData": "tidb-incubator",
+            "enterprise-plugin":"pingcap-inc",
         }
         org = repo_org_mapping.get(repo, "pingcap")
         return (org, repo)
@@ -60,7 +61,8 @@ def get_hash_by_pr_from_github(repo, pr):
 
 
 def get_hash_by_branch_from_fileserver(repo, branch, fileserver):
-    urlstr = fileserver + "/download/refs/pingcap/" + repo + "/" + branch + "/sha1"
+    org,repo = org_repo_parse(repo)
+    urlstr = "%s/download/refs/%s/%s/%s/sha1" %(fileserver, org, repo, branch)
     req = urllib2.Request(urlstr)
     response = urllib2.urlopen(req)
     return response.read().decode().strip()
@@ -96,7 +98,7 @@ def main(args):
     if args.source not in ['fileserver', 'github', None]:
         raise ValueError("bad source given")
     hash = get_hash_main(args)
-    print(hash)
+    print(hash, end='')
 
 
 if __name__ == "__main__":

--- a/tools/gethash/gethash.py
+++ b/tools/gethash/gethash.py
@@ -61,8 +61,8 @@ def get_hash_by_pr_from_github(repo, pr):
 
 
 def get_hash_by_branch_from_fileserver(repo, branch, fileserver):
-    org,repo = org_repo_parse(repo)
-    urlstr = "%s/download/refs/%s/%s/%s/sha1" %(fileserver, org, repo, branch)
+    urlstr = "%s/download/refs/pingcap/%s/%s/sha1" %(fileserver, repo, branch)
+    print(urlstr)
     req = urllib2.Request(urlstr)
     response = urllib2.urlopen(req)
     return response.read().decode().strip()

--- a/tools/gethash/gethash.py
+++ b/tools/gethash/gethash.py
@@ -62,7 +62,6 @@ def get_hash_by_pr_from_github(repo, pr):
 
 def get_hash_by_branch_from_fileserver(repo, branch, fileserver):
     urlstr = "%s/download/refs/pingcap/%s/%s/sha1" %(fileserver, repo, branch)
-    print(urlstr)
     req = urllib2.Request(urlstr)
     response = urllib2.urlopen(req)
     return response.read().decode().strip()


### PR DESCRIPTION
# Why
- build-common will use new repo position
- gethash.py will not output '\n' to avoid any trim problem
- RC will use `gethash image` directly

# How
- only RC/hotfix will build enterprise
- hotfix has used `gethash image` already

# Testing
- manually tested with a fake rc job