### PR TITLE
increase ticdc pulsar integration test resource

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
@@ -9,11 +9,11 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 16Gi
-          cpu: "8"
+          memory: 32Gi
+          cpu: "16"
         limits:
-          memory: 16Gi
-          cpu: "8"
+          memory: 32Gi
+          cpu: "16"
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
@@ -10,10 +10,10 @@ spec:
       resources:
         requests:
           memory: 32Gi
-          cpu: "16"
+          cpu: "12"
         limits:
           memory: 32Gi
-          cpu: "16"
+          cpu: "12"
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true


### PR DESCRIPTION
ticdc pulsar integration test failed frequently, but when we run it on local env, it never fail, so this PR increase ticdc pulsar integration test resource.