### PR TITLE
fix: disable some old tiflow pipeline trigger

### DIFF
--- a/jenkins/jobs/ci2/pingcap/tiflow/cdc_ghpr_integration_test.groovy
+++ b/jenkins/jobs/ci2/pingcap/tiflow/cdc_ghpr_integration_test.groovy
@@ -22,11 +22,9 @@ pipelineJob('cdc_ghpr_integration_test') {
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')
                     whitelist("")
                     orgslist("pingcap")
-                    blackListTargetBranches {
-                        ghprbBranch { branch('master') }
-                        ghprbBranch { branch('^(release-)?5\\.[3-4]\\d*(\\.\\d+)?(\\-.*)?$') }
-                        ghprbBranch { branch('^(release-)?6\\.[1|5]\\d*(\\.\\d+)?(\\-.*)?$') }
-                        ghprbBranch { branch('^(release-)?7\\.[1-9]\\d*(\\.\\d+)?(\\-.*)?$') }
+                    whiteListTargetBranches {
+                        ghprbBranch { branch('^(release-)?4\\.\\d+(\\.\\d+)?(\\-.*)?$') }
+                        ghprbBranch { branch('^(release-)?[5]\\.[0-2](\\.\\d+)?(\\-.*)?$') }
                     }
                     // ignore when only those file changed.(
                     //   multi line regex

--- a/jenkins/jobs/ci2/pingcap/tiflow/cdc_ghpr_kafka_integration_test.groovy
+++ b/jenkins/jobs/ci2/pingcap/tiflow/cdc_ghpr_kafka_integration_test.groovy
@@ -22,11 +22,9 @@ pipelineJob('cdc_ghpr_kafka_integration_test') {
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')
                     whitelist("")
                     orgslist("pingcap")
-                    blackListTargetBranches {
-                        ghprbBranch { branch('master') }
-                        ghprbBranch { branch('^(release-)?5\\.[3-4]\\d*(\\.\\d+)?(\\-.*)?$') }
-                        ghprbBranch { branch('^(release-)?6\\.[1|5]\\d*(\\.\\d+)?(\\-.*)?$') }
-                        ghprbBranch { branch('^(release-)?7\\.[1-9]\\d*(\\.\\d+)?(\\-.*)?$') }
+                    whiteListTargetBranches {
+                        ghprbBranch { branch('^(release-)?4\\.\\d+(\\.\\d+)?(\\-.*)?$') }
+                        ghprbBranch { branch('^(release-)?[5]\\.[0-2](\\.\\d+)?(\\-.*)?$') }
                     }
                     // ignore when only those file changed.(
                     //   multi line regex

--- a/jenkins/jobs/ci2/pingcap/tiflow/dm_ghpr_compatibility_test.groovy
+++ b/jenkins/jobs/ci2/pingcap/tiflow/dm_ghpr_compatibility_test.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('dm_ghpr_compatibility_test') {
+    disabled(true)
     logRotator {
         daysToKeep(30)
     }
@@ -23,12 +24,7 @@ pipelineJob('dm_ghpr_compatibility_test') {
                     whitelist("")
                     orgslist("pingcap")
                     whiteListTargetBranches {
-                        ghprbBranch { branch('^(release-)?[6]\\.[0-9](\\.\\d+)?(\\-.*)?$') }
-                        ghprbBranch { branch('^(release-)?[7]\\.0(\\.\\d+)?(\\-.*)?$') }
-                    }
-                    blackListTargetBranches {
-                        ghprbBranch { branch('^(release-)?6\\.[1|5]\\d*(\\.\\d+)?(\\-.*)?$') }
-                        ghprbBranch { branch('^(release-)?5\\.[3|4]\\d*(\\.\\d+)?(\\-.*)?$') }
+                        ghprbBranch { branch('^(release-)?[5]\\.[0-2](\\.\\d+)?(\\-.*)?$') }
                     }
                     // ignore when only those file changed.(
                     //   multi line regex

--- a/jenkins/jobs/ci2/pingcap/tiflow/dm_ghpr_integration_test.groovy
+++ b/jenkins/jobs/ci2/pingcap/tiflow/dm_ghpr_integration_test.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('dm_ghpr_integration_test') {
+    disabled(true)
     logRotator {
         daysToKeep(30)
     }
@@ -23,13 +24,9 @@ pipelineJob('dm_ghpr_integration_test') {
                     whitelist("")
                     orgslist("pingcap")
                     whiteListTargetBranches {
-                        ghprbBranch { branch('^(release-)?[6]\\.[0-9](\\.\\d+)?(\\-.*)?$') }
-                        ghprbBranch { branch('^(release-)?[7]\\.0(\\.\\d+)?(\\-.*)?$') }
+                        ghprbBranch { branch('^(release-)?[5]\\.[0-2](\\.\\d+)?(\\-.*)?$') }
                     }
-                    blackListTargetBranches {
-                        ghprbBranch { branch('^(release-)?6\\.[1|5]\\d*(\\.\\d+)?(\\-.*)?$') }
-                        ghprbBranch { branch('^(release-)?5\\.[3|4]\\d*(\\.\\d+)?(\\-.*)?$') }
-                    }
+
                     // ignore when only those file changed.(
                     //   multi line regex
                     // excludedRegions('.*\\.md')


### PR DESCRIPTION
* all old cdc pipeline only need trigger in old branch release-4.x or  release-5.[0-2].
* all old dm pipeline need disable because dm merged into tiflow since 5.3, all pipeline from 5.3 is trigger by new pipelines.