### PR TITLE
feat(tidb): optimize copr test ci

### DIFF
--- a/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -55,6 +55,10 @@ pipeline {
                         retry(2) {
                             script {
                                 component.checkout('https://github.com/tikv/copr-test.git', 'copr-test', REFS.base_ref, "", GIT_CREDENTIALS_ID)
+                                sh """
+                                git status
+                                git log -1
+                                """
                             }
                         }
                     }
@@ -94,7 +98,7 @@ pipeline {
                         make push-down-test
                     """
                 }
-            }               
+            }
         }
     }
 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -1,6 +1,6 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
-// should triggerd for master and latest release branches
+// should triggerd for master branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tidb"
@@ -53,24 +53,9 @@ pipeline {
                 dir("tikv-copr-test") {
                     cache(path: "./", includes: '**/*', key: "git/tikv/copr-test/rev-${REFS.base_sha}", restoreKeys: ['git/tikv/copr-test/rev-']) {
                         retry(2) {
-                            checkout(
-                                changelog: false,
-                                poll: false,
-                                scm: [
-                                    $class: 'GitSCM', branches: [[name: "${REFS.base_ref}" ]],
-                                    doGenerateSubmoduleConfigurations: false,
-                                    extensions: [
-                                        [$class: 'PruneStaleBranch'],
-                                        [$class: 'CleanBeforeCheckout'],
-                                        [$class: 'CloneOption', timeout: 15],
-                                    ],
-                                    submoduleCfg: [],
-                                    userRemoteConfigs: [[
-                                        refspec: "+refs/heads/*:refs/remotes/origin/*",
-                                        url: 'https://github.com/tikv/copr-test.git',
-                                    ]],
-                                ]
-                            )
+                            script {
+                                component.checkout('https://github.com/tikv/copr-test.git', 'copr-test', REFS.base_ref, "", GIT_CREDENTIALS_ID)
+                            }
                         }
                     }
                 }
@@ -79,16 +64,14 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/merged_mysql_test/rev-${BUILD_TAG}") {
-                        container("golang") {
-                            sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
-                            sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/*.sh
-                            ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/* bin/
-                            ls -alh bin/
-                            """
-                        }
+                    container("golang") {
+                        sh label: 'download binary', script: """
+                        chmod +x ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/*.sh
+                        ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                        mkdir -p bin
+                        mv third_bin/* bin/
+                        ls -alh bin/
+                        """
                     }
                 }
             }
@@ -97,13 +80,14 @@ pipeline {
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'  
-                    sh label: 'tikv-server', script: 'ls bin/tikv-server && chmod +x bin/tikv-server && ./bin/tikv-server -V'
-                    sh label: 'pd-server', script: 'ls bin/pd-server && chmod +x bin/pd-server && ./bin/pd-server -V'  
+                    sh label: 'print version', script: """
+                    chmod +x bin/*
+                    ./bin/tikv-server -V
+                    ./bin/pd-server -V
+                    """
                 }
                 dir('tikv-copr-test') {
-                    sh label: "Push Down Test", script: """
-                        #!/usr/bin/env bash
+                    sh label: "Push Down Test", script: """#!/usr/bin/env bash
                         pd_bin=${WORKSPACE}/tidb/bin/pd-server \
                         tikv_bin=${WORKSPACE}/tidb/bin/tikv-server \
                         tidb_src_dir=${WORKSPACE}/tidb \

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
@@ -8,12 +8,9 @@ spec:
       image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       tty: true
       resources:
-        requests:
-          memory: 12Gi
-          cpu: "4"
         limits:
-          memory: 16Gi
-          cpu: "6"
+          memory: 12Gi
+          cpu: "16"
     - name: net-tool
       image: wbitt/network-multitool
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
@@ -8,12 +8,9 @@ spec:
       image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       tty: true
       resources:
-        requests:
-          memory: 12Gi
-          cpu: "4"
         limits:
           memory: 16Gi
-          cpu: "6"
+          cpu: "16"
     - name: net-tool
       image: wbitt/network-multitool
       tty: true


### PR DESCRIPTION
*  Increase container cpu  limit to 16 core
* Optimize the checkout of copr-test code
* Remove unnecessary cache logic.

During the execution of the test, the actual CPU consumption was close to 18 cores.
<img width="983" alt="image" src="https://github.com/PingCAP-QE/ci/assets/16618216/bbb43a05-2e52-4b8e-803c-36894c776e45">
When the CPU limit is set to 6 cores, the following errors are often encountered.
```shell
2023/11/13 15:40:45 2023/11/13 15:39:56 Test fail: Outputs are not matching.
Test case: sql/randgen-topn/6_date_1.sql
Statement: #55 -  SELECT `col_varchar_1_key` - `col_double` AS field1, ADDTIME( 'l', `col_char_255` ) AS field2 FROM `table1000_int_autoinc` WHERE SUBTIME( ( FROM_UNIXTIME( 'hmpfzuuqajlvefkkbuhcxrpigdpfdstrrhanfbfvufhkdrpalxsuzsdsiqpucziftkqrwcmduexqzeqzixqczvwlcziytxzmsmmxfmwckuxpmldzdqosjfjtzstttgyicbqthjmmlrbpkhobcldwsbaysxmhtyodzdonjbhmgwjjzqisiqnbbbfxrfblzcyefeivbgrkqvfdnvf', ( TIMEDIFF( 3246, `col_tinyint` ) ) ) ), -22559 ) ORDER BY field1, field2 LIMIT 2 /* QNO 57 CON_ID 164 */ ;

NoPushDown Output: 
Error 1105: runtime error: invalid memory address or nil pointer dereference

WithPushDown Output: 
field1	field2
NULL	NULL
NULL	NULL

NoPushDown Plan: 
id	estRows	task	access object	operator info
Projection_7	2.00	root		minus(cast(push_down_test_db.table1000_int_autoinc.col_varchar_1_key, double BINARY), push_down_test_db.table1000_int_autoinc.col_double)->Column#62, addtime(l, push_down_test_db.table1000_int_autoinc.col_char_255)->Column#63
└─Projection_16	2.00	root		push_down_test_db.table1000_int_autoinc.col_varchar_1_key, push_down_test_db.table1000_int_autoinc.col_char_255, push_down_test_db.table1000_int_autoinc.col_double, push_down_test_db.table1000_int_autoinc.col_tinyint
  └─TopN_10	2.00	root		Column#64, Column#65, offset:0, count:2
    └─Projection_17	8000.00	root		push_down_test_db.table1000_int_autoinc.col_varchar_1_key, push_down_test_db.table1000_int_autoinc.col_char_255, push_down_test_db.table1000_int_autoinc.col_double, push_down_test_db.table1000_int_autoinc.col_tinyint, minus(cast(push_down_test_db.table1000_int_autoinc.col_varchar_1_key, double BINARY), push_down_test_db.table1000_int_autoinc.col_double)->Column#64, addtime(l, push_down_test_db.table1000_int_autoinc.col_char_255)->Column#65
      └─Selection_12	8000.00	root		subtime(from_unixtime(0, cast(timediff("3246", cast(push_down_test_db.table1000_int_autoinc.col_tinyint, var_string(20))), var_string(10))), "-22559")
        └─TableReader_14	10000.00	root		data:TableFullScan_13
          └─TableFullScan_13	10000.00	cop[tikv]	table:table1000_int_autoinc	keep order:false, stats:pseudo
WithPushDown Plan: 
id	estRows	task	access object	operator info
Projection_7	2.00	root		minus(cast(push_down_test_db.table1000_int_autoinc.col_varchar_1_key, double BINARY), push_down_test_db.table1000_int_autoinc.col_double)->Column#62, addtime(l, push_down_test_db.table1000_int_autoinc.col_char_255)->Column#63
└─Projection_16	2.00	root		push_down_test_db.table1000_int_autoinc.col_varchar_1_key, push_down_test_db.table1000_int_autoinc.col_char_255, push_down_test_db.table1000_int_autoinc.col_double, push_down_test_db.table1000_int_autoinc.col_tinyint
  └─TopN_10	2.00	root		Column#64, Column#65, offset:0, count:2
    └─Projection_17	8000.00	root		push_down_test_db.table1000_int_autoinc.col_varchar_1_key, push_down_test_db.table1000_int_autoinc.col_char_255, push_down_test_db.table1000_int_autoinc.col_double, push_down_test_db.table1000_int_autoinc.col_tinyint, minus(cast(push_down_test_db.table1000_int_autoinc.col_varchar_1_key, double BINARY), push_down_test_db.table1000_int_autoinc.col_double)->Column#64, addtime(l, push_down_test_db.table1000_int_autoinc.col_char_255)->Column#65
      └─Selection_12	8000.00	root		subtime(from_unixtime(0, cast(timediff("3246", cast(push_down_test_db.table1000_int_autoinc.col_tinyint, var_string(20))), var_string(10))), "-22559")
        └─TableReader_14	10000.00	root		data:TableFullScan_13
          └─TableFullScan_13	10000.00	cop[tikv]	table:table1000_int_autoinc	keep order:false, stats:pseudo
2023/11/13 15:40:45 Test summary: non-matching queries: 1, success queries: 836, skipped queries: 160
2023/11/13 15:40:45 Test summary(sql/randgen-topn/6_date_1.sql): Test case FAIL
```