### PR TITLE
fix: not to set jnlp conf in pod file

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
@@ -40,37 +40,6 @@ spec:
       - mountPath: "/tmp-memfs"
         name: "volume-7"
         readOnly: false
-    - name: jnlp
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
     - name: util
       image: hub.pingcap.net/jenkins/ks3util
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
@@ -48,25 +48,6 @@ spec:
     - mountPath: "/home/jenkins/agent"
       name: "workspace-volume"
       readOnly: false
-  - image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
-    name: "jnlp"    #  TODO: remove this default container
-    resources:
-      requests:
-        memory: "256Mi"
-        cpu: "100m"
-      limits:
-        memory: "256Mi"
-        cpu: "100m"
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
   volumes:
   - emptyDir:
       medium: ""

--- a/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
@@ -7,44 +7,11 @@ spec:
       command:
         - "cat"
       tty: true
+      # Notice: not set the resources limit, because limit will make unit test failed
       resources:
         requests:
           memory: "32Gi"
           cpu: "12000m"
-      volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
-    - name: jnlp  # TODO: remove this default container
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
       volumeMounts:
       - mountPath: "/home/jenkins/agent/rust"
         name: "volume-0"

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -125,7 +125,7 @@ pipeline {
                 stage("Proxy-Cache") {
                     steps {
                         script {
-                            proxy_cache_ready = fileExists("/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm")
+                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
                             println "proxy_cache_ready: ${proxy_cache_ready}"
 
                             sh label: "copy proxy if exist", script: """
@@ -215,8 +215,9 @@ pipeline {
                 script { 
                     def target_branch = REFS.base_ref 
                     def diff_flag = "--dump_diff_files_to '/tmp/tiflash-diff-files.json'"
-                    if (!fileExists("${WORKSPACE}/tiflash/format-diff.py")) {
-                        echo "skipped because this branch does not support format"
+                    def fileExists = sh(script: "test -f ${WORKSPACE}/tiflash/format-diff.p && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
+                    if (!fileExists) {
+                        echo "skipped format check because this branch does not support format"
                         return
                     }
                     // TODO: need to check format-diff.py for more details

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -126,8 +126,9 @@ pipeline {
                 stage("Proxy-Cache") {
                     steps {
                         script {
-                            proxy_cache_ready = fileExists("/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm")
+                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
                             println "proxy_cache_ready: ${proxy_cache_ready}"
+
                             sh label: "copy proxy if exist", script: """
                             proxy_suffix="amd64-linux-llvm"
                             proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-\${proxy_suffix}"


### PR DESCRIPTION
Not to set jnlp container config in pod yaml file.
* If we use the Groovy function fileExists, we must explicitly define the jnlp container because this function can only be executed in the jnlp container and cannot specify other containers.