### PR TITLE
ci: fix rust tool chain file name for rust-rocksdb

### DIFF
--- a/jenkins/pipelines/ci/rust-rocksdb/rust_rocksdb_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/rust-rocksdb/rust_rocksdb_ghpr_test.groovy
@@ -1,7 +1,7 @@
 pullId = params.get("ghprbPullId")
 commit = params.get("ghprbActualCommit")
 
-toolchain = "https://raw.githubusercontent.com/tikv/tikv/master/rust-toolchain"
+toolchain = "https://raw.githubusercontent.com/tikv/tikv/master/rust-toolchain.toml"
 common_features = "encryption,portable"
 x86_features = "jemalloc,sse"
 arm_features = "jemalloc"
@@ -70,8 +70,8 @@ def checkout() {
                     git submodule update
 
                     # sync rust-toolchain with TiKV
-                    curl ${toolchain} > ./rust-toolchain
-                    cat ./rust-toolchain
+                    curl ${toolchain} > ./rust-toolchain.toml
+                    cat ./rust-toolchain.toml
                 """
             }
             stash includes: "rust-rocksdb/**", name: "rust-rocksdb", useDefaultExcludes: false


### PR DESCRIPTION
The toolchain file name has been changed from `rust-toolchain` to `rust-toolchain.toml`