### PR TITLE
feat(pingcap/tidb): support run_if_changed for br module

### DIFF
--- a/prow-jobs/pingcap-tidb-latest-presubmits.yaml
+++ b/prow-jobs/pingcap-tidb-latest-presubmits.yaml
@@ -93,7 +93,7 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       context: pull-br-integration-test
-      always_run: false
+      run_if_changed: "br/.*"
       optional: false
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-br-integration-test(?: .*?)?$"


### PR DESCRIPTION
Reverts PingCAP-QE/ci#2899

We have updated the Prow status reconciler and fixed the bug that triggered all open pull requests after modifying the regex. https://github.com/ti-community-infra/test-infra/pull/47