### PR TITLE
Change tiflow CI to build sync_diff_inspector from source

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -110,7 +110,7 @@ pipeline {
                         // only build binarys if not exist, use the cached binarys if exist
                         // TODO: how to update cached binarys if needed
                         sh label: "prepare", script: """
-                            if [[ ! -f "bin/dm-master.test" || ! -f "bin/dm-test-tools/check_master_online" || ! -f "bin/dm-test-tools/check_worker_online" ]]; then
+                            if [[ ! -f "bin/sync_diff_inspector" || ! -f "bin/dm-master.test" || ! -f "bin/dm-test-tools/check_master_online" || ! -f "bin/dm-test-tools/check_worker_online" ]]; then
                                 echo "Building binaries..."
                                 make dm_integration_test_build
                                 mkdir -p bin/dm-test-tools && cp -r ./dm/tests/bin/* ./bin/dm-test-tools

--- a/pipelines/pingcap/tiflow/latest/pull_engine_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_engine_integration_test.groovy
@@ -136,11 +136,8 @@ pipeline {
                                         sh label: "prepare", script: """
                                             git rev-parse HEAD
                                             git status
-                                            sync_diff_download_url="http://fileserver.pingcap.net/download/test/tiflow/engine/ci/sync_diff.tar.gz"
-                                            mkdir -p ./bin/ && cd ./bin/
-                                            curl \${sync_diff_download_url} | tar -xz
-                                            ./sync_diff_inspector -V
-                                            cd -        
+                                            make sync-diff-inspector
+                                            ./bin/sync_diff_inspector -V
                                         """
                                     }
                                     withCredentials([usernamePassword(credentialsId: 'harbor-tiflow-engine', usernameVariable: 'HARBOR_CRED_USR', passwordVariable: 'HARBOR_CRED_PSW')]) {


### PR DESCRIPTION
Change the CI of pull_dm_integration_test and pull_engine_integration_test that are not covered by previous PR https://github.com/PingCAP-QE/ci/pull/3315.

Related retest:
- [pull_engine_integration_test](https://do.pingcap.net/jenkins/job/pingcap/job/tiflow/job/pull_engine_integration_test/3336/)
- [pull_dm_integration_test](https://do.pingcap.net/jenkins/job/pingcap/job/tiflow/job/pull_dm_integration_test/3934/)

