### PR TITLE
fix(tiflow): temp bypass qiniuyun block download

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -110,7 +110,12 @@ pipeline {
                             sh label: "download third_party", script: """
                                 export TIDB_BRANCH=${tidbBranch}
                                 pwd && ls -alh dm/tests/
-                                cd dm/tests && ./download-compatibility-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
+
+                                cd dm/tests
+                                # NOTE: temporary fix for the download url(download from http://download.pingcap.org/ is blocked by the qiniuyun)
+                                sed -i 's|http://download.pingcap.org/tidb-enterprise-tools-nightly-linux-amd64.tar.gz|http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-nightly-linux-amd64.tar.gz|g' download-compatibility-test-binaries.sh
+                                sed -i 's|http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz|http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-latest-linux-amd64.tar.gz|g' download-compatibility-test-binaries.sh
+                                ./download-compatibility-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
                                 cd - && cp -r dm/tests/bin/* ./bin
                                 ls -alh ./bin
                                 ./bin/tidb-server -V

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -107,7 +107,11 @@ pipeline {
                             """
                             sh label: "download third_party", script: """
                                 pwd && ls -alh dm/tests/
-                                cd dm/tests && ./download-compatibility-test-binaries.sh release-7.1 && ls -alh ./bin
+                                cd dm/tests
+                                # NOTE: temporary fix for the download url(download from http://download.pingcap.org/ is blocked by the qiniuyun)
+                                sed -i 's|http://download.pingcap.org/tidb-enterprise-tools-nightly-linux-amd64.tar.gz|http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-nightly-linux-amd64.tar.gz|g' download-compatibility-test-binaries.sh
+                                sed -i 's|http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz|http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-latest-linux-amd64.tar.gz|g' download-compatibility-test-binaries.sh
+                                ./download-compatibility-test-binaries.sh release-7.1 && ls -alh ./bin
                                 cd - && cp -r dm/tests/bin/* ./bin
                                 ls -alh ./bin
                                 ./bin/tidb-server -V

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -107,7 +107,12 @@ pipeline {
                             """
                             sh label: "download third_party", script: """
                                 pwd && ls -alh dm/tests/
-                                cd dm/tests && ./download-compatibility-test-binaries.sh release-7.5 && ls -alh ./bin
+
+                                cd dm/tests
+                                # NOTE: temporary fix for the download url(download from http://download.pingcap.org/ is blocked by the qiniuyun)
+                                sed -i 's|http://download.pingcap.org/tidb-enterprise-tools-nightly-linux-amd64.tar.gz|http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-nightly-linux-amd64.tar.gz|g' download-compatibility-test-binaries.sh
+                                sed -i 's|http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz|http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-latest-linux-amd64.tar.gz|g' download-compatibility-test-binaries.sh
+                                ./download-compatibility-test-binaries.sh release-7.5 && ls -alh ./bin
                                 cd - && cp -r dm/tests/bin/* ./bin
                                 ls -alh ./bin
                                 ./bin/tidb-server -V

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
@@ -107,7 +107,11 @@ pipeline {
                             """
                             sh label: "download third_party", script: """
                                 pwd && ls -alh dm/tests/
-                                cd dm/tests && ./download-compatibility-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
+                                cd dm/tests
+                                # NOTE: temporary fix for the download url(download from http://download.pingcap.org/ is blocked by the qiniuyun)
+                                sed -i 's|http://download.pingcap.org/tidb-enterprise-tools-nightly-linux-amd64.tar.gz|http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-nightly-linux-amd64.tar.gz|g' download-compatibility-test-binaries.sh
+                                sed -i 's|http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz|http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-latest-linux-amd64.tar.gz|g' download-compatibility-test-binaries.sh
+                                ./download-compatibility-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
                                 cd - && cp -r dm/tests/bin/* ./bin
                                 ls -alh ./bin
                                 ./bin/tidb-server -V

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
@@ -107,7 +107,11 @@ pipeline {
                             """
                             sh label: "download third_party", script: """
                                 pwd && ls -alh dm/tests/
-                                cd dm/tests && ./download-compatibility-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
+                                cd dm/tests
+                                # NOTE: temporary fix for the download url(download from http://download.pingcap.org/ is blocked by the qiniuyun)
+                                sed -i 's|http://download.pingcap.org/tidb-enterprise-tools-nightly-linux-amd64.tar.gz|http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-nightly-linux-amd64.tar.gz|g' download-compatibility-test-binaries.sh
+                                sed -i 's|http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz|http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-latest-linux-amd64.tar.gz|g' download-compatibility-test-binaries.sh
+                                ./download-compatibility-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
                                 cd - && cp -r dm/tests/bin/* ./bin
                                 ls -alh ./bin
                                 ./bin/tidb-server -V


### PR DESCRIPTION
Qiniu Cloud has currently blocked the IP of the data center, making it impossible to download related resources. This issue is temporarily bypassed.
1. http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-nightly-linux-amd64.tar.gz
2. http://fileserver.pingcap.net/download/builds/pingcap/tiflow/tidb-enterprise-tools-latest-linux-amd64.tar.gz