### PR TITLE
fix(qatest): fix issue of pipeline used by qatest

### DIFF
--- a/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
+++ b/jenkins/pipelines/ci/br/br_ghpr_unit_and_integration_test.groovy
@@ -500,6 +500,8 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                                 mkdir -p /tmp/backup_restore_test
                                 rm -rf cover
                                 mkdir cover
+                                rm -rf /tmp/group_cover
+                                mkdir -p /tmp/group_cover
 
                                 if [[ ! -e tests/${case_name}/run.sh ]]; then
                                     echo ${case_name} not exists, skip.
@@ -517,7 +519,7 @@ def run_integration_tests(case_names, tidb, tikv, pd, cdc, importer, tiflashBran
                                 # Must move coverage files to the current directory
                                 ls /tmp/backup_restore_test
                                 cp /tmp/backup_restore_test/cov.* cover/ || true
-                                ls cover
+                                cp /tmp/group_cover/cov.* cover/ || true
                                 """
                             } catch (Exception e) {
                                 sh "tail -4000 '/tmp/backup_restore_test/pd.log' || true"

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -371,10 +371,13 @@ def download_binaries() {
                 println "tidb_archive_path=${tidb_archive_path}"
                 break;
         }
-        def sync_diff_download_url = "${FILE_SERVER_URL}/download/builds/pingcap/cdc/sync_diff_inspector_hash-00998a9a_linux-amd64.tar.gz"
+        def sync_diff_download_url = "${FILE_SERVER_URL}/download/builds/pingcap/cdc/sync_diff_inspector_hash-d671b084_linux-amd64.tar.gz"
         if (ghprbTargetBranch.startsWith("release-") && ghprbTargetBranch < "release-6.0" ) {
             println "release branch detected, use the other sync_diff version"
             sync_diff_download_url = "http://fileserver.pingcap.net/download/builds/pingcap/cdc/new_sync_diff_inspector.tar.gz"
+        } else if ( ghprbTargetBranch.startsWith("release-") && ghprbTargetBranch < "release-7.4" ) {
+            println "release branch ${ghprbTargetBranch} detected, use the other sync_diff version"
+            sync_diff_download_url = "${FILE_SERVER_URL}/download/builds/pingcap/cdc/sync_diff_inspector_hash-00998a9a_linux-amd64.tar.gz"
         }
 
         println "tidb_url: ${tidb_url}"


### PR DESCRIPTION
* The save path for test coverage has changed, so create the directory in advance.
*  sync_diff that used in cdc test need updated since 7.4, ref https://github.com/pingcap/tiflow/pull/9781