### PR TITLE
fix: tidb tools on arm

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -143,6 +143,11 @@ def ifFileCacheExists() {
 // choose which go version to use. 
 def String needUpgradeGoVersion(String tag,String branch) {
     goVersion="go1.21"
+    // tidb-tools only use branch master and use newest go version
+    // only for version >= v5.3.0
+    if (REPO=="tidb-tools" && tag>="v5.3"){
+        return goVersion
+    }
     if (tag.startsWith("v") && tag >= "v7.0" && tag < "v7.4") {
         return "go1.20"
     }
@@ -193,64 +198,33 @@ def String needUpgradeGoVersion(String tag,String branch) {
 def goBuildPod = "build_go1210"
 def GO_BIN_PATH = "/usr/local/go1.21/bin"
 goVersion = needUpgradeGoVersion(params.RELEASE_TAG,params.TARGET_BRANCH)
-// tidb-tools only use branch master and use newest go version
-// only for version >= v5.3.0
-if (REPO == "tidb-tools" && RELEASE_TAG < "v5.3") {
-    switch (goVersion) {
-        case "go1.18":
-            goBuildPod = "build_go1180"
-            GO_BIN_PATH = "/usr/local/go1.18.10/bin"
-            break
-        case "go1.16":
-            goBuildPod = "${GO1160_BUILD_SLAVE}"
-            GO_BIN_PATH = "/usr/local/go1.16.4/bin"
-            break
-        case "go1.13":
-            goBuildPod = "${GO_BUILD_SLAVE}"
-            GO_BIN_PATH = "/usr/local/go/bin"
-            break
-        case "go1.19":
-            goBuildPod = "build_go1190"
-            GO_BIN_PATH = "/usr/local/go1.19/bin"
-            break
-        case "go1.20":
-            goBuildPod = "build_go1200"
-            GO_BIN_PATH = "/usr/local/go1.20/bin"
-            break
-        case "go1.21":
-            goBuildPod = "build_go1210"
-            GO_BIN_PATH = "/usr/local/go1.21/bin"
-            break
-        default:
-            throw new Exception("go version ${goVersion} not supported")
-    }
-} 
-if (REPO != "tidb-tools") {
-    if (goVersion == "go1.21") {
+switch (goVersion) {
+    case "go1.21":
         goBuildPod = "build_go1210"
         GO_BIN_PATH = "/usr/local/go1.21/bin"
-    }
-    if (goVersion == "go1.20") {
+        break
+    case "go1.20":
         goBuildPod = "build_go1200"
         GO_BIN_PATH = "/usr/local/go1.20/bin"
-    }
-    if (goVersion == "go1.19") {
+        break
+    case "go1.19":
         goBuildPod = "build_go1190"
         GO_BIN_PATH = "/usr/local/go1.19/bin"
-    }
-    if (goVersion == "go1.18") {
+        break
+    case "go1.18":
         goBuildPod = "build_go1180"
         GO_BIN_PATH = "/usr/local/go1.18.10/bin"
-    }
-    if (goVersion == "go1.16") {
+        break
+    case "go1.16":
         goBuildPod = "${GO1160_BUILD_SLAVE}"
         GO_BIN_PATH = "/usr/local/go1.16.4/bin"
-
-    }
-    if (goVersion == "go1.13") {
+        break
+    case "go1.13":
         goBuildPod = "${GO_BUILD_SLAVE}"
         GO_BIN_PATH = "/usr/local/go/bin"
-    }
+        break
+    default:
+        throw new Exception("go version ${goVersion} not supported")
 }
 
 // choose which node to use.


### PR DESCRIPTION
## Why:
- tidb-tools on arm will not auto use latest go, which is a bug because tidb-tools always use master branch
- go version selection is hard to understand

## How:
- for tidb-tools>=5.3, directly select latest go version
- refract go version selection code
  - use switch instead of multiple if, with re-ordering
  - for non tidb-tools, no difference
  - for tidb-tools<5.3, no difference
  - for tidb-tools >= 5.3, no difference
