### PR TITLE
pd_real_cluster: remove cd to specific dir

### DIFF
--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
@@ -73,7 +73,6 @@ pipeline {
             steps {
                 dir('pd') {
                     sh label: "PD Real Cluster Check", script: """
-                        cd tests/integrations/realtiup
                         make check
                     """
                 }

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
@@ -73,7 +73,7 @@ pipeline {
             steps {
                 dir('pd') {
                     sh label: "PD Real Cluster Check", script: """
-                        make check
+                        make test-real-cluster
                     """
                 }
             }


### PR DESCRIPTION
after https://github.com/tikv/pd/pull/7567 merged we can remove `cd` operator