### PR TITLE
feat: add 7.5 to lts

### DIFF
--- a/jenkins/pipelines/cd/tiup/tiup-package-offline-mirror-6.0.0.groovy
+++ b/jenkins/pipelines/cd/tiup/tiup-package-offline-mirror-6.0.0.groovy
@@ -6,7 +6,7 @@ if (DEBUG_MODE == "true") {
 
 }
 
-lts_versions = ["v6.1","v6.5","v7.1"]
+lts_versions = ["v6.1","v6.5","v7.1","v7.5"]
 
 def is_lts_version = { version ->
     for (lts_version in lts_versions) {


### PR DESCRIPTION
Why:
- 7.5 is lts
- while in publishing 7.5.0, we already rerun with this change