### PR TITLE
chore: disable report 

### DIFF
--- a/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-postsubmits.yaml
@@ -61,7 +61,7 @@ postsubmits:
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: ci/sqllogic-test
       max_concurrency: 1
-      skip_report: false
+      skip_report: true
       branches:
         - ^master$
     - name: pingcap/tidb/merged_integration_copr_test


### PR DESCRIPTION
merged-sqllogic-test the testing is not very stable. Reporting is temporarily disabled. It will be enabled after the testing is fixed.