### PR TITLE
fix: operator git commit

### DIFF
--- a/jenkins/pipelines/cd/tidb-operator.groovy
+++ b/jenkins/pipelines/cd/tidb-operator.groovy
@@ -189,6 +189,7 @@ pipeline {
                                             namespace K8S_NAMESPACE
                                         }
                                     }
+                                    environment {GIT_COMMIT = "$GitHash";}
                                     steps{ dir("operator"){
                                         checkout changelog: false, poll: false, scm: [
                                                 $class           : 'GitSCM',
@@ -206,6 +207,7 @@ pipeline {
                                     }}
                                 }
                                 stage("amd64"){
+                                    environment {GIT_COMMIT = "$GitHash";}
                                     steps {
                                         sh """git status
                                         printenv ENABLE_FIPS


### PR DESCRIPTION
# Why:
- arm binary now use independent arm builder for fips
- we need export GIT_COMMIT every time or it would be overwrited by jenkins