### PR TITLE
feat(tiproxy): disable docker build flow

### DIFF
--- a/jenkins/jobs/cd/tiproxy_docker.groovy
+++ b/jenkins/jobs/cd/tiproxy_docker.groovy
@@ -1,4 +1,6 @@
-pipelineJob('tiproxy-docker') {
+pipelineJob('tiproxy-docker') {    
+    disabled(true)
+    description('[Deprecated] it will automatic build and publish with new CD flows')
     definition {
         cpsScm {
             lightweight(true)


### PR DESCRIPTION
Now:
- image will published in repo: `hub.pingcap.net/pingcap/tiproxy/image`
- binaries will published in repo: `hub.pingcap.net/pingcap/tiproxy/package`
   - It can be list with the [link](https://internal.do.pingcap.net:30443/dl/oci-files/hub.pingcap.net/pingcap/tiproxy/package?tag=main-release_linux_arm64) for get latest `main`'s linux/arm64 binaries.
   - Then download it with url: https://internal.do.pingcap.net:30443/dl/oci-file/hub.pingcap.net/pingcap/tiproxy/package?tag=main-release_linux_arm64&file=tiproxy-v0.1.2-13-gec65e0f-linux-arm64.tar.gz

