### PR TITLE
feat: br ci support run_if_changed

### DIFF
--- a/prow-jobs/pingcap-tidb-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-presubmits.yaml
@@ -93,7 +93,7 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       context: pull-br-integration-test
-      always_run: false
+      run_if_changed: "br/.*"
       optional: false
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-br-integration-test(?: .*?)?$"
@@ -104,7 +104,7 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       context: pull-lightning-integration-test
-      always_run: false
+      run_if_changed: "lightning/.*"
       optional: false
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-lightning-integration-test(?: .*?)?$"

--- a/prow-jobs/pingcap-tidb-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-presubmits.yaml
@@ -104,7 +104,7 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       context: pull-lightning-integration-test
-      run_if_changed: "lightning/.*"
+      always_run: false
       optional: false
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-lightning-integration-test(?: .*?)?$"


### PR DESCRIPTION
The br & lightning pipeline supports triggering based on conditions. If code changes are detected in the corresponding directory, the corresponding test pipeline will be triggered. Block PR merging if the test pipeline execution fails.


It should be noted that because prow does not support configuring these two parameters at the same time (`run_if_changed` and `skip_if_only_changed`), after applying this change. If there are changes in pure document categories for br & lightning, it will also trigger the test pipeline.