### PR TITLE
feat(devbuild): support `ng-monitoring` and `tidb-dashboard` as component param

### DIFF
--- a/jenkins/jobs/cd/devbuild.groovy
+++ b/jenkins/jobs/cd/devbuild.groovy
@@ -24,7 +24,7 @@ pipelineJob('devbuild') {
     parameters {
         choiceParam {
             name('Product')
-            choices(['tidb', 'tikv', 'pd', 'tiflash', 'br', 'dumpling', 'tidb-lightning', 'ticdc', 'dm', 'tidb-binlog', 'tidb-tools'])
+            choices(['tidb', 'tikv', 'pd', 'tiflash', 'br', 'dumpling', 'tidb-lightning', 'ticdc', 'dm', 'tidb-binlog', 'tidb-tools', 'ng-monitoring', 'tidb-dashboard'])
             description('the product to build, e.g., tidb/tikv/pd')
         }
         stringParam {

--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -1,5 +1,5 @@
 final RepoDict = ["tidb":"tidb", "pd":"pd", "tiflash":"tics", "tikv":"tikv", "br":"tidb", "dumpling":"tidb", "tidb-lightning":"tidb", 
-    "ticdc":"tiflow", "dm":"tiflow", "tidb-binlog":"tidb-binlog", "tidb-tools":"tidb-tools", "ng-monitoring":"ng-monitoring"]
+    "ticdc":"tiflow", "dm":"tiflow", "tidb-binlog":"tidb-binlog", "tidb-tools":"tidb-tools", "ng-monitoring":"ng-monitoring", "tidb-dashboard":"tidb-dashboard"]
 final FileserverDownloadURL = "https://fileserver.pingcap.net/download"
 
 def GitHash = ''

--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -1,4 +1,5 @@
-final RepoDict = ["tidb":"tidb", "pd":"pd", "tiflash":"tics", "tikv":"tikv", "br":"tidb", "dumpling":"tidb", "tidb-lightning":"tidb", "ticdc":"tiflow", "dm":"tiflow", "tidb-binlog":"tidb-binlog", "tidb-tools":"tidb-tools"]
+final RepoDict = ["tidb":"tidb", "pd":"pd", "tiflash":"tics", "tikv":"tikv", "br":"tidb", "dumpling":"tidb", "tidb-lightning":"tidb", 
+    "ticdc":"tiflow", "dm":"tiflow", "tidb-binlog":"tidb-binlog", "tidb-tools":"tidb-tools", "ng-monitoring":"ng-monitoring"]
 final FileserverDownloadURL = "https://fileserver.pingcap.net/download"
 
 def GitHash = ''


### PR DESCRIPTION
# Why:
- support ng-monitoring and tidb-dashboard as params for devbuild

# How:
- avoid simple failing because of param
- detail implementation will be in another PR