### PR TITLE
fix: docker attestation manifest

### DIFF
--- a/jenkins/pipelines/cd/build-tidb-dashboard.groovy
+++ b/jenkins/pipelines/cd/build-tidb-dashboard.groovy
@@ -149,7 +149,7 @@ pipeline {
                         writeFile file:'build-tidb-dashboard.Dockerfile',text:dockerfile
                         sh 'cat build-tidb-dashboard.Dockerfile'
                         sh "docker buildx build . -f build-tidb-dashboard.Dockerfile -t hub.pingcap.net/rc/tidb-dashboard-builder:cache-amd64 --cache-from hub.pingcap.net/rc/tidb-dashboard-builder:cache-amd64 --target builder '--platform=linux/amd64' --build-arg 'BUILDKIT_INLINE_CACHE=1' --push"
-                        sh "docker buildx build . -f build-tidb-dashboard.Dockerfile -t hub.pingcap.net/rc/tidb-dashboard:${params.ReleaseTag}-amd64 --cache-from hub.pingcap.net/rc/tidb-dashboard-builder:cache-amd64 --push --platform=linux/amd64 --build-arg BUILDKIT_INLINE_CACHE=1 --progress=plain"
+                        sh "docker buildx build . -f build-tidb-dashboard.Dockerfile -t hub.pingcap.net/rc/tidb-dashboard:${params.ReleaseTag}-amd64 --cache-from hub.pingcap.net/rc/tidb-dashboard-builder:cache-amd64 --push --platform=linux/amd64 --build-arg BUILDKIT_INLINE_CACHE=1 --progress=plain --provenance=false"
                         sh """
                     docker pull hub.pingcap.net/rc/tidb-dashboard:${params.ReleaseTag}-amd64
                     docker run --platform=linux/amd64 --name=amd64 --entrypoint=/bin/cat  hub.pingcap.net/rc/tidb-dashboard:${params.ReleaseTag}-amd64
@@ -190,7 +190,7 @@ pipeline {
                         writeFile file:'build-tidb-dashboard.Dockerfile',text:dockerfile
                         sh 'cat build-tidb-dashboard.Dockerfile'
                         sh "docker buildx build . -f build-tidb-dashboard.Dockerfile -t hub.pingcap.net/rc/tidb-dashboard-builder:cache-arm64 --cache-from hub.pingcap.net/rc/tidb-dashboard-builder:cache-arm64 --target builder '--platform=linux/arm64' --build-arg 'BUILDKIT_INLINE_CACHE=1' --push"
-                        sh "docker buildx build . -f build-tidb-dashboard.Dockerfile -t hub.pingcap.net/rc/tidb-dashboard:${params.ReleaseTag}-arm64 --cache-from hub.pingcap.net/rc/tidb-dashboard-builder:cache-arm64 --push --platform=linux/arm64 --build-arg BUILDKIT_INLINE_CACHE=1 --progress=plain"
+                        sh "docker buildx build . -f build-tidb-dashboard.Dockerfile -t hub.pingcap.net/rc/tidb-dashboard:${params.ReleaseTag}-arm64 --cache-from hub.pingcap.net/rc/tidb-dashboard-builder:cache-arm64 --push --platform=linux/arm64 --build-arg BUILDKIT_INLINE_CACHE=1 --progress=plain --provenance=false"
                         sh """
                             docker pull hub.pingcap.net/rc/tidb-dashboard:${params.ReleaseTag}-arm64
                             docker run --platform=linux/arm64 --name=arm64 --entrypoint=/bin/cat  hub.pingcap.net/rc/tidb-dashboard:${params.ReleaseTag}-arm64


### PR DESCRIPTION
## Why:
- docker buildkit will now push attestation manifest by default, which will cause docker manifest fail. ref: https://docs.docker.com/build/attestations/

## How:
- disable attestation with commandline option