### PR TITLE
feat(tiflow): add tiflow postsubmit

### DIFF
--- a/jobs/pingcap/tiflow/latest/merged_unit_test.groovy
+++ b/jobs/pingcap/tiflow/latest/merged_unit_test.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/tiflow/merged_unit_test') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        githubProjectUrl("https://github.com/pingcap/tiflow")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tiflow/latest/merged_unit_test.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
@@ -1,0 +1,111 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master and latest release branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 40, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir("tiflow") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_CMD'
+                        values "dm_unit_test_in_verify_ci", "unit_test_in_verify_ci", "engine_unit_test_in_verify_ci"
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        yamlFile POD_TEMPLATE_FILE
+                        defaultContainer 'golang'
+                    }
+                } 
+                stages {
+                    stage("Test") {
+                        options { timeout(time: 40, unit: 'MINUTES') }
+                        environment { 
+                            CODECOV_TOKEN = credentials('codecov-token-tiflow')   
+                        }
+                        steps {
+                            dir('tiflow') {
+                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
+                                    sh label: "${TEST_CMD}", script: """
+                                        make ${TEST_CMD}
+                                    """
+                                }
+                            }
+                        }
+                        post {
+                            success {
+                                dir('tiflow') {
+                                    script {
+                                        def testConfigs = [
+                                            dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
+                                            unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/tidb_cdc_test/cov.unit.out"],
+                                            engine_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/engine_test/cov.unit_test.out"]
+                                        ]
+                                        def config = testConfigs[TEST_CMD]
+                                        if (config && config.coverage_file) {
+                                            prow.uploadCoverageToCodecov(REFS, config.flags, config.coverage_file)
+                                        }
+                                    }
+                                }
+                            }
+                            always {
+                                junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)  
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
+        limits:
+          memory: 16Gi
+          cpu: "6"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/prow-jobs/kustomization.yaml
+++ b/prow-jobs/kustomization.yaml
@@ -33,6 +33,7 @@ configMapGenerator:
       - pingcap-tidb-test-release-6.0-presubmits.yaml
       - pingcap-tidb-test-release-6.1-presubmits.yaml
       - pingcap-tidb-test-release-6.2-presubmits.yaml
+      - pingcap-tiflow-latest-postsubmits.yaml
       - pingcap-tiflow-latest-presubmits-wip.yaml
       - pingcap-tiflow-latest-presubmits.yaml
       - pingcap-tiflow-release-5.3-presubmits.yaml

--- a/prow-jobs/pingcap-tiflow-latest-postsubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-latest-postsubmits.yaml
@@ -1,0 +1,12 @@
+# struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Postsubmit
+postsubmits:
+  pingcap/tiflow:
+    - name: pingcap/tiflow/merged_unit_test
+      agent: jenkins
+      decorate: false # need add this.
+      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      context: ci/unit-test
+      max_concurrency: 1
+      skip_report: false
+      branches:
+        - ^master$

--- a/prow-jobs/pingcap-tiflow-latest-postsubmits.yaml
+++ b/prow-jobs/pingcap-tiflow-latest-postsubmits.yaml
@@ -7,6 +7,6 @@ postsubmits:
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: ci/unit-test
       max_concurrency: 1
-      skip_report: false
+      skip_report: true # change this after test passed
       branches:
         - ^master$


### PR DESCRIPTION
* Add tiflow postsubmit jobs.
* Add merged_unit_test to run unit tests and upload code coverage to codecov.io.
* Currently, coverage data is uploaded in tiflow PR, but the reporting data on master is missing, causing codecov bot to indicate a decrease in coverage.