### PR TITLE
feat: disable auto refresh cache image for master&8.4

### DIFF
--- a/jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy
+++ b/jenkins/pipelines/ci/tikv/tikv_ghpr_cache.groovy
@@ -106,8 +106,6 @@ RUN cd tikv-src \
 """, "latest", args, false)
         }
         
-        build_branch("master")
-        build_branch("release-8.4")
         build_branch("release-8.1")
         build_branch("release-7.5")
         build_branch("release-7.1")


### PR DESCRIPTION
Since 8.4, the base image has been switched from centos7 to rocky8, so we no longer use this task for cache image updates on branch master and 8.4.