### PR TITLE
feat: add tiproxy for v7.6.0 later

### DIFF
--- a/jenkins/pipelines/cd/tiup/tiup-package-offline-mirror-6.0.0.groovy
+++ b/jenkins/pipelines/cd/tiup/tiup-package-offline-mirror-6.0.0.groovy
@@ -36,13 +36,17 @@ def clone_server_package = { arch, dst ->
     if (VERSION>="v6.6.0"){
         dashboard_package =  " --tidb-dashboard $VERSION"
     }
+    def tiproxy_package = ""
+    if (VERSION>="v7.6.0"){
+        dashboard_package =  " --tiproxy latest"
+    }
     sh """
     tiup mirror set https://tiup-mirrors.pingcap.com
     tiup mirror clone $dst --os linux --arch ${arch} --tidb $VERSION --tikv $VERSION \
     --tiflash $VERSION --pd $VERSION --ctl $VERSION --grafana $VERSION --alertmanager latest \
     --blackbox_exporter latest --prometheus $VERSION --node_exporter latest \
     --tiup latest --cluster latest  --insight latest --diag latest --influxdb latest \
-    --playground latest $dashboard_package
+    --playground latest $dashboard_package $tiproxy_package
     """
 }
 

--- a/jenkins/pipelines/cd/tiup/tiup-package-offline-mirror-6.0.0.groovy
+++ b/jenkins/pipelines/cd/tiup/tiup-package-offline-mirror-6.0.0.groovy
@@ -38,7 +38,7 @@ def clone_server_package = { arch, dst ->
     }
     def tiproxy_package = ""
     if (VERSION>="v7.6.0"){
-        dashboard_package =  " --tiproxy latest"
+        tiproxy_package =  " --tiproxy latest"
     }
     sh """
     tiup mirror set https://tiup-mirrors.pingcap.com


### PR DESCRIPTION
Why:
- add tiproxy latest to server tiup offline package since v7.6.0