### PR TITLE
increase ticdc kafka integration test resource

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
@@ -26,10 +26,10 @@ spec:
       resources:
         requests:
           cpu: "12"
-          memory: 20Gi
+          memory: 32Gi
         limits:
           cpu: "12"
-          memory: 20Gi
+          memory: 32Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
@@ -9,7 +9,7 @@ spec:
       name: zookeeper
       resources:
         requests:
-          cpu: 200m
+          cpu: 2000m
           memory: 4Gi
         limits:
           cpu: 2000m
@@ -25,11 +25,11 @@ spec:
       name: golang
       resources:
         requests:
-          cpu: "2"
-          memory: 12Gi
+          cpu: "12"
+          memory: 20Gi
         limits:
-          cpu: "4"
-          memory: 16Gi
+          cpu: "12"
+          memory: 20Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp
@@ -68,11 +68,11 @@ spec:
       name: kafka
       resources:
         requests:
-          cpu: 200m
-          memory: 4Gi
+          cpu: 4000m
+          memory: 6Gi
         limits:
-          cpu: 2000m
-          memory: 4Gi
+          cpu: 4000m
+          memory: 6Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp


### PR DESCRIPTION
ticdc kafka integration test failed frequently, but when we ran it on local env, it never fail, so this PR increase ticdc kafka integration test resource.