### PR TITLE
chore: disable trigger on tikv old ut master branch

### DIFF
--- a/jenkins/jobs/ci/tikv/tikv/ghpr_test.groovy
+++ b/jenkins/jobs/ci/tikv/tikv/ghpr_test.groovy
@@ -30,6 +30,9 @@ pipelineJob('tikv_ghpr_test') {
                     buildDescTemplate('PR #$pullId: $abbrTitle\n$url')
                     whitelist('')
                     orgslist('pingcap tikv')
+                    blackListTargetBranches {
+                        ghprbBranch { branch('master') }
+                    }
                     // ignore when only those file changed.(
                     //   multi line regex
                     // excludedRegions('.*\\.md')


### PR DESCRIPTION
Disable trigger on tikv old ut master branch because the new pipeline is ready.