### PR TITLE
chore(pingcap/tidb): compatible with the coming package refactor contribution

### DIFF
--- a/pipelines/PingCAP-QE/tidb-test/latest/ghpr_mysql_test.groovy
+++ b/pipelines/PingCAP-QE/tidb-test/latest/ghpr_mysql_test.groovy
@@ -67,7 +67,7 @@ pipeline {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
                         // FIXME: https://github.com/PingCAP-QE/tidb-test/issues/1987
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -race -o bin/tidb-server ./tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || WITH_RACE=1 make server'
                     }
                 }
                 dir('tidb-test') {

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -55,7 +55,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -68,7 +68,7 @@ pipeline {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                         // FIXME: https://github.com/PingCAP-QE/tidb-test/issues/1987
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -race -o bin/tidb-server ./tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || WITH_RACE=1 make server'
                     }
                 }
                 dir('tidb-test') {

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
@@ -54,7 +54,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -55,7 +55,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -54,7 +54,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
@@ -54,7 +54,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -54,7 +54,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
@@ -54,7 +54,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
@@ -54,7 +54,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
@@ -54,7 +54,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
@@ -56,7 +56,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
@@ -56,7 +56,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
@@ -55,7 +55,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     cache(path: "./bin", filter: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server github.com/pingcap/tidb/tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
                     }
                     script {
                          component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')


### PR DESCRIPTION
## Why
In the coming pull requests of `pingcap/tidb` repo, the folder layout will be changed, but will keep make tasks persistent.
we need use make to build rather than native go build commands to make CI jobs be compatible.