### PR TITLE
fix: use clang-format 15 after v7.4

### DIFF
--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -169,6 +169,14 @@ pipeline {
                         """
                     }
                 }
+                stage("clang-foramt-15") {
+                    steps {
+                        sh label: "install clang-format-15", script: """
+                            cp '${dependency_dir}/clang-format-15' '/usr/local/bin/clang-format-15'
+                            chmod +x '/usr/local/bin/clang-format-15'
+                        """
+                    }
+                }
             }
         }
         stage("Configure Project") {


### PR DESCRIPTION
user clang-format 15 after v7.4

releate to https://github.com/pingcap/tiflash/pull/7927/files#diff-a847e281c62ad2738f1616a96cd3174ca1fa5eba8134bf6f5d802a425c92c8b2R86-R90