### PR TITLE
chore(tidb): update to use rocky8 image

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_ddl_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_mysql_client_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_mysql_client_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_tiflash_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_tiflash_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
Update to use rocky8 image in merge ci pipelines.