### PR TITLE
docs-pdf: remove v5.2 and v8.0 as they are archived

### DIFF
--- a/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5\.[2-4]$
+        - ^release-5\.[34]$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
-        - ^release-8\.[0-6]$
+        - ^release-8\.[1-6]$

--- a/prow-jobs/pingcap/docs/docs-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5\.[2-4]$
+        - ^release-5\.[34]$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
-        - ^release-8\.[0-6]$
+        - ^release-8\.[1-6]$


### PR DESCRIPTION
reason for this PRL: Remove v5.2/v8.0 from the PDF building workflow because v5.2/v8.0 docs have been archived at https://docs-archive.pingcap.com/tidb and will no longer receive new updates.