### PR TITLE
fix: remove ruby_orm test for tiproxy

### DIFF
--- a/prow-jobs/pingcap-tiproxy-latest-postsubmits.yaml
+++ b/prow-jobs/pingcap-tiproxy-latest-postsubmits.yaml
@@ -55,12 +55,3 @@ postsubmits:
       skip_report: false
       branches:
         - ^main$
-    - name: pingcap/tiproxy/merged_integration_ruby_orm_test
-      agent: jenkins
-      decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: merged-integration-ruby-orm-test # need change this.
-      max_concurrency: 1
-      skip_report: false
-      branches:
-        - ^main$


### PR DESCRIPTION
The ruby_orm always reports error, which is caused by TiDB. The CI in TiDB ignores ruby_orm, so TiProxy also ignores it.

Errors:
```
Failure:

SchemaDumperTest#test_schema_dumps_index_sort_order [/home/jenkins/agent/workspace/pingcap/tiproxy/merged_integration_ruby_orm_test/tidb-test/activerecord_orm_test/activerecord-orm-test/activerecord/test/cases/schema_dumper_test.rb:195]:

--- expected

+++ actual

@@ -1,3 +1 @@

-# encoding: UTF-8

-#    valid: true

-"t.index [\"name\", \"rating\"], name: \"index_companies_on_name_and_rating\", order: :desc"

+"t.index [\"name\", \"rating\"], name: \"index_companies_on_name_and_rating\""

rails test home/jenkins/agent/workspace/pingcap/tiproxy/merged_integration_ruby_orm_test/tidb-test/activerecord_orm_test/activerecord-orm-test/activerecord/test/cases/schema_dumper_test.rb:192

....................F

Failure:

SchemaDumperTest#test_schema_dumps_index_columns_in_right_order [/home/jenkins/agent/workspace/pingcap/tiproxy/merged_integration_ruby_orm_test/tidb-test/activerecord_orm_test/activerecord-orm-test/activerecord/test/cases/schema_dumper_test.rb:172]:

--- expected

+++ actual

@@ -1,3 +1 @@

-# encoding: UTF-8

-#    valid: true

-"t.index [\"firm_id\", \"type\", \"rating\"], name: \"company_index\", length: { type: 10 }, order: { rating: :desc }"

+"t.index [\"firm_id\", \"type\", \"rating\"], name: \"company_index\", length: { type: 10 }"

rails test home/jenkins/agent/workspace/pingcap/tiproxy/merged_integration_ruby_orm_test/tidb-test/activerecord_orm_test/activerecord-orm-test/activerecord/test/cases/schema_dumper_test.rb:168
```