### PR TITLE
docs: migrate from Qiniu Cloud to Tencent Cloud

### DIFF
--- a/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
+++ b/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
@@ -76,11 +76,6 @@ pipeline {
                         """
                         sh label: 'Upload pdf', script: """#!/usr/bin/env bash
                             set -e
-                            # TODO: pre-install rclone in the docker image
-                            # Download and setup rclone
-                            curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip
-                            unzip rclone-v1.69.0-linux-amd64.zip
-                            mv rclone-v1.69.0-linux-amd64/rclone ./
 
                             dst="\${TENCENTCLOUD_RCLONE_CONN}:\${TENCENTCLOUD_BUCKET_ID}/pdf"
                             case "${REFS.base_ref}" in
@@ -99,7 +94,7 @@ pipeline {
                                     ;;
                             esac
                             # Upload TiDB PDF to remote storage
-                            ./rclone copyto output.pdf "\${dst}/tidb-\${version}-zh-manual.pdf"
+                            rclone copyto output.pdf "\${dst}/tidb-\${version}-zh-manual.pdf"
                         """
                     }
                 }

--- a/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
+++ b/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
@@ -76,7 +76,7 @@ pipeline {
                         """
                         sh label: 'Upload pdf', script: """#!/usr/bin/env bash
                             set -e
-                            // TODO: pre-install rclone in the docker image
+                            # TODO: pre-install rclone in the docker image
                             # Download and setup rclone
                             curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip
                             unzip rclone-v1.69.0-linux-amd64.zip

--- a/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
+++ b/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
@@ -65,32 +65,42 @@ pipeline {
             steps {
                 dir("docs-cn") {
                     withCredentials([
-                        string(credentialsId: 'docs-cn-aws-ak', variable: 'AWS_ACCESS_KEY'),
-                        string(credentialsId: 'docs-cn-aws-sk', variable: 'AWS_SECRET_KEY'),
-                        string(credentialsId: 'docs-cn-aws-region', variable: 'AWS_REGION'),
-                        string(credentialsId: 'docs-cn-aws-bn', variable: 'AWS_BUCKET_NAME'),
-                        string(credentialsId: 'docs-cn-qiniu-ak', variable: 'QINIU_ACCESS_KEY'),
-                        string(credentialsId: 'docs-cn-qiniu-sk', variable: 'QINIU_SECRET_KEY'),
-                        string(credentialsId: 'docs-cn-qiniu-bn', variable: 'QINIU_BUCKET_NAME')
+                        string(credentialsId: 'docs-cn-tencent-ak', variable: 'TENCENTCLOUD_RCLONE_CONN'),
+                        string(credentialsId: 'docs-cn-tencent-bn', variable: 'TENCENTCLOUD_BUCKET_ID')
                     ]){
-                        sh label: 'Build pdf', script: """#!/usr/bin/env bash
-                            printf "%s\n" ${AWS_ACCESS_KEY} ${AWS_SECRET_KEY} ${AWS_REGION} "json" | aws configure
+                        sh label: 'Build pdf', script: """#!/usr/bin/env bash -e
                             find -name '*.md' | xargs -d '\n' grep -P '\t' && exit 1
                             python3 scripts/merge_by_toc.py
                             scripts/generate_pdf.sh
                         """
-                        sh label: 'Upload pdf', script: """#!/usr/bin/env bash
-                            target_version=\$(echo ${REFS.base_ref} | sed 's/release-//')
-                            if [ "${REFS.base_ref}" = "master" ]; then
-                                python3 scripts/upload.py output.pdf tidb-dev-zh-manual.pdf;
-                            elif [ "${REFS.base_ref}" = "release-8.5" ]; then
-                                python3 scripts/upload.py output.pdf tidb-stable-zh-manual.pdf;
-                            elif case "${REFS.base_ref}" in release-*) ;; *) false;; esac; then
-                                python3 scripts/upload.py output.pdf tidb-v\${target_version}-zh-manual.pdf;
-                            fi
+                        sh label: 'Upload pdf', script: """#!/usr/bin/env bash -e
+                            // TODO: pre-install rclone in the docker image
+                            # Download and setup rclone
+                            curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip
+                            unzip rclone-v1.69.0-linux-amd64.zip
+                            mv rclone-v1.69.0-linux-amd64/rclone ./
+
+                            dst="\${TENCENTCLOUD_RCLONE_CONN}:\${TENCENTCLOUD_BUCKET_ID}/pdf"
+                            case "${REFS.base_ref}" in
+                                "master")
+                                    version="dev"
+                                    ;;
+                                "release-8.5")
+                                    version="stable"
+                                    ;;
+                                "release-*")
+                                    version="v\$(echo ${REFS.base_ref} | sed 's/release-//')"
+                                    ;;
+                                *)
+                                    echo "Error: Unexpected base ref: ${REFS.base_ref}"
+                                    exit 1
+                                    ;;
+                            esac
+                            # Upload TiDB PDF to remote storage
+                            ./rclone copyto output.pdf "\${dst}/tidb-\${version}-zh-manual.pdf"
                         """
-                     }
-                } 
+                    }
+                }
             }
         }
     }

--- a/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
+++ b/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
@@ -90,7 +90,7 @@ pipeline {
                                 "release-8.5")
                                     version="stable"
                                     ;;
-                                "release-*")
+                                release-*)
                                     version="v\$(echo ${REFS.base_ref} | sed 's/release-//')"
                                     ;;
                                 *)

--- a/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
+++ b/pipelines/pingcap/docs-cn/latest/merged_update_docs_cn.groovy
@@ -68,12 +68,14 @@ pipeline {
                         string(credentialsId: 'docs-cn-tencent-ak', variable: 'TENCENTCLOUD_RCLONE_CONN'),
                         string(credentialsId: 'docs-cn-tencent-bn', variable: 'TENCENTCLOUD_BUCKET_ID')
                     ]){
-                        sh label: 'Build pdf', script: """#!/usr/bin/env bash -e
+                        sh label: 'Build pdf', script: """#!/usr/bin/env bash
+                            set -e
                             find -name '*.md' | xargs -d '\n' grep -P '\t' && exit 1
                             python3 scripts/merge_by_toc.py
                             scripts/generate_pdf.sh
                         """
-                        sh label: 'Upload pdf', script: """#!/usr/bin/env bash -e
+                        sh label: 'Upload pdf', script: """#!/usr/bin/env bash
+                            set -e
                             // TODO: pre-install rclone in the docker image
                             # Download and setup rclone
                             curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip

--- a/pipelines/pingcap/docs-cn/latest/pod-merged_update_docs_cn.yaml
+++ b/pipelines/pingcap/docs-cn/latest/pod-merged_update_docs_cn.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: hub.pingcap.net/jenkins/docs-cn-checker:v0.0.2
+      image: hub.pingcap.net/jenkins/docs-cn-checker:v1.0.0
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
+++ b/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
@@ -69,12 +69,14 @@ pipeline {
                         string(credentialsId: 'docs-cn-tencent-ak', variable: 'TENCENTCLOUD_RCLONE_CONN'),
                         string(credentialsId: 'docs-cn-tencent-bn', variable: 'TENCENTCLOUD_BUCKET_ID')
                     ]){
-                        sh label: 'Build pdf', script: """#!/usr/bin/env bash -e
+                        sh label: 'Build pdf', script: """#!/usr/bin/env bash
+                            set -e
                             grep -RP '\t' *  | tee | grep '.md' && exit 1; echo ok
                             python3 scripts/merge_by_toc.py en/; python3 scripts/merge_by_toc.py zh/;
                             scripts/generate_pdf.sh
                         """
-                        sh label: 'Upload pdf', script: """#!/usr/bin/env bash -e
+                        sh label: 'Upload pdf', script: """#!/usr/bin/env bash
+                            set -e
                             // TODO: pre-install rclone in the docker image
                             # Download and setup rclone
                             curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip

--- a/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
+++ b/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
@@ -77,11 +77,6 @@ pipeline {
                         """
                         sh label: 'Upload pdf', script: """#!/usr/bin/env bash
                             set -e
-                            # TODO: pre-install rclone in the docker image
-                            # Download and setup rclone
-                            curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip
-                            unzip rclone-v1.69.0-linux-amd64.zip
-                            mv rclone-v1.69.0-linux-amd64/rclone ./
 
                             dst="\${TENCENTCLOUD_RCLONE_CONN}:\${TENCENTCLOUD_BUCKET_ID}/pdf"
                             case "${REFS.base_ref}" in
@@ -100,8 +95,8 @@ pipeline {
                                     ;;
                             esac
                             # Upload TiDB Operator PDF to remote storage
-                            ./rclone copyto output_en.pdf "\${dst}/tidb-in-kubernetes-\${version}-en-manual.pdf"
-                            ./rclone copyto output_zh.pdf "\${dst}/tidb-in-kubernetes-\${version}-zh-manual.pdf"
+                            rclone copyto output_en.pdf "\${dst}/tidb-in-kubernetes-\${version}-en-manual.pdf"
+                            rclone copyto output_zh.pdf "\${dst}/tidb-in-kubernetes-\${version}-zh-manual.pdf"
                         """
                     }
                 }

--- a/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
+++ b/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
@@ -91,7 +91,7 @@ pipeline {
                                 "release-1.6")
                                     version="stable"
                                     ;;
-                                "release-*")
+                                release-*)
                                     version="v\$(echo ${REFS.base_ref} | sed 's/release-//')"
                                     ;;
                                 *)

--- a/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
+++ b/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
@@ -77,7 +77,7 @@ pipeline {
                         """
                         sh label: 'Upload pdf', script: """#!/usr/bin/env bash
                             set -e
-                            // TODO: pre-install rclone in the docker image
+                            # TODO: pre-install rclone in the docker image
                             # Download and setup rclone
                             curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip
                             unzip rclone-v1.69.0-linux-amd64.zip

--- a/pipelines/pingcap/docs-tidb-operator/latest/pod-merged_update.yaml
+++ b/pipelines/pingcap/docs-tidb-operator/latest/pod-merged_update.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: hub.pingcap.net/jenkins/docs-cn-checker:v0.0.1
+      image: hub.pingcap.net/jenkins/docs-cn-checker:v1.0.0
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -84,7 +84,7 @@ pipeline {
                         """
                         sh label: 'Upload pdf', script: """#!/usr/bin/env bash
                             set -e
-                            // TODO: pre-install rclone in the docker image
+                            # TODO: pre-install rclone in the docker image
                             # Download and setup rclone
                             curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip
                             unzip rclone-v1.69.0-linux-amd64.zip

--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -21,7 +21,7 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 45, unit: 'MINUTES')
+        timeout(time: 100, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
@@ -84,11 +84,6 @@ pipeline {
                         """
                         sh label: 'Upload pdf', script: """#!/usr/bin/env bash
                             set -e
-                            # TODO: pre-install rclone in the docker image
-                            # Download and setup rclone
-                            curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip
-                            unzip rclone-v1.69.0-linux-amd64.zip
-                            mv rclone-v1.69.0-linux-amd64/rclone ./
 
                             dst="\${TENCENTCLOUD_RCLONE_CONN}:\${TENCENTCLOUD_BUCKET_ID}/pdf"
                             case "${REFS.base_ref}" in
@@ -107,10 +102,10 @@ pipeline {
                                     ;;
                             esac
                             # Upload TiDB PDF to remote storage
-                            ./rclone copyto output.pdf "\${dst}/tidb-\${version}-en-manual.pdf"
+                            rclone copyto output.pdf "\${dst}/tidb-\${version}-en-manual.pdf"
                             # Upload TiDB Cloud PDF to remote storage if it exists
                             if [ -f "output_cloud.pdf" ]; then
-                                ./rclone copyto output_cloud.pdf "\${dst}/tidbcloud-en-manual.pdf"
+                                rclone copyto output_cloud.pdf "\${dst}/tidbcloud-en-manual.pdf"
                             fi
                         """
                     }

--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -81,7 +81,8 @@ pipeline {
                                 scripts/generate_cloud_pdf.sh
                             fi
                         """
-                        sh label: 'Upload pdf', script: """#!/usr/bin/env bash -e
+                        sh label: 'Upload pdf', script: """#!/usr/bin/env bash
+                            set -e
                             // TODO: pre-install rclone in the docker image
                             # Download and setup rclone
                             curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip

--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -62,7 +62,7 @@ pipeline {
             }
         }
         stage('Build pdf') {
-            options { timeout(time: 45, unit: 'MINUTES') }
+            options { timeout(time: 90, unit: 'MINUTES') }
 
             steps {
                 dir("docs") {

--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -67,36 +67,52 @@ pipeline {
             steps {
                 dir("docs") {
                     withCredentials([
-                        string(credentialsId: 'docs-cn-aws-ak', variable: 'AWS_ACCESS_KEY'),
-                        string(credentialsId: 'docs-cn-aws-sk', variable: 'AWS_SECRET_KEY'),
-                        string(credentialsId: 'docs-cn-aws-region', variable: 'AWS_REGION'),
-                        string(credentialsId: 'docs-cn-aws-bn', variable: 'AWS_BUCKET_NAME'),
-                        string(credentialsId: 'docs-cn-qiniu-ak', variable: 'QINIU_ACCESS_KEY'),
-                        string(credentialsId: 'docs-cn-qiniu-sk', variable: 'QINIU_SECRET_KEY'),
-                        string(credentialsId: 'docs-cn-qiniu-bn', variable: 'QINIU_BUCKET_NAME')
-                    ]){ 
-                        sh label: 'Build pdf', script: """#!/usr/bin/env bash
-                            printf "%s\n" ${AWS_ACCESS_KEY} ${AWS_SECRET_KEY} ${AWS_REGION} "json" | aws configure
+                        string(credentialsId: 'docs-cn-tencent-ak', variable: 'TENCENTCLOUD_RCLONE_CONN'),
+                        string(credentialsId: 'docs-cn-tencent-bn', variable: 'TENCENTCLOUD_BUCKET_ID')
+                    ]){
+                        sh label: 'Build pdf', script: """#!/usr/bin/env bash -e
                             find -name '*.md' | xargs -d '\n' grep -P '\t' && exit 1
+                            # Generate PDF for TiDB
                             python3 scripts/merge_by_toc.py
                             scripts/generate_pdf.sh
+                            # Generate PDF for TiDB Cloud
+                            if [ "${REFS.base_ref}" = "release-8.1" ]; then
+                                python3 scripts/merge_by_toc.py TOC-tidb-cloud.md doc_cloud.md tidb-cloud
+                                scripts/generate_cloud_pdf.sh
+                            fi
                         """
-                        sh label: 'Upload pdf', script: """#!/usr/bin/env bash
-                            target_version=\$(echo ${REFS.base_ref} | sed 's/release-//')
-                            if [ "${REFS.base_ref}" = "master" ]; then
-                                python3 scripts/upload.py output.pdf tidb-dev-en-manual.pdf;
-                            elif [ "${REFS.base_ref}" = "release-8.1" ]; then
-                                python3 scripts/merge_by_toc.py TOC-tidb-cloud.md doc_cloud.md tidb-cloud; scripts/generate_cloud_pdf.sh;
-                                python3 scripts/upload.py output_cloud.pdf tidbcloud-en-manual.pdf;
-                                python3 scripts/upload.py output.pdf tidb-v8.1-en-manual.pdf;
-                            elif [ "${REFS.base_ref}" = "release-8.5" ]; then
-                                python3 scripts/upload.py output.pdf tidb-stable-en-manual.pdf;
-                            elif case "${REFS.base_ref}" in release-*) ;; *) false;; esac; then
-                                python3 scripts/upload.py output.pdf tidb-v\${target_version}-en-manual.pdf;
+                        sh label: 'Upload pdf', script: """#!/usr/bin/env bash -e
+                            // TODO: pre-install rclone in the docker image
+                            # Download and setup rclone
+                            curl -O https://downloads.rclone.org/v1.69.0/rclone-v1.69.0-linux-amd64.zip
+                            unzip rclone-v1.69.0-linux-amd64.zip
+                            mv rclone-v1.69.0-linux-amd64/rclone ./
+
+                            dst="\${TENCENTCLOUD_RCLONE_CONN}:\${TENCENTCLOUD_BUCKET_ID}/pdf"
+                            case "${REFS.base_ref}" in
+                                "master")
+                                    version="dev"
+                                    ;;
+                                "release-8.5")
+                                    version="stable"
+                                    ;;
+                                "release-*")
+                                    version="v\$(echo ${REFS.base_ref} | sed 's/release-//')"
+                                    ;;
+                                *)
+                                    echo "Error: Unexpected base ref: ${REFS.base_ref}"
+                                    exit 1
+                                    ;;
+                            esac
+                            # Upload TiDB PDF to remote storage
+                            ./rclone copyto output.pdf "\${dst}/tidb-\${version}-en-manual.pdf"
+                            # Upload TiDB Cloud PDF to remote storage if it exists
+                            if [ -f "output_cloud.pdf" ]; then
+                                ./rclone copyto output_cloud.pdf "\${dst}/tidbcloud-en-manual.pdf"
                             fi
                         """
                     }
-                } 
+                }
             }
         }
     }

--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -98,7 +98,7 @@ pipeline {
                                 "release-8.5")
                                     version="stable"
                                     ;;
-                                "release-*")
+                                release-*)
                                     version="v\$(echo ${REFS.base_ref} | sed 's/release-//')"
                                     ;;
                                 *)

--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -70,7 +70,8 @@ pipeline {
                         string(credentialsId: 'docs-cn-tencent-ak', variable: 'TENCENTCLOUD_RCLONE_CONN'),
                         string(credentialsId: 'docs-cn-tencent-bn', variable: 'TENCENTCLOUD_BUCKET_ID')
                     ]){
-                        sh label: 'Build pdf', script: """#!/usr/bin/env bash -e
+                        sh label: 'Build pdf', script: """#!/usr/bin/env bash
+                            set -e
                             find -name '*.md' | xargs -d '\n' grep -P '\t' && exit 1
                             # Generate PDF for TiDB
                             python3 scripts/merge_by_toc.py

--- a/pipelines/pingcap/docs/latest/pod-merged_update_docs.yaml
+++ b/pipelines/pingcap/docs/latest/pod-merged_update_docs.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: hub.pingcap.net/jenkins/docs-cn-checker:v0.0.2
+      image: hub.pingcap.net/jenkins/docs-cn-checker:v1.0.0
       tty: true
       resources:
         requests:


### PR DESCRIPTION
- Upgrade the Docker image to `hub.pingcap.net/jenkins/docs-cn-checker:v1.0.0`, which includes rclone integration
- Migrate storage from Qiniu Cloud to Tencent Cloud, implementing rclone for remote storage uploads to ensure S3 compatibility
- Relocate the TiDB Cloud PDF building process from the upload step to the build step
- Extend the docs pipeline timeout to accommodate the additional time required for building multiple PDFs