### PR TITLE
fix(br): use failpoint tidb-server instead

### DIFF
--- a/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -74,7 +74,7 @@ pipeline {
                         ./br/tests/run_group_br_tests.sh others
                     """
                     sh label: "prepare build", script: """
-                        [ -f ./bin/tidb-server ] || make
+                        [ -f ./bin/tidb-server ] || (make failpoint-enable && make && make failpoint-disable)
                         [ -f ./bin/br.test ] || make build_for_br_integration_test
                         ls -alh ./bin
                         ./bin/tidb-server -V

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -81,7 +81,7 @@ pipeline {
                         // build br.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
                         sh label: "prepare", script: """
-                            [ -f ./bin/tidb-server ] || make
+                            [ -f ./bin/tidb-server ] || (make failpoint-enable && make && make failpoint-disable)
                             [ -f ./bin/br.test ] || make build_for_br_integration_test
                             ls -alh ./bin
                             ./bin/tidb-server -V

--- a/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
@@ -77,7 +77,7 @@ pipeline {
                         // build br.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
                         sh label: "prepare", script: """
-                            [ -f ./bin/tidb-server ] || make
+                            [ -f ./bin/tidb-server ] || (make failpoint-enable && make && make failpoint-disable)
                             [ -f ./bin/br.test ] || make build_for_br_integration_test
                             ls -alh ./bin
                             ./bin/tidb-server -V

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -81,7 +81,7 @@ pipeline {
                         // build br.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
                         sh label: "prepare", script: """
-                            [ -f ./bin/tidb-server ] || make
+                            [ -f ./bin/tidb-server ] || (make failpoint-enable && make && make failpoint-disable)
                             [ -f ./bin/br.test ] || make build_for_br_integration_test
                             ls -alh ./bin
                             ./bin/tidb-server -V

--- a/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
@@ -77,7 +77,7 @@ pipeline {
                         // build br.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
                         sh label: "prepare", script: """
-                            [ -f ./bin/tidb-server ] || make
+                            [ -f ./bin/tidb-server ] || (make failpoint-enable && make && make failpoint-disable)
                             [ -f ./bin/br.test ] || make build_for_br_integration_test
                             ls -alh ./bin
                             ./bin/tidb-server -V


### PR DESCRIPTION
Since https://github.com/pingcap/tidb/pull/52734, we need to use failpoint tidb-server for br integration test
