### PR TITLE
feat(tiflow): download exact version content for tiflow hotfix

### DIFF
--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
@@ -84,20 +84,54 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow
-                            chmod +x ../scripts/pingcap/tiflow/release-6.1/ticdc_download_integration_test_binaries.sh
-                            ${WORKSPACE}/scripts/pingcap/tiflow/release-6.1/ticdc_download_integration_test_binaries.sh
-                            ls -alh ./bin/
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                cp ${WORKSPACE}/scripts/pingcap/tiflow/release-6.1/ticdc_download_integration_test_binaries.sh ./
+                                chmod +x ticdc_download_integration_test_binaries.sh
+
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./ticdc_download_integration_test_binaries.sh
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./ticdc_download_integration_test_binaries.sh
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
@@ -106,18 +106,38 @@ pipeline {
                                 mv bin/dm-worker.test bin/dm-worker.test.current
                                 ls -alh ./bin/
                             """
-                            sh label: "download third_party", script: """
-                                chmod +x ../scripts/pingcap/tiflow/release-6.1/dm_download_compatibility_test_binaries.sh
-                                cp ../scripts/pingcap/tiflow/release-6.1/dm_download_compatibility_test_binaries.sh dm/tests/
-
-                                pwd && ls -alh dm/tests/
-                                cd dm/tests && ./dm_download_compatibility_test_binaries.sh && ls -alh ./bin
-                                cd - && cp -r dm/tests/bin/* ./bin
-                                ls -alh ./bin
-                                ./bin/tidb-server -V
-                                ./bin/sync_diff_inspector -V
-                                ./bin/mydumper -V
-                            """
+                            script {
+                                def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                                sh label: "download third_party", script: """
+                                    cp ${WORKSPACE}/scripts/pingcap/tiflow/release-6.1/dm_download_compatibility_test_binaries.sh dm/tests/
+                                    chmod +x dm/tests/dm_download_compatibility_test_binaries.sh
+                                    if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                        echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                        echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                        cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh dm/tests/
+                                        chmod +x dm/tests/download_test_binaries_by_tag.sh
+                                        # First download binary using the release branch script
+                                        cd dm/tests && ./dm_download_compatibility_test_binaries.sh
+                                        rm -rf bin/tidb-server
+                                        mv bin tmp_bin
+                                        # Then download and replace other components with exact versions
+                                        ./download_test_binaries_by_tag.sh ${branchInfo.versionTag} tidb
+                                        mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                        cd -
+                                    else
+                                        echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                        cd dm/tests && ./dm_download_compatibility_test_binaries.sh
+                                        cd -
+                                    fi
+                                    # Verify all required binaries
+                                    cp dm/tests/bin/* ./bin/
+                                    pwd && ls -alh ./bin
+                                    ls -alh dm/tests/bin
+                                    ./bin/tidb-server -V
+                                    ./bin/sync_diff_inspector -V
+                                    ./bin/mydumper -V
+                                """
+                            }
                         }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
@@ -130,7 +130,7 @@ pipeline {
                                         cd -
                                     fi
                                     # Verify all required binaries
-                                    cp dm/tests/bin/* ./bin/
+                                    cp -r dm/tests/bin/* ./bin/
                                     pwd && ls -alh ./bin
                                     ls -alh dm/tests/bin
                                     ./bin/tidb-server -V

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
@@ -83,7 +83,7 @@ pipeline {
         }
         stage("prepare") {
             when { expression { !skipRemainingStages} }
-            options { timeout(time: 25, unit: 'MINUTES') }
+            options { timeout(time: 35, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
                         retry(2) {

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_integration_test.groovy
@@ -86,17 +86,38 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            chmod +x ../scripts/pingcap/tiflow/release-6.1/dm_download_integration_test_binaries.sh
-                            cp ../scripts/pingcap/tiflow/release-6.1/dm_download_integration_test_binaries.sh ../tiflow/dm/tests/
-
-                            cd ../tiflow && ./dm/tests/dm_download_integration_test_binaries.sh && ls -alh ./bin
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                        """
+                        script {
+                                def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                                sh label: "download third_party", script: """
+                                    cp ${WORKSPACE}/scripts/pingcap/tiflow/release-6.1/dm_download_integration_test_binaries.sh ../tiflow/dm/tests/
+                                    chmod +x ${WORKSPACE}/tiflow/dm/tests/dm_download_integration_test_binaries.sh
+                                    if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                        echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                        echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                        
+                                        cp ${WORKSPACE}/scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ${WORKSPACE}/tiflow/dm/tests/
+                                        chmod +x ${WORKSPACE}/tiflow/dm/tests/download_test_binaries_by_tag.sh
+                                        # First download binary using the release branch script
+                                        cd ../tiflow && ./dm/tests/dm_download_integration_test_binaries.sh
+                                        rm -rf bin/tidb-server bin/pd-* bin/tikv-server
+                                        mv bin tmp_bin
+                                        # Then download and replace other components with exact versions
+                                        ./dm/tests/download_test_binaries_by_tag.sh ${branchInfo.versionTag} tidb pd tikv ctl
+                                        mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                        cd -
+                                    else
+                                        echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                        cd ../tiflow && ./dm/tests/dm_download_integration_test_binaries.sh
+                                        cd -
+                                    fi
+                                    # Verify all required binaries
+                                    mkdir -p bin && mv ../tiflow/bin/* ./bin/
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                """
+                            }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
@@ -84,20 +84,54 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow
-                            chmod +x ../scripts/pingcap/tiflow/release-6.5/ticdc_download_integration_test_binaries.sh
-                            ${WORKSPACE}/scripts/pingcap/tiflow/release-6.5/ticdc_download_integration_test_binaries.sh
-                            ls -alh ./bin/
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                cp ${WORKSPACE}/scripts/pingcap/tiflow/release-6.5/ticdc_download_integration_test_binaries.sh ./
+                                chmod +x ticdc_download_integration_test_binaries.sh
+
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./ticdc_download_integration_test_binaries.sh
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./ticdc_download_integration_test_binaries.sh
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
@@ -84,20 +84,54 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow
-                            chmod +x ../scripts/pingcap/tiflow/release-6.5/ticdc_download_integration_test_binaries.sh
-                            ${WORKSPACE}/scripts/pingcap/tiflow/release-6.5/ticdc_download_integration_test_binaries.sh
-                            ls -alh ./bin/
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                cp ${WORKSPACE}/scripts/pingcap/tiflow/release-6.5/ticdc_download_integration_test_binaries.sh ./
+                                chmod +x ticdc_download_integration_test_binaries.sh
+
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./ticdc_download_integration_test_binaries.sh
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./ticdc_download_integration_test_binaries.sh
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
@@ -130,7 +130,7 @@ pipeline {
                                         cd -
                                     fi
                                     # Verify all required binaries
-                                    cp dm/tests/bin/* ./bin/
+                                    cp -r dm/tests/bin/* ./bin/
                                     pwd && ls -alh ./bin
                                     ls -alh dm/tests/bin
                                     ./bin/tidb-server -V

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
@@ -83,7 +83,7 @@ pipeline {
         }
         stage("prepare") {
             when { expression { !skipRemainingStages} }
-            options { timeout(time: 25, unit: 'MINUTES') }
+            options { timeout(time: 35, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
                         retry(2) {

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
@@ -86,17 +86,38 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            chmod +x ../scripts/pingcap/tiflow/release-6.5/dm_download_integration_test_binaries.sh
-                            cp ../scripts/pingcap/tiflow/release-6.5/dm_download_integration_test_binaries.sh ../tiflow/dm/tests/
-
-                            cd ../tiflow && ./dm/tests/dm_download_integration_test_binaries.sh && ls -alh ./bin
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                        """
+                        script {
+                                def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                                sh label: "download third_party", script: """
+                                    cp ${WORKSPACE}/scripts/pingcap/tiflow/release-6.5/dm_download_integration_test_binaries.sh ../tiflow/dm/tests/
+                                    chmod +x ${WORKSPACE}/tiflow/dm/tests/dm_download_integration_test_binaries.sh
+                                    if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                        echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                        echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                        
+                                        cp ${WORKSPACE}/scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ${WORKSPACE}/tiflow/dm/tests/
+                                        chmod +x ${WORKSPACE}/tiflow/dm/tests/download_test_binaries_by_tag.sh
+                                        # First download binary using the release branch script
+                                        cd ../tiflow && ./dm/tests/dm_download_integration_test_binaries.sh
+                                        rm -rf bin/tidb-server bin/pd-* bin/tikv-server
+                                        mv bin tmp_bin
+                                        # Then download and replace other components with exact versions
+                                        ./dm/tests/download_test_binaries_by_tag.sh ${branchInfo.versionTag} tidb pd tikv ctl
+                                        mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                        cd -
+                                    else
+                                        echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                        cd ../tiflow && ./dm/tests/dm_download_integration_test_binaries.sh
+                                        cd -
+                                    fi
+                                    # Verify all required binaries
+                                    mkdir -p bin && mv ../tiflow/bin/* ./bin/
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                """
+                            }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -84,17 +84,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh release-7.1 && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+                                    
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from release-7.1"
+                                    ./scripts/download-integration-test-binaries.sh release-7.1
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -84,17 +84,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh release-7.1 && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -84,17 +84,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh release-7.1 && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+                                    
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from release-7.1"
+                                    ./scripts/download-integration-test-binaries.sh release-7.1
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
@@ -84,17 +84,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh release-7.1 && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -105,15 +105,36 @@ pipeline {
                                 mv bin/dm-worker.test bin/dm-worker.test.current
                                 ls -alh ./bin/
                             """
-                            sh label: "download third_party", script: """
-                                pwd && ls -alh dm/tests/
-                                cd dm/tests && ./download-compatibility-test-binaries.sh release-7.1 && ls -alh ./bin
-                                cd - && cp -r dm/tests/bin/* ./bin
-                                ls -alh ./bin
-                                ./bin/tidb-server -V
-                                ./bin/sync_diff_inspector -V
-                                ./bin/mydumper -V
-                            """
+                            script {
+                                def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                                sh label: "download third_party", script: """
+                                    if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                        echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                        echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                        cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh dm/tests/
+                                        chmod +x dm/tests/download_test_binaries_by_tag.sh
+                                        # First download binary using the release branch script
+                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-7.1
+                                        rm -rf bin/tidb-server
+                                        mv bin tmp_bin
+                                        # Then download and replace other components with exact versions
+                                        ./download_test_binaries_by_tag.sh ${branchInfo.versionTag} tidb
+                                        mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                        cd -
+                                    else
+                                        echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-7.1
+                                        cd -
+                                    fi
+                                    # Verify all required binaries
+                                    cp dm/tests/bin/* ./bin/
+                                    pwd && ls -alh ./bin
+                                    ls -alh dm/tests/bin
+                                    ./bin/tidb-server -V
+                                    ./bin/sync_diff_inspector -V
+                                    ./bin/mydumper -V
+                                """
+                            }
                         }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -127,7 +127,7 @@ pipeline {
                                         cd -
                                     fi
                                     # Verify all required binaries
-                                    cp dm/tests/bin/* ./bin/
+                                    cp -r dm/tests/bin/* ./bin/
                                     pwd && ls -alh ./bin
                                     ls -alh dm/tests/bin
                                     ./bin/tidb-server -V

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -82,7 +82,7 @@ pipeline {
         }
         stage("prepare") {
             when { expression { !skipRemainingStages} }
-            options { timeout(time: 25, unit: 'MINUTES') }
+            options { timeout(time: 35, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
                         retry(2) {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
@@ -86,14 +86,36 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-7.1 && ls -alh ./bin
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                        """
+                        script {
+                                def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                                sh label: "download third_party", script: """
+                                    if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                        echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                        echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                        
+                                        cp ${WORKSPACE}/scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ${WORKSPACE}/tiflow/dm/tests/
+                                        chmod +x ${WORKSPACE}/tiflow/dm/tests/download_test_binaries_by_tag.sh
+                                        # First download binary using the release branch script
+                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-7.1
+                                        rm -rf bin/tidb-server bin/pd-* bin/tikv-server
+                                        mv bin tmp_bin
+                                        # Then download and replace other components with exact versions
+                                        ./dm/tests/download_test_binaries_by_tag.sh ${branchInfo.versionTag} tidb pd tikv ctl
+                                        mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                        cd -
+                                    else
+                                        echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-7.1
+                                        cd -
+                                    fi
+                                    # Verify all required binaries
+                                    mkdir -p bin && mv ../tiflow/bin/* ./bin/
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                """
+                            }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -83,17 +83,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh release-7.5 && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -83,17 +83,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh release-7.5 && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -84,17 +84,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh release-7.5 && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -84,17 +84,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh release-7.5 && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -127,7 +127,7 @@ pipeline {
                                         cd -
                                     fi
                                     # Verify all required binaries
-                                    cp dm/tests/bin/* ./bin/
+                                    cp -r dm/tests/bin/* ./bin/
                                     pwd && ls -alh ./bin
                                     ls -alh dm/tests/bin
                                     ./bin/tidb-server -V

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -82,7 +82,7 @@ pipeline {
         }
         stage("prepare") {
             when { expression { !skipRemainingStages} }
-            options { timeout(time: 25, unit: 'MINUTES') }
+            options { timeout(time: 35, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
                         retry(2) {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -105,15 +105,36 @@ pipeline {
                                 mv bin/dm-worker.test bin/dm-worker.test.current
                                 ls -alh ./bin/
                             """
-                            sh label: "download third_party", script: """
-                                pwd && ls -alh dm/tests/
-                                cd dm/tests && ./download-compatibility-test-binaries.sh release-7.5 && ls -alh ./bin
-                                cd - && cp -r dm/tests/bin/* ./bin
-                                ls -alh ./bin
-                                ./bin/tidb-server -V
-                                ./bin/sync_diff_inspector -V
-                                ./bin/mydumper -V
-                            """
+                            script {
+                                def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                                sh label: "download third_party", script: """
+                                    if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                        echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                        echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                        cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh dm/tests/
+                                        chmod +x dm/tests/download_test_binaries_by_tag.sh
+                                        # First download binary using the release branch script
+                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-7.5
+                                        rm -rf bin/tidb-server
+                                        mv bin tmp_bin
+                                        # Then download and replace other components with exact versions
+                                        ./download_test_binaries_by_tag.sh ${branchInfo.versionTag} tidb
+                                        mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                        cd -
+                                    else
+                                        echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-7.5
+                                        cd -
+                                    fi
+                                    # Verify all required binaries
+                                    cp dm/tests/bin/* ./bin/
+                                    pwd && ls -alh ./bin
+                                    ls -alh dm/tests/bin
+                                    ./bin/tidb-server -V
+                                    ./bin/sync_diff_inspector -V
+                                    ./bin/mydumper -V
+                                """
+                            }
                         }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
@@ -85,14 +85,36 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-7.5 && ls -alh ./bin
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            sh label: "download third_party", script: """
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    cp ${WORKSPACE}/scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ${WORKSPACE}/tiflow/dm/tests/
+                                    chmod +x ${WORKSPACE}/tiflow/dm/tests/download_test_binaries_by_tag.sh
+                                    # First download binary using the release branch script
+                                    cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-7.5
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server
+                                    mv bin tmp_bin
+                                    # Then download and replace other components with exact versions
+                                    ./dm/tests/download_test_binaries_by_tag.sh ${branchInfo.versionTag} tidb pd tikv ctl
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                    cd -
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-7.5
+                                    cd -
+                                fi
+                                # Verify all required binaries
+                                mkdir -p bin && mv ../tiflow/bin/* ./bin/
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_engine_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_engine_integration_test.groovy
@@ -150,30 +150,41 @@ pipeline {
                                             echo "$HARBOR_CRED_PSW" | docker login -u $HARBOR_CRED_USR --password-stdin hub.pingcap.net
                                         """
                                     }
-                                    sh label: "prepare image", script: """
-                                        TIDB_CLUSTER_BRANCH=release-7.5
-                                        TIDB_TEST_TAG=nightly
+                                    script {
+                                        def pdImageTag = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-7.5')
+                                        def tikvImageTag = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-7.5')
+                                        def tidbImageTag = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-7.5')
+                                        def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                                        if (branchInfo.isHotfix) {
+                                            println "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} components"
+                                            pdImageTag = branchInfo.versionTag
+                                            tikvImageTag = branchInfo.versionTag
+                                            tidbImageTag = branchInfo.versionTag
+                                        }
+                                        sh label: "prepare image", script: """
+                                            TIDB_TEST_TAG=nightly
 
-                                        docker pull hub.pingcap.net/tiflow/minio:latest
-                                        docker tag hub.pingcap.net/tiflow/minio:latest minio/minio:latest
-                                        docker pull hub.pingcap.net/tiflow/minio:mc
-                                        docker tag hub.pingcap.net/tiflow/minio:mc minio/mc:latest
-                                        docker pull hub.pingcap.net/tiflow/mysql:5.7
-                                        docker tag hub.pingcap.net/tiflow/mysql:5.7 mysql:5.7
-                                        docker pull hub.pingcap.net/tiflow/mysql:8.0
-                                        docker tag hub.pingcap.net/tiflow/mysql:8.0 mysql:8.0
-                                        docker pull hub.pingcap.net/tiflow/etcd:latest
-                                        docker tag hub.pingcap.net/tiflow/etcd:latest quay.io/coreos/etcd:latest
-                                        docker pull hub.pingcap.net/qa/tidb:\${TIDB_CLUSTER_BRANCH}
-                                        docker tag hub.pingcap.net/qa/tidb:\${TIDB_CLUSTER_BRANCH} pingcap/tidb:\${TIDB_TEST_TAG} 
-                                        docker pull hub.pingcap.net/qa/tikv:\${TIDB_CLUSTER_BRANCH}
-                                        docker tag hub.pingcap.net/qa/tikv:\${TIDB_CLUSTER_BRANCH} pingcap/tikv:\${TIDB_TEST_TAG}
-                                        docker pull hub.pingcap.net/qa/pd:\${TIDB_CLUSTER_BRANCH}
-                                        docker tag hub.pingcap.net/qa/pd:\${TIDB_CLUSTER_BRANCH} pingcap/pd:\${TIDB_TEST_TAG}
-                                        docker pull hub.pingcap.net/tiflow/engine:${IMAGE_TAG}
-                                        docker tag hub.pingcap.net/tiflow/engine:${IMAGE_TAG} ${ENGINE_TEST_TAG}
-                                        docker images
-                                    """
+                                            docker pull hub.pingcap.net/tiflow/minio:latest
+                                            docker tag hub.pingcap.net/tiflow/minio:latest minio/minio:latest
+                                            docker pull hub.pingcap.net/tiflow/minio:mc
+                                            docker tag hub.pingcap.net/tiflow/minio:mc minio/mc:latest
+                                            docker pull hub.pingcap.net/tiflow/mysql:5.7
+                                            docker tag hub.pingcap.net/tiflow/mysql:5.7 mysql:5.7
+                                            docker pull hub.pingcap.net/tiflow/mysql:8.0
+                                            docker tag hub.pingcap.net/tiflow/mysql:8.0 mysql:8.0
+                                            docker pull hub.pingcap.net/tiflow/etcd:latest
+                                            docker tag hub.pingcap.net/tiflow/etcd:latest quay.io/coreos/etcd:latest
+                                            docker pull hub.pingcap.net/qa/tidb:${tidbImageTag}
+                                            docker tag hub.pingcap.net/qa/tidb:${tidbImageTag} pingcap/tidb:\${TIDB_TEST_TAG} 
+                                            docker pull hub.pingcap.net/qa/tikv:${tikvImageTag}
+                                            docker tag hub.pingcap.net/qa/tikv:${tikvImageTag} pingcap/tikv:\${TIDB_TEST_TAG}
+                                            docker pull hub.pingcap.net/qa/pd:${pdImageTag}
+                                            docker tag hub.pingcap.net/qa/pd:${pdImageTag} pingcap/pd:\${TIDB_TEST_TAG}
+                                            docker pull hub.pingcap.net/tiflow/engine:${IMAGE_TAG}
+                                            docker tag hub.pingcap.net/tiflow/engine:${IMAGE_TAG} ${ENGINE_TEST_TAG}
+                                            docker images
+                                        """
+                                    }
                                     sh label: "${TEST_GROUP}", script: """
                                         git config --global --add safe.directory '*'
                                         unset GOTOOLCHAIN && go env -w GOTOOLCHAIN=auto

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
@@ -127,7 +127,7 @@ pipeline {
                                         cd -
                                     fi
                                     # Verify all required binaries
-                                    cp dm/tests/bin/* ./bin/
+                                    cp -r dm/tests/bin/* ./bin/
                                     pwd && ls -alh ./bin
                                     ls -alh dm/tests/bin
                                     ./bin/tidb-server -V

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
@@ -82,7 +82,7 @@ pipeline {
         }
         stage("prepare") {
             when { expression { !skipRemainingStages} }
-            options { timeout(time: 25, unit: 'MINUTES') }
+            options { timeout(time: 35, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
                         retry(2) {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -84,17 +84,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -84,17 +84,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -84,17 +84,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -84,17 +84,52 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
-                            make check_third_party_binary
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                            ./bin/sync_diff_inspector --version
-                        """
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                            
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+                                
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                    
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+                                    
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+                                    
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                fi
+                                
+                                make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+                                
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
+                            """
+                        }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
@@ -114,7 +114,7 @@ pipeline {
                                         cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh dm/tests/
                                         chmod +x dm/tests/download_test_binaries_by_tag.sh
                                         # First download binary using the release branch script
-                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-8.1
+                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-8.5
                                         rm -rf bin/tidb-server
                                         mv bin tmp_bin
                                         # Then download and replace other components with exact versions
@@ -123,7 +123,7 @@ pipeline {
                                         cd -
                                     else
                                         echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-8.1
+                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-8.5
                                         cd -
                                     fi
                                     # Verify all required binaries

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
@@ -127,7 +127,7 @@ pipeline {
                                         cd -
                                     fi
                                     # Verify all required binaries
-                                    cp dm/tests/bin/* ./bin/
+                                    cp -r dm/tests/bin/* ./bin/
                                     pwd && ls -alh ./bin
                                     ls -alh dm/tests/bin
                                     ./bin/tidb-server -V

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
@@ -82,7 +82,7 @@ pipeline {
         }
         stage("prepare") {
             when { expression { !skipRemainingStages} }
-            options { timeout(time: 25, unit: 'MINUTES') }
+            options { timeout(time: 35, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
                         retry(2) {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                         cp ${WORKSPACE}/scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ${WORKSPACE}/tiflow/dm/tests/
                                         chmod +x ${WORKSPACE}/tiflow/dm/tests/download_test_binaries_by_tag.sh
                                         # First download binary using the release branch script
-                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-8.1
+                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-8.5
                                         rm -rf bin/tidb-server bin/pd-* bin/tikv-server
                                         mv bin tmp_bin
                                         # Then download and replace other components with exact versions
@@ -105,7 +105,7 @@ pipeline {
                                         cd -
                                     else
                                         echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-8.1
+                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-8.5
                                         cd -
                                     fi
                                     # Verify all required binaries

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -86,14 +86,36 @@ pipeline {
             steps {
                 dir("third_party_download") {
                     retry(2) {
-                        sh label: "download third_party", script: """
-                            cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
-                            cd - && mkdir -p bin && mv ../tiflow/bin/* ./bin/
-                            ls -alh ./bin
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                        """
+                        script {
+                                def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                                sh label: "download third_party", script: """
+                                    if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                        echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                        echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+                                        
+                                        cp ${WORKSPACE}/scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ${WORKSPACE}/tiflow/dm/tests/
+                                        chmod +x ${WORKSPACE}/tiflow/dm/tests/download_test_binaries_by_tag.sh
+                                        # First download binary using the release branch script
+                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-8.1
+                                        rm -rf bin/tidb-server bin/pd-* bin/tikv-server
+                                        mv bin tmp_bin
+                                        # Then download and replace other components with exact versions
+                                        ./dm/tests/download_test_binaries_by_tag.sh ${branchInfo.versionTag} tidb pd tikv ctl
+                                        mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                        cd -
+                                    else
+                                        echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-8.1
+                                        cd -
+                                    fi
+                                    # Verify all required binaries
+                                    mkdir -p bin && mv ../tiflow/bin/* ./bin/
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                """
+                            }
                     }
                 }
                 dir("tiflow") {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_engine_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_engine_integration_test.groovy
@@ -152,9 +152,16 @@ pipeline {
                                         """
                                     }
                                     script {
-                                        def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
-                                        def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
-                                        def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
+                                        def pdImageTag = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
+                                        def tikvImageTag = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
+                                        def tidbImageTag = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
+                                        def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+                                        if (branchInfo.isHotfix) {
+                                            println "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} components"
+                                            pdImageTag = branchInfo.versionTag
+                                            tikvImageTag = branchInfo.versionTag
+                                            tidbImageTag = branchInfo.versionTag
+                                        }
                                         sh label: "prepare image", script: """
                                             TIDB_TEST_TAG=nightly
 
@@ -168,12 +175,12 @@ pipeline {
                                             docker tag hub.pingcap.net/tiflow/mysql:8.0 mysql:8.0
                                             docker pull hub.pingcap.net/tiflow/etcd:latest
                                             docker tag hub.pingcap.net/tiflow/etcd:latest quay.io/coreos/etcd:latest
-                                            docker pull hub.pingcap.net/qa/tidb:${tidbBranch}
-                                            docker tag hub.pingcap.net/qa/tidb:${tidbBranch} pingcap/tidb:\${TIDB_TEST_TAG} 
-                                            docker pull hub.pingcap.net/qa/tikv:${tikvBranch}
-                                            docker tag hub.pingcap.net/qa/tikv:${tikvBranch} pingcap/tikv:\${TIDB_TEST_TAG}
-                                            docker pull hub.pingcap.net/qa/pd:${pdBranch}
-                                            docker tag hub.pingcap.net/qa/pd:${pdBranch} pingcap/pd:\${TIDB_TEST_TAG}
+                                            docker pull hub.pingcap.net/qa/tidb:${tidbImageTag}
+                                            docker tag hub.pingcap.net/qa/tidb:${tidbImageTag} pingcap/tidb:\${TIDB_TEST_TAG} 
+                                            docker pull hub.pingcap.net/qa/tikv:${tikvImageTag}
+                                            docker tag hub.pingcap.net/qa/tikv:${tikvImageTag} pingcap/tikv:\${TIDB_TEST_TAG}
+                                            docker pull hub.pingcap.net/qa/pd:${pdImageTag}
+                                            docker tag hub.pingcap.net/qa/pd:${pdImageTag} pingcap/pd:\${TIDB_TEST_TAG}
                                             docker pull hub.pingcap.net/tiflow/engine:${IMAGE_TAG}
                                             docker tag hub.pingcap.net/tiflow/engine:${IMAGE_TAG} ${ENGINE_TEST_TAG}
                                             docker images

--- a/pipelines/pingcap/tiflow/release-8.5/pull_engine_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_engine_integration_test.groovy
@@ -152,9 +152,9 @@ pipeline {
                                         """
                                     }
                                     script {
-                                        def pdImageTag = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
-                                        def tikvImageTag = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
-                                        def tidbImageTag = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
+                                        def pdImageTag = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
+                                        def tikvImageTag = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
+                                        def tidbImageTag = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
                                         def branchInfo = component.extractHotfixInfo(REFS.base_ref)
                                         if (branchInfo.isHotfix) {
                                             println "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} components"


### PR DESCRIPTION
Download exact version content for tiflow hotfix branch integration tests.
Over time, the release branch will be continuously updated, and for the hotfix branch (from the tag), using non-fixed artifacts in integration testing may lead to test failures due to incompatible changes in dependency components(tidb & tikv & pd & tiflash). Therefore, we handle hotfixes separately in the pipeline; when a hotfix branch is detected, we download and test the dependencies for that tag version.
1. current PR will support for those lts hotfix branch:  6.1 & 6.5 & 7. 1 & 7.5 & 8.5
2. Support for 8.1 is in this PR: https://github.com/PingCAP-QE/ci/pull/3380