### PR TITLE
fix: remove -c option for tiproxy mysql_test

### DIFF
--- a/pipelines/PingCAP-QE/tidb-test/latest/pull_tiproxy_mysql_test.groovy
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pull_tiproxy_mysql_test.groovy
@@ -107,7 +107,7 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-mysql-test") {
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
-                                        make deploy-mysqltest ARGS="-b -x -c y -s tikv -p ${PART}"
+                                        make deploy-mysqltest ARGS="-b -x y -s tikv -p ${PART}"
                                     """
                                 }
                             }

--- a/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
@@ -105,7 +105,7 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
-                                        make deploy-mysqltest ARGS="-b -x -c y -s tikv -p ${PART}"
+                                        make deploy-mysqltest ARGS="-b -x y -s tikv -p ${PART}"
                                     """
                                 }
                             }

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
@@ -105,7 +105,7 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
-                                        make deploy-mysqltest ARGS="-b -x -c y -s tikv -p ${PART}"
+                                        make deploy-mysqltest ARGS="-b -x y -s tikv -p ${PART}"
                                     """
                                 }
                             }


### PR DESCRIPTION
Refer to https://github.com/PingCAP-QE/tidb-test/pull/2315: the `-c` is removed.