### PR TITLE
Fix building tiflash-sanitizer

### DIFF
--- a/jenkins/pipelines/ci/tiflash/tiflash-sanitizer-daily.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-sanitizer-daily.groovy
@@ -110,11 +110,6 @@ def runCheckoutAndBuilderClosure(label, curws, Closure body) {
                     }
                 }
                 checkout()
-                sh """
-                git version
-                git config --global --add safe.directory ${curws}/tiflash/contrib/tiflash-proxy
-                git config --global --add safe.directory ${curws}/tiflash
-                """
             }
         }
         body()
@@ -191,6 +186,11 @@ def runWithCache(type, cwd) {
     stage("build") {
         container("builder") {
             dir("${cwd}/tiflash/build-${type}") {
+                sh """
+                git version
+                git config --global --add safe.directory ${cwd}/tiflash/contrib/tiflash-proxy
+                git config --global --add safe.directory ${cwd}/tiflash
+                """
                 sh "cmake ${cwd}/tiflash -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=${type} -DUSE_CCACHE=ON -DRUN_HAVE_STD_REGEX=0 -DCMAKE_PREFIX_PATH=/usr/local -DUSE_GM_SSL=0 -GNinja"
                 sh "ninja -j12 gtests_dbms gtests_libcommon gtests_libdaemon"
             }

--- a/jenkins/pipelines/ci/tiflash/tiflash-sanitizer-daily.groovy
+++ b/jenkins/pipelines/ci/tiflash/tiflash-sanitizer-daily.groovy
@@ -110,6 +110,11 @@ def runCheckoutAndBuilderClosure(label, curws, Closure body) {
                     }
                 }
                 checkout()
+                sh """
+                git version
+                git config --global --add safe.directory ${curws}/tiflash/contrib/tiflash-proxy
+                git config --global --add safe.directory ${curws}/tiflash
+                """
             }
         }
         body()


### PR DESCRIPTION
### **User description**
Fix that git considers the directory as not safe, making tiflash sanitizer failed to build


https://ci.pingcap.net/blue/organizations/jenkins/tiflash-sanitizer-daily/detail/tiflash-sanitizer-daily/1987/pipeline/
```
[2024-07-01T18:48:01.172Z] fatal: detected dubious ownership in repository at '/home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash'
[2024-07-01T18:48:01.172Z] To add an exception for this directory, call:
[2024-07-01T18:48:01.172Z] 
[2024-07-01T18:48:01.172Z] 	git config --global --add safe.directory /home/jenkins/agent/workspace/tiflash-sanitizer-daily/tiflash
```

ref https://github.com/pingcap/tiflash/issues/7193

___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Added commands to configure Git safe directories to avoid build failures due to dubious ownership detection.
- Ensured the directories `${curws}/tiflash/contrib/tiflash-proxy` and `${curws}/tiflash` are marked as safe.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tiflash-sanitizer-daily.groovy</strong><dd><code>Configure Git safe directories for tiflash-sanitizer build</code></dd></summary>
<hr>
      
jenkins/pipelines/ci/tiflash/tiflash-sanitizer-daily.groovy

<li>Added commands to configure Git safe directories.<br> <li> Ensured the directories used in the build process are marked as safe.<br>


</details>
    

  </td>
  <td><a href="https://github.com/PingCAP-QE/ci/pull/3019/files#diff-cf6e0f80b8d57ff16c04804cccb20aa2048f6041c6c159d041d860881b6fb9ae">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

