### PR TITLE
docs: bump pdf stable version to release-8.1

### DIFF
--- a/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
+++ b/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
@@ -85,7 +85,7 @@ pipeline {
                             target_version=\$(echo ${REFS.base_ref} | sed 's/release-//')
                             if [ "${REFS.base_ref}" = "master" ]; then
                                 python3 scripts/upload.py output.pdf tidb-dev-zh-manual.pdf;
-                            elif [ "${REFS.base_ref}" = "release-7.5" ]; then
+                            elif [ "${REFS.base_ref}" = "release-8.1" ]; then
                                 python3 scripts/upload.py output.pdf tidb-stable-zh-manual.pdf;
                             elif case "${REFS.base_ref}" in release-*) ;; *) false;; esac; then
                                 python3 scripts/upload.py output.pdf tidb-v\${target_version}-zh-manual.pdf;

--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -90,6 +90,8 @@ pipeline {
                             elif [ "${REFS.base_ref}" = "release-7.5" ]; then
                                 python3 scripts/merge_by_toc.py TOC-tidb-cloud.md doc_cloud.md tidb-cloud; scripts/generate_cloud_pdf.sh;
                                 python3 scripts/upload.py output_cloud.pdf tidbcloud-en-manual.pdf;
+                                python3 scripts/upload.py output.pdf tidb-v7.5-en-manual.pdf;
+                            elif [ "${REFS.base_ref}" = "release-8.1" ]; then
                                 python3 scripts/upload.py output.pdf tidb-stable-en-manual.pdf;
                             elif case "${REFS.base_ref}" in release-*) ;; *) false;; esac; then
                                 python3 scripts/upload.py output.pdf tidb-v\${target_version}-en-manual.pdf;

--- a/prow-jobs/pingcap-docs-cn-postsubmits.yaml
+++ b/prow-jobs/pingcap-docs-cn-postsubmits.yaml
@@ -13,4 +13,4 @@ postsubmits:
         - ^release-5\.[0-4]$
         - ^release-6\.[156]$
         - ^release-7\.[0-5]$
-        - ^release-8.0$
+        - ^release-8\.[0-1]$

--- a/prow-jobs/pingcap-docs-postsubmits.yaml
+++ b/prow-jobs/pingcap-docs-postsubmits.yaml
@@ -13,4 +13,4 @@ postsubmits:
         - ^release-5\.[0-4]$
         - ^release-6\.[156]$
         - ^release-7\.[0-5]$
-        - ^release-8.0$
+        - ^release-8\.[0-1]$


### PR DESCRIPTION
Update the stable PDF version of TiDB and TiDB Cloud:

- TiDB: the stable PDF version is updated from release-7.5 to release-8.1.
- TiDB Cloud: the stable PDF version will remain at release-7.5 to ensure consistency with the current TiDB Cloud documentation.