### PR TITLE
docs-pdf-building: remove v5.3 and v8.2 as they are archived

### DIFF
--- a/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5\.[34]$
+        - ^release-5.4$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
-        - ^release-8\.[1-5]$
+        - ^release-8\.[1345]$

--- a/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5.4$
+        - ^release-5\.4$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
         - ^release-8\.[1345]$

--- a/prow-jobs/pingcap/docs/docs-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5.\4$
+        - ^release-5\.4$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
         - ^release-8\.[1345]$

--- a/prow-jobs/pingcap/docs/docs-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5.4$
+        - ^release-5.\4$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
         - ^release-8\.[1345]$

--- a/prow-jobs/pingcap/docs/docs-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5\.[34]$
+        - ^release-5.4$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
-        - ^release-8\.[1-5]$
+        - ^release-8\.[1345]$

--- a/prow-jobs/pingcap/docs/docs-tidb-operator-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-tidb-operator-postsubmits.yaml
@@ -9,4 +9,4 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-1\.[2-6]$
+        - ^release-1\.[3-6]$


### PR DESCRIPTION
This PR stops the PDF builds of the following versions of docs as they have been archived. 

- TiDB v5.3
- TiDB v8.2
- TiDB Operator v1.2