### PR TITLE
fix(tiflow): comment some check ready code

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -140,14 +140,16 @@ pipeline {
                         steps {
                             dir('tiflow') {
                                 cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("pulsar") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for pulsar ready", script: """
-                                                echo "Waiting for pulsar to be ready..."
-                                                while ! nc -z localhost 6650; do sleep 10; done
-                                            """
-                                        }
-                                    }
+                                    // TODO: currently we encounter some issue when using pulsar container to run shell script
+                                    // so we comment out this part now.
+                                    // container("pulsar") {
+                                    //     timeout(time: 6, unit: 'MINUTES') {
+                                    //         sh label: "Waiting for pulsar ready", script: """
+                                    //             echo "Waiting for pulsar to be ready..."
+                                    //             while ! nc -z localhost 6650; do sleep 10; done
+                                    //         """
+                                    //     }
+                                    // }
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
                                         chmod +x ./tests/integration_tests/run_group.sh


### PR DESCRIPTION
currently we encounter some issue when using pulsar container to run shell script.
```shell
process apparently never started in /home/jenkins/agent/workspace/pingcap/tiflow/pull_cdc_integration_pulsar_test/tiflow@tmp/durable-0f4d238f

(running Jenkins temporarily with -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true might make the problem clearer)

script returned exit code -2
```