### PR TITLE
feat(tikv): start use rocky8 as base image since from 8.4

### DIFF
--- a/pipelines/tikv/tikv/latest/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/latest/pod-pull_unit_test.yaml
@@ -3,7 +3,8 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-master:latest"
+      image: "hub.pingcap.net/jenkins/tikv-ci:rocky8-base-cached-master"
+      imagePullPolicy: Always
       tty: true
       command:
         - "/bin/sh"

--- a/pipelines/tikv/tikv/latest/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/latest/pull_unit_test.groovy
@@ -10,7 +10,6 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 
 final EXTRA_NEXTEST_ARGS = "-j 8"
 
-
 pipeline {
     agent {
         kubernetes {
@@ -39,6 +38,7 @@ pipeline {
                     hostname
                     df -h
                     free -hm
+                    gcc --version
                     echo "-------------------------"
                     echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
                 """
@@ -91,8 +91,7 @@ pipeline {
                             export ROCKSDB_SYS_SSE=1
                             export RUST_BACKTRACE=1
                             export LOG_LEVEL=INFO
-                            echo using gcc 8
-                            source /opt/rh/devtoolset-8/enable
+
                             make clippy || (echo Please fix the clippy error; exit 1)
                         """
                     }
@@ -112,8 +111,7 @@ pipeline {
                             export LOG_LEVEL=INFO
                             export CARGO_INCREMENTAL=0
                             export RUSTDOCFLAGS="-Z unstable-options --persist-doctests"
-                            echo using gcc 8
-                            source /opt/rh/devtoolset-8/enable
+
                             set -e
                             set -o pipefail
 

--- a/pipelines/tikv/tikv/release-8.4/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-8.4/pod-pull_unit_test.yaml
@@ -3,7 +3,8 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-8.4:latest"
+      image: "hub.pingcap.net/jenkins/tikv-ci:rocky8-base-cached-release-8.4"
+      imagePullPolicy: Always
       tty: true
       command:
         - "/bin/sh"

--- a/pipelines/tikv/tikv/release-8.4/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-8.4/pull_unit_test.groovy
@@ -37,6 +37,7 @@ pipeline {
                     hostname
                     df -h
                     free -hm
+                    gcc --version
                     echo "-------------------------"
                     echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
                 """
@@ -89,8 +90,6 @@ pipeline {
                             export ROCKSDB_SYS_SSE=1
                             export RUST_BACKTRACE=1
                             export LOG_LEVEL=INFO
-                            echo using gcc 8
-                            source /opt/rh/devtoolset-8/enable
                             make clippy || (echo Please fix the clippy error; exit 1)
                         """
                     }
@@ -110,8 +109,6 @@ pipeline {
                             export LOG_LEVEL=INFO
                             export CARGO_INCREMENTAL=0
                             export RUSTDOCFLAGS="-Z unstable-options --persist-doctests"
-                            echo using gcc 8
-                            source /opt/rh/devtoolset-8/enable
                             set -e
                             set -o pipefail
 


### PR DESCRIPTION
CentOS 7 has reached the end of its life cycle. Starting from version 8.4, we began using Rocky Linux 8 as the base image.
* The default version of gcc in the new image is 8.5.0
* Temporarily use a docker image to implement the cargo cache, and after switching the base image, try to handle the cargo cache using the PVC