### PR TITLE
chore: remove wip for test pull-integration-e2e-test on 8.5

### DIFF
--- a/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
@@ -213,7 +213,7 @@ presubmits:
       decorate: false # need add this.
       always_run: false
       optional: true
-      context: wip/pull-integration-e2e-test # TODO: change to pull-integration-e2e-test after test
+      context: pull-integration-e2e-test
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-integration-e2e-test(?: .*?)?$"
       rerun_command: "/test pull-integration-e2e-test"


### PR DESCRIPTION
remove wip for test pull-integration-e2e-test on 8.5