### PR TITLE
feat: add 8.2 tikv cache image build 

### DIFF
--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy
@@ -107,6 +107,7 @@ RUN cd tikv-src \
         }
         
         build_branch("master")
+        build_branch("release-8.2")
         build_branch("release-8.1")
         build_branch("release-7.5")
         build_branch("release-7.1")


### PR DESCRIPTION
### **User description**
add 8.1 tikv cache image build


___

### **PR Type**
enhancement


___

### **Description**
- Added a new build step for the `release-8.2` branch in the TiKV cache image build process.
- Ensures that the `release-8.2` branch is included in the CI pipeline.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tikv_ghpr_cache.groovy</strong><dd><code>Add build step for `release-8.2` branch in TiKV cache image</code></dd></summary>
<hr>
      
jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy

- Added build step for `release-8.2` branch.



</details>
    

  </td>
  <td><a href="https://github.com/PingCAP-QE/ci/pull/3010/files#diff-42307aa09c6c78d80cec5458b31dff8753ec68a6d317699ba7cefaf2918a74b8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

