### PR TITLE
feat(tidb-engine-ext): Mount the necessary cargo home cache directory

### DIFF
--- a/prow-jobs/pingcap/tidb-engine-ext/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-engine-ext/latest-presubmits.yaml
@@ -35,15 +35,12 @@ presubmits:
               - name: cargo-cache
                 mountPath: /root/.cargo/git/db
                 subPath: git/db
-                readOnly: false
               - name: cargo-cache
                 mountPath: /root/.cargo/registry/index
                 subPath: registry/index
-                readOnly: false
               - name: cargo-cache
                 mountPath: /root/.cargo/registry/cache
                 subPath: registry/cache
-                readOnly: false
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/prow-jobs/pingcap/tidb-engine-ext/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-engine-ext/latest-presubmits.yaml
@@ -19,10 +19,6 @@ presubmits:
             command: [bash, -ce]
             args:
               - |
-                rm -rf /root/.cargo/.git
-                rm -rf /root/.cargo/registry
-                ln -s /cargo-cache/git /root/.cargo/git
-                ln -s /cargo-cache/registry /root/.cargo/registry
                 set -euox pipefail
                 make ci_fmt_check
                 make ci_test
@@ -37,7 +33,17 @@ presubmits:
                 cpu: "12"
             volumeMounts:
               - name: cargo-cache
-                mountPath: /cargo-cache
+                mountPath: /root/.cargo/git/db
+                subPath: git/db
+                readOnly: false
+              - name: cargo-cache
+                mountPath: /root/.cargo/registry/index
+                subPath: registry/index
+                readOnly: false
+              - name: cargo-cache
+                mountPath: /root/.cargo/registry/cache
+                subPath: registry/cache
+                readOnly: false
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/prow-jobs/pingcap/tidb-engine-ext/release-6.1-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-engine-ext/release-6.1-latest-presubmits.yaml
@@ -16,10 +16,6 @@ presubmits:
             command: [bash, -ce]
             args:
               - |
-                rm -rf /root/.cargo/.git
-                rm -rf /root/.cargo/registry
-                ln -s /cargo-cache/git /root/.cargo/git
-                ln -s /cargo-cache/registry /root/.cargo/registry
                 set -euox pipefail
                 make ci_fmt_check
                 make ci_test
@@ -34,7 +30,17 @@ presubmits:
                 cpu: "12"
             volumeMounts:
               - name: cargo-cache
-                mountPath: /cargo-cache
+                mountPath: /root/.cargo/git/db
+                subPath: git/db
+                readOnly: false
+              - name: cargo-cache
+                mountPath: /root/.cargo/registry/index
+                subPath: registry/index
+                readOnly: false
+              - name: cargo-cache
+                mountPath: /root/.cargo/registry/cache
+                subPath: registry/cache
+                readOnly: false
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/prow-jobs/pingcap/tidb-engine-ext/release-6.1-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-engine-ext/release-6.1-latest-presubmits.yaml
@@ -32,15 +32,12 @@ presubmits:
               - name: cargo-cache
                 mountPath: /root/.cargo/git/db
                 subPath: git/db
-                readOnly: false
               - name: cargo-cache
                 mountPath: /root/.cargo/registry/index
                 subPath: registry/index
-                readOnly: false
               - name: cargo-cache
                 mountPath: /root/.cargo/registry/cache
                 subPath: registry/cache
-                readOnly: false
         affinity:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Mount the necessary cargo home cache directory to reduce cache size.