### PR TITLE
fix(deps): update golang image for mysql_connector_test

### DIFF
--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_mysql_connector_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_mysql_connector_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "hub.pingcap.net/jenkins/golang-with-gcc11:1.21"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_connector_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_connector_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-with-gcc11:1.20"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_connector_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_connector_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "hub.pingcap.net/jenkins/golang-with-gcc11:1.21"
       securityContext:
         privileged: true
       tty: true


### PR DESCRIPTION
### **User description**
After upgrading tidb deps to v1.1.0 in tiproxy, the test `mysql_connector_test` reports:

```
/go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20240428083427-66ba419636ce/pkg/types/compare.go:18:2: package cmp is not in GOROOT (/usr/local/go/src/cmp)
note: imported by a module that requires go 1.21
/go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20240428083427-66ba419636ce/pkg/util/stmtsummary/v2/stmtsummary.go:20:2: package maps is not in GOROOT (/usr/local/go/src/maps)
note: imported by a module that requires go 1.21
/go/pkg/mod/github.com/tikv/client-go/v2@v2.0.8-0.20240424052342-0229f4077f0c/internal/locate/region_cache.go:44:2: package slices is not in GOROOT (/usr/local/go/src/slices)
note: imported by a module that requires go 1.21
```

Maybe I should upgrade the golang image.


___

### **PR Type**
dependencies, configuration changes


___

### **Description**
- Updated the Golang image version in `tidb-test` pipeline configuration to `golang-with-gcc11:1.21`.
- Updated the Golang image version in `tiproxy` pipeline configuration to `golang-with-gcc11:1.21`.
- These changes address issues with missing packages in the GOROOT for the `mysql_connector_test`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pod-pull_tiproxy_mysql_connector_test.yaml</strong><dd><code>Update Golang image version in tidb-test pipeline configuration</code></dd></summary>
<hr>

pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_mysql_connector_test.yaml

<li>Updated the Golang image version from <code>centos7_golang-1.21:latest</code> to <br><code>golang-with-gcc11:1.21</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ci/pull/3021/files#diff-9f1cd4ec65284e432c4696bc9279873bb22b540b1e0ebbbced07122dc0743669">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pod-pull_mysql_connector_test.yaml</strong><dd><code>Update Golang image version in tiproxy pipeline configuration</code></dd></summary>
<hr>

pipelines/pingcap/tiproxy/latest/pod-pull_mysql_connector_test.yaml

<li>Updated the Golang image version from <code>golang-with-gcc11:1.20</code> to <br><code>golang-with-gcc11:1.21</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ci/pull/3021/files#diff-44748dc433ffe13a4eeb252d77c5db7809cb6f8fe8c2f5e5faa7f9290b010ec9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

