### PR TITLE
feat: optimize ci repo fetch

### DIFF
--- a/jobs/pingcap/tidb/latest/canary_ghpr_unit_test.groovy
+++ b/jobs/pingcap/tidb/latest/canary_ghpr_unit_test.groovy
@@ -22,10 +22,12 @@ pipelineJob('pingcap/tidb/canary_ghpr_unit_test') {
                 git{
                     remote {
                         url('https://github.com/PingCAP-QE/ci.git')
+                        refspec('+refs/heads/main:refs/remotes/origin/main') 
                     }
-                    branch('main')
+                    branch('refs/heads/main')
                     extensions {
                         cloneOptions {
+                            noTags(true)
                             depth(1)
                             shallow(true)
                             timeout(5)


### PR DESCRIPTION
To optimize ci repo fetch. First, use this task for testing to reduce the bandwidth consumption of fetch.