### PR TITLE
chore(tidb): set two canary job as optional

### DIFF
--- a/prow-jobs/pingcap-tidb-latest-presubmits-canary.yaml
+++ b/prow-jobs/pingcap-tidb-latest-presubmits-canary.yaml
@@ -17,7 +17,6 @@ presubmits:
       always_run: false
       optional: true
       context: canary-unit-test
-      trigger: "(?m)^/test (?:.*? )?canary-unit-test(?: .*?)?$"
       branches:
         - ^master$
         - ^feature[_/].+

--- a/prow-jobs/pingcap-tidb-latest-presubmits-canary.yaml
+++ b/prow-jobs/pingcap-tidb-latest-presubmits-canary.yaml
@@ -5,6 +5,7 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       always_run: false
+      optional: true
       context: canary-scan-security
       trigger: "(?m)^/test (?:.*? )?canary-scan-security(?: .*?)?$"
       rerun_command: "/test canary-scan-security"
@@ -14,7 +15,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       always_run: false
+      optional: true
       context: canary-unit-test
+      trigger: "(?m)^/test (?:.*? )?canary-unit-test(?: .*?)?$"
       branches:
         - ^master$
         - ^feature[_/].+


### PR DESCRIPTION
Set two canary job as optional
* pingcap/tidb/canary-scan-security
* pingcap/tidb/canary_ghpr_unit_test

In order to make the trigger command prompts of the bot clearer:
<img width="824" alt="image" src="https://github.com/PingCAP-QE/ci/assets/16618216/bb0ed7ba-bf11-4003-b4e5-b803d64c155c">
