### PR TITLE
feat(scripts/ops): add script static-prow-jobs.ts

### DIFF
--- a/scripts/ops/statics-prow-jobs.ts
+++ b/scripts/ops/statics-prow-jobs.ts
@@ -1,0 +1,105 @@
+interface prowJobRun {
+  spec: {
+    type: string;
+    agent: string;
+    cluster: string;
+    namespace: string;
+    job: string;
+    refs?: {
+      org: string;
+      repo: string;
+      base_ref: string;
+    };
+  };
+  report: boolean;
+  status: {
+    state: string;
+    startTime: string;
+    completionTime: string;
+  };
+}
+
+async function main() {
+  const res = await fetch(
+    "https://prow.tidb.net/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec",
+  );
+  const js = await res.text();
+  const list = js.replace(/^var\s+allBuilds\s*=\s*/g, "").replace(/;$/, "");
+  const data = JSON.parse(list) as { items: prowJobRun[] };
+  const runs = data.items;
+  const groupedRuns = runs.reduce((acc, run) => {
+    if (!run.spec.refs) {
+      return acc;
+    }
+    const key =
+      `${run.spec.refs?.org}/${run.spec.refs?.repo}/${run.spec.refs?.base_ref}|${run.spec.job}`;
+    if (!acc[key]) {
+      acc[key] = [];
+    }
+    acc[key].push(run);
+    return acc;
+  }, {} as { [key: string]: prowJobRun[] });
+
+  const cols = [
+    "repo",
+    "branch",
+    "job_type",
+    "job_name",
+    "success_count",
+    "failure_count",
+    "success_rate",
+    "avg_timecost_minutes",
+  ];
+
+  console.log(cols.join(", "));
+  for (const [_, runs] of Object.entries(groupedRuns)) {
+    // print the job info
+    const fullRepo = `${runs[0].spec.refs?.org}/${runs[0].spec.refs?.repo}`;
+    const branch = runs[0].spec.refs?.base_ref;
+    const jobType = runs[0].spec.type;
+    const job = runs[0].spec.job;
+
+    // static the succeeded and failed count and timecost
+    const groupedState = runs.reduce((acc, run) => {
+      const key = run.status.state;
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      acc[key].push(run);
+      return acc;
+    }, {} as { [key: string]: prowJobRun[] });
+    // failure | success
+
+    const successRuns = groupedState["success"] || [];
+    const failedRuns = groupedState["failure"] || [];
+
+    let successRate = 0;
+    if (successRuns.length > 0) {
+      successRate = successRuns.length /
+        (successRuns.length + failedRuns.length);
+    }
+    const totalTimecostsMsOfsucceededRuns = successRuns.reduce((acc, run) => {
+      const startTime = new Date(run.status.startTime).getTime();
+      const completionTime = new Date(run.status.completionTime).getTime();
+      return acc + (completionTime - startTime);
+    }, 0);
+    const avgTimecostMinutes = totalTimecostsMsOfsucceededRuns /
+      successRuns.length / 60000;
+
+    const values = [
+      fullRepo,
+      branch,
+      jobType,
+      job,
+      successRuns.length,
+      failedRuns.length,
+      successRate,
+      avgTimecostMinutes,
+    ];
+    console.log(values.join(", "));
+  }
+}
+
+// Should run it weekly.
+await main();
+console.log("~~~~~~~~~~~end~~~~~~~~~~~~~~");


### PR DESCRIPTION
Run with:
```bash
deno run --allow-net ./scripts/ops/statics-prow-jobs.ts
```

results:
```csv
repo, branch, job_type, job_name, success_count, failure_count, success_rate, avg_timecost_minutes
pingcap/tiflow, master, presubmit, pingcap/tiflow/pull_dm_integration_test, 47, 25, 0.6527777777777778, 35.430851063829785
pingcap/tidb, master, presubmit, pingcap/tidb/ghpr_build, 270, 120, 0.6923076923076923, 32.98759259259259
pingcap/tidb, master, presubmit, pingcap/tidb/pull_integration_ddl_test, 373, 45, 0.8923444976076556, 15.359830205540662
pingcap/tidb, master, presubmit, pingcap/tidb/ghpr_check, 298, 130, 0.6962616822429907, 19.887639821029083
pingcap/tidb, master, presubmit, pingcap/tidb/ghpr_check2, 283, 122, 0.6987654320987654, 27.266902237926974
pingcap/tidb, master, presubmit, pingcap/tidb/ghpr_mysql_test, 372, 60, 0.8611111111111112, 13.632437275985664
pingcap/tidb, master, presubmit, pingcap/tidb/ghpr_unit_test, 260, 223, 0.5383022774327122, 15.202307692307691
pingcap/tidb, master, presubmit, pingcap/tidb/pull_mysql_client_test, 440, 32, 0.9322033898305084, 6.793333333333333
```