### PR TITLE
chore(tiflash): retry only after get src code cache from ks3

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -53,27 +53,27 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) { 
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
+                    script {
+                        container("util") {
+                            withCredentials(
+                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
+                            ) { 
+                                sh "rm -rf ./*"
+                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
+                                sh """
+                                ls -alh
+                                chown 1000:1000 src-tiflash.tar.gz
+                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
+                                ls -alh
+                                """
                             }
-                            sh """
-                            git config --global --add safe.directory "*"
-                            git version
-                            git status
-                            """
+                        }
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        git status
+                        """
+                        retry(2) {
                             prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                             println "tiflash_commit_hash: ${tiflash_commit_hash}"

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -56,27 +56,27 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) { 
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
+                    script {
+                        container("util") {
+                            withCredentials(
+                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
+                            ) { 
+                                sh "rm -rf ./*"
+                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
+                                sh """
+                                ls -alh
+                                chown 1000:1000 src-tiflash.tar.gz
+                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
+                                ls -alh
+                                """
                             }
-                            sh """
-                            git config --global --add safe.directory "*"
-                            git version
-                            git status
-                            """
+                        }
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        git status
+                        """
+                        retry(2) {
                             prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()


### PR DESCRIPTION
Retry only after get src code cache from ks3. It takes about 7 minutes to retrieve and decompress the code cache from ks3. We only need to retry when git fetch fails to update due to network.