### PR TITLE
feat(tidb-test):  adjust image from centos7 to rocky8

### DIFF
--- a/pipelines/PingCAP-QE/tidb-test/latest/ghpr_integration_mysql_test.groovy
+++ b/pipelines/PingCAP-QE/tidb-test/latest/ghpr_integration_mysql_test.groovy
@@ -135,7 +135,7 @@ pipeline {
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
-                                        ./test.sh -blacklist=1 -part=${PART}
+                                        ./test.sh 1 ${PART}
                                     """
                                 }
                             }

--- a/pipelines/PingCAP-QE/tidb-test/latest/ghpr_mysql_test.groovy
+++ b/pipelines/PingCAP-QE/tidb-test/latest/ghpr_mysql_test.groovy
@@ -107,7 +107,7 @@ pipeline {
                                     sh label: "part ${PART}", script: """
                                     export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
                                     export TIDB_TEST_STORE_NAME="unistore"
-                                    ./test.sh -backlist=1 -part=${PART}
+                                    ./test.sh 1 ${PART}
                                     """
                                 }
                             }

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_build.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_common_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_common_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_jdbc_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_python_orm_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_integration_python_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_common_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_jdbc_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_mysql_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_ruby_orm_test.yaml
+++ b/pipelines/PingCAP-QE/tidb-test/latest/pod-pull_tiproxy_ruby_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       securityContext:
         privileged: true
       tty: true


### PR DESCRIPTION
Adjust image from centos7 to rocky8 because centos7 end of life.