### PR TITLE
fix(scripts): fix update-prow-owners.ts

### DIFF
--- a/scripts/pingcap/community/update-prow-owners.ts
+++ b/scripts/pingcap/community/update-prow-owners.ts
@@ -609,7 +609,12 @@ async function main(
         ownersMap,
         draft,
         force,
-      );
+      ).catch((error: any) => {
+        console.warn(
+          `❌ skiped for repo ${owner}/${repository}, error happened.`,
+          error,
+        );
+      });
 
       if (pr) {
         console.info(


### PR DESCRIPTION
skip the repository when the bot has no rights to create refs.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>