### PR TITLE
chore(tiflash): use clang-format in image

### DIFF
--- a/pipelines/pingcap/tiflash/release-6.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.1/pull_integration_test.groovy
@@ -169,15 +169,6 @@ pipeline {
                         """
                     }
                 }
-                // for version <= 7.4, use clang-format-12
-                stage("clang-foramt-12") {
-                    steps {
-                        sh label: "install clang-format-12", script: """
-                            cp '${dependency_dir}/clang-format-12' '/usr/local/bin/clang-format'
-                            chmod +x '/usr/local/bin/clang-format'
-                        """
-                    }
-                }
             }
         }
         stage("Configure Project") {

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -169,15 +169,6 @@ pipeline {
                         """
                     }
                 }
-                // for version <= 7.4, use clang-format-12
-                stage("clang-foramt-12") {
-                    steps {
-                        sh label: "install clang-format-12", script: """
-                            cp '${dependency_dir}/clang-format-12' '/usr/local/bin/clang-format'
-                            chmod +x '/usr/local/bin/clang-format'
-                        """
-                    }
-                }
             }
         }
         stage("Configure Project") {

--- a/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
@@ -169,15 +169,6 @@ pipeline {
                         """
                     }
                 }
-                // for version <= 7.4, use clang-format-12
-                stage("clang-foramt-12") {
-                    steps {
-                        sh label: "install clang-format-12", script: """
-                            cp '${dependency_dir}/clang-format-12' '/usr/local/bin/clang-format'
-                            chmod +x '/usr/local/bin/clang-format'
-                        """
-                    }
-                }
             }
         }
         stage("Configure Project") {

--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -169,6 +169,7 @@ pipeline {
                         """
                     }
                 }
+                // v7.5 ~ v8.1.0 use clang-format-15
                 stage("clang-foramt-15") {
                     steps {
                         sh label: "install clang-format-15", script: """

--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -169,7 +169,7 @@ pipeline {
                         """
                     }
                 }
-                // v7.5 ~ v8.1.0 use clang-format-15
+                // v7.5 ~ v8.1.x use clang-format-15
                 stage("clang-foramt-15") {
                     steps {
                         sh label: "install clang-format-15", script: """

--- a/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
@@ -167,6 +167,7 @@ pipeline {
                         """
                     }
                 }
+                // v7.5 ~ v8.1.0 use clang-format-15
                 stage("clang-foramt-15") {
                     steps {
                         sh label: "install clang-format-15", script: """

--- a/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
@@ -167,7 +167,7 @@ pipeline {
                         """
                     }
                 }
-                // v7.5 ~ v8.1.0 use clang-format-15
+                // v7.5 ~ v8.1.x use clang-format-15
                 stage("clang-foramt-15") {
                     steps {
                         sh label: "install clang-format-15", script: """


### PR DESCRIPTION
Remove clang-format-12, since we do not maintain the llvm@12 image.

For v6.1 ~ v7.1, using clang-format-13
For v7.5 ~ v8.1, using clang-format-15