### PR TITLE
chore(deps): bump tag image for security scan task

### DIFF
--- a/prow-jobs/pingcap-qe/ee-apps/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ee-apps/presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       spec:
         containers:
           - name: main
-            image: ghcr.io/pingcap-qe/ci/secure-merge-check:v1.0.0_linux_amd64 # TODO: request a multi-arch image.
+            image: ghcr.io/pingcap-qe/ci/secure-merge-check:v1.0.0 # TODO: request a multi-arch image.
             envFrom:
               - secretRef:
                   name: secuirty-scan


### PR DESCRIPTION
This pull request includes a small change to the `prow-jobs/pingcap-qe/ee-apps/presubmits.yaml` file. The change updates the image reference for the `secure-merge-check` container to remove the platform-specific suffix.

* [`prow-jobs/pingcap-qe/ee-apps/presubmits.yaml`](diffhunk://#diff-db56dc8ed1c82668a58b1ec5ccc1354f07976cbf913f080448232d3c5c497f99L13-R13): Updated the `image` field for the `secure-merge-check` container to use a more general image reference.