### PR TITLE
chore(tidb): temporarily skip until the test is fixed

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -79,7 +79,7 @@ postsubmits:
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: ci/integration-copr-test
       max_concurrency: 1
-      skip_report: false
+      skip_report: true
       branches:
         - ^master$
     - name: pingcap/tidb/merged_tiflash_test


### PR DESCRIPTION
Copr-test is broken after PR https://github.com/pingcap/tidb/pull/58261, temporarily skip report until the issue https://github.com/pingcap/tidb/issues/58509  fixed.