### PR TITLE
chore(tiflow): enable report cdc-integration-pulsar-test

### DIFF
--- a/prow-jobs/pingcap-tiflow-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-latest-presubmits.yaml
@@ -43,11 +43,11 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       always_run: false
-      #run_before_merge: false
+      run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: true
-      trigger: "(?m)^/debug (?:.*? )?(cdc-integration-pulsar-test)(?: .*?)?$"
-      rerun_command: "/debug cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test cdc-integration-pulsar-test"
       branches:
         - ^master$
     - name: pingcap/tiflow/pull_dm_compatibility_test


### PR DESCRIPTION
enable report cdc-integration-pulsar-test.

test passed https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftiflow%2Fpull_cdc_integration_pulsar_test/detail/pull_cdc_integration_pulsar_test/9/pipeline/495/

Wait for https://github.com/pingcap/tiflow/pull/9766 to be merged first.