### PR TITLE
chore(tidb): adjust timeout for check_dev2

### DIFF
--- a/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     environment {
@@ -106,7 +106,7 @@ pipeline {
                 stages {
                     stage('Test')  {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
-                        options { timeout(time: 60, unit: 'MINUTES') }
+                        options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {


### PR DESCRIPTION
adjust timeout for check_dev2, from 30min to 65mins (same as master branch)