### PR TITLE
chore(tiflow): keep the trigger command and context consistent

### DIFF
--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -96,8 +96,8 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify
+      context: pull-verify
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches: *branches

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -14,8 +14,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches: *branches
 
     # TODO: combine other CDC integration tests to a single one,
@@ -28,8 +28,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches: *branches
 
     - name: pingcap/tiflow/pull_cdc_integration_storage_test
@@ -40,8 +40,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches: *branches
 
     - name: pingcap/tiflow/pull_cdc_integration_pulsar_test
@@ -52,8 +52,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test"
       branches: *branches
 
     - name: pingcap/tiflow/pull_dm_compatibility_test
@@ -64,8 +64,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches: *branches
 
     - name: pingcap/tiflow/pull_dm_integration_test
@@ -76,8 +76,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches: *branches
 
     - name: pingcap/tiflow/pull_engine_integration_test
@@ -88,8 +88,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches: *branches
 
     - name: pingcap/tiflow/ghpr_verify

--- a/prow-jobs/pingcap/tiflow/release-5.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-5.3-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-5\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-5.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-5.3-presubmits.yaml
@@ -19,8 +19,8 @@ presubmits:
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-5\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-5.3/pull_cdc_integration_test
@@ -31,8 +31,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-5\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-5.3/pull_dm_compatibility_test
@@ -43,8 +43,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-5\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-5.3/pull_dm_integration_test
@@ -55,7 +55,7 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-5\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-5.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-5.3-presubmits.yaml
@@ -5,10 +5,10 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-5\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-5.3/pull_cdc_integration_kafka_test

--- a/prow-jobs/pingcap/tiflow/release-5.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-5.4-presubmits.yaml
@@ -19,8 +19,8 @@ presubmits:
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-5\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-5.4/pull_cdc_integration_test
@@ -31,8 +31,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-5\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-5.4/pull_dm_compatibility_test
@@ -43,8 +43,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-5\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-5.4/pull_dm_integration_test
@@ -55,7 +55,7 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-5\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-5.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-5.4-presubmits.yaml
@@ -5,10 +5,10 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-5\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-5.4/pull_cdc_integration_kafka_test

--- a/prow-jobs/pingcap/tiflow/release-6.0-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.0-presubmits.yaml
@@ -5,9 +5,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify
+      context: pull-verify
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-6\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-6.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.1-presubmits.yaml
@@ -19,8 +19,8 @@ presubmits:
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-6\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-6.1/pull_cdc_integration_test
@@ -31,8 +31,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-6\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-6.1/pull_dm_compatibility_test
@@ -43,8 +43,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-6\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-6.1/pull_dm_integration_test
@@ -55,7 +55,7 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-6\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-6.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.1-presubmits.yaml
@@ -5,10 +5,10 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-6\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test

--- a/prow-jobs/pingcap/tiflow/release-6.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.2-presubmits.yaml
@@ -5,9 +5,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-6\.[2-4](\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-6.5-20241101-v6.5.7-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.5-20241101-v6.5.7-presubmits.yaml
@@ -19,8 +19,8 @@ presubmits:
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-6\.5-20241101-v6\.5\.7$ # trigger for specific hotfix branch
     - name: pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_test
@@ -31,8 +31,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-6\.5-20241101-v6\.5\.7$ # trigger for specific hotfix branch
     - name: pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_compatibility_test
@@ -43,8 +43,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-6\.5-20241101-v6\.5\.7$ # trigger for specific hotfix branch
     - name: pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_integration_test
@@ -55,7 +55,7 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-6\.5-20241101-v6\.5\.7$ # trigger for specific hotfix branch

--- a/prow-jobs/pingcap/tiflow/release-6.5-20241101-v6.5.7-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.5-20241101-v6.5.7-presubmits.yaml
@@ -5,10 +5,10 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-6\.5-20241101-v6\.5\.7$ # trigger for specific hotfix branch
     - name: pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_kafka_test

--- a/prow-jobs/pingcap/tiflow/release-6.5-fips-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.5-fips-presubmits.yaml
@@ -5,10 +5,10 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^feature/release-6.5-fips$
     - name: pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test

--- a/prow-jobs/pingcap/tiflow/release-6.5-fips-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.5-fips-presubmits.yaml
@@ -19,8 +19,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^feature/release-6.5-fips$
     - name: pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test
@@ -31,8 +31,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^feature/release-6.5-fips$
     - name: pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test
@@ -43,8 +43,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^feature/release-6.5-fips$
     - name: pingcap/tiflow/release-6.5-fips/pull_dm_integration_test
@@ -55,7 +55,7 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^feature/release-6.5-fips$

--- a/prow-jobs/pingcap/tiflow/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.5-presubmits.yaml
@@ -5,10 +5,10 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-6\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
       skip_branches:

--- a/prow-jobs/pingcap/tiflow/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.5-presubmits.yaml
@@ -21,8 +21,8 @@ presubmits:
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-6\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
       skip_branches:
@@ -35,8 +35,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-6\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
       skip_branches:
@@ -49,8 +49,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-6\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
       skip_branches:
@@ -63,8 +63,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-6\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
       skip_branches:

--- a/prow-jobs/pingcap/tiflow/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.1-presubmits.yaml
@@ -78,9 +78,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-7\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.1-presubmits.yaml
@@ -9,8 +9,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-7\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.1/pull_cdc_integration_test
@@ -21,8 +21,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-7\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test
@@ -33,8 +33,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches:
         - ^release-7\.1$
         - ^release-7\.1-(\d{8})-(v7\.1\.[1-9]\d*)(-\d+)?$ # exclude v7.1.0 hotfix branch
@@ -46,8 +46,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-7\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.1/pull_dm_integration_test
@@ -58,8 +58,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-7\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.1/pull_engine_integration_test
@@ -70,8 +70,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches:
         - ^release-7\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.1/ghpr_verify

--- a/prow-jobs/pingcap/tiflow/release-7.1.0-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.1.0-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches:
         - ^release-7\.1-\d{8}-v7\.1\.0(-\d+)?$  # only v7.1.0 hotfix branch

--- a/prow-jobs/pingcap/tiflow/release-7.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.2-presubmits.yaml
@@ -9,8 +9,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/pull_cdc_integration_test
@@ -21,8 +21,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test
@@ -33,8 +33,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/pull_dm_compatibility_test
@@ -45,8 +45,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/pull_dm_integration_test
@@ -57,8 +57,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/pull_engine_integration_test
@@ -69,8 +69,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/ghpr_verify

--- a/prow-jobs/pingcap/tiflow/release-7.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.2-presubmits.yaml
@@ -77,9 +77,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-7.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.3-presubmits.yaml
@@ -9,8 +9,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/pull_cdc_integration_test
@@ -21,8 +21,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test
@@ -33,8 +33,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/pull_dm_compatibility_test
@@ -45,8 +45,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/pull_dm_integration_test
@@ -57,8 +57,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/pull_engine_integration_test
@@ -69,8 +69,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/ghpr_verify

--- a/prow-jobs/pingcap/tiflow/release-7.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.3-presubmits.yaml
@@ -77,9 +77,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-7.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.4-presubmits.yaml
@@ -89,9 +89,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-7.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.4-presubmits.yaml
@@ -9,8 +9,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test
@@ -21,8 +21,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test
@@ -33,8 +33,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test"
       branches:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test
@@ -45,8 +45,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_dm_compatibility_test
@@ -57,8 +57,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_dm_integration_test
@@ -69,8 +69,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_engine_integration_test
@@ -81,8 +81,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/ghpr_verify

--- a/prow-jobs/pingcap/tiflow/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.5-presubmits.yaml
@@ -89,9 +89,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.5-presubmits.yaml
@@ -9,8 +9,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test
@@ -21,8 +21,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test
@@ -33,8 +33,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test"
       branches:
         - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test
@@ -45,8 +45,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches:
         - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.5/pull_dm_compatibility_test
@@ -57,8 +57,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.5/pull_dm_integration_test
@@ -69,8 +69,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.5/pull_engine_integration_test
@@ -81,8 +81,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches:
         - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.5/ghpr_verify

--- a/prow-jobs/pingcap/tiflow/release-7.6-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.6-presubmits.yaml
@@ -9,8 +9,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test
@@ -21,8 +21,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test
@@ -33,8 +33,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test"
       branches:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test
@@ -45,8 +45,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_dm_compatibility_test
@@ -57,8 +57,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_dm_integration_test
@@ -69,8 +69,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_engine_integration_test
@@ -81,8 +81,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/ghpr_verify

--- a/prow-jobs/pingcap/tiflow/release-7.6-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.6-presubmits.yaml
@@ -89,9 +89,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-8.0-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.0-presubmits.yaml
@@ -9,8 +9,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test
@@ -21,8 +21,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test
@@ -33,8 +33,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test"
       branches:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test
@@ -45,8 +45,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_dm_compatibility_test
@@ -57,8 +57,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_dm_integration_test
@@ -69,8 +69,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_engine_integration_test
@@ -81,8 +81,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/ghpr_verify

--- a/prow-jobs/pingcap/tiflow/release-8.0-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.0-presubmits.yaml
@@ -89,9 +89,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.1-presubmits.yaml
@@ -89,9 +89,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.1-presubmits.yaml
@@ -9,8 +9,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test
@@ -21,8 +21,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test
@@ -33,8 +33,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test"
       branches:
         - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test
@@ -45,8 +45,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches:
         - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.1/pull_dm_compatibility_test
@@ -57,8 +57,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.1/pull_dm_integration_test
@@ -69,8 +69,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.1/pull_engine_integration_test
@@ -81,8 +81,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches:
         - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.1/ghpr_verify

--- a/prow-jobs/pingcap/tiflow/release-8.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.2-presubmits.yaml
@@ -9,8 +9,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test
@@ -21,8 +21,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test
@@ -33,8 +33,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test"
       branches:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test
@@ -45,8 +45,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_dm_compatibility_test
@@ -57,8 +57,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_dm_integration_test
@@ -69,8 +69,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_engine_integration_test
@@ -81,8 +81,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/ghpr_verify

--- a/prow-jobs/pingcap/tiflow/release-8.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.2-presubmits.yaml
@@ -89,9 +89,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$

--- a/prow-jobs/pingcap/tiflow/release-8.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.3-presubmits.yaml
@@ -15,8 +15,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test
       agent: jenkins
@@ -26,8 +26,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test
       agent: jenkins
@@ -37,8 +37,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test
       agent: jenkins
@@ -48,8 +48,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_dm_compatibility_test
       agent: jenkins
@@ -59,8 +59,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_dm_integration_test
       agent: jenkins
@@ -70,8 +70,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_engine_integration_test
       agent: jenkins
@@ -81,8 +81,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.3/ghpr_verify
       agent: jenkins

--- a/prow-jobs/pingcap/tiflow/release-8.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.3-presubmits.yaml
@@ -88,8 +88,8 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches: *branches

--- a/prow-jobs/pingcap/tiflow/release-8.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.4-presubmits.yaml
@@ -15,8 +15,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test
       agent: jenkins
@@ -26,8 +26,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test
       agent: jenkins
@@ -37,8 +37,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test
       agent: jenkins
@@ -48,8 +48,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_dm_compatibility_test
       agent: jenkins
@@ -59,8 +59,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_dm_integration_test
       agent: jenkins
@@ -70,8 +70,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_engine_integration_test
       agent: jenkins
@@ -81,8 +81,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.4/ghpr_verify
       agent: jenkins

--- a/prow-jobs/pingcap/tiflow/release-8.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.4-presubmits.yaml
@@ -88,8 +88,8 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches: *branches

--- a/prow-jobs/pingcap/tiflow/release-8.5-centos-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.5-centos-presubmits.yaml
@@ -11,8 +11,8 @@ presubmits:
       always_run: false
       optional: true
       context: pull-cdc-integration-kafka-test-centos
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test-centos)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test-centos"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test-centos)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test-centos"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test_centos
       agent: jenkins
@@ -20,8 +20,8 @@ presubmits:
       always_run: false
       optional: true
       context: pull-cdc-integration-mysql-test-centos
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test-centos)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test-centos"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test-centos)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test-centos"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test_centos
       agent: jenkins
@@ -29,8 +29,8 @@ presubmits:
       always_run: false
       optional: true
       context: pull-cdc-integration-pulsar-test-centos
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test-centos)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test-centos"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test-centos)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test-centos"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test_centos
       agent: jenkins
@@ -38,8 +38,8 @@ presubmits:
       always_run: false
       optional: true
       context: pull-cdc-integration-storage-test-centos
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test-centos)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test-centos"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test-centos)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test-centos"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_dm_compatibility_test_centos
       agent: jenkins
@@ -47,8 +47,8 @@ presubmits:
       always_run: false
       optional: true
       context: pull-dm-compatibility-test-centos
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test-centos)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test-centos"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test-centos)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test-centos"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_dm_integration_test_centos
       agent: jenkins
@@ -56,8 +56,8 @@ presubmits:
       always_run: false
       optional: true
       context: pull-dm-integration-test-centos
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test-centos)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test-centos"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test-centos)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test-centos"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_engine_integration_test_centos
       agent: jenkins
@@ -65,6 +65,6 @@ presubmits:
       always_run: false
       optional: true
       context: pull-engine-integration-test-centos
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test-centos)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test-centos"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test-centos)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test-centos"
       branches: *branches

--- a/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
@@ -15,8 +15,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-kafka-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-kafka-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-kafka-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-kafka-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-kafka-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test
       agent: jenkins
@@ -26,8 +26,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-mysql-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-mysql-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-mysql-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-mysql-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-mysql-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test
       agent: jenkins
@@ -37,8 +37,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-pulsar-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-pulsar-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-pulsar-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-pulsar-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-pulsar-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test
       agent: jenkins
@@ -48,8 +48,8 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-integration-storage-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(cdc-integration-storage-test|all)(?: .*?)?$"
-      rerun_command: "/test cdc-integration-storage-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-integration-storage-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-integration-storage-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_dm_compatibility_test
       agent: jenkins
@@ -59,8 +59,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-compatibility-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-compatibility-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-compatibility-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_dm_integration_test
       agent: jenkins
@@ -70,8 +70,8 @@ presubmits:
       run_before_merge: true
       context: pull-dm-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(dm-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test dm-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/pull_engine_integration_test
       agent: jenkins
@@ -81,8 +81,8 @@ presubmits:
       run_before_merge: true
       context: pull-engine-integration-test
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(engine-integration-test|all)(?: .*?)?$"
-      rerun_command: "/test engine-integration-test"
+      trigger: "(?m)^/test (?:.*? )?(pull-engine-integration-test|all)(?: .*?)?$"
+      rerun_command: "/test pull-engine-integration-test"
       branches: *branches
     - name: pingcap/tiflow/release-8.5/ghpr_verify
       agent: jenkins

--- a/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
@@ -88,8 +88,8 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
-      context: jenkins-ticdc/verify 
+      context: pull-verify 
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?verify(?: .*?)?$"
-      rerun_command: "/test verify"
+      trigger: "(?m)^/test (?:.*? )?pull-verify(?: .*?)?$"
+      rerun_command: "/test pull-verify"
       branches: *branches


### PR DESCRIPTION
To reduce the memory cost of triggering commands, keep the trigger command consistent with the context.

Taking pull-cdc-integration-kafka-test as an example. Context of this pipeline is `pull-cdc-integration-kafka-test` 
* The current trigger command is `/test cdc-integration-kafka-test`
* The adjusted trigger command is `/test pull-cdc-integration-kafka-test`

For `jenkins-ticdc/verify`, because this pipeline includes unit tests and build for multiple components (CDC and other components),  so we update this context to `pull-verify`
* The context will change from `jenkins-ticdc/verify` to `pull-verify`
* The trigger command will change from `/test verify` to `/test pull-verify`