### PR TITLE
tikv-migration: increase pipeline timeout

### DIFF
--- a/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 25, unit: 'MINUTES') }
+                        options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('migration') {
                                cache(path: "./cdc", includes: '**/*', key: "ws/${BUILD_TAG}/tikvcdc") {

--- a/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 40, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
         skipDefaultCheckout()
     }

--- a/pipelines/tikv/migration/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 25, unit: 'MINUTES') }
+                        options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('migration') {
                                cache(path: "./cdc", includes: '**/*', key: "ws/${BUILD_TAG}/tikvcdc") { 

--- a/pipelines/tikv/migration/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 40, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
         skipDefaultCheckout()
     }


### PR DESCRIPTION
### Changes

For tikv-migration CDC pipelines:

- Increase timeout from `40` to `65` minutes 
  - Original `40 minues` is not sufficient. See https://do.pingcap.net/jenkins/blue/organizations/jenkins/tikv%2Fmigration%2Fpull_integration_kafka_test/detail/pull_integration_kafka_test/28/pipeline/261/.
- Increase timeout of `Test` stage from `25` to `45` minutes 