### PR TITLE
chore(tidb): archive log if test not successful

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -118,7 +118,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
-                            failure {
+                            unsuccessful {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
                         }


### PR DESCRIPTION
### **User description**
archive log if test not successful, eg test timeout


___

### **PR Type**
enhancement


___

### **Description**
- Modified the post-build action in the `ghpr_mysql_test.groovy` pipeline script to archive logs if the test is unsuccessful instead of only on failure.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ghpr_mysql_test.groovy</strong><dd><code>Archive logs if test is unsuccessful instead of failure</code>&nbsp; &nbsp; </dd></summary>
<hr>

pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy

<li>Changed the post-build action from <code>failure</code> to <code>unsuccessful</code> for <br>archiving artifacts.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ci/pull/3028/files#diff-1a06f14532e2be1eefc21763f67d1a83b63ab9740c315b30ae4132768be19121">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

