### PR TITLE
feat: build tiflash with rust cache 

### DIFF
--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -161,6 +161,7 @@ spec:
                                     string(name: "GITHUB_REPO", value: params.GithubRepo),
                                     string(name: "BUILD_ENV", value: params.BuildEnv),
                                     string(name: "BUILDER_IMG", value: params.BuilderImg),
+                                    string(name: "USE_TIFLASH_RUST_CACHE", value: 'true'),
                                     [$class: 'BooleanParameterValue', name: 'NEED_SOURCE_CODE', value: false],
                                     [$class: 'BooleanParameterValue', name: 'FORCE_REBUILD', value: true],
                                     [$class: 'BooleanParameterValue', name: 'FAILPOINT', value: params.Features.contains('failpoint')],


### PR DESCRIPTION
### **User description**
build tiflash with rust cache for reducing external traffic downloads


___

### **PR Type**
enhancement


___

### **Description**
- Added a new string parameter `USE_TIFLASH_RUST_CACHE` with the value 'true' to the build specification in `dev-build.groovy`.
- This change aims to build TiFlash with Rust cache to reduce external traffic downloads.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dev-build.groovy</strong><dd><code>Add `USE_TIFLASH_RUST_CACHE` parameter to build spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jenkins/pipelines/cd/dev-build.groovy

<li>Added a new string parameter <code>USE_TIFLASH_RUST_CACHE</code> with the value <br>'true' to the build specification.<br>


</details>


  </td>
  <td><a href="https://github.com/PingCAP-QE/ci/pull/3031/files#diff-883dea4e305e8d8dffff92a73f812d069fd76eaf118e96b9efd1bdc219de9fe6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

