### PR TITLE
feat(pingcap/tidb): update UT job for master branch to cover enterprise extension

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -103,11 +103,13 @@ pipeline {
         }
         stage('Test Enterprise Extensions') {
             when {
+                // Only run the tests when there are changes in the `pkg/extension` folder.
                 expression {
-                    // Q: why this step is not existed in presubmit job of master branch?
-                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
-                    // if it failed, the enterprise extension owners should fix it.
-                    return REFS.base_ref != 'master' || REFS.pulls == null || REFS.pulls.size() == 0
+                    def changesInExtensionDir = false
+                    dir(REFS.repo) {
+                        changesInExtensionDir = sh(script: "git diff --name-only ${REFS.base_sha} HEAD | grep -qE '^pkg/extension/'", returnStatus: true) == 0
+                    }
+                    return changesInExtensionDir
                 }
             }
             environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }


### PR DESCRIPTION
run the UT of pkg/extension/enterprise/... when changes are made on `pkg/extension` path.

Close #3376 