### PR TITLE
fix: correct move dest binary name

### DIFF
--- a/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
@@ -64,7 +64,7 @@ pipeline {
                     // cache it for other pods
                     cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}") {
                         sh """
-                            mv bin/tidb-server bin/explain_test_tidb-server
+                            mv bin/tidb-server bin/integration_test_tidb-server
                             touch rev-${REFS.pulls[0].sha}
                         """
                     }


### PR DESCRIPTION
fix issue of pipeline check2 of release-7.4: tidb-server start failed because binary path not correct.