### PR TITLE
fix: checkout tiflash unclean

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -328,7 +328,7 @@ def checkoutCode() {
                                                 refspec      : specRef,
                                                 url          : repo]]]
     }
-
+    sh "git config --global --add safe.directory '*'"
     sh 'test -z "$(git status --porcelain)"'
     if(params.PRODUCT == 'enterprise-plugin'){
         sh """
@@ -660,6 +660,7 @@ cp bin/* ${TARGET}/bin/
 """
 
 buildsh["tics"] = """
+git config --global --add safe.directory '*'
 if [ ${RELEASE_TAG}x != ''x ];then
     for a in \$(git tag --contains ${GIT_HASH}); do echo \$a && git tag -d \$a;done
     git tag -f ${RELEASE_TAG} ${GIT_HASH}

--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -329,7 +329,7 @@ def checkoutCode() {
                                                 url          : repo]]]
     }
     // special for tiflash submodule
-    if (params.OS=="linux"){
+    if (params.OS=="linux" && params.PRODUCT in ["tiflash", "tics"]){
         container('jnlp'){
             sh "git submodule deinit -f . && git reset --hard HEAD && git submodule update  --init --recursive"
             sh "git status"

--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -242,10 +242,10 @@ if (params.PRODUCT == "tikv" || params.PRODUCT == "importer") {
 }
 if (params.PRODUCT == "tics") {
     nodeLabel = "build_tiflash"
-    containerLabel = "tiflash"
+    containerLabel = "tiflash-llvm"
     if (params.ARCH == "arm64" && params.OS == "linux"){
         nodeLabel = "tiflash_build_arm"
-        containerLabel = "tiflash"
+        containerLabel = "tiflash-llvm"
     }
 }
 if (params.ARCH == "arm64" && params.OS == "linux" && !useArmPodTemplate && params.PRODUCT != "tics") {
@@ -328,13 +328,7 @@ def checkoutCode() {
                                                 refspec      : specRef,
                                                 url          : repo]]]
     }
-    // special for tiflash submodule
-    if (params.OS=="linux" && params.PRODUCT in ["tiflash", "tics"]){
-        container('jnlp'){
-            sh "git submodule deinit -f . && git reset --hard HEAD && git submodule update  --init --recursive"
-            sh "git status"
-        }
-    }
+
     sh 'test -z "$(git status --porcelain)"'
     if(params.PRODUCT == 'enterprise-plugin'){
         sh """
@@ -892,6 +886,8 @@ def release(product, label) {
                 image_tag_suffix = config.image_tag_suffix
             }
             label = "tiflash-llvm${image_tag_suffix}".replaceAll('\\.', '-')
+        }else if (fileExists('release-centos7/Makefile') && params.OS != "darwin"){
+            label = "tiflash"
         }
     }
 

--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -328,7 +328,13 @@ def checkoutCode() {
                                                 refspec      : specRef,
                                                 url          : repo]]]
     }
-
+    // special for tiflash submodule
+    if (params.OS=="linux"){
+        container('jnlp'){
+            sh "git submodule deinit -f . && git reset --hard HEAD && git submodule update  --init --recursive"
+            sh "git status"
+        }
+    }
     sh 'test -z "$(git status --porcelain)"'
     if(params.PRODUCT == 'enterprise-plugin'){
         sh """

--- a/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
@@ -95,6 +95,12 @@ def doBuild = {
                                         refspec      : specRef,
                                         url          : "git@github.com:pingcap/tiflash.git"]]
                     ]
+        if (OS=="linux"){
+            container('jnlp'){
+                sh "git submodule deinit -f . && git reset --hard HEAD && git submodule update  --init --recursive"
+                sh "git status"
+            }
+        }
             sh 'test -z "$(git status --porcelain)"'
             }
         }

--- a/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
@@ -95,12 +95,6 @@ def doBuild = {
                                         refspec      : specRef,
                                         url          : "git@github.com:pingcap/tiflash.git"]]
                     ]
-        if (OS=="linux"){
-            container('jnlp'){
-                sh "git submodule deinit -f . && git reset --hard HEAD && git submodule update  --init --recursive"
-                sh "git status"
-            }
-        }
             sh 'test -z "$(git status --porcelain)"'
             }
         }
@@ -227,7 +221,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: builder
-    image: hub.pingcap.net/jenkins/tiflash-builder
+    image: hub.pingcap.net/jenkins/tiflash-builder-llvm
     volumeMounts:
     - name: ccache
       mountPath: "/var/cache/ccache"
@@ -291,7 +285,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: builder
-    image: hub.pingcap.net/jenkins/tiflash-builder
+    image: hub.pingcap.net/jenkins/tiflash-builder-llvm
     volumeMounts:
     - name: ccache
       mountPath: "/var/cache/ccache"

--- a/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
@@ -221,7 +221,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: builder
-    image: hub.pingcap.net/jenkins/tiflash-builder-llvm:v20231106
+    image: hub.pingcap.net/ee/ci/release-build-base-tiflash:v20231106
     volumeMounts:
     - name: ccache
       mountPath: "/var/cache/ccache"
@@ -285,7 +285,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: builder
-    image: hub.pingcap.net/jenkins/tiflash-builder-llvm:v20231106
+    image: hub.pingcap.net/ee/ci/release-build-base-tiflash:v20231106
     volumeMounts:
     - name: ccache
       mountPath: "/var/cache/ccache"

--- a/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
@@ -95,6 +95,7 @@ def doBuild = {
                                         refspec      : specRef,
                                         url          : "git@github.com:pingcap/tiflash.git"]]
                     ]
+            sh "git config --global --add safe.directory '*'"
             sh 'test -z "$(git status --porcelain)"'
             }
         }

--- a/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
@@ -221,7 +221,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: builder
-    image: hub.pingcap.net/jenkins/tiflash-builder-llvm
+    image: hub.pingcap.net/jenkins/tiflash-builder-llvm:v20231106
     volumeMounts:
     - name: ccache
       mountPath: "/var/cache/ccache"
@@ -285,7 +285,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: builder
-    image: hub.pingcap.net/jenkins/tiflash-builder-llvm
+    image: hub.pingcap.net/jenkins/tiflash-builder-llvm:v20231106
     volumeMounts:
     - name: ccache
       mountPath: "/var/cache/ccache"


### PR DESCRIPTION
# Why:
checkout tiflash unclean, use newer image for git

# How:
- new builder image, ref: https://github.com/pingcap/tiflash/pull/8325
- edited cd jenkins pod template
- change the default container from tiflash(old, gcc) to tiflash-llvm(upgraded) while checkout