### PR TITLE
RocksDB CI: use static link

### DIFF
--- a/jenkins/pipelines/ci/rocksdb/rocksdb_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/rocksdb/rocksdb_ghpr_test.groovy
@@ -77,7 +77,7 @@ def build = { target, do_cache ->
             sh """
                 echo using gcc 8
                 source /opt/rh/devtoolset-8/enable
-                V=1 make ${target} -j 3
+                LIB_MODE=static V=1 make ${target} -j 3
             """
         }
         if (do_cache) {

--- a/jenkins/pipelines/ci/tikv/rocksdb/rocksdb_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/tikv/rocksdb/rocksdb_ghpr_test.groovy
@@ -77,7 +77,7 @@ def build = { target, do_cache ->
             sh """
                 echo using gcc 8
                 source /opt/rh/devtoolset-8/enable
-                V=1 make ${target} -j 3
+                LIB_MODE=static V=1 make ${target} -j 3
             """
         }
         if (do_cache) {


### PR DESCRIPTION
RocksDB switched to dynamic link. We may want to stick to static link for better portability,