### PR TITLE
chore: update image to go1.23

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-periodics.yaml
+++ b/prow-jobs/pingcap/tidb/latest-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
     spec:
       containers:
         - name: check
-          image: hub.pingcap.net/ee/ci/base:v20230810-go1.21
+          image: ghcr.io/pingcap-qe/ci/base:v2024.10.8-32-ge807718-go1.23
           command: [bash, -ce]
           args:
             - |


### PR DESCRIPTION
 update image to go1.23