### PR TITLE
chore(tiflash): revert to use llvm13 image on master

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-17.0.6"
+      image: "hub.pingcap.net/tiflash/tiflash-llvm13-amd64:v20231214"
       command:
         - "cat"
       tty: true

--- a/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-17.0.6"
+      image: "hub.pingcap.net/tiflash/tiflash-llvm13-amd64:v20231214"
       command:
         - "cat"
       tty: true


### PR DESCRIPTION
revert to use llvm13 image on master tiflash new ut pipeline.