### PR TITLE
docs-pdf: remove v5.1 and v7.5 as they are archived 

### DIFF
--- a/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5\.[1-4]$
+        - ^release-5\.[2-4]$
         - ^release-6\.[15]$
-        - ^release-7\.[156]$
+        - ^release-7\.[15]$
         - ^release-8\.[0-6]$

--- a/prow-jobs/pingcap/docs/docs-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5\.[1-4]$
+        - ^release-5\.[2-4]$
         - ^release-6\.[15]$
-        - ^release-7\.[156]$
+        - ^release-7\.[15]$
         - ^release-8\.[0-6]$


### PR DESCRIPTION
### **User description**
v5.1 and v7.5 PDFs are archived and will no longer trigger new PDF builds.


___

### **PR Type**
configuration changes


___

### **Description**
- Removed `release-5.1` branch from postsubmits configuration in `docs-cn-postsubmits.yaml` and `docs-postsubmits.yaml`.
- Removed `release-7.6` branch from postsubmits configuration in `docs-cn-postsubmits.yaml` and `docs-postsubmits.yaml`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs-cn-postsubmits.yaml</strong><dd><code>Update postsubmits configuration for archived branches</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml

<li>Removed branch <code>release-5.1</code> from postsubmits<br> <li> Removed branch <code>release-7.6</code> from postsubmits<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ci/pull/3029/files#diff-a8bd1b126b4211a56553a1a30b5216df53edaba89d5a577790b6832288b489e4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docs-postsubmits.yaml</strong><dd><code>Update postsubmits configuration for archived branches</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

prow-jobs/pingcap/docs/docs-postsubmits.yaml

<li>Removed branch <code>release-5.1</code> from postsubmits<br> <li> Removed branch <code>release-7.6</code> from postsubmits<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ci/pull/3029/files#diff-b1066d5a5f50efe588f78cadcc9c9441d11c1b017c00a85627e2af77af140bf7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

