### PR TITLE
feat(tidb): support fetch verify artifact

### DIFF
--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -96,18 +96,20 @@ def checkoutV2(gitUrl, keyInComment, prTargetBranch, prCommentBody, credentialsI
 }
 
 // fetch component artifact from artifactory(current http server)
-def fetchAndExtractArtifact(serverUrl, keyInComment, prTargetBranch, prCommentBody, artifactPath, pathInArchive="", trunkBranch="master") {
+def fetchAndExtractArtifact(serverUrl, keyInComment, prTargetBranch, prCommentBody, artifactPath, pathInArchive="", trunkBranch="master", artifactVerify=false) {
     def componentBranch = computeBranchFromPR(keyInComment, prTargetBranch, prCommentBody,  trunkBranch)
-
+    def refUrl="${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1"
+    if (artifactVerify) {
+        refUrl="${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1.verify"
+    }
     sh(label: 'download and extract from server', script: """
         sha1=""
 
         if [[ "commit_${componentBranch}" =~ ^commit_[0-9a-f]{40}\$ ]]; then
             sha1=${componentBranch}
         else
-            refUrl="${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1"
-            echo "🔍 ref url: \${refUrl}"
-            sha1="\$(curl --fail \${refUrl} | head -1)"
+            echo "🔍 ref url: ${refUrl}"
+            sha1="\$(curl --fail ${refUrl} | head -1)"
         fi
         
         artifactUrl="${serverUrl}/download/builds/pingcap/${keyInComment}/\${sha1}/${artifactPath}"

--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -98,18 +98,18 @@ def checkoutV2(gitUrl, keyInComment, prTargetBranch, prCommentBody, credentialsI
 // fetch component artifact from artifactory(current http server)
 def fetchAndExtractArtifact(serverUrl, keyInComment, prTargetBranch, prCommentBody, artifactPath, pathInArchive="", trunkBranch="master", artifactVerify=false) {
     def componentBranch = computeBranchFromPR(keyInComment, prTargetBranch, prCommentBody, trunkBranch)
-    def refUrl = "${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1"
-    if (artifactVerify) {
-        refUrl = "${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1.verify"
-    }
     sh(label: 'download and extract from server', script: """
         sha1=""
 
         if [[ "commit_${componentBranch}" =~ ^commit_[0-9a-f]{40}\$ ]]; then
             sha1=${componentBranch}
         else
-            echo "🔍 ref url: ${refUrl}"
-            sha1="\$(curl --fail ${refUrl} | head -1)"
+            refUrl="${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1"
+            if [[ "${artifactVerify}" = "true" ]]; then
+                refUrl="${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1.verify"
+            fi
+            echo "🔍 ref url: \${refUrl}"
+            sha1="\$(curl --fail \${refUrl} | head -1)"
         fi
         
         artifactUrl="${serverUrl}/download/builds/pingcap/${keyInComment}/\${sha1}/${artifactPath}"

--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -97,10 +97,10 @@ def checkoutV2(gitUrl, keyInComment, prTargetBranch, prCommentBody, credentialsI
 
 // fetch component artifact from artifactory(current http server)
 def fetchAndExtractArtifact(serverUrl, keyInComment, prTargetBranch, prCommentBody, artifactPath, pathInArchive="", trunkBranch="master", artifactVerify=false) {
-    def componentBranch = computeBranchFromPR(keyInComment, prTargetBranch, prCommentBody,  trunkBranch)
-    def refUrl="${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1"
+    def componentBranch = computeBranchFromPR(keyInComment, prTargetBranch, prCommentBody, trunkBranch)
+    def refUrl = "${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1"
     if (artifactVerify) {
-        refUrl="${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1.verify"
+        refUrl = "${serverUrl}/download/refs/pingcap/${keyInComment}/${componentBranch}/sha1.verify"
     }
     sh(label: 'download and extract from server', script: """
         sha1=""

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -58,8 +58,8 @@ pipeline {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                     script {
-                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')
-                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'pd', REFS.base_ref, REFS.pulls[0].title, 'centos7/pd-server.tar.gz', 'bin')
+                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin', trunkBranch="master", artifactVerify=true)
+                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'pd', REFS.base_ref, REFS.pulls[0].title, 'centos7/pd-server.tar.gz', 'bin', trunkBranch="master", artifactVerify=true)
                     }
                     // cache it for other pods
                     cache(path: "./", filter: '**/*', key: "ws/${BUILD_TAG}") {


### PR DESCRIPTION
Currently, we obtain the latest compiled binary for the corresponding branch. This approach has a hidden risk as dependencies can cause issues that affect the current pipeline.
This PR support fetch artifact binary that already passed some e2e tests to avoid the above-mentioned problems.