### PR TITLE
chore: fix OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,3 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 approvers:
   - sig-approvers-ee
-reviewers:
-  - sig-reviewers-security

--- a/jobs/OWNERS
+++ b/jobs/OWNERS
@@ -2,3 +2,5 @@ labels:
   - area/jobs/jenkins-DSL
 approvers:
   - sig-approvers-ee
+reviewers:
+  - sig-reviewers-security


### PR DESCRIPTION
wrong introduce security team as reviewers in top OWNERS file.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>