### PR TITLE
fix(tidb-engine-ext): link git and registry cargo cache

### DIFF
--- a/prow-jobs/pingcap/tidb-engine-ext/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-engine-ext/latest-presubmits.yaml
@@ -19,6 +19,10 @@ presubmits:
             command: [bash, -ce]
             args:
               - |
+                rm -rf /root/.cargo/.git
+                rm -rf /root/.cargo/registry
+                ln -s /cargo-cache/git /root/.cargo/git
+                ln -s /cargo-cache/registry /root/.cargo/registry
                 set -euox pipefail
                 make ci_fmt_check
                 make ci_test
@@ -27,8 +31,6 @@ presubmits:
                 value: http://goproxy.pingcap.net,direct
               - name: CARGO_NET_GIT_FETCH_WITH_CLI
                 value: "true"
-              - name: CARGO_HOME
-                value: /cargo-cache
             resources:
               limits:
                 memory: 32Gi

--- a/prow-jobs/pingcap/tidb-engine-ext/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-engine-ext/latest-presubmits.yaml
@@ -34,7 +34,7 @@ presubmits:
             resources:
               limits:
                 memory: 32Gi
-                cpu: "6"
+                cpu: "12"
             volumeMounts:
               - name: cargo-cache
                 mountPath: /cargo-cache

--- a/prow-jobs/pingcap/tidb-engine-ext/release-6.1-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-engine-ext/release-6.1-latest-presubmits.yaml
@@ -16,6 +16,10 @@ presubmits:
             command: [bash, -ce]
             args:
               - |
+                rm -rf /root/.cargo/.git
+                rm -rf /root/.cargo/registry
+                ln -s /cargo-cache/git /root/.cargo/git
+                ln -s /cargo-cache/registry /root/.cargo/registry
                 set -euox pipefail
                 make ci_fmt_check
                 make ci_test
@@ -24,8 +28,6 @@ presubmits:
                 value: http://goproxy.pingcap.net,direct
               - name: CARGO_NET_GIT_FETCH_WITH_CLI
                 value: "true"
-              - name: CARGO_HOME
-                value: /cargo-cache
             resources:
               limits:
                 memory: 16Gi

--- a/prow-jobs/pingcap/tidb-engine-ext/release-6.1-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-engine-ext/release-6.1-latest-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
             resources:
               limits:
                 memory: 16Gi
-                cpu: "6"
+                cpu: "12"
             volumeMounts:
               - name: cargo-cache
                 mountPath: /cargo-cache


### PR DESCRIPTION
Directly setting the CARGO_HOME variable will result in losing the default config and env configurations，so just creat link for git and registry of cargo cache.