### PR TITLE
debug: test optional

### DIFF
--- a/prow-jobs/pingcap-qe-ci-presubmits.yaml
+++ b/prow-jobs/pingcap-qe-ci-presubmits.yaml
@@ -19,6 +19,26 @@ presubmits:
               limits:
                 memory: 128Mi
                 cpu: 200m
+    - name: pull-verify-optional
+      decorate: true
+      max_concurrency: 1
+      always_run: false
+      optional: false
+      branches:
+        - main
+      spec:
+        containers:
+          - name: main
+            image: wbitt/network-multitool
+            command: [bash, -ce]
+            args:
+              - |
+                echo "This is a optional job, it will always fail."
+                exit 1
+            resources:
+              limits:
+                memory: 128Mi
+                cpu: 200m
     - name: pull-verify-prow-jobs
       decorate: true
       extra_refs:


### PR DESCRIPTION
I need to verify such a scenario, where a presumbit is set with two parameters
```shell
      always_run: false
      optional: false
```
what i want: 
1.  it can be merged normally for PRs that have not triggered this task.
2. it can be block merged for PRs that have not triggered this task and this task failed.