### PR TITLE
fix(jenkins/pipelines/cd/atom-jobs): avoid useless clonings of CI repo

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/jenkins-image-syncer.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/jenkins-image-syncer.groovy
@@ -16,7 +16,10 @@ pipeline{
             defaultContainer 'regctl'
         }
     }
-    options { retry(3) }
+    options { 
+      skipDefaultCheckout true
+      retry(3)
+    }
     stages{
       stage("login gcr") {
         environment { HUB = credentials('gcr-registry-key') }


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>