### PR TITLE
Remove TiKV useless features

### DIFF
--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_clippy_linux_arm64.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_clippy_linux_arm64.groovy
@@ -39,7 +39,7 @@ try {
                         git checkout -f ${ghprbActualCommit}
                         echo using gcc 8
                         source /opt/rh/devtoolset-8/enable
-                        ENABLE_FEATURES="test-engines-panic cloud-aws nortcheck" NO_DEFAULT_TEST_ENGINES=1 NO_CLOUD=1 make clippy
+                        ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
                     """
                 }
             }


### PR DESCRIPTION
https://github.com/tikv/tikv/pull/16602 is going to remove "cloud-aws", "cloud-gcp", and "cloud-azure". 