### PR TITLE
feat(tikv,pingcap): add lint job for community repos

### DIFF
--- a/prow-jobs/kustomization.yaml
+++ b/prow-jobs/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
       - pingcap-inc_enterprise-extensions_presubmits.yaml=pingcap-inc/enterprise-extensions/presubmits.yaml
       - pingcap-qe_ci_presubmits.yaml=pingcap-qe/ci/presubmits.yaml
       - pingcap_community_postsubmits.yaml=pingcap/community/postsubmits.yaml
+      - pingcap_community_presubmits.yaml=pingcap/community/presubmits.yaml
       - pingcap_docs_docs-cn-latest-presubmits.yaml=pingcap/docs/docs-cn-latest-presubmits.yaml
       - pingcap_docs_docs-cn-postsubmits.yaml=pingcap/docs/docs-cn-postsubmits.yaml
       - pingcap_docs_docs-latest-presubmits.yaml=pingcap/docs/docs-latest-presubmits.yaml
@@ -98,6 +99,7 @@ configMapGenerator:
       - ti-community-infra_prow_postsubmits.yaml=ti-community-infra/prow/postsubmits.yaml
       - ti-community-infra_prow_presubmits.yaml=ti-community-infra/prow/presubmits.yaml
       - tikv_community_postsubmits.yaml=tikv/community/postsubmits.yaml
+      - tikv_community_presubmits.yaml=tikv/community/presubmits.yaml
       - tikv_migration_latest-presubmits.yaml=tikv/migration/latest-presubmits.yaml
       - tikv_pd_latest-presubmits.yaml=tikv/pd/latest-presubmits.yaml
       - tikv_pd_release-6.1-presubmits.yaml=tikv/pd/release-6.1-presubmits.yaml

--- a/prow-jobs/pingcap/community/postsubmits.yaml
+++ b/prow-jobs/pingcap/community/postsubmits.yaml
@@ -6,7 +6,7 @@ postsubmits:
       max_concurrency: 1
       run_if_changed: teams/.*/membership\.json
       branches:
-        - master
+        - ^master$
       spec:
         containers:
           - name: main

--- a/prow-jobs/pingcap/community/presubmits.yaml
+++ b/prow-jobs/pingcap/community/presubmits.yaml
@@ -1,0 +1,25 @@
+presubmits:
+  pingcap/community:
+    - name: pull-verify
+      decorate: true
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      branches:
+        - ^master$
+      spec:
+        containers:
+          - name: check
+            image: wbitt/network-multitool
+            command: [bash, -ceo, pipefail]
+            args:
+              - |
+                for f in $(find teams -name "*.json" -type f); do
+                  echo -n "check file: $f ... "
+                  (jq . $f > /dev/null && echo "✅") || exit 1
+                done
+            resources:
+              limits:
+                cpu: "200m"
+                memory: 512Mi
+              requests:
+                cpu: "100m"
+                memory: 256Mi

--- a/prow-jobs/tikv/community/presubmits.yaml
+++ b/prow-jobs/tikv/community/presubmits.yaml
@@ -1,0 +1,25 @@
+presubmits:
+  tikv/community:
+    - name: pull-verify
+      decorate: true
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      branches:
+        - ^master$
+      spec:
+        containers:
+          - name: check
+            image: wbitt/network-multitool
+            command: [bash, -ceo, pipefail]
+            args:
+              - |
+                for f in $(find teams -name "*.json" -type f); do
+                  echo -n "check file: $f ... "
+                  (jq . $f > /dev/null && echo "✅") || exit 1
+                done
+            resources:
+              limits:
+                cpu: "200m"
+                memory: 512Mi
+              requests:
+                cpu: "100m"
+                memory: 256Mi


### PR DESCRIPTION
This pull request includes updates to the `prow-jobs` configuration files to add new presubmit jobs and refine existing configurations. The most important changes include adding new presubmit job configurations for `pingcap/community` and `tikv/community`, and refining branch specifications for postsubmit jobs.

### Why

Some times the community maintainers contribute wrong format team membership json files, It will make the bot(ti-chi-bot) can not work to sync the OWNERS files for the controlled repositories. I made the pull request to add basic json verify jobs for membership json files to block wrong changes on format.

### New presubmit job configurations:

* [`prow-jobs/pingcap/community/presubmits.yaml`](diffhunk://#diff-201e72a2e194854030a794a5b8bbf9cbf0464c4ea4dfc225871c70eb822a4f23R1-R25): Added a new presubmit job `pull-verify` for `pingcap/community` to check JSON files using `jq`.
* [`prow-jobs/tikv/community/presubmits.yaml`](diffhunk://#diff-30ab0438808b8b152ea23af14f48aaa5ef79bcdb57e58c78fd96573a7f82246aR1-R25): Added a new presubmit job `pull-verify` for `tikv/community` to check JSON files using `jq`.
