### PR TITLE
fix: solve yum install slow for centos 8

### DIFF
--- a/jenkins/Dockerfile/release/linux-arm64/enterprise/tidb
+++ b/jenkins/Dockerfile/release/linux-arm64/enterprise/tidb
@@ -1,7 +1,4 @@
-FROM pingcap/centos-stream:8
-RUN set -e && \
-    dnf install bind-utils curl nmap-ncat -y && \
-    dnf clean all
+FROM pingcap/tidb-base:centos8
 COPY tidb-server /tidb-server
 COPY audit-1.so /plugins/audit-1.so
 COPY whitelist-1.so /plugins/whitelist-1.so

--- a/jenkins/Dockerfile/release/linux-arm64/tidb
+++ b/jenkins/Dockerfile/release/linux-arm64/tidb
@@ -1,7 +1,4 @@
-FROM pingcap/centos-stream:8
-RUN set -e && \
-    dnf install bind-utils curl nmap-ncat -y && \
-    dnf clean all
+FROM pingcap/tidb-base:centos8
 COPY tidb-server /tidb-server
 EXPOSE 4000
 ENTRYPOINT ["/tidb-server"]


### PR DESCRIPTION
# Why:
- yum install is very slow because centos has been deprecated.(usually 1 hour)

# How:
- use dockerfile from https://github.com/PingCAP-QE/artifacts/blob/main/dockerfiles/bases/tidb-base/release-6.5.Dockerfile
- sync it to dockerhub to avoid any network problem