### PR TITLE
fix(scripts/artifacts): workaround tikv amd64 building hang problem

### DIFF
--- a/scripts/artifacts/check-tiup.sh
+++ b/scripts/artifacts/check-tiup.sh
@@ -68,8 +68,13 @@ function check_results() {
     # check tiup git_sha and published time
     for pkg in $(yq '.tiup | keys | .[]' results.yaml); do
         echo "🚧 check tiup built on git-sha for $pkg ..."
-        yq -e ".tiup[\"$pkg\"].git_sha | map(.) | unique | length == 1" results.yaml
-        record_failure $?
+        if [ "$pkg" == "tikv" ]; then
+            yq -e ".tiup[\"$pkg\"].git_sha | map(.) | unique | length <= 2" results.yaml
+            record_failure $?
+        else
+            yq -e ".tiup[\"$pkg\"].git_sha | map(.) | unique | length == 1" results.yaml
+            record_failure $?
+        fi
 
         echo "🚧 check tiup published time for $pkg ..."
         yq -e ".tiup[\"$pkg\"].published > (.tiup[\"$pkg\"].oci_published | map(.) | sort | .[0])" results.yaml


### PR DESCRIPTION
### **User description**
Signed-off-by: wuhuizuo <wuhuizuo@126.com>


___

### **PR Type**
Bug fix


___

### **Description**
- Added a conditional check in `check_results` function to handle the `tikv` package differently during git_sha verification.
- This change addresses the issue of `tikv` amd64 building hang by allowing more than two unique git_sha values for `tikv`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check-tiup.sh</strong><dd><code>Add workaround for `tikv` amd64 building hang in check-tiup.sh</code></dd></summary>
<hr>

scripts/artifacts/check-tiup.sh

<li>Added conditional check for <code>tikv</code> package to handle git_sha <br>verification differently.<br> <li> Modified the <code>check_results</code> function to address the building hang <br>problem for <code>tikv</code> on amd64.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ci/pull/3024/files#diff-83f2cad14e0bb5b9198ff6572612ce9402249949544b3abf6b6e50ae9a9c02bb">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

