### PR TITLE
feat: tikv_ghpr_cache image build update

### DIFF
--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy
@@ -107,7 +107,7 @@ RUN cd tikv-src \
         }
         
         build_branch("master")
-        build_branch("release-7.4")
+        build_branch("release-7.5")
         build_branch("release-7.1")
         build_branch("release-6.5")
         build_branch("release-6.1")


### PR DESCRIPTION
* update release-7.5 tikv cache image build.
* remove dmr version 7.4 image build.