### PR TITLE
fix(tidb): checkout to minor version of tidb-test for hotfix

### DIFF
--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -167,27 +167,6 @@ def checkoutSupportBatch(gitUrl, component, prTargetBranch, prTitle, refs, crede
             checkoutPRWithPreMerge(gitUrl, prTargetBranch, filteredRefs.collect { it.split(":")[1] } as List, credentialsId)
         }
     }
-
-    // pre-merge for the PRs.
-    if (tidbTestRefs.isEmpty()) {
-        echo "No tidb-test refs specified in PR title, checkout the base branch ${componentBranch} of ${component}."
-        checkoutSingle(gitUrl, componentBranch, componentBranch, credentialsId)
-    } else if (tidbTestRefs.size() == 1 && tidbTestRefs[0].startsWith("Branch:")) {
-        // 1. feature branch or hotfix branch
-        // 2. Single PR with branch or commit sha specified
-        echo "Single PR with tidb-test branch specified: ${prTargetBranch}"
-        def branch = tidbTestRefs[0].split(":")[1]
-        println("Checkout the branch: ${branch} of ${component}")
-        checkoutSingle(gitUrl, prTargetBranch, branch, credentialsId)
-    // if tidbTestRefs size > 1 and any of tidbTestRefs start with branch , then error and exit
-    } else if (tidbTestRefs.size() > 1 && branchOrCommitSpecified) {
-        echo "Error: Specifying a tidb-test branch is not supported for multiple tidb PRs."
-        throw new Exception("Error: Specifying a tidb-test branch is not supported for multiple tidb PRs batch.")
-    } else {
-        // multi PR specified PR (notice: for batch merge with specific branch is not supported)
-        // single PR with specified PR
-        checkoutPRWithPreMerge(gitUrl, prTargetBranch, tidbTestRefs.collect { it.split(":")[1] } as List, credentialsId)
-    }
 }
 
 def checkoutSingle(gitUrl, prTargetBranch, branchOrCommit, credentialsId, timeout=5) {

--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -455,11 +455,15 @@ def validateAndFilterRefs(tidbTestRefs) {
     def branchRefs = tidbTestRefs.findAll { it.startsWith("Branch:") }
     
     // Check if all refs are PRs
+    // if all refs are PRs, need to merge the PRs with the same base branch
     if (prRefs.size() == tidbTestRefs.size()) {
         return [true, prRefs.unique()]
     }
     
     // Check if all refs are Branches and there's only one unique branch
+    // 1. for hotfix branch batch merge, valid
+    // 2. for feature branch batch merge, valid
+    // 3. for multi PR with different branches, invalid
     if (branchRefs.size() == tidbTestRefs.size()) {
         def uniqueBranches = branchRefs.unique()
         if (uniqueBranches.size() > 1) {
@@ -469,6 +473,6 @@ def validateAndFilterRefs(tidbTestRefs) {
         return [true, uniqueBranches]
     }
     
-    // Mixed refs - return false and the combined unique refs
+    // Mixed refs is invalid - return false and the combined unique refs
     return [false, (prRefs + branchRefs).unique()]
 }

--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -446,17 +446,17 @@ def ks3_download_fileserver(remote, local, credentialsId="ks3util-config"){
     }
 }
 
-def validateAndFilterRefs(tidbTestRefs) {
-    if (tidbTestRefs.isEmpty()) {
+def validateAndFilterRefs(componentRefs) {
+    if (componentRefs.isEmpty()) {
         return [true, []]
     }
 
-    def prRefs = tidbTestRefs.findAll { it.startsWith("PR:") }
-    def branchRefs = tidbTestRefs.findAll { it.startsWith("Branch:") }
+    def prRefs = componentRefs.findAll { it.startsWith("PR:") }
+    def branchRefs = componentRefs.findAll { it.startsWith("Branch:") }
     
     // Check if all refs are PRs
     // if all refs are PRs, need to merge the PRs with the same base branch
-    if (prRefs.size() == tidbTestRefs.size()) {
+    if (prRefs.size() == componentRefs.size()) {
         return [true, prRefs.unique()]
     }
     
@@ -464,7 +464,7 @@ def validateAndFilterRefs(tidbTestRefs) {
     // 1. for hotfix branch batch merge, valid
     // 2. for feature branch batch merge, valid
     // 3. for multi PR with different branches, invalid
-    if (branchRefs.size() == tidbTestRefs.size()) {
+    if (branchRefs.size() == componentRefs.size()) {
         def uniqueBranches = branchRefs.unique()
         if (uniqueBranches.size() > 1) {
             // Multiple PR with different branches specified - not supported

--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -166,9 +166,11 @@ def checkoutSupportBatch(gitUrl, component, prTargetBranch, prTitle, refs, crede
             // 2. multi PR with the same PR of tidb-test specified
             def componentPr = filteredRefs[0].split(":")[1]
             println("Checkout the PR: ${componentPr} of ${component}")
+            println("Note: When specifying tidb-test=pr/xxx in the PR title, the base branch of tidb-test pr must be the same as the base branch of tidb pr.If not, please specify tidb-test=<branch> or tidb-test=<commit-hash>.")
             checkoutPRWithPreMerge(gitUrl, prTargetBranch, filteredRefs, credentialsId)
         } else {
             // multi PR specified component PR (notice: for batch merge with specific branch is not supported)
+            println("Note: When specifying tidb-test=pr/xxx in the PR title, the base branch of tidb-test pr must be the same as the base branch of tidb pr.If not, please specify tidb-test=<branch> or tidb-test=<commit-hash>.")
             checkoutPRWithPreMerge(gitUrl, prTargetBranch, filteredRefs.collect { it.split(":")[1] } as List, credentialsId)
         }
     }

--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -153,7 +153,7 @@ def checkoutSupportBatch(gitUrl, component, prTargetBranch, prTitle, refs, crede
         throw new Exception("Error: invalid ${component} refs in multiple PRs.")
     } else {
         if (filteredRefs.isEmpty()) {
-            echo "No tidb-test refs specified in PR title, checkout the base branch ${componentBranch} of ${component}."
+            echo "No tidb-test refs specified in PR title, checkout the default branch ${componentBranch} of ${component}."
             checkoutSingle(gitUrl, componentBranch, componentBranch, credentialsId)
         } else if (filteredRefs.size() == 1 && filteredRefs[0].startsWith("Branch:")) {
             // 1. feature branch or hotfix branch
@@ -161,9 +161,14 @@ def checkoutSupportBatch(gitUrl, component, prTargetBranch, prTitle, refs, crede
             def branch = filteredRefs[0].split(":")[1]
             println("Checkout the branch: ${branch} of ${component}")
             checkoutSingle(gitUrl, prTargetBranch, branch, credentialsId)
-        } else if (filteredRefs.size() > 1) {
+        } else if (filteredRefs.size() == 1 && filteredRefs[0].startsWith("PR:")) {
+            // 1. single PR with PR specified
+            // 2. multi PR with the same PR of tidb-test specified
+            def componentPr = filteredRefs[0].split(":")[1]
+            println("Checkout the PR: ${componentPr} of ${component}")
+            checkoutPRWithPreMerge(gitUrl, prTargetBranch, filteredRefs, credentialsId)
+        } else {
             // multi PR specified component PR (notice: for batch merge with specific branch is not supported)
-            // single PR with specified PR
             checkoutPRWithPreMerge(gitUrl, prTargetBranch, filteredRefs.collect { it.split(":")[1] } as List, credentialsId)
         }
     }


### PR DESCRIPTION
For the hotfix branch(example release-8.5-20250114-v8.5.0), we need to checkout the corresponding minimum version of the tidb-test code (release-8.5.0).