### PR TITLE
Only build bench for the master branch

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
@@ -130,7 +130,12 @@ def getBuildTarget() {
     }
 
     if (params.BUILD_TESTS) {
-        targets = "bench_dbms gtests_dbms gtests_libcommon gtests_libdaemon ${targets}"
+        targets = "gtests_dbms gtests_libcommon gtests_libdaemon ${targets}"
+
+        // Only build bench binary for the master branch
+        if (params.TARGET_BRANCH == "master") {
+            targets = "bench_dbms ${targets}"
+        }
     }
 
     if (params.BUILD_PAGE_TOOLS) {


### PR DESCRIPTION
The previous PR enables the bench_dbms https://github.com/PingCAP-QE/ci/pull/2515 to ensure the new code changes do not break building the bench binary.
But in the old branches, the bench binary have been broken for a long days and it brings trouble for cherry-pick to LTS branches and hotfix branches.

This PR only build the bench_dbms on the master branch. Ignore it for the LTS branches and hotfix branches.