### PR TITLE
Remove mac test pipeline from storage repos

### DIFF
--- a/jenkins/pipelines/ci/rocksdb/rocksdb_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/rocksdb/rocksdb_ghpr_test.groovy
@@ -119,15 +119,6 @@ parallel(
             test("", "db_block_cache_test", "", do_cache)
         }
     },
-    /*
-    mac: {
-        node("mac-i7") {
-            def do_cache = false
-            build("all", do_cache)
-            test("", "db_block_cache_test", "", do_cache)
-        }
-    },
-    */
     x86: {
         def do_cache = true
         run_with_x86_pod {

--- a/jenkins/pipelines/ci/rust-rocksdb/rust_rocksdb_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/rust-rocksdb/rust_rocksdb_ghpr_test.groovy
@@ -175,12 +175,6 @@ parallel(
             run_test(common_features + "," + arm_features, use_gcc8)
         }
     },
-    test_mac: {
-        def use_gcc8 = false
-        node("mac-i7") {
-            run_test(common_features, use_gcc8)
-        }
-    },
     formater: {
         run_formatter()
     },

--- a/jenkins/pipelines/ci/tikv/rocksdb/rocksdb_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/tikv/rocksdb/rocksdb_ghpr_test.groovy
@@ -119,15 +119,6 @@ parallel(
             test("", "db_block_cache_test", "", do_cache)
         }
     },
-    /*
-    mac: {
-        node("mac-i7") {
-            def do_cache = false
-            build("all", do_cache)
-            test("", "db_block_cache_test", "", do_cache)
-        }
-    },
-    */
     x86: {
         def do_cache = true
         run_with_x86_pod {

--- a/jenkins/pipelines/ci/tikv/rust-rocksdb/rust_rocksdb_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/tikv/rust-rocksdb/rust_rocksdb_ghpr_test.groovy
@@ -169,12 +169,6 @@ parallel(
             run_test(common_features + "," + arm_features, use_gcc8)
         }
     },
-    test_mac: {
-        def use_gcc8 = false
-        node("mac-i7") {
-            run_test(common_features, use_gcc8)
-        }
-    },
     formater: {
         run_formatter()
     },

--- a/jenkins/pipelines/ci/tikv/titan/titan_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/tikv/titan/titan_ghpr_test.groovy
@@ -206,12 +206,6 @@ parallel(
             }
         }
     },
-    test_mac: {
-        def use_gcc8 = false
-        node("mac-i7") {
-            run_test("", "ASAN", use_gcc8)
-        }
-    },
     test_arm: {
         def use_gcc8 = true
         node("arm") {

--- a/jenkins/pipelines/ci/titan/titan_ghpr_test.groovy
+++ b/jenkins/pipelines/ci/titan/titan_ghpr_test.groovy
@@ -176,12 +176,6 @@ parallel(
             }
         }
     },
-    test_mac: {
-        def use_gcc8 = false
-        node("mac-i7") {
-            run_test("", "ASAN", use_gcc8)
-        }
-    },
     test_arm: {
         def use_gcc8 = true
         node("arm") {


### PR DESCRIPTION
TiKV's RocksDB's fork's CI disabled `mac` build anyway. And `mac` build is too slow in Titan's and rust-rocksdb's CI. So, disable `mac` build across storage repos' (RocksDB, Titan, rust-rocksdb) CI.