### PR TITLE
fix(pingcap/tidb): fix bazel error

### DIFF
--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_check.groovy
@@ -55,6 +55,7 @@ pipeline {
             // !!! concurrent go builds will encounter conflicts probabilistically.
             steps {
                 dir('tidb') {
+                    sh label: 'fix bazel', script: 'rm -rf /home/jenkins/.cache/bazel/_bazel_jenkins/install/a09dbb90c658248f08f9aa0eba11997d'
                     sh script: 'make gogenerate check explaintest'
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5-fips/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/ghpr_check.groovy
@@ -55,6 +55,7 @@ pipeline {
             // !!! concurrent go builds will encounter conflicts probabilistically.
             steps {
                 dir('tidb') {
+                    sh label: 'fix bazel', script: 'rm -rf /home/jenkins/.cache/bazel/_bazel_jenkins/install/a09dbb90c658248f08f9aa0eba11997d'
                     sh script: 'make gogenerate check explaintest'
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_check.groovy
@@ -55,6 +55,7 @@ pipeline {
             // !!! concurrent go builds will encounter conflicts probabilistically.
             steps {
                 dir('tidb') {
+                    sh label: 'fix bazel', script: 'rm -rf /home/jenkins/.cache/bazel/_bazel_jenkins/install/a09dbb90c658248f08f9aa0eba11997d'
                     sh script: 'make gogenerate check explaintest'
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check.groovy
@@ -55,6 +55,7 @@ pipeline {
             // !!! concurrent go builds will encounter conflicts probabilistically.
             steps {
                 dir('tidb') {
+                    sh label: 'fix bazel', script: 'rm -rf /home/jenkins/.cache/bazel/_bazel_jenkins/install/a09dbb90c658248f08f9aa0eba11997d'
                     sh script: 'make gogenerate check explaintest'
                 }
             }


### PR DESCRIPTION
An error will be encountered when executing make bazel_prepare.
```shell
make bazel_prepare
./tools/check/check-bazel-prepare.sh
make[1]: Entering directory `/home/jenkins/agent/workspace/pingcap/tidb/release-6.5/ghpr_check/tidb'
bazel run //:gazelle
FATAL: corrupt installation: file '/home/jenkins/.cache/bazel/_bazel_jenkins/install/a09dbb90c658248f08f9aa0eba11997d/A-server.jar' is missing or modified.  Please remove '/home/jenkins/.cache/bazel/_bazel_jenkins/install/a09dbb90c658248f08f9aa0eba11997d' and try again.
make[1]: *** [bazel_prepare] Error 36
```
To fix the error, we need to delete this directory first.

Related issue  https://github.com/bazelbuild/bazel/issues/14355 