### PR TITLE
fix: ignore error if tar logs fail

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -138,7 +138,7 @@ pipeline {
                                     mv pd*.log \${logs_dir} || true
                                     mv tikv*.log \${logs_dir} || true
                                     mv tests/integrationtest/integration-test.out \${logs_dir} || true
-                                    tar -czvf \${logs_dir}.tar.gz \${logs_dir}
+                                    tar -czvf \${logs_dir}.tar.gz \${logs_dir} || true
                                     """
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
                                 }

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -134,7 +134,7 @@ pipeline {
                                     mv pd*.log \${logs_dir} || true
                                     mv tikv*.log \${logs_dir} || true
                                     mv tests/integrationtest/integration-test.out \${logs_dir} || true
-                                    tar -czvf \${logs_dir}.tar.gz \${logs_dir}
+                                    tar -czvf \${logs_dir}.tar.gz \${logs_dir} || true
                                     """
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
                                 }


### PR DESCRIPTION
ignore error if tar logs fail.

<img width="847" alt="image" src="https://github.com/PingCAP-QE/ci/assets/16618216/003ac457-e3f5-4e3c-b12f-99ebf031a7ee">
