### PR TITLE
chore: update prometheus version to 2.49.1

### DIFF
--- a/jenkins/pipelines/cd/tiup/prometheus-tiup-mirror-update.groovy
+++ b/jenkins/pipelines/cd/tiup/prometheus-tiup-mirror-update.groovy
@@ -2,7 +2,11 @@ def name="ng-monitoring"
 def ng_monitoring_sha1
 
 def download = { version, os, arch ->
-    if (os == "darwin" && arch == "arm64") {
+    if (version >= "2.49.1"){
+        sh """
+        wget -qnc "https://github.com/prometheus/prometheus/releases/download/v${version}/prometheus-${version}.${os}-${arch}.tar.gz"
+        """
+    } else if (os == "darwin" && arch == "arm64") {
         sh """
         curl -O ${FILE_SERVER_URL}/download/pingcap/prometheus-${version}.${os}-${arch}.tar.gz
         """
@@ -180,11 +184,17 @@ run_with_pod {
                 }
             }
         }
-
-        if (RELEASE_TAG >="v5.3.0" || RELEASE_TAG =="nightly" ) {
+        if (RELEASE_TAG >="v8.0.0" || RELEASE_TAG =="nightly" ){
+            VERSION = "2.49.1"
+        }else if (RELEASE_TAG >="v5.3.0" ) {
             VERSION = "2.27.1"
         }
-
+        def MAC_ARM_VER = ""
+        if (RELEASE_TAG >="v8.0.0" || RELEASE_TAG =="nightly" ){
+            MAC_ARM_VER = "2.49.1"
+        }else if (RELEASE_TAG >="v5.1.0"){
+            MAC_ARM_VER = "2.28.1"
+        }
         if (params.ARCH_X86) {
             stage("linux/amd64"){
                 update VERSION, "linux", "amd64"
@@ -201,10 +211,10 @@ run_with_pod {
             }
         }
         if (params.ARCH_MAC_ARM) {
-            if (RELEASE_TAG >="v5.1.0" || RELEASE_TAG =="nightly") {
+            if (MAC_ARM_VER) {
                 stage("darwin/arm64"){
                     // prometheus did not provide the binary we need so we upgrade it.
-                    update "2.28.1", "darwin", "arm64"
+                    update MAC_ARM_VER, "darwin", "arm64"
                 }
             }
         }


### PR DESCRIPTION
# Why:
- v8.0.0 later will use prometheus version to 2.49.1, keep the same as https://github.com/PingCAP-QE/artifacts/blob/32b627f679746b7d1b521c9d630b99ed27ec6fa8/packages/packages.yaml.tmpl#L229

# Testing:
- tested via rerun https://cd.pingcap.net/blue/organizations/jenkins/prometheus-tiup-mirror-update/detail/prometheus-tiup-mirror-update/275/pipeline