### PR TITLE
fix: use internal image to avoid dockerhub rate limit

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_build.yaml
@@ -42,7 +42,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2_debug.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2_debug.yaml
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2_v2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2_v2.yaml
@@ -17,7 +17,7 @@ spec:
         - name: containerinfo
           mountPath: /etc/containerinfo
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -41,7 +41,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_build.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_build.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
@@ -12,7 +12,7 @@ spec:
           memory: 12Gi
           cpu: "20"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_ddl_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_nodejs_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_mysql_client_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_mysql_client_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 16Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml
@@ -49,7 +49,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
@@ -47,7 +47,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-periodics_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-periodics_integration_test.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_common_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
@@ -12,7 +12,7 @@ spec:
           memory: 16Gi
           cpu: "20"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_mysql_client_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_mysql_client_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 16Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_tiflash_test.yaml
@@ -49,7 +49,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_build.yaml
@@ -27,7 +27,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check.yaml
@@ -27,7 +27,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check2.yaml
@@ -27,7 +27,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_mysql_test.yaml
@@ -27,7 +27,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_unit_test.yaml
@@ -27,7 +27,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.1/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-pull_br_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_build.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check2.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_mysql_test.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_unit_test.yaml
@@ -47,7 +47,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_build.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check2.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_mysql_test.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_unit_test.yaml
@@ -47,7 +47,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_build.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check2.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_mysql_test.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_unit_test.yaml
@@ -47,7 +47,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_build.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check2.yaml
@@ -40,7 +40,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_mysql_test.yaml
@@ -22,7 +22,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_unit_test.yaml
@@ -41,7 +41,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-pull_br_integration_test.yaml
@@ -18,7 +18,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_build.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_check2.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_mysql_test.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_unit_test.yaml
@@ -41,7 +41,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_mysql_test.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
@@ -41,7 +41,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_br_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_build.yaml
@@ -42,7 +42,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml
@@ -42,7 +42,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_mysql_test.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_unit_test.yaml
@@ -44,7 +44,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_build.yaml
@@ -37,7 +37,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_check.yaml
@@ -40,7 +40,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_check2.yaml
@@ -37,7 +37,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_mysql_test.yaml
@@ -20,7 +20,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_unit_test.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_build.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check.yaml
@@ -40,7 +40,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_mysql_test.yaml
@@ -20,7 +20,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
@@ -41,7 +41,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.2/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.2/pod-ghpr_build.yaml
@@ -42,7 +42,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.2/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.2/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.2/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.2/pod-ghpr_check2.yaml
@@ -42,7 +42,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.2/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.2/pod-ghpr_mysql_test.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.2/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.2/pod-ghpr_unit_test.yaml
@@ -44,7 +44,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.3/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.3/pod-ghpr_build.yaml
@@ -42,7 +42,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.3/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.3/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.3/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.3/pod-ghpr_check2.yaml
@@ -42,7 +42,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.3/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.3/pod-ghpr_mysql_test.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.3/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.3/pod-ghpr_unit_test.yaml
@@ -44,7 +44,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.3/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.3/pod-pull_br_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.4/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.4/pod-ghpr_build.yaml
@@ -42,7 +42,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.4/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.4/pod-ghpr_check.yaml
@@ -45,7 +45,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.4/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.4/pod-ghpr_check2.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.4/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.4/pod-ghpr_mysql_test.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.4/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.4/pod-ghpr_unit_test.yaml
@@ -41,7 +41,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.4/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.4/pod-pull_br_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_build.yaml
@@ -37,7 +37,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check.yaml
@@ -40,7 +40,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
@@ -39,7 +39,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_mysql_test.yaml
@@ -20,7 +20,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml
@@ -41,7 +41,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
@@ -41,7 +41,7 @@ spec:
         name: "volume-7"
         readOnly: false
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
@@ -82,7 +82,7 @@ spec:
           cpu: "500m"
           memory: "500Mi"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
@@ -72,7 +72,7 @@ spec:
         name: "volume-7"
         readOnly: false
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
@@ -105,7 +105,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
@@ -27,7 +27,7 @@ spec:
           cpu: "6"
       command: ["bin/pulsar", "standalone"]
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_engine_integration_test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: volume-tmp
           mountPath: /tmp
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-5.3/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-5.3/pod-ghpr_verify.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-5.3/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-5.3/pod-pull_cdc_integration_kafka_test.yaml
@@ -113,7 +113,7 @@ spec:
         - mountPath: "/home/jenkins"
           name: volume-1
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-5.3/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-5.3/pod-pull_cdc_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-5.3/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-5.3/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-5.3/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-5.3/pod-pull_dm_integration_test.yaml
@@ -55,7 +55,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-5.4/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-5.4/pod-ghpr_verify.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-5.4/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-5.4/pod-pull_cdc_integration_kafka_test.yaml
@@ -113,7 +113,7 @@ spec:
         - mountPath: "/home/jenkins"
           name: volume-1
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-5.4/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-5.4/pod-pull_cdc_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-5.4/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-5.4/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-5.4/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-5.4/pod-pull_dm_integration_test.yaml
@@ -55,7 +55,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.0/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.0/pod-ghpr_verify.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.1/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.1/pod-ghpr_verify.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.1/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.1/pod-pull_cdc_integration_kafka_test.yaml
@@ -113,7 +113,7 @@ spec:
         - mountPath: "/home/jenkins"
           name: volume-1
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.1/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.1/pod-pull_cdc_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.1/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.1/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.1/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.1/pod-pull_dm_integration_test.yaml
@@ -55,7 +55,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.2/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.2/pod-ghpr_verify.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-ghpr_verify.yaml
@@ -20,7 +20,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_kafka_test.yaml
@@ -105,7 +105,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_test.yaml
@@ -18,7 +18,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_integration_test.yaml
@@ -56,7 +56,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-ghpr_verify.yaml
@@ -20,7 +20,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -105,7 +105,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_integration_test.yaml
@@ -55,7 +55,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1.0/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pod-pull_cdc_integration_storage_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-ghpr_verify.yaml
@@ -20,7 +20,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_kafka_test.yaml
@@ -105,7 +105,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_storage_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_engine_integration_test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: volume-tmp
           mountPath: /tmp
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-ghpr_verify.yaml
@@ -20,7 +20,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_kafka_test.yaml
@@ -105,7 +105,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_storage_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_integration_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_engine_integration_test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: volume-tmp
           mountPath: /tmp
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-ghpr_verify.yaml
@@ -20,7 +20,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_kafka_test.yaml
@@ -105,7 +105,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_storage_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_integration_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_engine_integration_test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: volume-tmp
           mountPath: /tmp
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-ghpr_verify.yaml
@@ -25,7 +25,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_kafka_test.yaml
@@ -105,7 +105,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_mysql_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_pulsar_test.yaml
@@ -27,7 +27,7 @@ spec:
           cpu: "6"
       command: ["bin/pulsar", "standalone"]
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_storage_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_integration_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_engine_integration_test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: volume-tmp
           mountPath: /tmp
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-ghpr_verify.yaml
@@ -20,7 +20,7 @@ spec:
         - name: gopathcache
           mountPath: /share/.go
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -105,7 +105,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml
@@ -27,7 +27,7 @@ spec:
           cpu: "6"
       command: ["bin/pulsar", "standalone"]
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_storage_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_compatibility_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml
@@ -53,7 +53,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_engine_integration_test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: volume-tmp
           mountPath: /tmp
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-ghpr_build.yaml
@@ -15,7 +15,7 @@ spec:
               memory: 8Gi
               cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
           limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-ghpr_check.yaml
@@ -15,7 +15,7 @@ spec:
               memory: 8Gi
               cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
           limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-ghpr_unit_test.yaml
@@ -15,7 +15,7 @@ spec:
               memory: 8Gi
               cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
           limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_common_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_common_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_jdbc_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_prisma_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_prisma_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_python_orm_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_ruby_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_ruby_orm_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_sequelize_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_sequelize_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_mysql_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_sqllogic_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_sqllogic_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_common_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_jdbc_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_prisma_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_prisma_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_python_orm_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_ruby_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_ruby_orm_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_sequelize_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_sequelize_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_connector_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_connector_test.yaml
@@ -29,7 +29,7 @@ spec:
           memory: 16Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_sqllogic_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:


### PR DESCRIPTION
use internal image to avoid dockerhub rate limit.