### PR TITLE
docs: change the cloud doc branch to release-8.1 for PDF output

### DIFF
--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -85,11 +85,9 @@ pipeline {
                             target_version=\$(echo ${REFS.base_ref} | sed 's/release-//')
                             if [ "${REFS.base_ref}" = "master" ]; then
                                 python3 scripts/upload.py output.pdf tidb-dev-en-manual.pdf;
-                            elif [ "${REFS.base_ref}" = "release-7.5" ]; then
+                            elif [ "${REFS.base_ref}" = "release-8.1" ]; then
                                 python3 scripts/merge_by_toc.py TOC-tidb-cloud.md doc_cloud.md tidb-cloud; scripts/generate_cloud_pdf.sh;
                                 python3 scripts/upload.py output_cloud.pdf tidbcloud-en-manual.pdf;
-                                python3 scripts/upload.py output.pdf tidb-v7.5-en-manual.pdf;
-                            elif [ "${REFS.base_ref}" = "release-8.1" ]; then
                                 python3 scripts/upload.py output.pdf tidb-stable-en-manual.pdf;
                             elif case "${REFS.base_ref}" in release-*) ;; *) false;; esac; then
                                 python3 scripts/upload.py output.pdf tidb-v\${target_version}-en-manual.pdf;


### PR DESCRIPTION
As the default version for new TiDB Dedicated clusters has been updated to v8.1.0, this PR updates the cloud documentation branch to release-8.1 for PDF generation.