### PR TITLE
fix(cd): update docker image repo and dockerfiles for devbuild job

### DIFF
--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -14,6 +14,8 @@ final ProductForBuildMapping = [
     "drainer":"tidb-binlog",
     "pump":"tidb-binlog",
 ]
+
+// image prefix with `hub.pingcap.net/devbuild/` for no hotfix build and `hub.pingcap.net/` for hotfix build.
 final DockerImgRepoMapping = [
     "tidb-binlog": "pingcap/tidb-binlog/image",
     "drainer":"pingcap/tidb-binlog/image",
@@ -33,6 +35,9 @@ final DockerImgRepoMapping = [
     "tidb-dashboard": "pingcap/tidb-dashboard/image",
 ]
 
+// image prefix with `gcr.io/pingcap-public/dbaas/`
+final GcrDockerImgRepoMapping = ["drainer":"tidb-binlog", "pump":"tidb-binlog"]
+
 final FileserverDownloadURL = "https://fileserver.pingcap.net/download"
 
 def GitHash = ''
@@ -49,6 +54,7 @@ def PipelineEndAt = ''
 def RepoForBuild = ''
 def ProductForBuild = ''
 def ProductForDocker = ''
+def ShortImageRepoForGCR = ''
 def NeedEnterprisePlugin = false
 def PrintedVersion = ''
 
@@ -150,19 +156,21 @@ spec:
                     BinBuildPathDict["arm64"] = "builds/devbuild/$BUILD_NUMBER/$Product-build-linux-arm64.tar.gz"
                     ProductForBuild = ProductForBuildMapping.getOrDefault(Product, Product)
                     ProductForDocker = DockerImgRepoMapping.getOrDefault(Product, Product)
+                    ShortImageRepoForGCR = GcrDockerImgRepoMapping.getOrDefault(Product, Product)
                     def date = new Date()
                     PipelineStartAt =new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(date)
                     Image = "hub.pingcap.net/devbuild/$ProductForDocker:$Version-$BUILD_NUMBER"
                     if (params.TargetImg!=""){
                         Image = params.TargetImg
                     }
-                    ImageForGcr = "gcr.io/pingcap-public/dbaas/$ProductForDocker:$Version-$BUILD_NUMBER-dev"
+                    ImageForGcr = "gcr.io/pingcap-public/dbaas/$ShortImageRepoForGCR:$Version-$BUILD_NUMBER-dev"
+
                     if (params.IsHotfix.toBoolean()){
                         Image = "hub.pingcap.net/$ProductForDocker:$Version-$BUILD_NUMBER"
                         if (params.Features != ""){
                             error "hotfix artifact but with extra features"
                         }
-                        ImageForGcr = "gcr.io/pingcap-public/dbaas/$ProductForDocker:$Version"
+                        ImageForGcr = "gcr.io/pingcap-public/dbaas/$ShortImageRepoForGCR:$Version"
                         BinPathDict["amd64"] = "builds/hotfix/$Product/$Version/$BUILD_NUMBER/$Product-patch-linux-amd64.tar.gz"
                         BinPathDict["arm64"] = "builds/hotfix/$Product/$Version/$BUILD_NUMBER/$Product-patch-linux-arm64.tar.gz"
                         PluginBinPathDict["amd64"] = "builds/hotfix/enterprise-plugin/$Version/$BUILD_NUMBER/enterprise-plugin-linux-amd64.tar.gz"

--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -1,7 +1,38 @@
-final RepoDict = ["tiflash":"tics", "br":"tidb", "dumpling":"tidb", "tidb-lightning":"tidb", 
-    "ticdc":"tiflow", "dm":"tiflow", "drainer":"tidb-binlog", "pump":"tidb-binlog"]
-final ProductForBuildMapping = ["tiflash":"tics", "tidb-lightning":"br", "drainer":"tidb-binlog", "pump":"tidb-binlog"]
-final DockerMapping = ["drainer":"tidb-binlog", "pump":"tidb-binlog"]
+final RepoDict = [
+    "tiflash":"tics",
+    "br":"tidb",
+    "dumpling":"tidb",
+    "tidb-lightning":"tidb",
+    "ticdc":"tiflow",
+    "dm":"tiflow",
+    "drainer":"tidb-binlog",
+    "pump":"tidb-binlog",
+]
+final ProductForBuildMapping = [
+    "tiflash":"tics",
+    "tidb-lightning":"br",
+    "drainer":"tidb-binlog",
+    "pump":"tidb-binlog",
+]
+final DockerImgRepoMapping = [
+    "tidb-binlog": "pingcap/tidb-binlog/image",
+    "drainer":"pingcap/tidb-binlog/image",
+    "pump":"pingcap/tidb-binlog/image",
+    "tidb": "pingcap/tidb/images/tidb-server",
+    "tidb-lightning": "pingcap/tidb/images/tidb-lightning",
+    "br": "pingcap/tidb/images/br",
+    "dumpling": "pingcap/tidb/images/dumpling",
+    "tidb-tools": "pingcap/tidb-tools/image",
+    "tidb-dashboard": "pingcap/tidb-dashboard/image",
+    "tikv": "tikv/tikv/image",
+    "pd": "tikv/pd/image",
+    "tiflash": "pingcap/tiflash/image",
+    "dm": "pingcap/tiflow/images/dm"
+    "ticdc": "pingcap/tiflow/images/ticdc"
+    "ng-monitoring": "pingcap/ng-monitoring/image",
+    "tidb-dashboard": "pingcap/tidb-dashboard/image",
+]
+
 final FileserverDownloadURL = "https://fileserver.pingcap.net/download"
 
 def GitHash = ''
@@ -23,20 +54,51 @@ def PrintedVersion = ''
 
 
 def get_dockerfile_url={arch ->
-    def fileName = ProductForDocker
     if (params.ProductDockerfile){
         return params.ProductDockerfile
     }
     if (Version>='v6.6.0'){
-        if (Product == "tidb" && Edition == "enterprise") { 
-            fileName = fileName + '-enterprise'
+        if (Product == "tidb" && Edition == "enterprise") {
+            return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/tidb.enterprise.Dockerfile"
         }
-        return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${fileName}.Dockerfile"
-    }else{
-        if (Product == "tidb" && Edition == "enterprise") { 
-            fileName = "enterprise/${Product}"
+
+        return [
+            "tidb":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/tidb.Dockerfile",
+            "tidb-lightning":   "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/tidb-lightning.Dockerfile",
+            "br":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/br.Dockerfile",
+            "dumpling":         "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/dumpling.Dockerfile",
+            "tiflash":          "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflash/Dockerfile",
+            "dm":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflow/dm.Dockerfile",
+            "ticdc":            "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflow/ticdc.Dockerfile",
+            "drainer":          "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-binlog/Dockerfile",
+            "pump":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-binlog/Dockerfile",
+            "tidb-tools":       "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-tools/Dockerfile",
+            "tidb-dashboard":   "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-dashboard/Dockerfile",
+            "tikv":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tikv/Dockerfile",
+            "pd":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/pd/Dockerfile",
+            "ng-monitoring":    "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/ng-monitoring/Dockerfile",
+        ][Product]
+    } else {
+        if (Product == "tidb" && Edition == "enterprise") {
+            return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/lt6.5.12/tidb.enterprise.Dockerfile"
         }
-        return "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-${arch}/${fileName}"
+
+        return [
+            "tidb":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/lt6.5.12/tidb.Dockerfile",
+            "tidb-lightning":   "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/lt6.5.12/tidb-lightning.Dockerfile",
+            "br":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/lt6.5.12/br.Dockerfile",
+            "dumpling":         "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/lt6.5.12/dumpling.Dockerfile",
+            "tiflash":          "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflash/lt6.5.12/Dockerfile",
+            "dm":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflow/lt6.5.12/dm.Dockerfile",
+            "ticdc":            "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflow/lt6.5.12/ticdc.Dockerfile",
+            "drainer":          "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-binlog/lt6.5.12/Dockerfile",
+            "pump":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-binlog/lt6.5.12/Dockerfile",
+            "tidb-tools":       "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-tools/lt6.5.12/Dockerfile",
+            "tidb-dashboard":   "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-dashboard/lt6.5.12/Dockerfile",
+            "tikv":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tikv/lt6.5.12/Dockerfile",
+            "pd":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/pd/lt6.5.12/Dockerfile",
+            "ng-monitoring":    "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/ng-monitoring/lt6.5.12/Dockerfile",
+        ][Product]
     }
 }
 pipeline{
@@ -87,7 +149,7 @@ spec:
                     BinBuildPathDict["amd64"] = "builds/devbuild/$BUILD_NUMBER/$Product-build-linux-amd64.tar.gz"
                     BinBuildPathDict["arm64"] = "builds/devbuild/$BUILD_NUMBER/$Product-build-linux-arm64.tar.gz"
                     ProductForBuild = ProductForBuildMapping.getOrDefault(Product, Product)
-                    ProductForDocker = DockerMapping.getOrDefault(Product, Product)
+                    ProductForDocker = DockerImgRepoMapping.getOrDefault(Product, Product)
                     def date = new Date()
                     PipelineStartAt =new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(date)
                     Image = "hub.pingcap.net/devbuild/$ProductForDocker:$Version-$BUILD_NUMBER"
@@ -96,7 +158,7 @@ spec:
                     }
                     ImageForGcr = "gcr.io/pingcap-public/dbaas/$ProductForDocker:$Version-$BUILD_NUMBER-dev"
                     if (params.IsHotfix.toBoolean()){
-                        Image = "hub.pingcap.net/qa/$ProductForDocker:$Version-$BUILD_NUMBER"
+                        Image = "hub.pingcap.net/$ProductForDocker:$Version-$BUILD_NUMBER"
                         if (params.Features != ""){
                             error "hotfix artifact but with extra features"
                         }
@@ -214,7 +276,7 @@ spec:
                             }
                         }
                         steps{
-                           sh "package_tiup.py $Product ${BinPathDict[arch]} ${BinBuildPathDict[arch]}" 
+                           sh "package_tiup.py $Product ${BinPathDict[arch]} ${BinBuildPathDict[arch]}"
                         }
                     }
                     stage("docker"){

--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -27,8 +27,8 @@ final DockerImgRepoMapping = [
     "tikv": "tikv/tikv/image",
     "pd": "tikv/pd/image",
     "tiflash": "pingcap/tiflash/image",
-    "dm": "pingcap/tiflow/images/dm"
-    "ticdc": "pingcap/tiflow/images/ticdc"
+    "dm": "pingcap/tiflow/images/dm",
+    "ticdc": "pingcap/tiflow/images/ticdc",
     "ng-monitoring": "pingcap/ng-monitoring/image",
     "tidb-dashboard": "pingcap/tidb-dashboard/image",
 ]


### PR DESCRIPTION
This pull request includes significant changes to the `jenkins/pipelines/cd/dev-build.groovy` file to improve the mapping and retrieval of Docker image URLs and Dockerfile URLs. The most important changes include the introduction of a new mapping for Docker image repositories, updates to the Dockerfile URL retrieval logic, and adjustments to the image naming conventions.

Improvements to Docker image and Dockerfile mappings:

* [`jenkins/pipelines/cd/dev-build.groovy`](diffhunk://#diff-883dea4e305e8d8dffff92a73f812d069fd76eaf118e96b9efd1bdc219de9fe6L1-R35): Introduced `DockerImgRepoMapping` to map products to their respective Docker image repositories. This replaces the previous `DockerMapping` and expands the coverage to include more products.
* [`jenkins/pipelines/cd/dev-build.groovy`](diffhunk://#diff-883dea4e305e8d8dffff92a73f812d069fd76eaf118e96b9efd1bdc219de9fe6L26-R101): Updated the `get_dockerfile_url` function to use a more comprehensive mapping for retrieving Dockerfile URLs based on the product and version. The new mapping covers both versions >= 'v6.6.0' and < 'v6.6.0'.

Adjustments to image naming conventions:

* [`jenkins/pipelines/cd/dev-build.groovy`](diffhunk://#diff-883dea4e305e8d8dffff92a73f812d069fd76eaf118e96b9efd1bdc219de9fe6L90-R152): Changed the `ProductForDocker` assignment to use `DockerImgRepoMapping` instead of the old `DockerMapping`. This ensures consistency with the new Docker image repository mapping.
* [`jenkins/pipelines/cd/dev-build.groovy`](diffhunk://#diff-883dea4e305e8d8dffff92a73f812d069fd76eaf118e96b9efd1bdc219de9fe6L99-R161): Modified the image naming logic for hotfixes to remove the `qa` prefix from the image repository path.