### PR TITLE
chore: disable merged-e2e-test report

### DIFF
--- a/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
@@ -7,7 +7,7 @@ postsubmits:
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: ci/e2e-test
       max_concurrency: 1
-      skip_report: false
+      skip_report: true
       branches:
         - ^master$
     - name: pingcap/tidb/merged_common_test


### PR DESCRIPTION
merged-e2e-test is unstable recently, @pingyu is working on this. We temporarily disable the status reporting , and will enable it again after testing and fixing stability.