### PR TITLE
fix: update git version to 2.40.3 in image

### DIFF
--- a/pipelines/pingcap/tiflash/release-8.1/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.1/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvmorg-14.0.6"
+      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-13.0.0"
       command:
         - "/bin/bash"
         - "-c"

--- a/pipelines/pingcap/tiflash/release-8.1/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.1/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvmorg-14.0.6"
+      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-13.0.0"
       command:
         - "cat"
       tty: true


### PR DESCRIPTION
The git version in the original image was too old(v1.8.3), missing some command options, so the git version has been upgraded here(update git to v2.40.3).