### PR TITLE
fix: fix checkout submoudle in fail

### DIFF
--- a/pipelines/pingcap/tidb/latest/periodics_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/periodics_integration_test.groovy
@@ -77,12 +77,13 @@ pipeline {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${TARGET_BRANCH}", restoreKeys: ['git/pingcap/tidb/rev-']) {
                         retry(2) {
                             script {
-                                component.checkout('https://github.com/pingcap/tidb.git', 'tidb', TARGET_BRANCH, "")
+                                component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', TARGET_BRANCH, "", trunkBranch=TARGET_BRANCH, timeout=5, credentialsId="")
                                 sh label: "checkout tidb code", script: """
                                     git status
                                     git fetch origin ${TARGET_BRANCH}:local_${TARGET_BRANCH}
                                     git checkout local_${TARGET_BRANCH}
                                     git checkout -f ${tidb_commit_sha}
+                                    git status -s 
                                 """
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/periodics_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/periodics_integration_test.groovy
@@ -145,7 +145,6 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        options { timeout(time: 60, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {


### PR DESCRIPTION
Currently, the following errors may occur during the checkout stage. In fact, submodule code will not be used in the current pipeline, so here another checkout lib function is used.

```shell
ERROR: Error fetching remote repo 'origin'
hudson.plugins.git.GitException: Failed to fetch from https://github.com/pingcap/tidb.git
	at hudson.plugins.git.GitSCM.fetchFrom(GitSCM.java:999)
	at hudson.plugins.git.GitSCM.retrieveChanges(GitSCM.java:1241)
	at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1305)
	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep.checkout(SCMStep.java:129)
	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep$StepExecutionImpl.run(SCMStep.java:97)
	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep$StepExecutionImpl.run(SCMStep.java:84)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: hudson.plugins.git.GitException: org.eclipse.jgit.api.errors.TransportException: git@github.com:pingcap-inc/enterprise-extensions.git: remote hung up unexpectedly
```