### PR TITLE
fix: fix the typeorm scripts

### DIFF
--- a/pipelines/PingCAP-QE/tidb-test/latest/ghpr_integration_typeorm_test.groovy
+++ b/pipelines/PingCAP-QE/tidb-test/latest/ghpr_integration_typeorm_test.groovy
@@ -120,9 +120,9 @@ pipeline {
                                     container("nodejs") {
                                         sh label: "test_params=${TEST_PARAMS} ", script: """
                                             #!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
+                                            set -- \${TEST_PARAMS}
+                                            TEST_DIR=\$1
+                                            TEST_SCRIPT=\$2
                                             echo "TEST_DIR=\${TEST_DIR}"
                                             echo "TEST_SCRIPT=\${TEST_SCRIPT}"
                                             if [[ "${TEST_STORE}" == "tikv" ]]; then


### PR DESCRIPTION
The bash interpreter in the `hub.pingcap.net/ee/ci/base` image doesn't support the array feature, and @purelind provides a way to work around it.

cc: @wuhuizuo 