### PR TITLE
chore(dm): use target branch to downloda tidb binary

### DIFF
--- a/jenkins/pipelines/ci/ticdc/dm_ghpr_compatibility_test.groovy
+++ b/jenkins/pipelines/ci/ticdc/dm_ghpr_compatibility_test.groovy
@@ -11,7 +11,7 @@ if (params.containsKey("release_test")) {
 }
 
 
-def TIDB_BRANCH = "master"
+def TIDB_BRANCH = "${ghprbTargetBranch}"
 def BUILD_NUMBER = "${env.BUILD_NUMBER}"
 
 def PRE_COMMIT = "${ghprbTargetBranch}"


### PR DESCRIPTION
use target branch to downloda tidb binary, only support for qa-release-test trigger