### PR TITLE
Revert "refactor(jenkins/pipelines,pipelines): use the new dockerfile url location"

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
@@ -180,7 +180,7 @@ def buildBin={
 def buildDocker={
     sh 'printenv HUB_PSW | docker login -u $HUB_USR --password-stdin hub.pingcap.net'
     sh """
-        curl --fail --retry 3 -o Dockerfile https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflash.Dockerfile
+        curl --fail --retry 3 -o Dockerfile https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/tiflash.Dockerfile
         curl --fail --retry 3 -o tiflash.tar.gz ${getBinDownloadURL()}
         tar -xzvf tiflash.tar.gz
         rm -f tiflash.tar.gz

--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -27,11 +27,17 @@ def get_dockerfile_url={arch ->
     if (params.ProductDockerfile){
         return params.ProductDockerfile
     }
+    if (params.ProductBaseImg){
+        if (Product == "tidb" && Edition == "enterprise") {
+            fileName = fileName + '-enterprise'
+        }
+        return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${fileName}.Dockerfile"
+    }
     if (Version>='v6.6.0'){
         if (Product == "tidb" && Edition == "enterprise") { 
             fileName = fileName + '-enterprise'
         }
-        return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${fileName}.Dockerfile"
+        return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/${fileName}.Dockerfile"
     }else{
         if (Product == "tidb" && Edition == "enterprise") { 
             fileName = "enterprise/${Product}"

--- a/jenkins/pipelines/cd/nightly/release-all-images-by-branch.groovy
+++ b/jenkins/pipelines/cd/nightly/release-all-images-by-branch.groovy
@@ -215,7 +215,7 @@ def get_dockerfile_url(arch, repo, isDebug){
     }
     def fileName = Product
     if (RELEASE_TAG >='v6.6.0'){
-        return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${fileName}.Dockerfile"
+        return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/${fileName}.Dockerfile"
     }else{
         if (isDebug){
             return "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/${fileName}"

--- a/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
+++ b/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
@@ -12,7 +12,7 @@ def get_dockerfile_url(product, is_enterprise, is_debug){
     if (is_debug) {
         fileName = fileName + "-debug"
     }
-    return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${fileName}.Dockerfile"
+    return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/${fileName}.Dockerfile"
 }
 
 def get_image_str_for_community(product, arch, is_failpoint, is_debug) {

--- a/jenkins/pipelines/cd/pre-release-enterprise-docker-rocky.groovy
+++ b/jenkins/pipelines/cd/pre-release-enterprise-docker-rocky.groovy
@@ -77,7 +77,7 @@ def get_image_str_for_enterprise(product, arch, tag) {
 def build_tidb_enterprise_image(product, sha1, plugin_hash, arch) {
     def binary = "builds/pingcap/${product}/optimization/${RELEASE_TAG}/${sha1}/centos7/${product}-linux-${arch}-enterprise.tar.gz"
     def plugin_binary = "builds/pingcap/enterprise-plugin/optimization/${RELEASE_TAG}/${plugin_hash}/centos7/enterprise-plugin-linux-${arch}-enterprise.tar.gz"
-    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${product}-enterprise.Dockerfile"
+    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/${product}-enterprise.Dockerfile"
     def image = get_image_str_for_enterprise("tidb", arch, RELEASE_TAG)
     def paramsDocker = [
             string(name: "ARCH", value: arch),
@@ -101,7 +101,7 @@ def build_enterprise_image(product, sha1, arch) {
     if (product == "tidb-lightning") {
         binary = "builds/pingcap/br/optimization/${RELEASE_TAG}/${sha1}/centos7/br-linux-${arch}-enterprise.tar.gz"
     }
-    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${product}.Dockerfile"
+    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/${product}.Dockerfile"
     def repo = product
     def image = get_image_str_for_enterprise(product, arch, RELEASE_TAG)
 

--- a/pipelines/pingcap/tidb/latest/merged_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_tiflash_test.groovy
@@ -99,7 +99,7 @@ pipeline {
                     }
                     dir("build-docker-image") {
                         sh label: 'generate dockerfile', script: """
-                        curl -o tidb.Dockerfile https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb.Dockerfile
+                        curl -o tidb.Dockerfile https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/tidb.Dockerfile
                         cat tidb.Dockerfile
                         cp ../tidb/bin/tidb-server tidb-server
                         ./tidb-server -V

--- a/pipelines/pingcap/tidb/latest/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_tiflash_test.groovy
@@ -82,7 +82,7 @@ pipeline {
                     }
                     dir("build-docker-image") {
                         sh label: 'generate dockerfile', script: """
-                        curl -o tidb.Dockerfile https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb.Dockerfile
+                        curl -o tidb.Dockerfile https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/tidb.Dockerfile
                         cat tidb.Dockerfile
                         cp ../tidb/bin/tidb-server tidb-server
                         ./tidb-server -V


### PR DESCRIPTION
Reverts PingCAP-QE/ci#2958

It broken the dev-builds since of the issue, we must solve it atomic:
```log
[2024-05-10T10:29:43.850Z] + docker build --pull -t 325168c9-8528-454b-9e0f-2041080ee440 . --build-arg 'BASE_IMG='
```

