### PR TITLE
fix(tikv): cargo install with --locked to fix error

### DIFF
--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_coverage.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_coverage.groovy
@@ -44,7 +44,7 @@ stage("Cover") {
                     git fetch origin
                     git checkout -f origin/${ghprbTargetBranch}
                     rustup component add llvm-tools-preview
-                    cargo install grcov
+                    cargo install --locked grcov
                 """
 
                 def should_skip = sh (label: 'Check if can skip', script: """


### PR DESCRIPTION
fix error when run `cargo install grcov`
```
11:54:09  error: failed to compile `grcov v0.8.19`, intermediate artifacts can be found at `/tmp/cargo-install7uDpjN`
11:54:09  
11:54:09  Caused by:
11:54:09    package `anstyle-parse v0.2.2` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.67.0-nightly
11:54:09    Try re-running cargo install with `--locked`
```