### PR TITLE
chore: adjust timeout for tidb ci

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     environment {
@@ -106,7 +106,7 @@ pipeline {
                 stages {
                     stage('Test')  {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
-                        options { timeout(time: 45, unit: 'MINUTES') }
+                        options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {


### PR DESCRIPTION
Currently, Bazel will retry three times by default. If the timeout is set to "long", each timeout limit for each attempt is 15 minutes. If there are timeout issues with the case, when it reaches three timeouts, the entire task will be terminated will cause the test logs to not be output to stdout.

So here we will increase the timeout for the entire task by five minutes.

PS: At the same time, it would be better to adjust the bazel timeout (`long` -> `moderate `) for testing.