### PR TITLE
feat: support checkout tidb-test with pr in batch merge

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -59,7 +59,7 @@ pipeline {
                     cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
                         retry(2) {
                             script {
-                                component.checkout('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                                component.checkoutSupportBatch('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
                             }
                         }
                     }
@@ -124,7 +124,7 @@ pipeline {
                         }
                     }
                 }
-            }        
+            }
         }
     }
     post {


### PR DESCRIPTION
When checking out the tidb-test code, it is necessary to determine whether the tidb-test PR has been specified based on the tidb pr title. During batch merge, multiple tidb PRs will be processed simultaneously. At this checkout step, we need to obtain all tidb pr titles to determine if the tidb-test PR has been specified.

Which situation is not allowed?
during batch merge, it is not allowed to specify the tidb-test branch or commit in the pr title for checking out code.

