### PR TITLE
Revert "feat(br): enable condition trigger of br test on 8.1"

### DIFF
--- a/prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml
@@ -50,7 +50,9 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       context: pull-br-integration-test
-      run_if_changed: "(br|pkg/(ddl|domain|infoschema))/.*"
+      always_run: false
+      optional: true
+      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-br-integration-test(?: .*?)?$"
       rerun_command: "/test pull-br-integration-test"
       branches:


### PR DESCRIPTION
Reverts PingCAP-QE/ci#3332

Some br tests have failed; automatic triggering will be enabled after the tests are fixed.

test link:
1. https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftidb%2Frelease-8.1%2Fpull_br_integration_test/detail/pull_br_integration_test/29/pipeline/241
<img width="338" alt="image" src="https://github.com/user-attachments/assets/3d0f8a9a-c030-4bfa-9e6f-00197d117465" />
