### PR TITLE
fix(tidb/mergeci):  unstable test context will skip report

### DIFF
--- a/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
@@ -43,7 +43,7 @@ postsubmits:
       context: ci/integration-jdbc-test
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       max_concurrency: 1
-      skip_report: false
+      skip_report: true
       branches:
         - ^master$
     - name: pingcap/tidb/merged_integration_mysql_test
@@ -114,7 +114,7 @@ postsubmits:
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: ci/integration-nodejs-test
       max_concurrency: 1
-      skip_report: false
+      skip_report: true
       branches:
         - ^master$
     - name: pingcap/tidb/merged_mysql_client_test


### PR DESCRIPTION
Skip report context of some unstable test ci in mergeci.
* integration-jdbc-test
* integration-nodejs-test

After the relevant issues are fixed, the status reporting will be enabled.