### PR TITLE
fix: handle non-standard version information of dumpling

### DIFF
--- a/scripts/ops/release-check-version/check_docker_images.py
+++ b/scripts/ops/release-check-version/check_docker_images.py
@@ -29,6 +29,7 @@ def get_image_version_info(full_image_name, component, version, edition, git_com
                 capture_output=True, text=True, check=True)
             # 假设成功执行命令返回非空结果即为有效
             # dmctl and dumpling output version info to stderr, so we need to check both stdout and stderr
+            # issue https://github.com/pingcap/tidb/issues/53591
             if result.stdout.strip() or result.stderr.strip():
                 version_info = result.stdout.strip() if result.stdout.strip() else result.stderr.strip()
                 print(f"Version info ({entrypoint}): {version_info}")

--- a/scripts/ops/release-check-version/check_offline_package.py
+++ b/scripts/ops/release-check-version/check_offline_package.py
@@ -248,10 +248,10 @@ def check_tiup_component_version(component, version, commit_hash, edition):
             result = subprocess.run(
                 ["tiup", f"{tiup_component}:{tiup_check_version}", version_command], capture_output=True, text=True, check=True)
             # 假设成功执行命令返回非空结果即为有效
-            print(result)
-            # Notice: dmctl and dumpling output version info to stderr, so we need to check both stdout and stderr
+            # dmctl and dumpling output version info to stderr, so we need to check both stdout and stderr
+            # issue https://github.com/pingcap/tidb/issues/53591
             if result.stdout.strip() or result.stderr.strip():
-                version_info = result.stdout.strip() if result.stdout.strip() else result.stderr.strip()
+                version_info = '\n'.join(result.stdout.strip(), result.stderr.strip())
                 print(f"Version info ({tiup_component}):\n{version_info}")
                 version_check_passed = check_version(version_info, expected_version, expected_edition,
                                                      expected_commit_hash,

--- a/scripts/ops/release-check-version/check_tiup.py
+++ b/scripts/ops/release-check-version/check_tiup.py
@@ -111,8 +111,11 @@ def check_tiup_component_version(component, version, commit_hash, is_tiup_stagin
                 ["tiup", f"{tiup_component}:{tiup_check_version}", version_command], capture_output=True, text=True, check=True)
             # 假设成功执行命令返回非空结果即为有效
             # dmctl and dumpling output version info to stderr, so we need to check both stdout and stderr
+            # issue https://github.com/pingcap/tidb/issues/53591
             if result.stdout.strip() or result.stderr.strip():
-                version_info = result.stdout.strip() if result.stdout.strip() else result.stderr.strip()
+                # version_info = result.stdout.strip() if result.stdout.strip() else result.stderr.strip()
+                version_info = '\n'.join(result.stdout.strip(), result.stderr.strip())
+
                 print(f"Version info ({tiup_component}):\n{version_info}")
                 version_check_passed = check_version(version_info, expected_version, expected_edition,
                                                      expected_commit_hash,


### PR DESCRIPTION
handle non-standard version information of dumpling on release-check-version.