### PR TITLE
feat(lib): use git shallow clone for lib cache

### DIFF
--- a/jobs/pingcap-inc/aa_folder.groovy
+++ b/jobs/pingcap-inc/aa_folder.groovy
@@ -11,13 +11,13 @@ folder('pingcap-inc') {
                             scm {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
-                                }
-                                extensions {
-                                    cloneOptions {
-                                        depth(1)
-                                        shallow(true)
-                                        timeout(5)
-                                    } 
+                                    extensions {
+                                        cloneOptions {
+                                            depth(1)
+                                            shallow(true)
+                                            timeout(5)
+                                        } 
+                                    }
                                 }
                             }
                             // A relative path from the root of the SCM to the root of the library.

--- a/jobs/pingcap-inc/aa_folder.groovy
+++ b/jobs/pingcap-inc/aa_folder.groovy
@@ -12,6 +12,13 @@ folder('pingcap-inc') {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
                                 }
+                                extensions {
+                                    cloneOptions {
+                                        depth(1)
+                                        shallow(true)
+                                        timeout(5)
+                                    } 
+                                }
                             }
                             // A relative path from the root of the SCM to the root of the library.
                             libraryPath('libraries/tipipeline')

--- a/jobs/pingcap-qe/aa_folder.groovy
+++ b/jobs/pingcap-qe/aa_folder.groovy
@@ -12,6 +12,13 @@ folder('pingcap-qe') {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
                                 }
+                                extensions {
+                                    cloneOptions {
+                                        depth(1)
+                                        shallow(true)
+                                        timeout(5)
+                                    } 
+                                }
                             }
                             // A relative path from the root of the SCM to the root of the library.
                             libraryPath('libraries/tipipeline')

--- a/jobs/pingcap-qe/aa_folder.groovy
+++ b/jobs/pingcap-qe/aa_folder.groovy
@@ -11,13 +11,13 @@ folder('pingcap-qe') {
                             scm {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
-                                }
-                                extensions {
-                                    cloneOptions {
-                                        depth(1)
-                                        shallow(true)
-                                        timeout(5)
-                                    } 
+                                    extensions {
+                                        cloneOptions {
+                                            depth(1)
+                                            shallow(true)
+                                            timeout(5)
+                                        } 
+                                    }
                                 }
                             }
                             // A relative path from the root of the SCM to the root of the library.

--- a/jobs/pingcap/aa_folder.groovy
+++ b/jobs/pingcap/aa_folder.groovy
@@ -11,13 +11,13 @@ folder('pingcap') {
                             scm {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
-                                }
-                                extensions {
-                                    cloneOptions {
-                                        depth(1)
-                                        shallow(true)
-                                        timeout(5)
-                                    } 
+                                    extensions {
+                                        cloneOptions {
+                                            depth(1)
+                                            shallow(true)
+                                            timeout(5)
+                                        } 
+                                    }
                                 }
                             }
                             // A relative path from the root of the SCM to the root of the library.

--- a/jobs/pingcap/aa_folder.groovy
+++ b/jobs/pingcap/aa_folder.groovy
@@ -12,6 +12,13 @@ folder('pingcap') {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
                                 }
+                                extensions {
+                                    cloneOptions {
+                                        depth(1)
+                                        shallow(true)
+                                        timeout(5)
+                                    } 
+                                }
                             }
                             // A relative path from the root of the SCM to the root of the library.
                             libraryPath('libraries/tipipeline')
@@ -22,7 +29,8 @@ folder('pingcap') {
                     // If checked, versions fetched using this library will be cached on the controller.
                     cachingConfiguration {
                         // Determines the amount of time until the cache is refreshed.
-                        refreshTimeMinutes(1440)
+                        // 0 means disable auto refresh
+                        refreshTimeMinutes(0)
                         // Space separated list of versions to exclude from caching via substring search using .contains() method.
                         excludedVersionsStr('feature/ fix/ bugfix/')
                         //Space separated list of versions to include to allow caching via substring search using .contains() method. Ex: "release/ master".

--- a/jobs/tikv/aa_folder.groovy
+++ b/jobs/tikv/aa_folder.groovy
@@ -12,6 +12,13 @@ folder('tikv') {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
                                 }
+                                extensions {
+                                    cloneOptions {
+                                        depth(1)
+                                        shallow(true)
+                                        timeout(5)
+                                    } 
+                                }
                             }
                             // A relative path from the root of the SCM to the root of the library.
                             libraryPath('libraries/tipipeline')

--- a/jobs/tikv/aa_folder.groovy
+++ b/jobs/tikv/aa_folder.groovy
@@ -11,13 +11,13 @@ folder('tikv') {
                             scm {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
-                                }
-                                extensions {
-                                    cloneOptions {
-                                        depth(1)
-                                        shallow(true)
-                                        timeout(5)
-                                    } 
+                                    extensions {
+                                        cloneOptions {
+                                            depth(1)
+                                            shallow(true)
+                                            timeout(5)
+                                        } 
+                                    }
                                 }
                             }
                             // A relative path from the root of the SCM to the root of the library.


### PR DESCRIPTION
* Use git shallow clone for lib cache to optimize the issue of incomplete library downloads caused by network quality.
* Disable the autorefresh lib for folder pingcap