### PR TITLE
tiproxy: fix container for nodejs test

### DIFF
--- a/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
@@ -13,7 +13,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yamlFile POD_TEMPLATE_FILE
-            defaultContainer 'golang'
+            defaultContainer 'nodejs'
         }
     }
     environment {

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
@@ -13,7 +13,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yamlFile POD_TEMPLATE_FILE
-            defaultContainer 'golang'
+            defaultContainer 'nodejs'
         }
     }
     environment {


### PR DESCRIPTION
The container was wrong:
https://prow.tidb.net/log?job=pingcap/tiproxy/merged_integration_nodejs_test&id=1747866918376706052