### PR TITLE
Fix building tiflash using clang-17 docker image

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-build-common.groovy
@@ -279,6 +279,11 @@ def checkoutStage(repo_path, checkout_target) {
                 """
             }
             checkoutTiFlash(checkout_target, true)
+            sh """
+            git version
+            git config --global --add safe.directory /home/jenkins/agent/workspace/tiflash-build-common/tiflash/contrib/tiflash-proxy
+            git config --global --add safe.directory /home/jenkins/agent/workspace/tiflash-build-common/tiflash
+            """
         }
         sh label: "Print build information", script: """
         set +x
@@ -604,6 +609,10 @@ def cmakeConfigureTiFlash(repo_path, build_dir, install_dir, proxy_cache_ready) 
     """
     dir(build_dir) {
         sh """
+            git version
+            git config --global --add safe.directory /home/jenkins/agent/workspace/tiflash-build-common/tiflash/contrib/tiflash-proxy
+            git config --global --add safe.directory /home/jenkins/agent/workspace/tiflash-build-common/tiflash
+
             cmake '${repo_path}' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
                 -G '${generator}' \\
                 -DENABLE_FAILPOINTS=${params.ENABLE_FAILPOINTS} \\


### PR DESCRIPTION
Try to build tiflash using clang-17 docker image https://github.com/pingcap/tiflash/pull/8537

But the CI will run into errors like https://ci.pingcap.net/job/tiflash-build-common/33843/console
```
[2023-12-30T15:06:42.887Z] + git log -1 --format=%H
[2023-12-30T15:06:42.887Z] fatal: detected dubious ownership in repository at '/home/jenkins/agent/workspace/tiflash-build-common/tiflash/contrib/tiflash-proxy'
[2023-12-30T15:06:42.887Z] To add an exception for this directory, call:
```
```
23:16:59  fatal: detected dubious ownership in repository at '/home/jenkins/agent/workspace/tiflash-build-common/tiflash'
23:16:59  To add an exception for this directory, call:
23:16:59  
23:16:59  	git config --global --add safe.directory /home/jenkins/agent/workspace/tiflash-build-common/tiflash
23:16:59  CMake Error at dbms/cmake/version.cmake:20 (execute_process):
23:16:59    execute_process failed command indexes:
23:16:59  
23:16:59      1: "Child return code: 128"
23:16:59  
23:16:59  Call Stack (most recent call first):
23:16:59    dbms/CMakeLists.txt:25 (include)
```

Add git safe.directory to workaround the errors. After these changes, the pipeline can build tiflash with clang-17 successfully: https://ci.pingcap.net/job/tiflash-build-common/33844/consoleFull