### PR TITLE
chore(pingcap/tiup): disable auto sync OWNERS files

### DIFF
--- a/prow-jobs/pingcap-community-postsubmits.yaml
+++ b/prow-jobs/pingcap-community-postsubmits.yaml
@@ -20,7 +20,6 @@ postsubmits:
               - --inputs=teams/tiunimanager/membership.json
               - --inputs=teams/tidb/membership.json
               - --inputs=teams/tiflash/membership.json
-              - --inputs=teams/tiup/membership.json
               - --inputs=teams/kubernetes/membership.json
               - --inputs=teams/migration/membership.json
               - --inputs=teams/bigdata/membership.json


### PR DESCRIPTION
Currently most community members of `tiup` is not active. We need stop the auto syncing for this repository.