### PR TITLE
chore: remove wip from ci context

### DIFF
--- a/prow-jobs/pingcap-tidb-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-presubmits.yaml
@@ -108,7 +108,7 @@ presubmits:
     - name: pingcap/tidb/pull_lightning_integration_test
       agent: jenkins
       decorate: false # need add this.
-      context: wip/pull-lightning-integration-test  # need remove wip/ after test passed.
+      context: pull-lightning-integration-test
       always_run: false
       optional: true
       skip_report: false


### PR DESCRIPTION
remove wip from ci context on `pull-lightning-integration-test`