### PR TITLE
feat: checkout enterprise-plugin with branch release-x.y.z

### DIFF
--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -13,7 +13,7 @@ def computeBranchFromPR(String keyInComment, String prTargetBranch, String prCom
     final featureBranchReg = /^feature[\/_].*/
 
     // the components that will created the patch release branch when version released: release-X.Y.Z
-    final componentsSupportPatchReleaseBranch = ['tidb-test']
+    final componentsSupportPatchReleaseBranch = ['tidb-test', 'plugin']
 
     def componentBranch = prTargetBranch
     // example pr tilte : "feat: add new feature | tidb=pr/123"


### PR DESCRIPTION
To ensure the consistency of dependency package versions between tidb and plugin, for tidb branch like release-6.1-20231229-v6.1.7, checkout plugin with branch release-6.1.7