### PR TITLE
tiproxy: add more tiproxy jobs

### DIFF
--- a/jobs/pingcap/tiproxy/OWNERS
+++ b/jobs/pingcap/tiproxy/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - purelind
+  - wuhuizuo
+  - djshow832
+  - xhebox
+approvers:
+  - purelind
+  - wuhuizuo
+  - djshow832
+  - xhebox

--- a/jobs/pingcap/tiproxy/latest/OWNERS
+++ b/jobs/pingcap/tiproxy/latest/OWNERS
@@ -1,6 +1,4 @@
 reviewers: []
 approvers:
-  - purelind
-  - wuhuizuo
   - djshow832
   - xhebox

--- a/jobs/pingcap/tiproxy/latest/OWNERS
+++ b/jobs/pingcap/tiproxy/latest/OWNERS
@@ -1,8 +1,4 @@
-reviewers:
-  - purelind
-  - wuhuizuo
-  - djshow832
-  - xhebox
+reviewers: []
 approvers:
   - purelind
   - wuhuizuo

--- a/jobs/pingcap/tiproxy/latest/ghpr_build.groovy
+++ b/jobs/pingcap/tiproxy/latest/ghpr_build.groovy
@@ -1,0 +1,39 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/tiproxy/ghpr_build') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tiproxy")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tiproxy/latest/ghpr_build.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/tiproxy/latest/ghpr_check.groovy
+++ b/jobs/pingcap/tiproxy/latest/ghpr_check.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/tiproxy/ghpr_check') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tiproxy")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tiproxy/latest/ghpr_check.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/tiproxy/latest/ghpr_unit_test.groovy
+++ b/jobs/pingcap/tiproxy/latest/ghpr_unit_test.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/tiproxy/ghpr_unit_test') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tiproxy")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tiproxy/latest/ghpr_unit_test.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tiproxy/OWNERS
+++ b/pipelines/pingcap/tiproxy/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - purelind
+  - wuhuizuo
+  - djshow832
+  - xhebox
+approvers:
+  - purelind
+  - wuhuizuo
+  - djshow832
+  - xhebox

--- a/pipelines/pingcap/tiproxy/cd/OWNERS
+++ b/pipelines/pingcap/tiproxy/cd/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - lijie0123
+  - wuhuizuo
+reviewers:
+  - wuhuizuo
+  - purelind

--- a/pipelines/pingcap/tiproxy/latest/OWNERS
+++ b/pipelines/pingcap/tiproxy/latest/OWNERS
@@ -1,6 +1,4 @@
 reviewers: []
 approvers:
-  - purelind
-  - wuhuizuo
   - djshow832
   - xhebox

--- a/pipelines/pingcap/tiproxy/latest/OWNERS
+++ b/pipelines/pingcap/tiproxy/latest/OWNERS
@@ -1,8 +1,4 @@
-reviewers:
-  - purelind
-  - wuhuizuo
-  - djshow832
-  - xhebox
+reviewers: []
 approvers:
   - purelind
   - wuhuizuo

--- a/pipelines/pingcap/tiproxy/latest/ghpr_build.groovy
+++ b/pipelines/pingcap/tiproxy/latest/ghpr_build.groovy
@@ -1,0 +1,66 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'pingcap/tiproxy'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiproxy/latest/pod-ghpr_build.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 15, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+        skipDefaultCheckout()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 5, unit: 'MINUTES') }
+            steps {
+                dir("tiproxy") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                dir('tiproxy') {
+                    sh '''
+                        make
+                    '''
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tiproxy/latest/ghpr_check.groovy
+++ b/pipelines/pingcap/tiproxy/latest/ghpr_check.groovy
@@ -1,0 +1,62 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master and latest releases branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'pingcap/tiproxy'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiproxy/latest/pod-ghpr_check.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    ls -l /dev/null
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            steps {
+                dir('tiproxy') {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        script {
+                            git.setSshKey(GIT_CREDENTIALS_ID)
+                            retry(2) {
+                                prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("Checks") {
+            steps {
+                dir('tiproxy') {
+                    sh script: 'make lint build'
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tiproxy/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/ghpr_unit_test.groovy
@@ -1,0 +1,72 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master and latest releases branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'pingcap/tiproxy'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiproxy/latest/pod-ghpr_unit_test.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    ls -l /dev/null
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            steps {
+                dir('tiproxy') {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        script {
+                            git.setSshKey(GIT_CREDENTIALS_ID)
+                            retry(2) {
+                                prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("Checks") {
+            environment { CODECOV_TOKEN = credentials('codecov-token-tiproxy') }
+            steps {
+                dir('tiproxy') {
+                    sh script: 'make test'
+                }
+            }
+            post {
+                success {
+                    dir("tiproxy") {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
@@ -1,0 +1,123 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'PingCAP-QE/tidb-test'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiproxy/latest/pod-merged_mysql_test.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 45, unit: 'MINUTES')
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    ls -l /dev/null
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 5, unit: 'MINUTES') }
+            steps {
+                dir("tiproxy") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+                dir("tidb-test") {
+                    cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
+                        retry(2) {
+                            script {
+                                component.checkoutV2('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', "master", REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir('tiproxy') {
+                    sh label: 'tiproxy', script: 'ls bin/tiproxy || make'
+                }
+                dir('tidb-test') {
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-mysql-test") {
+                        sh "touch ws-${BUILD_TAG}"
+                        sh label: 'prepare thirdparty binary', script: """
+                        chmod +x download_binary.sh
+                        ./download_binary.sh --tidb=master --pd=master --tikv=master
+                        cp ../tiproxy/bin/tiproxy ./bin/
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tiproxy --version
+                        """
+                    }
+                }
+            }
+        }
+        stage('MySQL Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'PART'
+                        values '1', '2', '3', '4'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        defaultContainer 'golang'
+                        yamlFile POD_TEMPLATE_FILE
+                    }
+                }
+                stages {
+                    stage("Test") {
+                        steps {
+                            dir('tidb-test') {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-mysql-test") {
+                                    sh label: "PART ${PART}", script: """
+                                        #!/usr/bin/env bash
+                                        make deploy-mysqltest ARGS="-b -x -c y -s tikv -p ${PART}"
+                                    """
+                                }
+                            }
+                        }
+                        post{
+                            always {
+                                junit(testResults: "**/result.xml")
+                            }
+                        }
+                    }
+                }
+            }        
+        }
+    }
+}

--- a/pipelines/pingcap/tiproxy/latest/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-ghpr_build.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+spec:
+    securityContext:
+        fsGroup: 1000
+    containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      tty: true
+      resources:
+          requests:
+              memory: 8Gi
+              cpu: "4"
+          limits:
+              memory: 8Gi
+              cpu: "4"
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+          limits:
+              memory: 128Mi
+              cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+          limits:
+              memory: 256Mi
+              cpu: 100m
+    affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - amd64

--- a/pipelines/pingcap/tiproxy/latest/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-ghpr_check.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+spec:
+    securityContext:
+        fsGroup: 1000
+    containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      tty: true
+      resources:
+          requests:
+              memory: 8Gi
+              cpu: "4"
+          limits:
+              memory: 8Gi
+              cpu: "4"
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+          limits:
+              memory: 128Mi
+              cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+          limits:
+              memory: 256Mi
+              cpu: 100m
+    affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - amd64

--- a/pipelines/pingcap/tiproxy/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-ghpr_unit_test.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+spec:
+    securityContext:
+        fsGroup: 1000
+    containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      tty: true
+      resources:
+          requests:
+              memory: 8Gi
+              cpu: "4"
+          limits:
+              memory: 8Gi
+              cpu: "4"
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+          limits:
+              memory: 128Mi
+              cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+          limits:
+              memory: 256Mi
+              cpu: 100m
+    affinity:
+        nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - amd64

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_common_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_ruby_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_ruby_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_mysql_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_mysql_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_mysql_test.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        requests:
+          memory: 8Gi
+          cpu: "4"
+        limits:
+          memory: 24Gi
+          cpu: "8"
+    - name: net-tool
+      image: wbitt/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_ruby_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_ruby_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       securityContext:
         privileged: true
       tty: true

--- a/prow-jobs/pingcap-tiproxy-latest-postsubmits.yaml
+++ b/prow-jobs/pingcap-tiproxy-latest-postsubmits.yaml
@@ -1,6 +1,15 @@
 # struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Postsubmit
 postsubmits:
   pingcap/tiproxy:
+    - name: pingcap/tiproxy/merged_mysql_test
+      agent: jenkins
+      decorate: false # need add this.
+      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      context: merged-mysql-test # need change this.
+      max_concurrency: 1
+      skip_report: false
+      branches:
+        - ^main$
     - name: pingcap/tiproxy/merged_integration_prisma_test
       agent: jenkins
       decorate: false # need add this.

--- a/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
-      context: idc-jenkins-ci-tiproxy/check_dev
+      context: idc-jenkins-ci-tiproxy/check
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(check|all)(?: .*?)?$"
       rerun_command: "/test check"

--- a/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
@@ -42,8 +42,8 @@ presubmits:
       run_before_merge: true
       context: pull-mysql-connector-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(pull-mysql-connector-test|all)(?: .*?)?$"
-      rerun_command: "/test pull-mysql-connector-test"
+      trigger: "(?m)^/test (?:.*? )?(mysql-connector-test|all)(?: .*?)?$"
+      rerun_command: "/test mysql-connector-test"
       branches:
         - ^main$
     - name: pingcap/tiproxy/pull_mysql_test
@@ -53,8 +53,8 @@ presubmits:
       context: pull-mysql-test
       skip_report: false
       optional: true
-      trigger: "(?m)^/test (?:.*? )?pull-mysql-test(?: .*?)?$"
-      rerun_command: "/test pull-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?mysql-test(?: .*?)?$"
+      rerun_command: "/test mysql-test"
       branches:
         - ^main$
     - name: pingcap/tiproxy/pull_integration_jdbc_test
@@ -64,8 +64,8 @@ presubmits:
       context: pull-integration-jdbc-test # need change this.
       skip_report: false
       optional: true
-      trigger: "(?m)^/test (?:.*? )?pull-integration-jdbc-test(?: .*?)?$"
-      rerun_command: "/test pull-integration-jdbc-test"
+      trigger: "(?m)^/test (?:.*? )?integration-jdbc-test(?: .*?)?$"
+      rerun_command: "/test integration-jdbc-test"
       branches:
         - ^main$
     - name: pingcap/tiproxy/pull_integration_common_test
@@ -74,8 +74,8 @@ presubmits:
       always_run: false
       context: pull-integration-common-test # need change this.
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?pull-integration-common-test(?: .*?)?$"
-      rerun_command: "/test pull-integration-common-test"
+      trigger: "(?m)^/test (?:.*? )?integration-common-test(?: .*?)?$"
+      rerun_command: "/test integration-common-test"
       branches:
         - ^main$
     - name: pingcap/tiproxy/pull_integration_ruby_orm_test
@@ -84,8 +84,8 @@ presubmits:
       always_run: false  
       context: pull-integration-ruby-orm-test # need change this.
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?pull-integration-ruby-orm-test(?: .*?)?$"
-      rerun_command: "/test pull-integration-ruby-orm-test"
+      trigger: "(?m)^/test (?:.*? )?integration-ruby-orm-test(?: .*?)?$"
+      rerun_command: "/test integration-ruby-orm-test"
       branches:
         - ^main$
     - name: pingcap/tiproxy/pull_integration_prisma_test
@@ -95,8 +95,8 @@ presubmits:
       context: pull-integration-prisma-test
       skip_report: false
       optional: true
-      trigger: "(?m)^/test (?:.*? )?pull-integration-prisma-test(?: .*?)?$"
-      rerun_command: "/test pull-integration-prisma-test"
+      trigger: "(?m)^/test (?:.*? )?integration-prisma-test(?: .*?)?$"
+      rerun_command: "/test integration-prisma-test"
       branches:
         - ^main$
     - name: pingcap/tiproxy/pull_integration_python_orm_test
@@ -106,8 +106,8 @@ presubmits:
       context: pull-integration-python-orm-test
       skip_report: false
       optional: true
-      trigger: "(?m)^/test (?:.*? )?pull-integration-python-orm-test(?: .*?)?$"
-      rerun_command: "/test pull-integration-python-orm-test"
+      trigger: "(?m)^/test (?:.*? )?integration-python-orm-test(?: .*?)?$"
+      rerun_command: "/test integration-python-orm-test"
       branches:
         - ^main$
     - name: pingcap/tiproxy/pull_integration_sequelize_test
@@ -117,8 +117,8 @@ presubmits:
       context: pull-integration-sequelize-test
       skip_report: false
       optional: true
-      trigger: "(?m)^/test (?:.*? )?pull-integration-sequelize-test(?: .*?)?$"
-      rerun_command: "/test pull-integration-sequelize-test"
+      trigger: "(?m)^/test (?:.*? )?integration-sequelize-test(?: .*?)?$"
+      rerun_command: "/test integration-sequelize-test"
       branches:
         - ^main$
     - name: pingcap/tiproxy/pull_sqllogic_test
@@ -128,7 +128,7 @@ presubmits:
       context: pull-sqllogic-test
       skip_report: false
       optional: true
-      trigger: "(?m)^/test (?:.*? )?pull-sqllogic-test(?: .*?)?$"
-      rerun_command: "/test pull-sqllogic-test"
+      trigger: "(?m)^/test (?:.*? )?sqllogic-test(?: .*?)?$"
+      rerun_command: "/test sqllogic-test"
       branches:
         - ^main$

--- a/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
-      context: idc-jenkins-ci-tiproxy/build
+      context: pull-build
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(build|all)(?: .*?)?$"
       rerun_command: "/test build"
@@ -17,7 +17,7 @@ presubmits:
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
-      context: idc-jenkins-ci-tiproxy/check
+      context: pull-check
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(check|all)(?: .*?)?$"
       rerun_command: "/test check"
@@ -28,7 +28,7 @@ presubmits:
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
-      context: idc-jenkins-ci-tiproxy/unit-test
+      context: pull-unit-test
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(unit-test|all)(?: .*?)?$"
       rerun_command: "/test unit-test"

--- a/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tiproxy-latest-presubmits.yaml
@@ -1,15 +1,37 @@
 # struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Presubmit
 presubmits:
   pingcap/tiproxy:
-    - name: pingcap/tiproxy/pull_mysql_test
+    - name: pingcap/tiproxy/ghpr_build
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
-      context: pull-mysql-test
+      context: idc-jenkins-ci-tiproxy/build
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(pull-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test pull-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(build|all)(?: .*?)?$"
+      rerun_command: "/test build"
+      branches:
+        - ^main$
+    - name: pingcap/tiproxy/ghpr_check
+      agent: jenkins
+      decorate: false # need add this.
+      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      run_before_merge: true
+      context: idc-jenkins-ci-tiproxy/check_dev
+      skip_report: false
+      trigger: "(?m)^/test (?:.*? )?(check|all)(?: .*?)?$"
+      rerun_command: "/test check"
+      branches:
+        - ^main$
+    - name: pingcap/tiproxy/ghpr_unit_test
+      agent: jenkins
+      decorate: false # need add this.
+      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      run_before_merge: true
+      context: idc-jenkins-ci-tiproxy/unit-test
+      skip_report: false
+      trigger: "(?m)^/test (?:.*? )?(unit-test|all)(?: .*?)?$"
+      rerun_command: "/test unit-test"
       branches:
         - ^main$
     - name: pingcap/tiproxy/pull_mysql_connector_test
@@ -22,6 +44,17 @@ presubmits:
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(pull-mysql-connector-test|all)(?: .*?)?$"
       rerun_command: "/test pull-mysql-connector-test"
+      branches:
+        - ^main$
+    - name: pingcap/tiproxy/pull_mysql_test
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false
+      context: pull-mysql-test
+      skip_report: false
+      optional: true
+      trigger: "(?m)^/test (?:.*? )?pull-mysql-test(?: .*?)?$"
+      rerun_command: "/test pull-mysql-test"
       branches:
         - ^main$
     - name: pingcap/tiproxy/pull_integration_jdbc_test


### PR DESCRIPTION
- Add more tiproxy jobs:
  - build: make
  - check: make lint build
  - unit_test: make test & upload code coverage
- Move mysql_test from presubmit to postsubmit because it may fail when TiDB PR is not merged
- Update the golang versions of some tests from 1.20 to 1.21
- Add OWNERS files to tiproxy directories
