### PR TITLE
feat(pd): update base image to use rockylinux 8

### DIFF
--- a/pipelines/tikv/pd/latest/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/latest/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/latest/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_unit_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
CentOS 7 has reached the end of its life cycle. Starting from version 8.4, we begin using Rocky Linux 8 as the base image.