### PR TITLE
feat: remove manifest tool

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/manifest-multiarch-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/manifest-multiarch-common.groovy
@@ -6,6 +6,7 @@ node("delivery") {
             printenv harborPassword | docker login -u ${harborUser} --password-stdin hub.pingcap.net
             export DOCKER_CLI_EXPERIMENTAL=enabled
             docker manifest create ${MULTI_ARCH_IMAGE}  -a ${AMD64_IMAGE} -a ${ARM64_IMAGE}
+            docker manifest push ${MULTI_ARCH_IMAGE}
             """
             }
         }

--- a/jenkins/pipelines/cd/atom-jobs/manifest-multiarch-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/manifest-multiarch-common.groovy
@@ -3,32 +3,12 @@ node("delivery") {
         stage("build multi-arch") {
             withCredentials([usernamePassword(credentialsId: 'harbor-pingcap', usernameVariable: 'harborUser', passwordVariable: 'harborPassword')]) {
                 sh """
-            docker login -u ${harborUser} -p ${harborPassword} hub.pingcap.net
-            cat <<EOF > manifest.yaml
-image: ${MULTI_ARCH_IMAGE}
-manifests:
--
-    image: ${ARM64_IMAGE}
-    platform:
-    architecture: arm64
-    os: linux
--
-    image: ${AMD64_IMAGE}
-    platform:
-    architecture: amd64
-    os: linux
-
-EOF
-            cat manifest.yaml
-            curl -o manifest-tool ${FILE_SERVER_URL}/download/cicd/tools/manifest-tool-linux-amd64
-            chmod +x manifest-tool
-            ./manifest-tool push from-spec manifest.yaml
+            printenv harborPassword | docker login -u ${harborUser} --password-stdin hub.pingcap.net
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+            docker manifest create ${MULTI_ARCH_IMAGE}  -a ${AMD64_IMAGE} -a ${ARM64_IMAGE}
             """
-
             }
-            archiveArtifacts artifacts: "manifest.yaml", fingerprint: true
         }
-
     }
     println "multi arch image: ${MULTI_ARCH_IMAGE}"
 }


### PR DESCRIPTION
# Why:
- there is a file manifest-tool not managed by git
- docker is enough
- communicated with @purelind , remove manifest.yaml is ok

related issue: https://github.com/PingCAP-QE/ci/issues/2445