### PR TITLE
feat(tidb): add ddlv1 unit test pipeline

### DIFF
--- a/jobs/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
+++ b/jobs/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/tidb/pull_unit_test_ddlv1') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tidb")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
@@ -1,0 +1,75 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 90, unit: 'MINUTES')
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    ls -l /dev/null
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            steps {
+                dir(REFS.repo) {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        script {
+                            git.setSshKey(GIT_CREDENTIALS_ID)
+                            retry(2) {
+                                prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Test') {
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh """
+                        sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
+                        git diff .
+                        git status
+                    """
+                    sh """#! /usr/bin/env bash
+                        set -o pipefail
+                        make bazel_coverage_test_ddlargsv1
+                    """
+                }
+            }
+        }
+    }
+}

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -51,6 +51,18 @@ presubmits:
       branches:
         - ^master$
         - ^feature/.+
+    - name: pingcap/tidb/pull_unit_test_ddlv1
+      agent: jenkins
+      decorate: false # need add this.
+      # skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      context: wip/pull-unit-test-ddlv1
+      always_run: false
+      optional: true
+      trigger: "(?m)^/test (?:.*? )?pull-unit-test-ddlv1(?: .*?)?$"
+      rerun_command: "/test pull-unit-test-ddlv1"
+      branches:
+        - ^master$
+        - ^feature/.+
     - name: pingcap/tidb/pull_integration_mysql_test
       agent: jenkins
       decorate: false # need add this.


### PR DESCRIPTION
This pull request introduces a new Jenkins pipeline job for running unit tests on the latest version of the `pingcap/tidb` repository. It includes the creation of the pipeline job, its definition, and updates to the relevant presubmits configuration.

### New Jenkins Pipeline Job:

* [`jobs/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy`](diffhunk://#diff-1774a984294d89d34230774eb9ef00228b3ff3aecda9adc1e48adf624c810bb8R1-R38): Added a new pipeline job definition for `pingcap/tidb/pull_unit_test_ddlv1`, including parameters, properties, and SCM configuration.
* [`pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy`](diffhunk://#diff-5bba6bdccf3d6f4b2c714649e73aa7e35188dda4e40683190e0e2fbb8b4b573cR1-R75): Implemented the pipeline script for the new job, setting up Kubernetes agents, environment variables, and stages for debugging, checkout, and testing.

### Presubmits Configuration:

* [`prow-jobs/pingcap/tidb/latest-presubmits.yaml`](diffhunk://#diff-35ccc0efb0c9d75d84787908ce4f772045178169d13836c8b429bfed39b986d6R54-R65): Added a new presubmit configuration for the `pingcap/tidb/pull_unit_test_ddlv1` job, including branches, trigger commands, and context settings.Add a new pipeline foro ddlv1 unit test, we need to monitor the stability of the new pipeline, only support trigger manually currently.