### PR TITLE
remove tk-ctl and debug image

### DIFF
--- a/jenkins/pipelines/cd/tidb-operator.groovy
+++ b/jenkins/pipelines/cd/tidb-operator.groovy
@@ -9,7 +9,6 @@ def EnableE2E = false
 
 
 final CHART_ITEMS = 'tidb-operator tidb-cluster tidb-backup tidb-drainer tidb-lightning'
-final TOOLS_BUILD_DIR = 'output/tkctl'
 final CHARTS_BUILD_DIR = 'output/chart'
 final K8S_CLUSTER = "kubernetes"
 final K8S_NAMESPACE="jenkins-cd"
@@ -158,26 +157,6 @@ pipeline {
                                 sh "git status"
                                 sh "GOOS=linux GOARCH=arm64 make build"
                                 sh "GOOS=linux GOARCH=amd64 make build"
-                                // todo only x86
-                                sh "GOOS=linux GOARCH=amd64 make debug-build"
-
-                                script {
-                                    sh "mkdir -p ${TOOLS_BUILD_DIR}"
-                                    for (OS in ["linux", "darwin", "windows"]) {
-                                        for (ARCH in ["amd64", "arm64"]) {
-                                            if ("$OS/$ARCH" == "windows/arm64") {
-                                                // unsupported platform
-                                                continue
-                                            }
-                                            sh """
-                                            TKCTL_CLI_PACKAGE="tkctl-${OS}-${ARCH}-${ReleaseTag}"
-                                            GOOS=${OS} GOARCH=${ARCH} make cli
-                                            tar -czf ${TOOLS_BUILD_DIR}/\${TKCTL_CLI_PACKAGE}.tgz tkctl
-                                            sha256sum ${TOOLS_BUILD_DIR}/\${TKCTL_CLI_PACKAGE}.tgz > ${TOOLS_BUILD_DIR}/\${TKCTL_CLI_PACKAGE}.sha256
-                                            """
-                                        }
-                                    }
-                                }
                             }
                         }
                         stage("e2e bin") {
@@ -233,7 +212,7 @@ pipeline {
                         }
                         stage("stash") {
                             steps {
-                                stash name: "bin", includes: "Makefile,tests/images/e2e/bin/,images/,${TOOLS_BUILD_DIR}/,${CHARTS_BUILD_DIR}/,misc/images/"
+                                stash name: "bin", includes: "Makefile,tests/images/e2e/bin/,images/,${CHARTS_BUILD_DIR}/,misc/images/"
                             }
                         }
                     }
@@ -288,7 +267,7 @@ pipeline {
                             // todo only x86
                             steps {
                                 script {
-                                    ["debug-launcher", "tidb-control", "tidb-debug"].each {
+                                    [""tidb-control"].each {
                                         sh """
                                            docker buildx build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from hub.pingcap.net/rc/${it} --platform=linux/amd64 --push -t hub.pingcap.net/rc/${it}:${ReleaseTag} misc/images/${it}
                                            """
@@ -311,9 +290,8 @@ pipeline {
             }
             steps {
                 unstash "bin"
-                println("these images to publish are hub.pingcap.net/rc/[debug-launcher, tidb-control, tidb-debug, tidb-operator, tidb-backup-manager]:$ReleaseTag")
+                println("these images to publish are hub.pingcap.net/rc/[tidb-control, tidb-operator, tidb-backup-manager]:$ReleaseTag")
                 println("the charts to publish are in workspace $CHARTS_BUILD_DIR")
-                println("the tools to publish are in workspace $TOOLS_BUILD_DIR")
                 input("continue?")
             }
         }
@@ -335,7 +313,7 @@ pipeline {
                                 axes {
                                     axis {
                                         name 'component'
-                                        values 'debug-launcher', 'tidb-control', 'tidb-debug', 'tidb-operator', 'tidb-backup-manager'
+                                        values 'tidb-control', 'tidb-operator', 'tidb-backup-manager'
                                     }
                                 }
                                 stages {
@@ -471,29 +449,6 @@ pipeline {
                                     }
                                     sh "cat index.yaml"
                                     sh "upload_qiniu.py index.yaml index.yaml"
-                                }
-                            }
-                        }
-                        stage("tkcli") {
-                            environment {
-                                QINIU_BUCKET_NAME = "tidb";
-                            }
-                            steps {
-                                script {
-                                    for (OS in ["linux", "darwin", "windows"]) {
-                                        for (ARCH in ["amd64", "arm64"]) {
-                                            if ("$OS/$ARCH" == "windows/arm64") {
-                                                // unsupported platform
-                                                continue
-                                            }
-                                            sh """
-                                                TKCTL_CLI_PACKAGE="tkctl-${OS}-${ARCH}-${ReleaseTag}"
-                                                cd ${TOOLS_BUILD_DIR}
-                                                upload_qiniu.py \${TKCTL_CLI_PACKAGE}.tgz \${TKCTL_CLI_PACKAGE}.tgz
-                                                upload_qiniu.py \${TKCTL_CLI_PACKAGE}.sha256 \${TKCTL_CLI_PACKAGE}.sha256
-                                               """
-                                        }
-                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
ref https://github.com/pingcap/tidb-operator/pull/5420.

They have been deprecated for some time, and no need to release them in the previous release-* versions.