### PR TITLE
fix(tidb): add unit test step for enterprise extensions

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -104,7 +104,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -68,14 +68,14 @@ pipeline {
                         set -o pipefail
 
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
-                        '''
+                    '''
                 }
             }
             post {
                  success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -101,6 +101,34 @@ pipeline {
                 }
             }
         }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
+                }
+            }
+        }        
     }
     post {
         success {

--- a/pipelines/pingcap/tidb/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_unit_test.groovy
@@ -64,21 +64,13 @@ pipeline {
 
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
                     '''
-                    sh(
-                        // Q: why this step is not existed in presubmit job?
-                        // A: we should not forbiden the community contrubutor on the unit test on private submodules.
-                        // if it failed, the enterprise extension owners should fix it.
-                        label: 'test enterprise extensions',
-                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
-                    )
                 }
             }
             post {
-                 success {
+                success {
                     dir(REFS.repo) {
                         script {
                             prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
-                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
                         }
                     }
                 }
@@ -101,6 +93,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_unit_test.groovy
@@ -99,7 +99,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_unit_test.groovy
@@ -68,14 +68,14 @@ pipeline {
                         set -o pipefail
 
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
-                        '''
+                    '''
                 }
             }
             post {
                 success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -98,6 +98,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_unit_test.groovy
@@ -104,7 +104,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_unit_test.groovy
@@ -36,6 +36,9 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
                 }
             }
         }
@@ -61,14 +64,14 @@ pipeline {
                         set -o pipefail
 
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
-                        '''
+                    '''
                 }
             }
             post {
                 success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -91,6 +94,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_unit_test.groovy
@@ -100,7 +100,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_unit_test.groovy
@@ -36,6 +36,9 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
                 }
             }
         }
@@ -61,14 +64,14 @@ pipeline {
                         set -o pipefail
 
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
-                        '''
+                    '''
                 }
             }
             post {
                 success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -77,7 +80,6 @@ pipeline {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                         archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
                     }
-
                     sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
                     sh label: 'Send event to cloudevents server', script: """timeout 10 \
                         curl --verbose --request POST --url http://cloudevents-server.apps.svc/events \
@@ -92,6 +94,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_unit_test.groovy
@@ -100,7 +100,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_unit_test.groovy
@@ -35,6 +35,9 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
                 }
             }
         }
@@ -65,23 +68,22 @@ pipeline {
                         set -o pipefail
 
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
-                        '''
+                    '''
                 }
             }
             post {
                 success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
-                }                
+                }
                 always {
                     dir(REFS.repo) {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                         archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
                     }
-
                     sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
                     sh label: 'Send event to cloudevents server', script: """timeout 10 \
                         curl --verbose --request POST --url http://cloudevents-server.apps.svc/events \
@@ -96,6 +98,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_unit_test.groovy
@@ -104,7 +104,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_unit_test.groovy
@@ -104,7 +104,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_unit_test.groovy
@@ -68,14 +68,14 @@ pipeline {
                         set -o pipefail
 
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
-                        '''
+                    '''
                 }
             }
             post {
                 success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -84,7 +84,6 @@ pipeline {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                         archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
                     }
-
                     sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
                     sh label: 'Send event to cloudevents server', script: """timeout 10 \
                         curl --verbose --request POST --url http://cloudevents-server.apps.svc/events \
@@ -99,6 +98,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-7.6/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_unit_test.groovy
@@ -35,6 +35,9 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
                 }
             }
         }
@@ -63,6 +66,7 @@ pipeline {
                     """
                     sh '''#! /usr/bin/env bash
                         set -o pipefail
+
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
                     '''
                 }
@@ -71,7 +75,7 @@ pipeline {
                 success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -80,7 +84,6 @@ pipeline {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                         archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
                     }
-
                     sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
                     sh label: 'Send event to cloudevents server', script: """timeout 10 \
                         curl --verbose --request POST --url http://cloudevents-server.apps.svc/events \
@@ -95,6 +98,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-7.6/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_unit_test.groovy
@@ -104,7 +104,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-8.0/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/ghpr_unit_test.groovy
@@ -103,7 +103,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-8.0/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/ghpr_unit_test.groovy
@@ -35,6 +35,9 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
                 }
             }
         }
@@ -71,7 +74,7 @@ pipeline {
                 success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -80,7 +83,6 @@ pipeline {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                         archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
                     }
-
                     sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
                     sh label: 'Send event to cloudevents server', script: """timeout 10 \
                         curl --verbose --request POST --url http://cloudevents-server.apps.svc/events \
@@ -95,6 +97,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_unit_test.groovy
@@ -66,6 +66,7 @@ pipeline {
                     """
                     sh '''#! /usr/bin/env bash
                         set -o pipefail
+
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
                     '''
                 }
@@ -74,7 +75,7 @@ pipeline {
                 success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -83,7 +84,6 @@ pipeline {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                         archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
                     }
-
                     sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
                     sh label: 'Send event to cloudevents server', script: """timeout 10 \
                         curl --verbose --request POST --url http://cloudevents-server.apps.svc/events \
@@ -98,6 +98,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_unit_test.groovy
@@ -104,7 +104,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-8.2/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_unit_test.groovy
@@ -75,7 +75,7 @@ pipeline {
                  success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -98,6 +98,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-8.2/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_unit_test.groovy
@@ -104,7 +104,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-8.3/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_unit_test.groovy
@@ -75,7 +75,7 @@ pipeline {
                  success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -98,6 +98,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-8.3/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_unit_test.groovy
@@ -104,7 +104,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-8.4/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_unit_test.groovy
@@ -75,7 +75,7 @@ pipeline {
                  success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -98,6 +98,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-8.4/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_unit_test.groovy
@@ -104,7 +104,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
@@ -104,7 +104,7 @@ pipeline {
         stage('Test Enterprise Extensions') {
             when {
                 expression {
-                    // Q: why this step is not existed in presubmit job?
+                    // Q: why this step is not existed in presubmit job of master branch?
                     // A: we should not forbiden the community contrubutor on the unit test on private submodules.
                     // if it failed, the enterprise extension owners should fix it.                    
                     return REFS.base_ref != 'master' || REFS.pulls.size() == 0

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
@@ -64,17 +64,18 @@ pipeline {
                         git diff .
                         git status
                     """
-                    sh """#! /usr/bin/env bash
+                    sh '''#! /usr/bin/env bash
                         set -o pipefail
+
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
-                    """
+                    '''
                 }
             }
             post {
                  success {
                     dir(REFS.repo) {
                         script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage.dat')
                         }
                     }
                 }
@@ -97,6 +98,34 @@ pipeline {
                         --data @bazel-go-test-problem-cases.json || true
                     """
                     archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
+                }
+            }
+        }
+        stage('Test Enterprise Extensions') {
+            when {
+                expression {
+                    // Q: why this step is not existed in presubmit job?
+                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
+                    // if it failed, the enterprise extension owners should fix it.                    
+                    return REFS.base_ref != 'master' || REFS.pulls.size() == 0
+                }
+            }
+            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh(
+                        label: 'test enterprise extensions',
+                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
+                    )
+                }
+            }
+            post {
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', 'coverage-extension.dat')
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This pull request includes several changes to the unit test pipelines for different branches of the `pingcap/tidb` repository. The main focus is on adding a new stage for testing enterprise extensions. 

## Key changes include:

### Addition of Enterprise Extension Testing Stage:
* Added a new stage named 'Test Enterprise Extensions' in multiple pipeline files to ensure that private submodules are tested. This stage includes steps to run tests and upload coverage data. [[1]](diffhunk://#diff-b56f73beeb61b056a6dd2b10e709f4e2c3fb1ce386038e2cba0e9fcaf75bf469R104-R131) [[2]](diffhunk://#diff-09bf784057b556598a5c45e45288e856c35774a5992096173ee90f949cefff4aL55-R122) [[3]](diffhunk://#diff-d07b38910eb3c884055beb55a4a6bf94a63c9a6906ef2fd7f9fa4a0bff783d55R104-R131) [[4]](diffhunk://#diff-fbb8d1f563c1585d02c3bc01ada595ccaec77a4632da766aa08d9f34f4c92a44R100-R127) [[5]](diffhunk://#diff-0489bf3acebce52e52ca06c3943f8cac4791fa35f8e03f225dac6fb0984a6858R100-R127) [[6]](diffhunk://#diff-74bed0db67c2a71bbeff8c63856c50c83f9728e05b65c621c11a281541fca667R104-R131) [[7]](diffhunk://#diff-ec7d8e755ee8101075a0e4049ac2e358e62b26ccd3bb6e5f73e0d3fdf4e1245aR104-R131)

### Affects
- Affects pre-submit type jobs for branches: `release-7.1` ... `release-8.5`.
- Affects post-submit type jobs for branch: `master`.

## Minor changes include:

### Update to Coverage Upload Path:
* Modified the `prow.uploadCoverageToCodecov` function call to remove the leading './' from the coverage data file path in various pipeline files. [[1]](diffhunk://#diff-b56f73beeb61b056a6dd2b10e709f4e2c3fb1ce386038e2cba0e9fcaf75bf469L78-R78) [[2]](diffhunk://#diff-d07b38910eb3c884055beb55a4a6bf94a63c9a6906ef2fd7f9fa4a0bff783d55L78-R78) [[3]](diffhunk://#diff-fbb8d1f563c1585d02c3bc01ada595ccaec77a4632da766aa08d9f34f4c92a44L71-R74) [[4]](diffhunk://#diff-0489bf3acebce52e52ca06c3943f8cac4791fa35f8e03f225dac6fb0984a6858L71-R74) [[5]](diffhunk://#diff-74bed0db67c2a71bbeff8c63856c50c83f9728e05b65c621c11a281541fca667L75-R78) [[6]](diffhunk://#diff-ec7d8e755ee8101075a0e4049ac2e358e62b26ccd3bb6e5f73e0d3fdf4e1245aL78-R78)

### Setting Pull Request Descriptions:
* Added a step to set the pull request description using `prow.setPRDescription` in the `net-tool` container for several pipeline files. [[1]](diffhunk://#diff-fbb8d1f563c1585d02c3bc01ada595ccaec77a4632da766aa08d9f34f4c92a44R39-R41) [[2]](diffhunk://#diff-0489bf3acebce52e52ca06c3943f8cac4791fa35f8e03f225dac6fb0984a6858R39-R41) [[3]](diffhunk://#diff-74bed0db67c2a71bbeff8c63856c50c83f9728e05b65c621c11a281541fca667R38-R40) [[4]](diffhunk://#diff-54a40bd562f68c7c2857bbb6e53d6a159afdbf0189ac861a52bb85d5e25d5c29R38-R40)

### Other Pipeline Adjustments:
* Removed unnecessary timeout options and renamed directories to use `REFS.repo` instead of hardcoded values in the `merged_unit_test.groovy` file.
* Added steps to parse flaky test case results and send events to the cloudevents server in the `merged_unit_test.groovy` file.