### PR TITLE
tikv-migration: collect logs with -maxdepth 2

### DIFF
--- a/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
@@ -119,10 +119,10 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tikv_cdc_test/
-                                    tar -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tikv_cdc_test/ -type f -name "*.log")    
-                                    ls -alh  log-${TEST_GROUP}.tar.gz  
+                                    tar -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tikv_cdc_test/ -maxdepth 2 -type f -name "*.log")
+                                    ls -alh log-${TEST_GROUP}.tar.gz
                                 """
-                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true 
+                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                         }
                     }

--- a/pipelines/tikv/migration/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_test.groovy
@@ -103,6 +103,16 @@ pipeline {
                                }
                             }
                         }
+                        post {
+                            failure {
+                                sh label: "collect logs", script: """
+                                    ls /tmp/tikv_cdc_test/
+                                    tar -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tikv_cdc_test/ -maxdepth 2 -type f -name "*.log")
+                                    ls -alh log-${TEST_GROUP}.tar.gz
+                                """
+                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Changes

- Collect logs with `-maxdepth 2` to exclude WAL of TiKV & PD and reduce artifact size
- Add collect logs for `pull_integration_test` pipeline.