### PR TITLE
feat: build images after binary

### DIFF
--- a/jenkins/jobs/cd/community_docker_multi_products.groovy
+++ b/jenkins/jobs/cd/community_docker_multi_products.groovy
@@ -8,7 +8,7 @@ pipelineJob('community-docker-multi-products') {
                     remote {
                         url('https://github.com/PingCAP-QE/ci.git')
                     }
-                    branch('feat/tiup_image')
+                    branch('main')
                     extensions {
                         cloneOptions {
                             depth(1)

--- a/jenkins/jobs/cd/community_docker_multi_products.groovy
+++ b/jenkins/jobs/cd/community_docker_multi_products.groovy
@@ -22,63 +22,18 @@ pipelineJob('community-docker-multi-products') {
     }
 
     parameters {
-        stringParam {
-            name('RELEASE_BRANCH')
-            defaultValue('')
-            trim(true)
-        }
-        stringParam {
-            name('RELEASE_TAG')
-            defaultValue('')
-            trim(true)
-        }
-        booleanParam {
-            name('FORCE_REBUILD')
-            defaultValue(true)
-        }
-        booleanParam {
-            name('NEED_DEBUG_IMAGE')
-            defaultValue(true)
-        }
-        booleanParam {
-            name('DEBUG_MODE')
-            defaultValue(false)
-        }
-        stringParam {
-            name('TIDB_HASH')
-            defaultValue('')
-            trim(true)
-        }
-        stringParam {
-            name('TIKV_HASH')
-            defaultValue('')
-            trim(true)
-        }
-        stringParam {
-            name('PD_HASH')
-            defaultValue('')
-            trim(true)
-        }
-        stringParam {
-            name('TIFLASH_HASH')
-            defaultValue('')
-            trim(true)
-        }
-        stringParam {
-            name('NG_MONITORING_HASH')
-            defaultValue('')
-            trim(true)
-        }
-        stringParam {
-            name('TIDB_BINLOG_HASH')
-            defaultValue('')
-            trim(true)
-        }
-        stringParam {
-            name('TICDC_HASH')
-            defaultValue('')
-            trim(true)
-        }
+        stringParam ('RELEASE_BRANCH','','')
+        stringParam ('RELEASE_TAG','','')
+        booleanParam ('FORCE_REBUILD', true, '')
+        booleanParam ('NEED_DEBUG_IMAGE', true, '')
+        booleanParam ('DEBUG_MODE', false, '')
+        stringParam('TIDB_HASH', '', '')
+        stringParam('TIKV_HASH', '', '')
+        stringParam('PD_HASH', '', '')
+        stringParam('TIFLASH_HASH','','')
+        stringParam('NG_MONITORING_HASH','','')
+        stringParam('TIDB_BINLOG_HASH','','')
+        stringParam('TICDC_HASH','','')
         stringParam('POSTFIX',  '-rocky-pre', '')
         stringParam('HUB_PROJECT', 'qa', '')
     }

--- a/jenkins/jobs/cd/community_docker_multi_products.groovy
+++ b/jenkins/jobs/cd/community_docker_multi_products.groovy
@@ -36,6 +36,6 @@ pipelineJob('community-docker-multi-products') {
         stringParam('TICDC_HASH','','')
         stringParam('IMAGE_TAG',  '', 'default RELEASE_TAG-rocky-pre')
         stringParam('HUB_PROJECT', 'qa', '')
-        booleanParam('NO_FAILPOINT', false, '')
+        booleanParam('NEED_FAILPOINT', true, '')
     }
 }

--- a/jenkins/jobs/cd/community_docker_multi_products.groovy
+++ b/jenkins/jobs/cd/community_docker_multi_products.groovy
@@ -34,7 +34,7 @@ pipelineJob('community-docker-multi-products') {
         stringParam('NG_MONITORING_HASH','','')
         stringParam('TIDB_BINLOG_HASH','','')
         stringParam('TICDC_HASH','','')
-        stringParam('POSTFIX',  '-rocky-pre', '')
+        stringParam('IMAGE_TAG',  '', 'default RELEASE_TAG-rocky-pre')
         stringParam('HUB_PROJECT', 'qa', '')
         booleanParam('NO_FAILPOINT', false, '')
     }

--- a/jenkins/jobs/cd/community_docker_multi_products.groovy
+++ b/jenkins/jobs/cd/community_docker_multi_products.groovy
@@ -1,0 +1,85 @@
+pipelineJob('community-docker-multi-products') {
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath('jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy')
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('feat/tiup_image')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    parameters {
+        stringParam {
+            name('RELEASE_BRANCH')
+            defaultValue('')
+            trim(true)
+        }
+        stringParam {
+            name('RELEASE_TAG')
+            defaultValue('')
+            trim(true)
+        }
+        booleanParam {
+            name('FORCE_REBUILD')
+            defaultValue(true)
+        }
+        booleanParam {
+            name('NEED_DEBUG_IMAGE')
+            defaultValue(true)
+        }
+        booleanParam {
+            name('DEBUG_MODE')
+            defaultValue(false)
+        }
+        stringParam {
+            name('TIDB_HASH')
+            defaultValue('')
+            trim(true)
+        }
+        stringParam {
+            name('TIKV_HASH')
+            defaultValue('')
+            trim(true)
+        }
+        stringParam {
+            name('PD_HASH')
+            defaultValue('')
+            trim(true)
+        }
+        stringParam {
+            name('TIFLASH_HASH')
+            defaultValue('')
+            trim(true)
+        }
+        stringParam {
+            name('NG_MONITORING_HASH')
+            defaultValue('')
+            trim(true)
+        }
+        stringParam {
+            name('TIDB_BINLOG_HASH')
+            defaultValue('')
+            trim(true)
+        }
+        stringParam {
+            name('TICDC_HASH')
+            defaultValue('')
+            trim(true)
+        }
+        stringParam('POSTFIX',  '-rocky-pre', '')
+        stringParam('HUB_PROJECT', 'qa', '')
+    }
+}

--- a/jenkins/jobs/cd/community_docker_multi_products.groovy
+++ b/jenkins/jobs/cd/community_docker_multi_products.groovy
@@ -36,5 +36,6 @@ pipelineJob('community-docker-multi-products') {
         stringParam('TICDC_HASH','','')
         stringParam('POSTFIX',  '-rocky-pre', '')
         stringParam('HUB_PROJECT', 'qa', '')
+        booleanParam('NO_FAILPOINT', false, '')
     }
 }

--- a/jenkins/jobs/cd/pre_release_community_docker_rocky.groovy
+++ b/jenkins/jobs/cd/pre_release_community_docker_rocky.groovy
@@ -79,7 +79,7 @@ pipelineJob('pre-release-community-docker-rocky') {
             defaultValue('')
             trim(true)
         }
-        stringParam('POSTFIX',  '-rocky-pre', '')
+        stringParam('IMAGE_TAG',  '', 'default RELEASE_TAG-rocky-pre')
         stringParam('HUB_PROJECT', 'qa', '')
         booleanParam('NO_FAILPOINT', false, '')
     }

--- a/jenkins/jobs/cd/pre_release_community_docker_rocky.groovy
+++ b/jenkins/jobs/cd/pre_release_community_docker_rocky.groovy
@@ -81,6 +81,6 @@ pipelineJob('pre-release-community-docker-rocky') {
         }
         stringParam('IMAGE_TAG',  '', 'default RELEASE_TAG-rocky-pre')
         stringParam('HUB_PROJECT', 'qa', '')
-        booleanParam('NO_FAILPOINT', false, '')
+        booleanParam('NEED_FAILPOINT', true, '')
     }
 }

--- a/jenkins/jobs/cd/pre_release_community_docker_rocky.groovy
+++ b/jenkins/jobs/cd/pre_release_community_docker_rocky.groovy
@@ -81,5 +81,6 @@ pipelineJob('pre-release-community-docker-rocky') {
         }
         stringParam('POSTFIX',  '-rocky-pre', '')
         stringParam('HUB_PROJECT', 'qa', '')
+        booleanParam('NO_FAILPOINT', false, '')
     }
 }

--- a/jenkins/jobs/cd/pre_release_community_docker_rocky.groovy
+++ b/jenkins/jobs/cd/pre_release_community_docker_rocky.groovy
@@ -79,5 +79,7 @@ pipelineJob('pre-release-community-docker-rocky') {
             defaultValue('')
             trim(true)
         }
+        stringParam('POSTFIX',  '-rocky-pre', '')
+        stringParam('HUB_PROJECT', 'qa', '')
     }
 }

--- a/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
@@ -232,7 +232,7 @@ retry(2) {
                     PRODUCED_VERSION = job.getBuildVariables().PRODUCED_VERSION
                 }
                 jobs["docker"] = {
-                    build job: "pre-release-community-docker-rocky",
+                    build job: "community-docker-multi-products",
                     parameters: [
                         string(name: 'RELEASE_BRANCH', value: 'master'),
                         string(name: 'RELEASE_TAG', value: RELEASE_TAG),

--- a/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
@@ -232,22 +232,22 @@ retry(2) {
                 }
                 jobs["docker"] = {
                     build job: "community-docker-multi-products",
-                    parameters: [
-                        string(name: 'RELEASE_BRANCH', value: 'master'),
-                        string(name: 'RELEASE_TAG', value: RELEASE_TAG),
-                        booleanParam(name: 'FORCE_REBUILD', value: true),
-                        booleanParam(name: 'NEED_DEBUG_IMAGE', value: false),
-                        string(name: 'TIDB_HASH', value: tidb_sha1),
-                        string(name: 'TIKV_HASH', value: tikv_sha1),
-                        string(name: 'PD_HASH', value: pd_sha1),
-                        string(name: 'TIFLASH_HASH', value: tiflash_sha1),
-                        string(name: 'NG_MONITORING_HASH', value: ng_monitoring_sha1),
-                        string(name: 'TIDB_BINLOG_HASH', value: tidb_binlog_sha1),
-                        string(name: 'TICDC_HASH', value: cdc_sha1),
-                        string(name: 'POSTFIX', value: ''),
-                        string(name: 'HUB_PROJECT', value: 'rc')
-                        string(name: 'NO_FAILPOINT', value: true)
-                    ]
+                        parameters: [
+                            string(name: 'RELEASE_BRANCH', value: 'master'),
+                            string(name: 'RELEASE_TAG', value: RELEASE_TAG),
+                            booleanParam(name: 'FORCE_REBUILD', value: true),
+                            booleanParam(name: 'NEED_DEBUG_IMAGE', value: false),
+                            string(name: 'TIDB_HASH', value: tidb_sha1),
+                            string(name: 'TIKV_HASH', value: tikv_sha1),
+                            string(name: 'PD_HASH', value: pd_sha1),
+                            string(name: 'TIFLASH_HASH', value: tiflash_sha1),
+                            string(name: 'NG_MONITORING_HASH', value: ng_monitoring_sha1),
+                            string(name: 'TIDB_BINLOG_HASH', value: tidb_binlog_sha1),
+                            string(name: 'TICDC_HASH', value: cdc_sha1),
+                            string(name: 'POSTFIX', value: ''),
+                            string(name: 'HUB_PROJECT', value: 'rc'),
+                            booleanParam(name: 'NO_FAILPOINT', value: true)
+                        ]
                     def syncs = [:]
                     for (product in ["br", "dm", "dumpling", "ng-monitoring", "pd", "ticdc", "tidb", "tidb-binlog", 
                             "tidb-lightning", "tidb-monitor-initializer", "tiflash", "tikv"]){

--- a/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
@@ -246,8 +246,8 @@ retry(2) {
                             string(name: 'TIDB_BINLOG_HASH', value: tidb_binlog_sha1),
                             string(name: 'TICDC_HASH', value: cdc_sha1),
                             string(name: 'IMAGE_TAG', value: NIGHTLY_RELEASE_TAG),
-                            string(name: 'HUB_PROJECT', value: 'rc'),
-                            booleanParam(name: 'NO_FAILPOINT', value: true)
+                            string(name: 'HUB_PROJECT', value: 'qa'),
+                            booleanParam(name: 'NEED_FAILPOINT', value: false)
                         ]
                     def syncs = [:]
                     for (_product in ["br", "dm", "dumpling", "ng-monitoring", "pd", "ticdc", "tidb", "tidb-binlog", 
@@ -256,7 +256,7 @@ retry(2) {
                         syncs["sync image ${product}"] = {
                             build job: 'jenkins-image-syncer',
                                 parameters: [
-                                        string(name: 'SOURCE_IMAGE', value: "hub.pingcap.net/rc/${product}:${NIGHTLY_RELEASE_TAG}"),
+                                        string(name: 'SOURCE_IMAGE', value: "hub.pingcap.net/qa/${product}:${NIGHTLY_RELEASE_TAG}"),
                                         string(name: 'TARGET_IMAGE', value: "docker.io/pingcap/${product}:${NIGHTLY_RELEASE_TAG}")
                                 ]
                         }

--- a/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
@@ -249,7 +249,8 @@ retry(2) {
                         string(name: 'HUB_PROJECT', value: 'rc')
                     ]
                     def syncs = [:]
-                    for product in ["br", "dm", "dumpling", "ng-monitoring", "pd", "ticdc", "tidb", "tidb-binlog", "tidb-lightning", "tidb-monitor-initializer", "tiflash", "tikv"]{
+                    for (product in ["br", "dm", "dumpling", "ng-monitoring", "pd", "ticdc", "tidb", "tidb-binlog", 
+                            "tidb-lightning", "tidb-monitor-initializer", "tiflash", "tikv"]){
                         syncs["sync image ${product}"] = {
                             build job: 'jenkins-image-syncer',
                                 parameters: [

--- a/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
@@ -218,7 +218,6 @@ retry(2) {
                 parallel builds
             }
 
-            RELEASE_TAG = "nightly"
 
             stage("Publish"){
                 jobs = [:]
@@ -226,7 +225,7 @@ retry(2) {
                     def job = build job: "tiup-mirror-online-ga",
                         wait: true,
                         parameters: [
-                                [$class: 'StringParameterValue', name: 'RELEASE_TAG', value: RELEASE_TAG],
+                                [$class: 'StringParameterValue', name: 'RELEASE_TAG', value:'nightly'],
                                 [$class: 'StringParameterValue', name: 'TIUP_ENV', value: "prod"],
                         ]
                     PRODUCED_VERSION = job.getBuildVariables().PRODUCED_VERSION
@@ -247,6 +246,7 @@ retry(2) {
                         string(name: 'TICDC_HASH', value: cdc_sha1),
                         string(name: 'POSTFIX', value: ''),
                         string(name: 'HUB_PROJECT', value: 'rc')
+                        string(name: 'NO_FAILPOINT', value: true)
                     ]
                     def syncs = [:]
                     for (product in ["br", "dm", "dumpling", "ng-monitoring", "pd", "ticdc", "tidb", "tidb-binlog", 

--- a/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
@@ -222,10 +222,11 @@ retry(2) {
             stage("Publish"){
                 jobs = [:]
                 jobs["tiup"] = {
+                    def TIUP_RELEASE_TAG = 'nightly'
                     def job = build job: "tiup-mirror-online-ga",
                         wait: true,
                         parameters: [
-                                [$class: 'StringParameterValue', name: 'RELEASE_TAG', value:'nightly'],
+                                [$class: 'StringParameterValue', name: 'RELEASE_TAG', value: TIUP_RELEASE_TAG],
                                 [$class: 'StringParameterValue', name: 'TIUP_ENV', value: "prod"],
                         ]
                     PRODUCED_VERSION = job.getBuildVariables().PRODUCED_VERSION

--- a/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
@@ -220,14 +220,47 @@ retry(2) {
 
             RELEASE_TAG = "nightly"
 
-            stage("TiUP build") {
-                def job = build job: "tiup-mirror-online-ga",
+            stage("Publish"){
+                jobs = [:]
+                jobs["tiup"] = {
+                    def job = build job: "tiup-mirror-online-ga",
                         wait: true,
                         parameters: [
                                 [$class: 'StringParameterValue', name: 'RELEASE_TAG', value: RELEASE_TAG],
                                 [$class: 'StringParameterValue', name: 'TIUP_ENV', value: "prod"],
                         ]
-                PRODUCED_VERSION = job.getBuildVariables().PRODUCED_VERSION
+                    PRODUCED_VERSION = job.getBuildVariables().PRODUCED_VERSION
+                }
+                jobs["docker"] = {
+                    build job: "pre-release-community-docker-rocky",
+                    parameters: [
+                        string(name: 'RELEASE_BRANCH', value: 'master'),
+                        string(name: 'RELEASE_TAG', value: RELEASE_TAG),
+                        booleanParam(name: 'FORCE_REBUILD', value: true),
+                        booleanParam(name: 'NEED_DEBUG_IMAGE', value: false),
+                        string(name: 'TIDB_HASH', value: tidb_sha1),
+                        string(name: 'TIKV_HASH', value: tikv_sha1),
+                        string(name: 'PD_HASH', value: pd_sha1),
+                        string(name: 'TIFLASH_HASH', value: tiflash_sha1),
+                        string(name: 'NG_MONITORING_HASH', value: ng_monitoring_sha1),
+                        string(name: 'TIDB_BINLOG_HASH', value: tidb_binlog_sha1),
+                        string(name: 'TICDC_HASH', value: cdc_sha1),
+                        string(name: 'POSTFIX', value: ''),
+                        string(name: 'HUB_PROJECT', value: 'rc')
+                    ]
+                    def syncs = [:]
+                    for product in ["br", "dm", "dumpling", "ng-monitoring", "pd", "ticdc", "tidb", "tidb-binlog", "tidb-lightning", "tidb-monitor-initializer", "tiflash", "tikv"]{
+                        syncs["sync image ${product}"] = {
+                            build job: 'jenkins-image-syncer',
+                                parameters: [
+                                        string(name: 'SOURCE_IMAGE', value: "hub.pingcap.net/rc/${product}:${RELEASE_TAG}"),
+                                        string(name: 'TARGET_IMAGE', value: "docker.io/pingcap/${product}:${RELEASE_TAG}")
+                                ]
+                        }
+                    }
+                    parallel syncs
+                }
+                parallel jobs
             }
 
             stage("Tiup nightly test") {

--- a/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
@@ -250,8 +250,9 @@ retry(2) {
                             booleanParam(name: 'NO_FAILPOINT', value: true)
                         ]
                     def syncs = [:]
-                    for (product in ["br", "dm", "dumpling", "ng-monitoring", "pd", "ticdc", "tidb", "tidb-binlog", 
+                    for (_product in ["br", "dm", "dumpling", "ng-monitoring", "pd", "ticdc", "tidb", "tidb-binlog", 
                             "tidb-lightning", "tidb-monitor-initializer", "tiflash", "tikv"]){
+                        def product = _product //fix bug in closure
                         syncs["sync image ${product}"] = {
                             build job: 'jenkins-image-syncer',
                                 parameters: [

--- a/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/tiup-release-tidb-master-nightly.groovy
@@ -220,13 +220,13 @@ retry(2) {
 
 
             stage("Publish"){
+                def NIGHTLY_RELEASE_TAG = 'nightly'
                 jobs = [:]
                 jobs["tiup"] = {
-                    def TIUP_RELEASE_TAG = 'nightly'
                     def job = build job: "tiup-mirror-online-ga",
                         wait: true,
                         parameters: [
-                                [$class: 'StringParameterValue', name: 'RELEASE_TAG', value: TIUP_RELEASE_TAG],
+                                [$class: 'StringParameterValue', name: 'RELEASE_TAG', value: NIGHTLY_RELEASE_TAG],
                                 [$class: 'StringParameterValue', name: 'TIUP_ENV', value: "prod"],
                         ]
                     PRODUCED_VERSION = job.getBuildVariables().PRODUCED_VERSION
@@ -236,7 +236,7 @@ retry(2) {
                         parameters: [
                             string(name: 'RELEASE_BRANCH', value: 'master'),
                             string(name: 'RELEASE_TAG', value: RELEASE_TAG),
-                            booleanParam(name: 'FORCE_REBUILD', value: true),
+                            booleanParam(name: 'FORCE_REBUILD', value: false),
                             booleanParam(name: 'NEED_DEBUG_IMAGE', value: false),
                             string(name: 'TIDB_HASH', value: tidb_sha1),
                             string(name: 'TIKV_HASH', value: tikv_sha1),
@@ -245,7 +245,7 @@ retry(2) {
                             string(name: 'NG_MONITORING_HASH', value: ng_monitoring_sha1),
                             string(name: 'TIDB_BINLOG_HASH', value: tidb_binlog_sha1),
                             string(name: 'TICDC_HASH', value: cdc_sha1),
-                            string(name: 'POSTFIX', value: ''),
+                            string(name: 'IMAGE_TAG', value: NIGHTLY_RELEASE_TAG),
                             string(name: 'HUB_PROJECT', value: 'rc'),
                             booleanParam(name: 'NO_FAILPOINT', value: true)
                         ]
@@ -255,8 +255,8 @@ retry(2) {
                         syncs["sync image ${product}"] = {
                             build job: 'jenkins-image-syncer',
                                 parameters: [
-                                        string(name: 'SOURCE_IMAGE', value: "hub.pingcap.net/rc/${product}:${RELEASE_TAG}"),
-                                        string(name: 'TARGET_IMAGE', value: "docker.io/pingcap/${product}:${RELEASE_TAG}")
+                                        string(name: 'SOURCE_IMAGE', value: "hub.pingcap.net/rc/${product}:${NIGHTLY_RELEASE_TAG}"),
+                                        string(name: 'TARGET_IMAGE', value: "docker.io/pingcap/${product}:${NIGHTLY_RELEASE_TAG}")
                                 ]
                         }
                     }

--- a/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
+++ b/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
@@ -239,7 +239,7 @@ def release_docker(releaseRepos, builds, arch) {
         }
     }
 
-    if (arch == "amd64") {
+    if (arch == "amd64" && ! params.NO_FAILPOINT.toBoolean()) {
         failpointRepos = ["tidb", "pd", "tikv"]
         for (item in failpointRepos) {
             def product = "${item}"

--- a/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
+++ b/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
@@ -16,7 +16,10 @@ def get_dockerfile_url(product, is_enterprise, is_debug){
 }
 
 def get_image_str_for_community(product, arch, tag, is_failpoint, is_debug) {
-    def imageTag = tag + params.POSTFIX
+    def imageTag = params.IMAGE_TAG
+    if (! imageTag){
+        imageTag = tag + "-rocky"+ "-pre"
+    }
     def imageName = product
     if (product == "monitoring") {
         imageName = "tidb-monitor-initializer"

--- a/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
+++ b/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
@@ -242,7 +242,7 @@ def release_docker(releaseRepos, builds, arch) {
         }
     }
 
-    if (arch == "amd64" && ! params.NO_FAILPOINT.toBoolean()) {
+    if (arch == "amd64" && params.NEED_FAILPOINT.toBoolean()) {
         failpointRepos = ["tidb", "pd", "tikv"]
         for (item in failpointRepos) {
             def product = "${item}"

--- a/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
+++ b/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
@@ -1,67 +1,4 @@
-properties([
-        parameters([
-                string(
-                        defaultValue: '',
-                        name: 'RELEASE_BRANCH',
-                        trim: true
-                ),
-                string(
-                        defaultValue: '',
-                        name: 'RELEASE_TAG',
-                        trim: true
-                ),
-                booleanParam(
-                        defaultValue: true,
-                        name: 'FORCE_REBUILD'
-                ),
-                booleanParam(
-                        defaultValue: true,
-                        name: 'NEED_DEBUG_IMAGE'
-                ),
-                booleanParam(
-                        defaultValue: false,
-                        name: 'DEBUG_MODE'
-                ),
-                string(
-                        defaultValue: '',
-                        name: 'TIDB_HASH',
-                        trim: true
-                ),
-                string(
-                        defaultValue: '',
-                        name: 'TIKV_HASH',
-                        trim: true
-                ),
-                string(
-                        defaultValue: '',
-                        name: 'PD_HASH',
-                        trim: true
-                ),
-                string(
-                        defaultValue: '',
-                        name: 'TIFLASH_HASH',
-                        trim: true
-                ),
-                string(
-                        defaultValue: '',
-                        name: 'NG_MONITORING_HASH',
-                        trim: true
-                ),
-                string(
-                        defaultValue: '',
-                        name: 'TIDB_BINLOG_HASH',
-                        trim: true
-                ),
-                string(
-                        defaultValue: '',
-                        name: 'TICDC_HASH',
-                        trim: true
-                ),
-        ])
-])
-
-
-HARBOR_REGISTRY_PROJECT_PREFIX = 'hub.pingcap.net/qa'
+HARBOR_REGISTRY_PROJECT_PREFIX = "hub.pingcap.net/${params.HUB_PROJECT}"
 if (params.DEBUG_MODE) {
     HARBOR_REGISTRY_PROJECT_PREFIX = 'hub.pingcap.net/ee-debug'
     println('DEBUG_MODE is true, use hub.pingcap.net/ee-debug')
@@ -79,7 +16,7 @@ def get_dockerfile_url(product, is_enterprise, is_debug){
 }
 
 def get_image_str_for_community(product, arch, tag, is_failpoint, is_debug) {
-    def imageTag = tag + "-rocky"+ "-pre"
+    def imageTag = tag + params.POSTFIX
     def imageName = product
     if (product == "monitoring") {
         imageName = "tidb-monitor-initializer"

--- a/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
+++ b/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
@@ -15,10 +15,10 @@ def get_dockerfile_url(product, is_enterprise, is_debug){
     return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/${fileName}.Dockerfile"
 }
 
-def get_image_str_for_community(product, arch, tag, is_failpoint, is_debug) {
+def get_image_str_for_community(product, arch, is_failpoint, is_debug) {
     def imageTag = params.IMAGE_TAG
     if (! imageTag){
-        imageTag = tag + "-rocky"+ "-pre"
+        imageTag = params.RELEASE_TAG + "-rocky"+ "-pre"
     }
     def imageName = product
     if (product == "monitoring") {
@@ -150,7 +150,7 @@ def release_one(repo, arch, failpoint) {
 
 
     def dockerfile = get_dockerfile_url(repo, false, false)
-    def image = get_image_str_for_community(repo, arch, RELEASE_TAG, failpoint, false)
+    def image = get_image_str_for_community(repo, arch, failpoint, false)
 
     def paramsDocker = [
             string(name: "ARCH", value: arch),
@@ -171,7 +171,7 @@ def release_one(repo, arch, failpoint) {
 
     if (NEED_DEBUG_IMAGE.toBoolean() && arch == "amd64") {
         def dockerfileForDebug = get_dockerfile_url(repo, false, true)
-        def imageForDebug = get_image_str_for_community(repo, "", RELEASE_TAG, failpoint, true)
+        def imageForDebug = get_image_str_for_community(repo, "", failpoint, true)
         def paramsDockerForDebug = [
                 string(name: "ARCH", value: "amd64"),
                 string(name: "OS", value: "linux"),
@@ -195,7 +195,7 @@ def release_one(repo, arch, failpoint) {
     if (repo == "br") {
         println("start build tidb-lightning")
         def dockerfileLightning = get_dockerfile_url("tidb-lightning", false, false)
-        def imageLightling = get_image_str_for_community("tidb-lightning", arch, RELEASE_TAG,false,false)
+        def imageLightling = get_image_str_for_community("tidb-lightning", arch, false,false)
         def paramsDockerLightning = [
                 string(name: "ARCH", value: arch),
                 string(name: "OS", value: "linux"),
@@ -212,7 +212,7 @@ def release_one(repo, arch, failpoint) {
 
         if (NEED_DEBUG_IMAGE.toBoolean() && arch == "amd64") {
             def dockerfileLightningForDebug = get_dockerfile_url("tidb-lightning", false, true)
-            def imageLightlingForDebug = get_image_str_for_community("tidb-lightning", "",RELEASE_TAG,failpoint,true)
+            def imageLightlingForDebug = get_image_str_for_community("tidb-lightning", "",failpoint,true)
             def paramsDockerLightningForDebug = [
                     string(name: "ARCH", value: "amd64"),
                     string(name: "OS", value: "linux"),
@@ -273,9 +273,9 @@ stage("create multi-arch image") {
         def product = item // important: groovy closure may use the last status of loop var
         manifest_multiarch_builds[product] = {
             def paramsManifest = [
-                    string(name: "AMD64_IMAGE", value: get_image_str_for_community(product, "amd64", RELEASE_TAG, false, false)),
-                    string(name: "ARM64_IMAGE", value: get_image_str_for_community(product, "arm64", RELEASE_TAG, false, false)),
-                    string(name: "MULTI_ARCH_IMAGE", value: get_image_str_for_community(product, "", RELEASE_TAG, false, false)),
+                    string(name: "AMD64_IMAGE", value: get_image_str_for_community(product, "amd64", false, false)),
+                    string(name: "ARM64_IMAGE", value: get_image_str_for_community(product, "arm64", false, false)),
+                    string(name: "MULTI_ARCH_IMAGE", value: get_image_str_for_community(product, "", false, false)),
             ]
             println "paramsManifest: ${paramsManifest}"
             build job: "manifest-multiarch-common",


### PR DESCRIPTION
# Why:
- build nightly image usually get file 404, because binary has not been build yet
- CI do not has this problem
- cd only product single arch image for a few products

# How
- reuse the rc sub pipeline to produce multiple products with multi-arch