### PR TITLE
chore: to use clang-format 12 for tiflash version less than v7.4

### DIFF
--- a/pipelines/pingcap/tiflash/release-6.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.1/pull_integration_test.groovy
@@ -169,6 +169,15 @@ pipeline {
                         """
                     }
                 }
+                // for version <= 7.4, use clang-format-12
+                stage("clang-foramt-12") {
+                    steps {
+                        sh label: "install clang-format-12", script: """
+                            cp '${dependency_dir}/clang-format-12' '/usr/local/bin/clang-format'
+                            chmod +x '/usr/local/bin/clang-format'
+                        """
+                    }
+                }
             }
         }
         stage("Configure Project") {

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -169,6 +169,15 @@ pipeline {
                         """
                     }
                 }
+                // for version <= 7.4, use clang-format-12
+                stage("clang-foramt-12") {
+                    steps {
+                        sh label: "install clang-format-12", script: """
+                            cp '${dependency_dir}/clang-format-12' '/usr/local/bin/clang-format'
+                            chmod +x '/usr/local/bin/clang-format'
+                        """
+                    }
+                }
             }
         }
         stage("Configure Project") {

--- a/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
@@ -169,6 +169,15 @@ pipeline {
                         """
                     }
                 }
+                // for version <= 7.4, use clang-format-12
+                stage("clang-foramt-12") {
+                    steps {
+                        sh label: "install clang-format-12", script: """
+                            cp '${dependency_dir}/clang-format-12' '/usr/local/bin/clang-format'
+                            chmod +x '/usr/local/bin/clang-format'
+                        """
+                    }
+                }
             }
         }
         stage("Configure Project") {


### PR DESCRIPTION
for version <= 7.4, need use clang-format 12