### PR TITLE
refactor(pingcap/tidb-binlog): refactor check job to prow style

### DIFF
--- a/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
@@ -2,9 +2,9 @@ global_definitions:
   brancher: &brancher
     branches:
       - ^master$
-      - ^release-.+$
-      - ^feature/.+
-      - ^feature/release-\d+\.\d+(.\d+)?-.+$
+      - ^release-6[.][1-9].*$
+      - ^release-[78][.].*$
+
   skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
@@ -15,6 +15,7 @@ presubmits:
       agent: kubernetes
       cluster: gcp-prow-ksyun
       decorate: true # need add this.
+      skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-binlog/build
       spec:
         containers:
@@ -24,6 +25,46 @@ presubmits:
             args:
               - |
                 make build
+            env:
+              - name: GO_PROXY
+                value: http://goproxy.apps.svc,direct
+              - name: GOMODCACHE
+                value: /share/go/pkg/mod
+            volumeMounts:
+              - name: gomod-cache
+                mountPath: /share/go/pkg/mod
+            resources:
+              limits:
+                memory: 8Gi
+                cpu: "4"
+        volumes:
+          - name: gomod-cache
+            persistentVolumeClaim:
+              claimName: gomod-cache
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+    - <<: *brancher
+      name: pull-check
+      agent: kubernetes
+      cluster: gcp-prow-ksyun
+      decorate: true # need add this.
+      skip_if_only_changed: *skip_if_only_changed
+      context: idc-jenkins-ci-binlog/check
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tidb:v2024.10.8-12-gb9ffe36-centos7-go1.21
+            command: [bash, -ce]
+            args:
+              - |
+                make check
             env:
               - name: GO_PROXY
                 value: http://goproxy.apps.svc,direct


### PR DESCRIPTION
Close #3345

This pull request includes several updates to the `prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml` file. The changes primarily focus on updating branch patterns and adding new presubmit job configurations.

Branch pattern updates:

* Updated the branch patterns in the `brancher` section to be more specific, replacing the previous patterns with `^release-6[.][1-9].*Close #3345

 and `^release-[78][.].*Close #3345

.

Presubmit job configurations:

* Added the `skip_if_only_changed` field to the existing presubmit job configuration for `idc-jenkins-ci-binlog/build`.
* Introduced a new presubmit job named `pull-check` with detailed specifications, including container settings, environment variables, resource limits, and node affinity requirements.