### PR TITLE
fix: check git dir clean after checkout in ut ci 

### DIFF
--- a/pipelines/tikv/migration/latest/pull_unit_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_unit_test.groovy
@@ -64,6 +64,11 @@ pipeline {
                                 ]
                             )
                         }
+                        sh """
+                        git rev-parse --show-toplevel
+                        git status
+                        git status -s .
+                        """
                     }
                 }
             }

--- a/pipelines/tikv/migration/latest/pull_unit_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_unit_test.groovy
@@ -43,7 +43,6 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("migration") {
-                    cache(path: "./", includes: '**/*', key: "git/tikv/migration/rev-${ghprbActualCommit}", restoreKeys: ['git/tikv/migration/rev-']) {
                         retry(2) {
                             checkout(
                                 changelog: false,
@@ -69,7 +68,6 @@ pipeline {
                         git status
                         git status -s .
                         """
-                    }
                 }
             }
         }


### PR DESCRIPTION
* check git dir clean after checkout
* not use cache code because restored code The code recovered from the backup will lose the .git directory.

TODO
1. We will refactor this pipeline, using Prow for triggering and simultaneously using Lib functions for checking out code.

replay link
https://do.pingcap.net/jenkins/blue/organizations/jenkins/tikv%2Fmigration%2Fpull_unit_test/detail/pull_unit_test/104/pipeline/