### PR TITLE
add grafana panel for tiproxy

### DIFF
--- a/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update-test.groovy
+++ b/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update-test.groovy
@@ -53,6 +53,7 @@ def pack = { version, os, arch ->
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/blackbox_exporter.json || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/node.json || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/kafka.json || true; \
+    wget -qnc https://raw.githubusercontent.com/pingcap/tiproxy/main/pkg/metrics/grafana/tiproxy_summary.json || true; \
     if [ ${RELEASE_TAG} \\> "v5.2.0" ] || [ ${RELEASE_TAG} == "v5.2.0" ]; then \
         wget -qnc https://raw.githubusercontent.com/pingcap/tidb/${tag}/br/metrics/grafana/lightning.json || true; \
         wget -qnc https://raw.githubusercontent.com/pingcap/tidb/${tag}/br/metrics/grafana/br.json || true; \

--- a/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update-test.groovy
+++ b/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update-test.groovy
@@ -53,7 +53,6 @@ def pack = { version, os, arch ->
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/blackbox_exporter.json || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/node.json || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/grafana/kafka.json || true; \
-    wget -qnc https://raw.githubusercontent.com/pingcap/tiproxy/main/pkg/metrics/grafana/tiproxy_summary.json || true; \
     if [ ${RELEASE_TAG} \\> "v5.2.0" ] || [ ${RELEASE_TAG} == "v5.2.0" ]; then \
         wget -qnc https://raw.githubusercontent.com/pingcap/tidb/${tag}/br/metrics/grafana/lightning.json || true; \
         wget -qnc https://raw.githubusercontent.com/pingcap/tidb/${tag}/br/metrics/grafana/br.json || true; \

--- a/jenkins/pipelines/cd/tiup/prometheus-tiup-mirror-update.groovy
+++ b/jenkins/pipelines/cd/tiup/prometheus-tiup-mirror-update.groovy
@@ -96,7 +96,8 @@ def pack = { version, os, arch ->
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/blacker.rules.yml || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/bypass.rules.yml || true; \
     wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/kafka.rules.yml || true; \
-    wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/node.rules.yml || true;
+    wget -qnc https://raw.githubusercontent.com/pingcap/monitoring/master/platform-monitoring/ansible/rule/node.rules.yml || true; \
+    wget -qnc https://raw.githubusercontent.com/pingcap/tiproxy/main/pkg/metrics/alertmanager/tiproxy.rules.yml || true;
 
 
     cd ..


### PR DESCRIPTION
Add the grafana panel for tiproxy.

The tag for TiProxy is different with that of TiDB, so always fetch the latest one.