### PR TITLE
remove tidb-cluster and tidb-backup Helm chart for TiDB Operator CD

### DIFF
--- a/jenkins/pipelines/cd/tidb-operator.groovy
+++ b/jenkins/pipelines/cd/tidb-operator.groovy
@@ -8,7 +8,7 @@ def EnableE2E = false
 
 
 
-final CHART_ITEMS = 'tidb-operator tidb-cluster tidb-backup tidb-drainer tidb-lightning'
+final CHART_ITEMS = 'tidb-operator tidb-drainer tidb-lightning'
 final CHARTS_BUILD_DIR = 'output/chart'
 final K8S_CLUSTER = "kubernetes"
 final K8S_NAMESPACE="jenkins-cd"


### PR DESCRIPTION
remove `tidb-cluster` and `tidb-backup` Helm chart as they have been deprecated for a long time.

ref https://github.com/pingcap/tidb-operator/pull/5422