### PR TITLE
k8s docs: bump pdf stable version to release-1.6

### DIFF
--- a/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
+++ b/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
@@ -88,7 +88,7 @@ pipeline {
                             if [ "${REFS.base_ref}" = "master" ]; then
                                 python3 scripts/upload.py output_en.pdf tidb-in-kubernetes-dev-en-manual.pdf;
                                 python3 scripts/upload.py output_zh.pdf tidb-in-kubernetes-dev-zh-manual.pdf;
-                            elif [ "${REFS.base_ref}" = "release-1.5" ]; then
+                            elif [ "${REFS.base_ref}" = "release-1.6" ]; then
                                 python3 scripts/upload.py output_en.pdf tidb-in-kubernetes-stable-en-manual.pdf;
                                 python3 scripts/upload.py output_zh.pdf tidb-in-kubernetes-stable-zh-manual.pdf;
                             elif case "${REFS.base_ref}" in release-*) ;; *) false;; esac; then


### PR DESCRIPTION
Update the stable PDF version of TiDB Operator from release-1.5 to release-1.6