### PR TITLE
fix(tiflow/dm): use tini image to avoid zombie process

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
@@ -17,8 +17,10 @@ spec:
           name: "mysql-config-volume"
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:tini"
       tty: true
+      args:
+        - cat
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,9 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "hub.pingcap.net/jenkins/golang-tini:1.20"
+      args:
+        - cat
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml
@@ -5,8 +5,10 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
       tty: true
+      args:
+        - cat
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_integration_test.yaml
@@ -5,8 +5,10 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
       tty: true
+      args:
+        - cat
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_integration_test.yaml
@@ -5,8 +5,10 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
       tty: true
+      args:
+        - cat
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_integration_test.yaml
@@ -5,8 +5,10 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
       tty: true
+      args:
+        - cat
       resources:
         requests:
           memory: 12Gi
@@ -20,7 +22,7 @@ spec:
       resources:
         limits:
           memory: 4Gi
-          cpu: 2
+          cpu: "2"
       env:
         - name: MYSQL_ROOT_PASSWORD
           value: "123456"
@@ -38,7 +40,7 @@ spec:
       resources:
         limits:
           memory: 4Gi
-          cpu: 2
+          cpu: "2"
       env:
         - name: MYSQL_ROOT_PASSWORD
           value: "123456"

--- a/pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_integration_test.yaml
@@ -5,8 +5,10 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
       tty: true
+      args:
+        - cat
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_integration_test.yaml
@@ -5,8 +5,10 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
       tty: true
+      args:
+        - cat
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_integration_test.yaml
@@ -5,8 +5,10 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/golang-tini:1.23"
       tty: true
+      args:
+        - cat
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
@@ -5,8 +5,10 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/golang-tini:1.23"
       tty: true
+      args:
+        - cat
       resources:
         requests:
           memory: 12Gi
@@ -20,7 +22,7 @@ spec:
       resources:
         limits:
           memory: 4Gi
-          cpu: 2
+          cpu: "2"
       env:
         - name: MYSQL_ROOT_PASSWORD
           value: "123456"
@@ -38,7 +40,7 @@ spec:
       resources:
         limits:
           memory: 4Gi
-          cpu: 2
+          cpu: "2"
       env:
         - name: MYSQL_ROOT_PASSWORD
           value: "123456"


### PR DESCRIPTION
Use tini as init process in image to avoid zombie process after test kill some process.