### PR TITLE
chore: temporary disable failed job

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: ci/integration-common-test
       max_concurrency: 1
-      skip_report: false
+      skip_report: true # TODO: change to false after failed test is fixed.
       branches:
         - ^master$
     - name: pingcap/tidb/merged_integration_ddl_test


### PR DESCRIPTION
Temporary disable failed job merged_integration_common_test due to https://github.com/pingcap/tidb/pull/56463, enable status reporting after fixing the test failure issue.