### PR TITLE
chore(tiflash): run license check before build

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -121,9 +121,6 @@ pipeline {
             }
         }
         stage("License check") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     // TODO: add license-eye to docker image

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -120,6 +120,27 @@ pipeline {
                 }
             }
         }
+        stage("License check") {
+            when {
+                expression { !build_cache_ready }
+            }
+            steps {
+                dir("${WORKSPACE}/tiflash") {
+                    // TODO: add license-eye to docker image
+                    sh label: "license header check", script: """
+                        echo "license check"
+                        if [[ -f .github/licenserc.yml ]]; then
+                            wget -q -O license-eye http://fileserver.pingcap.net/download/cicd/ci-tools/license-eye_v0.4.0
+                            chmod +x license-eye
+                            ./license-eye -c .github/licenserc.yml header check
+                        else
+                            echo "skip license check"
+                            exit 0
+                        fi
+                    """
+                }
+            }
+        }
         stage("Prepare Cache") {
             when {
                 expression { !build_cache_ready }
@@ -290,27 +311,6 @@ pipeline {
                     sh """
                     ccache -s
                     ls -lha ${WORKSPACE}/install/tiflash
-                    """
-                }
-            }
-        }
-        stage("License check") {
-            when {
-                expression { !build_cache_ready }
-            }
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    // TODO: add license-eye to docker image
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            wget -q -O license-eye http://fileserver.pingcap.net/download/cicd/ci-tools/license-eye_v0.4.0
-                            chmod +x license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
                     """
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -121,6 +121,9 @@ pipeline {
             }
         }
         stage("License check") {
+            when {
+                expression { !build_cache_ready }
+            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     // TODO: add license-eye to docker image
@@ -308,6 +311,27 @@ pipeline {
                     sh """
                     ccache -s
                     ls -lha ${WORKSPACE}/install/tiflash
+                    """
+                }
+            }
+        }
+        stage("License check") {
+            when {
+                expression { !build_cache_ready }
+            }
+            steps {
+                dir("${WORKSPACE}/tiflash") {
+                    // TODO: add license-eye to docker image
+                    sh label: "license header check", script: """
+                        echo "license check"
+                        if [[ -f .github/licenserc.yml ]]; then
+                            wget -q -O license-eye http://fileserver.pingcap.net/download/cicd/ci-tools/license-eye_v0.4.0
+                            chmod +x license-eye
+                            ./license-eye -c .github/licenserc.yml header check
+                        else
+                            echo "skip license check"
+                            exit 0
+                        fi
                     """
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -315,27 +315,6 @@ pipeline {
                 }
             }
         }
-        stage("License check") {
-            when {
-                expression { !build_cache_ready }
-            }
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    // TODO: add license-eye to docker image
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            wget -q -O license-eye http://fileserver.pingcap.net/download/cicd/ci-tools/license-eye_v0.4.0
-                            chmod +x license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
-                    """
-                }
-            }
-        }
         stage("Post Build") {
             when {
                 expression { !build_cache_ready }


### PR DESCRIPTION
Compilation is time-consuming, so we put the license check first to avoid wasting time on recompilation.