### PR TITLE
fix(tidb): archive log for all unsuccessful task

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -135,9 +135,9 @@ pipeline {
                                     str="$SCRIPT_AND_ARGS"
                                     logs_dir="logs_\${str// /_}"
                                     mkdir -p \${logs_dir}
-                                    mv pd*.log \${logs_dir}
-                                    mv tikv*.log \${logs_dir}
-                                    mv tests/integrationtest/integration-test.out \${logs_dir}
+                                    mv pd*.log \${logs_dir} || true
+                                    mv tikv*.log \${logs_dir} || true
+                                    mv tests/integrationtest/integration-test.out \${logs_dir} || true
                                     tar -czvf \${logs_dir}.tar.gz \${logs_dir}
                                     """
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -131,9 +131,9 @@ pipeline {
                                     str="$SCRIPT_AND_ARGS"
                                     logs_dir="logs_\${str// /_}"
                                     mkdir -p \${logs_dir}
-                                    mv pd*.log \${logs_dir}
-                                    mv tikv*.log \${logs_dir}
-                                    mv tests/integrationtest/integration-test.out \${logs_dir}
+                                    mv pd*.log \${logs_dir} || true
+                                    mv tikv*.log \${logs_dir} || true
+                                    mv tests/integrationtest/integration-test.out \${logs_dir} || true
                                     tar -czvf \${logs_dir}.tar.gz \${logs_dir}
                                     """
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)


### PR DESCRIPTION
* Currently, only when the task fails will it be archived. If the task times out or fails unstably, no logs can be collected.
* The logs generated by parallel tasks will overlap with each other, so here we first use tar to package the logs and then archive them.