### PR TITLE
feat: support target image path

### DIFF
--- a/jenkins/jobs/cd/devbuild.groovy
+++ b/jenkins/jobs/cd/devbuild.groovy
@@ -84,6 +84,11 @@ pipelineJob('devbuild') {
             defaultValue('')
         }
         stringParam {
+            name('TargetImg')
+            description('optional target image path')
+            defaultValue('')
+        }
+        stringParam {
             name('TiBuildID')
             description('the ID of TiBuild object, just leave empty if you do not know')
         }

--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -97,6 +97,9 @@ spec:
                     def date = new Date()
                     PipelineStartAt =new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(date)
                     Image = "hub.pingcap.net/devbuild/$ProductForDocker:$Version-$BUILD_NUMBER"
+                    if (params.TargetImg!=""){
+                        Image = params.TargetImg
+                    }
                     ImageForGcr = "gcr.io/pingcap-public/dbaas/$ProductForDocker:$Version-$BUILD_NUMBER-dev"
                     if (params.IsHotfix.toBoolean()){
                         Image = "hub.pingcap.net/qa/$ProductForDocker:$Version-$BUILD_NUMBER"


### PR DESCRIPTION
# Why:
- support given target image path for some cron jobs to be easier