### PR TITLE
fix(br): use failpoint tidb-server instead

### DIFF
--- a/pipelines/qa/qa-release-br-integration-test.groovy
+++ b/pipelines/qa/qa-release-br-integration-test.groovy
@@ -74,8 +74,8 @@ pipeline {
                     // build br.test for integration test
                     // only build binarys if not exist, use the cached binarys if exist
                     sh label: "prepare", script: """
-                        [ -f ./bin/tidb-server ] || make
                         [ -f ./bin/tidb-server ] || (make failpoint-enable && make && make failpoint-disable)
+                        [ -f ./bin/br.test ] || make build_for_br_integration_test
                         ls -alh ./bin
                         ./bin/tidb-server -V
                     """

--- a/pipelines/qa/qa-release-br-integration-test.groovy
+++ b/pipelines/qa/qa-release-br-integration-test.groovy
@@ -75,7 +75,7 @@ pipeline {
                     // only build binarys if not exist, use the cached binarys if exist
                     sh label: "prepare", script: """
                         [ -f ./bin/tidb-server ] || make
-                        [ -f ./bin/br.test ] || make build_for_br_integration_test
+                        [ -f ./bin/tidb-server ] || (make failpoint-enable && make && make failpoint-disable)
                         ls -alh ./bin
                         ./bin/tidb-server -V
                     """


### PR DESCRIPTION
Since https://github.com/pingcap/tidb/pull/52734, we need to use failpoint tidb-server for br integration test