### PR TITLE
fix: not set the limit memory

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
@@ -11,9 +11,6 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "16000m"
-        limits:
-          memory: "32Gi"
-          cpu: "16000m"
       volumeMounts:
       - mountPath: "/home/jenkins/agent/rust"
         name: "volume-0"

--- a/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
@@ -11,9 +11,6 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "16000m"
-        limits:
-          memory: "32Gi"
-          cpu: "16000m"
       volumeMounts:
       - mountPath: "/home/jenkins/agent/rust"
         name: "volume-0"

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -37,7 +37,10 @@ pipeline {
                 sh label: 'Debug info', script: """
                     printenv
                     echo "-------------------------"
-                    go env
+                    env
+                    hostname
+                    df -h
+                    free -hm
                     echo "-------------------------"
                     echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
                 """


### PR DESCRIPTION
When the limit memory is set, the size of tmpfs will be restricted to a certain value. At this time, it was found that some tests failed or the probability of interruption increased. Therefore, for now, we will remove the memory restriction here.