### PR TITLE
Revert "feat: br ci support run_if_changed"

### DIFF
--- a/prow-jobs/pingcap-tidb-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-presubmits.yaml
@@ -93,7 +93,7 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       context: pull-br-integration-test
-      run_if_changed: "br/.*"
+      always_run: false
       optional: false
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-br-integration-test(?: .*?)?$"


### PR DESCRIPTION
Reverts PingCAP-QE/ci#2885

We found that even without modifying the br/ directory code, it will still trigger, so we revert first and then investigate the reason before enabling it again.