### PR TITLE
feat: using ci base image for typeorm test

### DIFF
--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_typeorm_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_typeorm_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: nodejs
-      image: "hub.pingcap.net/temp/centos7_golang-1.16_nodejs-16.x:latest"
+      image: "hub.pingcap.net/ee/ci/base:latest"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
As @wuhuizuo suggestion, I updated the docker image of typeorm test https://github.com/PingCAP-QE/ci-dockerfile/pull/70#issuecomment-1752099006