### PR TITLE
fix(tiflow): update pull_dm_compatibility_test.groovy

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -90,7 +90,10 @@ pipeline {
                                 echo "build binary for previous version"
                                 git fetch origin ${REFS.base_ref}:local
                                 git checkout local
-                                git rev-parse HEAD
+                                # git rev-parse HEAD
+                                # revert this later
+                                git checkout e51f517655ed7f27035721c35760b99ff698c82d
+                                git status
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous


### PR DESCRIPTION
revert this pr after https://github.com/pingcap/tiflow/pull/10631 merged.