### PR TITLE
docs: bump pdf stable version to release-8.5

### DIFF
--- a/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
+++ b/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
@@ -83,7 +83,7 @@ pipeline {
                             target_version=\$(echo ${REFS.base_ref} | sed 's/release-//')
                             if [ "${REFS.base_ref}" = "master" ]; then
                                 python3 scripts/upload.py output.pdf tidb-dev-zh-manual.pdf;
-                            elif [ "${REFS.base_ref}" = "release-8.1" ]; then
+                            elif [ "${REFS.base_ref}" = "release-8.5" ]; then
                                 python3 scripts/upload.py output.pdf tidb-stable-zh-manual.pdf;
                             elif case "${REFS.base_ref}" in release-*) ;; *) false;; esac; then
                                 python3 scripts/upload.py output.pdf tidb-v\${target_version}-zh-manual.pdf;

--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -88,6 +88,8 @@ pipeline {
                             elif [ "${REFS.base_ref}" = "release-8.1" ]; then
                                 python3 scripts/merge_by_toc.py TOC-tidb-cloud.md doc_cloud.md tidb-cloud; scripts/generate_cloud_pdf.sh;
                                 python3 scripts/upload.py output_cloud.pdf tidbcloud-en-manual.pdf;
+                                python3 scripts/upload.py output.pdf tidb-v8.1-en-manual.pdf;
+                            elif [ "${REFS.base_ref}" = "release-8.5" ]; then
                                 python3 scripts/upload.py output.pdf tidb-stable-en-manual.pdf;
                             elif case "${REFS.base_ref}" in release-*) ;; *) false;; esac; then
                                 python3 scripts/upload.py output.pdf tidb-v\${target_version}-en-manual.pdf;

--- a/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
@@ -12,4 +12,4 @@ postsubmits:
         - ^release-5\.[34]$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
-        - ^release-8\.[1-6]$
+        - ^release-8\.[1-5]$

--- a/prow-jobs/pingcap/docs/docs-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-postsubmits.yaml
@@ -12,4 +12,4 @@ postsubmits:
         - ^release-5\.[34]$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
-        - ^release-8\.[1-6]$
+        - ^release-8\.[1-5]$


### PR DESCRIPTION
Update the stable PDF version of TiDB and TiDB Cloud:

TiDB: the stable PDF version is updated from release-8.1 to release-8.5.
TiDB Cloud: the stable PDF version will remain at release-8.1 to ensure consistency with the current TiDB Cloud documentation.