### PR TITLE
opt(tikv/pd): fix the pull_integration_copr_test job for [v7.4 ~ v8.4]

### DIFF
--- a/pipelines/tikv/pd/release-8.1/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-8.1/pull_integration_copr_test.groovy
@@ -78,13 +78,13 @@ pipeline {
                 dir('pd') {
                     container("golang") {
                         sh label: 'pd-server', script: '[ -f bin/pd-server ] || make'
-                        sh label: 'tikv-server', script: """
-                        chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                        ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --tikv=${REFS.base_ref}
-                        rm -rf third_bin/bin && mv third_bin/* bin/ && ls -alh bin/
-                        bin/pd-server -V
-                        bin/tikv-server -V
-                        """
+                        script {
+                            component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin', trunkBranch="master", artifactVerify=true)
+                        }
+                        sh label: 'print component versions', script: '''
+                            bin/pd-server -V
+                            bin/tikv-server -V
+                        '''
                     }
                 }
             }

--- a/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
@@ -26,4 +26,5 @@ presubmits:
       context: wip/pull-integration-test
       trigger: "(?m)^/debug (?:.*? )?pull-integration-test(?: .*?)?$"
       rerun_command: "/debug pull-integration-test"
-      branches: *branches
+      branches:
+        - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$


### PR DESCRIPTION
add supports for release feature branches and hotfix branches, keep it same with TiDB's CI jobs.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>