### PR TITLE
chore: enable trigger for new tikv ut on lts branch

### DIFF
--- a/pipelines/tikv/tikv/release-6.1/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-6.1/pull_unit_test.groovy
@@ -44,7 +44,7 @@ pipeline {
                 container(name: 'net-tool') {
                     sh 'dig github.com'
                     script {
-                        currentBuild.description = "PR #${REFS.pulls[0].number}: ${REFS.pulls[0].title} ${REFS.pulls[0].link}"
+                        prow.setPRDescription(REFS)
                     }
                 }
             }

--- a/pipelines/tikv/tikv/release-6.5/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-6.5/pull_unit_test.groovy
@@ -45,7 +45,7 @@ pipeline {
                 container(name: 'net-tool') {
                     sh 'dig github.com'
                     script {
-                        currentBuild.description = "PR #${REFS.pulls[0].number}: ${REFS.pulls[0].title} ${REFS.pulls[0].link}"
+                        prow.setPRDescription(REFS)
                     }
                 }
             }

--- a/pipelines/tikv/tikv/release-7.1/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-7.1/pull_unit_test.groovy
@@ -45,7 +45,7 @@ pipeline {
                 container(name: 'net-tool') {
                     sh 'dig github.com'
                     script {
-                        currentBuild.description = "PR #${REFS.pulls[0].number}: ${REFS.pulls[0].title} ${REFS.pulls[0].link}"
+                        prow.setPRDescription(REFS)
                     }
                 }
             }

--- a/pipelines/tikv/tikv/release-7.5/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-7.5/pull_unit_test.groovy
@@ -45,7 +45,7 @@ pipeline {
                 container(name: 'net-tool') {
                     sh 'dig github.com'
                     script {
-                        currentBuild.description = "PR #${REFS.pulls[0].number}: ${REFS.pulls[0].title} ${REFS.pulls[0].link}"
+                        prow.setPRDescription(REFS)
                     }
                 }
             }

--- a/pipelines/tikv/tikv/release-8.1/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-8.1/pull_unit_test.groovy
@@ -45,7 +45,7 @@ pipeline {
                 container(name: 'net-tool') {
                     sh 'dig github.com'
                     script {
-                        currentBuild.description = "PR #${REFS.pulls[0].number}: ${REFS.pulls[0].title} ${REFS.pulls[0].link}"
+                        prow.setPRDescription(REFS)
                     }
                 }
             }

--- a/prow-jobs/kustomization.yaml
+++ b/prow-jobs/kustomization.yaml
@@ -81,6 +81,10 @@ configMapGenerator:
       - ti-community-infra-test-infra-presubmits.yaml
       - tikv-migration-latest-presubmits.yaml
       - tikv-tikv-latest-presubmits.yaml
+      - tikv-tikv-release-6.5-presubmits.yaml
+      - tikv-tikv-release-7.1-presubmits.yaml
+      - tikv-tikv-release-7.5-presubmits.yaml
+      - tikv-tikv-release-8.1-presubmits.yaml
       - tikv-pd-latest-presubmits.yaml
       - tikv-pd-release-6.1-presubmits.yaml
       - tikv-pd-release-6.5-fips-presubmits.yaml

--- a/prow-jobs/tikv-tikv-release-6.5-presubmits.yaml
+++ b/prow-jobs/tikv-tikv-release-6.5-presubmits.yaml
@@ -1,0 +1,14 @@
+# struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Presubmit
+presubmits:
+  tikv/tikv:
+    - name: tikv/tikv/release-6.5/pull_unit_test
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false  # update here after test passed
+      optional: true # update here after test passed
+      skip_report: true # update here after test passed
+      context: wip/pull-unit-test
+      trigger: "(?m)^/debug (?:.*? )?pull-unit-test(?: .*?)?$"
+      rerun_command: "/debug pull-unit-test"
+      branches:
+        - ^release-6\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/tikv-tikv-release-7.1-presubmits.yaml
+++ b/prow-jobs/tikv-tikv-release-7.1-presubmits.yaml
@@ -1,0 +1,14 @@
+# struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Presubmit
+presubmits:
+  tikv/tikv:
+    - name: tikv/tikv/release-7.1/pull_unit_test
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false  # update here after test passed
+      optional: true # update here after test passed
+      skip_report: true # update here after test passed
+      context: wip/pull-unit-test
+      trigger: "(?m)^/debug (?:.*? )?pull-unit-test(?: .*?)?$"
+      rerun_command: "/debug pull-unit-test"
+      branches:
+        - ^release-7\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/tikv-tikv-release-7.5-presubmits.yaml
+++ b/prow-jobs/tikv-tikv-release-7.5-presubmits.yaml
@@ -1,0 +1,14 @@
+# struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Presubmit
+presubmits:
+  tikv/tikv:
+    - name: tikv/tikv/release-7.5/pull_unit_test
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false  # update here after test passed
+      optional: true # update here after test passed
+      skip_report: true # update here after test passed
+      context: wip/pull-unit-test
+      trigger: "(?m)^/debug (?:.*? )?pull-unit-test(?: .*?)?$"
+      rerun_command: "/debug pull-unit-test"
+      branches:
+        - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/tikv-tikv-release-8.1-presubmits.yaml
+++ b/prow-jobs/tikv-tikv-release-8.1-presubmits.yaml
@@ -12,4 +12,3 @@ presubmits:
       rerun_command: "/debug pull-unit-test"
       branches:
         - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
-

--- a/prow-jobs/tikv-tikv-release-8.1-presubmits.yaml
+++ b/prow-jobs/tikv-tikv-release-8.1-presubmits.yaml
@@ -1,0 +1,15 @@
+# struct ref: https://pkg.go.dev/k8s.io/test-infra/prow/config#Presubmit
+presubmits:
+  tikv/tikv:
+    - name: tikv/tikv/release-8.1/pull_unit_test
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false  # update here after test passed
+      optional: true # update here after test passed
+      skip_report: true # update here after test passed
+      context: wip/pull-unit-test
+      trigger: "(?m)^/debug (?:.*? )?pull-unit-test(?: .*?)?$"
+      rerun_command: "/debug pull-unit-test"
+      branches:
+        - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
+


### PR DESCRIPTION
Enable trigger for new tikv ut on lts branch. After a period of testing, we will enable status reporting and automatic triggering.