### PR TITLE
fix: using bash with abs path

### DIFF
--- a/pipelines/PingCAP-QE/tidb-test/latest/ghpr_integration_nodejs_test.groovy
+++ b/pipelines/PingCAP-QE/tidb-test/latest/ghpr_integration_nodejs_test.groovy
@@ -111,7 +111,7 @@ pipeline {
                                         ls -alh bin/
                                     """
                                     sh label: "${TEST_DIR} ", script: """
-                                        #!/usr/bin/env bash
+                                        #!/bin/bash
                                         export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
                                         export TIDB_TEST_STORE_NAME="${TEST_STORE}"
                                         if [[ "${TEST_STORE}" == "tikv" ]]; then
@@ -120,7 +120,7 @@ pipeline {
                                             export TIKV_PATH="127.0.0.1:2379"
                                         fi
 
-                                       cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
+                                        cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
                                     """
                                 }
                             }

--- a/pipelines/PingCAP-QE/tidb-test/latest/ghpr_integration_nodejs_test.groovy
+++ b/pipelines/PingCAP-QE/tidb-test/latest/ghpr_integration_nodejs_test.groovy
@@ -110,8 +110,7 @@ pipeline {
                                         cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                                         ls -alh bin/
                                     """
-                                    sh label: "${TEST_DIR} ", script: """
-                                        #!/bin/bash
+                                    sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
                                         export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
                                         export TIDB_TEST_STORE_NAME="${TEST_STORE}"
                                         if [[ "${TEST_STORE}" == "tikv" ]]; then


### PR DESCRIPTION
Error:

> + [[ tikv == tikv ]]
> /home/jenkins/agent/workspace/pingcap-qe/tidb-test/ghpr_integration_nodejs_test/tidb-test@tmp/durable-17bcd1ba/script.sh: 5: [[: not found

https://superuser.com/questions/374406/why-do-i-get-not-found-when-running-a-script
