### PR TITLE
fix: use internal image to avoid dockerhub rate limit

### DIFF
--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_build.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_build.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_common_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_common_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_common_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_common_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_jdbc_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_jdbc_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_nodejs_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_nodejs_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_python_orm_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_python_orm_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_common_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_common_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_jdbc_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_jdbc_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_mysql_connector_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_mysql_connector_test.yaml
@@ -29,7 +29,7 @@ spec:
           memory: 16Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_ruby_orm_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_ruby_orm_test.yaml
@@ -27,7 +27,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/release-6.0/pod-ghpr_build.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/release-6.0/pod-ghpr_build.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/release-6.0/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/release-6.0/pod-ghpr_integration_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/release-6.0/pod-ghpr_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/release-6.0/pod-ghpr_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/release-6.1/pod-ghpr_build.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/release-6.1/pod-ghpr_build.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/release-6.1/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/release-6.1/pod-ghpr_integration_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/release-6.1/pod-ghpr_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/release-6.1/pod-ghpr_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/release-6.2/pod-ghpr_build.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/release-6.2/pod-ghpr_build.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/release-6.2/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/release-6.2/pod-ghpr_integration_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/PingCAP-QE/tidb-test/release-6.2/pod-ghpr_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/release-6.2/pod-ghpr_mysql_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "8"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/ti-community-infra/test-prod/pod-prow_debug.yaml
+++ b/pipelines/ti-community-infra/test-prod/pod-prow_debug.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/migration/latest/pod-pull_integration_test.yaml
+++ b/pipelines/tikv/migration/latest/pod-pull_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/migration/latest/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/migration/latest/pod-pull_unit_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/pd/latest/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/latest/pod-ghpr_build.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/pd/release-6.5-fips/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-6.5-fips/pod-ghpr_build.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/pd/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-6.5/pod-ghpr_build.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/pd/release-7.1/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-7.1/pod-ghpr_build.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/pd/release-7.1/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/release-7.1/pod-pull_integration_copr_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/tikv/latest/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/latest/pod-pull_unit_test.yaml
@@ -25,7 +25,7 @@ spec:
         name: "volume-tmp"
         readOnly: false
     - name: net-tool
-      image: wbitt/network-multitool
+      image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:


### PR DESCRIPTION
 use internal image to avoid dockerhub rate limit.