### PR TITLE
use custom golang and pulsar docker image to run ticdc pulsar integration tests

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,27 +5,15 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:pulsar-test"
       tty: true
       resources:
         requests:
-          memory: 12Gi
-          cpu: "4"
+          memory: 16Gi
+          cpu: "8"
         limits:
           memory: 16Gi
-          cpu: "6"
-    - name: pulsar
-      image: "apachepulsar/pulsar:2.10.4"
-      imagePullPolicy: IfNotPresent
-      tty: true
-      resources:
-        requests:
-          memory: 4Gi
-          cpu: "4"
-        limits:
-          memory: 6Gi
-          cpu: "6"
-      command: ["bin/pulsar", "standalone"]
+          cpu: "8"
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -143,16 +143,6 @@ pipeline {
                         steps {
                             dir('tiflow') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    // TODO: currently we encounter some issue when using pulsar container to run shell script
-                                    // so we comment out this part now.
-                                    // container("pulsar") {
-                                    //     timeout(time: 6, unit: 'MINUTES') {
-                                    //         sh label: "Waiting for pulsar ready", script: """
-                                    //             echo "Waiting for pulsar to be ready..."
-                                    //             while ! nc -z localhost 6650; do sleep 10; done
-                                    //         """
-                                    //     }
-                                    // }
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
                                         chmod +x ./tests/integration_tests/run_group.sh


### PR DESCRIPTION
use custom golang and pulsar docker image to run ticdc pulsar integration tests. relate to https://github.com/pingcap/tiflow/pull/10654.