### PR TITLE
fix: change default staging mirror address

### DIFF
--- a/jenkins/jobs/cd/tiup_mirror_online_rc.groovy
+++ b/jenkins/jobs/cd/tiup_mirror_online_rc.groovy
@@ -26,7 +26,7 @@ pipelineJob('tiup-mirror-online-rc') {
     }
     parameters {
         stringParam('RELEASE_TAG', 'nightly', '')
-        stringParam('TIUP_MIRRORS','http://172.16.5.139:8988', '')
+        stringParam('TIUP_MIRRORS','http://tiup.pingcap.net:8988', '')
         stringParam('TIDB_HASH', '', '')
         stringParam('TIKV_HASH', '', '')
         stringParam('PD_HASH', '', '')


### PR DESCRIPTION
Why:
- the staging tiup address is changed, but it does not matter for this situation, because parent pipeline will pass the right address