### PR TITLE
chore: update etcd from 3.3.10 to 3.4.21(since 6.5)

### DIFF
--- a/jenkins/pipelines/cd/nightly/release_tidb_master-nightly.groovy
+++ b/jenkins/pipelines/cd/nightly/release_tidb_master-nightly.groovy
@@ -111,7 +111,7 @@ retry(2) {
                             sh "curl -C - --fail --retry 3 ${FILE_SERVER_URL}/download/builds/pingcap/dumpling/${dumpling_sha1}/centos7/dumpling.tar.gz | tar xz"
                         }
                         dir('etcd') {
-                            sh "curl -L --fail ${FILE_SERVER_URL}/download/pingcap/etcd-v3.3.10-linux-amd64.tar.gz | tar xz"
+                            sh "curl -L --fail ${FILE_SERVER_URL}/download/pingcap/etcd-v3.4.21-linux-amd64.tar.gz | tar xz"
                         }
                     }
                     stage("publish docker image") {

--- a/jenkins/pipelines/cd/release-GA-v5-extra-packages.groovy
+++ b/jenkins/pipelines/cd/release-GA-v5-extra-packages.groovy
@@ -88,8 +88,8 @@ catchError {
                 }
 
                 dir('etcd') {
-                    sh "curl -L ${FILE_SERVER_URL}/download/pingcap/etcd-v3.3.10-linux-amd64.tar.gz | tar xz"
-                    sh "curl -L ${FILE_SERVER_URL}/download/pingcap/etcd-v3.3.10-linux-arm64.tar.gz | tar xz"
+                    sh "curl -L ${FILE_SERVER_URL}/download/pingcap/etcd-v3.4.21-linux-amd64.tar.gz | tar xz"
+                    sh "curl -L ${FILE_SERVER_URL}/download/pingcap/etcd-v3.4.21-linux-arm64.tar.gz | tar xz"
                 }
             }
 
@@ -106,7 +106,7 @@ catchError {
                            cp ${ws}/centos7/bin/tidb-server ./bin
                            cp ${ws}/centos7/bin/tikv-ctl ./bin
                            cp ${ws}/centos7/bin/tikv-server ./bin
-                           cp ${ws}/etcd/etcd-v3.3.10-linux-amd64/etcdctl ./bin
+                           cp ${ws}/etcd/etcd-v3.4.21-linux-amd64/etcdctl ./bin
                            cp ${ws}/centos7/bin/pump ./bin
                            cp ${ws}/centos7/bin/drainer ./bin
                            cp ${ws}/centos7/bin/reparo ./bin
@@ -155,7 +155,7 @@ catchError {
                            cp ${ws}/arm/bin/tidb-server ./bin
                            cp ${ws}/arm/bin/tikv-ctl ./bin
                            cp ${ws}/arm/bin/tikv-server ./bin
-                           cp ${ws}/etcd/etcd-v3.3.10-linux-arm64/etcdctl ./bin
+                           cp ${ws}/etcd/etcd-v3.4.21-linux-arm64/etcdctl ./bin
                            cp ${ws}/arm/bin/pump ./bin
                            cp ${ws}/arm/bin/drainer ./bin
                            cp ${ws}/arm/bin/reparo ./bin

--- a/jenkins/pipelines/cd/tiup/tiup-mirror-update-multi-products.groovy
+++ b/jenkins/pipelines/cd/tiup/tiup-mirror-update-multi-products.groovy
@@ -20,7 +20,7 @@
 
 // tiup-ctl 一般不会变更，可以固定使用 v1.8.1 版本
 final TIUP_VERSION = 'v1.8.1'
-final ETCDCTL_VERSION = 'v3.3.10'
+final ETCDCTL_VERSION = 'v3.4.21'
 
 def get_hash = { hash_or_branch, repo ->
     if (DEBUG_MODE == "true") {
@@ -270,7 +270,7 @@ def update_ctl = { version, os, arch ->
     curl -L http://fileserver.pingcap.net/download/tiup/releases/${TIUP_VERSION}/tiup-${TIUP_VERSION}-${os}-${arch}.tar.gz | tar -C tiup/components/ctl -xz bin/tiup-ctl
     mv tiup/components/ctl/bin/tiup-ctl ctls/ctl
     curl -L ${FILE_SERVER_URL}/download/pingcap/etcd-${ETCDCTL_VERSION}-${os}-${arch}.tar.gz | tar xz
-    mv etcd-v3.3.10-${os}-${arch}/etcdctl ctls/
+    mv etcd-v3.4.21-${os}-${arch}/etcdctl ctls/
     tar -C ctls -czvf package/ctl-${version}-${os}-${arch}.tar.gz \$(ls ctls)
     tiup mirror publish ctl ${tidb_version} package/ctl-${version}-${os}-${arch}.tar.gz ctl --arch ${arch} --os ${os} --desc="${ctl_desc}"
     rm -rf ctls

--- a/jenkins/pipelines/cd/tiup/tiup-package-offline-mirror-6.0.0-hotfix.groovy
+++ b/jenkins/pipelines/cd/tiup/tiup-package-offline-mirror-6.0.0-hotfix.groovy
@@ -115,7 +115,7 @@ def package_tools = { plat, arch ->
         if [ ${arch} == 'amd64' ]; then
             wget -qnc ${FILE_SERVER_URL}/download/builds/pingcap/mydumper/${mydumper_sha1}/centos7/mydumper-linux-${arch}.tar.gz
         fi;
-        wget -qnc ${FILE_SERVER_URL}/download/pingcap/etcd-v3.3.10-linux-${arch}.tar.gz
+        wget -qnc ${FILE_SERVER_URL}/download/pingcap/etcd-v3.4.21-linux-${arch}.tar.gz
 
 
         tar xf tidb-binlog-linux-${arch}.tar.gz
@@ -125,7 +125,7 @@ def package_tools = { plat, arch ->
         if [ ${arch} == 'amd64' ]; then
             tar xf mydumper-linux-${arch}.tar.gz 
         fi;
-        tar xf etcd-v3.3.10-linux-${arch}.tar.gz
+        tar xf etcd-v3.4.21-linux-${arch}.tar.gz
 
         
         cp bin/binlogctl ${toolkit_dir}/
@@ -136,7 +136,7 @@ def package_tools = { plat, arch ->
         if [ ${arch} == 'amd64' ]; then
             cp mydumper-linux-${arch}/bin/mydumper ${toolkit_dir}/
         fi;
-        cp etcd-v3.3.10-linux-${arch}/etcdctl ${toolkit_dir}/
+        cp etcd-v3.4.21-linux-${arch}/etcdctl ${toolkit_dir}/
         
         tar czvf ${toolkit_dir}.tar.gz ${toolkit_dir}
         curl --fail -F release/${toolkit_dir}.tar.gz=@${toolkit_dir}.tar.gz ${FILE_SERVER_URL}/upload | egrep 'success'

--- a/jenkins/pipelines/cd/tiup/tiup-package-offline-mirror-6.0.0.groovy
+++ b/jenkins/pipelines/cd/tiup/tiup-package-offline-mirror-6.0.0.groovy
@@ -217,14 +217,14 @@ def package_tools = { plat, arch ->
         wget -qnc ${FILE_SERVER_URL}/download/builds/pingcap/pd/optimization/${release_tag_actual}/${pd_hash}/centos7/pd-linux-${arch}.tar.gz
         wget -qnc ${FILE_SERVER_URL}/download/builds/pingcap/tidb-tools/optimization/${release_tag_actual}/${tools_hash}/centos7/tidb-tools-linux-${arch}.tar.gz
         wget -qnc ${FILE_SERVER_URL}/download/builds/pingcap/br/optimization/${release_tag_actual}/${br_hash}/centos7/br-linux-${arch}.tar.gz
-        wget -qnc ${FILE_SERVER_URL}/download/pingcap/etcd-v3.3.10-linux-${arch}.tar.gz
+        wget -qnc ${FILE_SERVER_URL}/download/pingcap/etcd-v3.4.21-linux-${arch}.tar.gz
 
 
         tar xf tidb-binlog-linux-${arch}.tar.gz
         tar xf pd-linux-${arch}.tar.gz
         tar xf tidb-tools-linux-${arch}.tar.gz
         tar xf br-linux-${arch}.tar.gz
-        tar xf etcd-v3.3.10-linux-${arch}.tar.gz
+        tar xf etcd-v3.4.21-linux-${arch}.tar.gz
 
         
         cp bin/binlogctl ${toolkit_dir}/
@@ -232,7 +232,7 @@ def package_tools = { plat, arch ->
         cp bin/reparo ${toolkit_dir}/
         cp bin/arbiter ${toolkit_dir}/
         cp bin/tidb-lightning-ctl ${toolkit_dir}/
-        cp etcd-v3.3.10-linux-${arch}/etcdctl ${toolkit_dir}/
+        cp etcd-v3.4.21-linux-${arch}/etcdctl ${toolkit_dir}/
         
         ${mydumper_cmd}
 


### PR DESCRIPTION
Why:
- 3.3.10 is too old, even tidb 5.x use 3.4.3
- from tidb 6.5, use 3.4.21
- 3.4.21 copatible 3.4.3 by semantic versioning

How:
- use official etcd release package for linux, darwin/amd64
- build for darwin/arm64 with dockerfile:
```Dockerfile
FROM golang:1.19
ENV GOOS=darwin\
        GOARCH=arm64
ADD . /go/src/github.com/coreos/etcd
WORKDIR /go/src/github.com/coreos/etcd
RUN  ./build
```