### PR TITLE
fix(tiflash): add new param for build-common

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash_ghpr_build_release.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash_ghpr_build_release.groovy
@@ -34,7 +34,8 @@ def release_one_amd64(repo,hash) {
             string(name: "GIT_HASH", value: hash),
             string(name: "TARGET_BRANCH", value: ghprbTargetBranch),
             string(name: "GIT_PR", value: ghprbPullId),
-
+            string(name: "BUILD_ENV", value: ''),
+            string(name: "BUILDER_IMG", value: ''),
             [$class: 'BooleanParameterValue', name: 'FORCE_REBUILD', value: true],
     ]
     echo("default build params: ${paramsBuild}")


### PR DESCRIPTION
Add new param for build-common, relate to https://github.com/PingCAP-QE/ci/pull/2615.