### PR TITLE
feat(ticdc): new ticdc add mysql it pipeline

### DIFF
--- a/jobs/pingcap/ticdc/aa_folder.groovy
+++ b/jobs/pingcap/ticdc/aa_folder.groovy
@@ -1,0 +1,3 @@
+folder('pingcap/ticdc') {
+    description("Folder for pipelines of pingcap/ticdc repo")
+}

--- a/jobs/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/ticdc/pull_cdc_mysql_integration_heavy') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        githubProjectUrl("https://github.com/pingcap/ticdc")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/ticdc/pull_cdc_mysql_integration_light') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        githubProjectUrl("https://github.com/pingcap/ticdc")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_heavy.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_heavy.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      tty: true
+      resources:
+        limits:
+          memory: 16Gi
+          cpu: "12"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_light.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      tty: true
+      resources:
+        limits:
+          memory: 8Gi
+          cpu: "4"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
@@ -1,0 +1,153 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_heavy.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+def skipRemainingStages = false
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir("tiflow") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("prepare") {
+            options { timeout(time: 20, unit: 'MINUTES') }
+            steps {
+                dir("third_party_download") {
+                    script {
+                        def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
+                        def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+                        def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+                        def tiflashBranch = component.computeBranchFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+                        retry(2) {
+                            sh label: "download third_party", script: """
+                                export TIDB_BRANCH=${tidbBranch}
+                                export PD_BRANCH=${pdBranch}
+                                export TIKV_BRANCH=${tikvBranch}
+                                export TIFLASH_BRANCH=${tiflashBranch}
+                                cd ../ticdc && ./tests/scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
+                                make check_third_party_binary
+                                cd - && mkdir -p bin && mv ../ticdc/bin/* ./bin/
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                            """
+                        }
+                    }   
+                }
+                dir("ticdc") {
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'ticdc-integration')) {
+                        // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
+                        // only build binarys if not exist, use the cached binarys if exist
+                        sh label: "prepare", script: """
+                            ls -alh ./bin
+                            [ -f ./bin/cdc ] || make cdc
+                            [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
+                            [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
+                            [ -f ./bin/cdc.test ] || make integration_test_build
+                            ls -alh ./bin
+                            ./bin/cdc version
+                        """
+                    }
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") { 
+                        sh label: "prepare", script: """
+                            cp -r ../third_party_download/bin/* ./bin/
+                            ls -alh ./bin
+                        """
+                    }
+                }
+            }
+        }
+
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_GROUP'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06', 'G07', 'G08', 'G09', 'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        yamlFile POD_TEMPLATE_FILE
+                        defaultContainer 'golang'
+                    }
+                } 
+                stages {
+                    stage("Test") {
+                        options { timeout(time: 40, unit: 'MINUTES') }
+                        steps {
+                            dir('tiflow') {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
+                                    sh label: "${TEST_GROUP}", script: """
+                                        ./tests/integration_tests/run_heavy_it_in_ci.sh mysql ${TEST_GROUP}
+                                    """
+                                }
+                            }
+                        }
+                        post {
+                            failure {
+                                sh label: "collect logs", script: """
+                                    ls /tmp/tidb_cdc_test/
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")    
+                                    ls -alh  log-${TEST_GROUP}.tar.gz  
+                                """
+                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true 
+                            }
+                        }
+                    }
+                }
+            }        
+        }
+    }
+}

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy
@@ -1,0 +1,153 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_light.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+def skipRemainingStages = false
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir("tiflow") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("prepare") {
+            options { timeout(time: 20, unit: 'MINUTES') }
+            steps {
+                dir("third_party_download") {
+                    script {
+                        def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
+                        def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+                        def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+                        def tiflashBranch = component.computeBranchFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+                        retry(2) {
+                            sh label: "download third_party", script: """
+                                export TIDB_BRANCH=${tidbBranch}
+                                export PD_BRANCH=${pdBranch}
+                                export TIKV_BRANCH=${tikvBranch}
+                                export TIFLASH_BRANCH=${tiflashBranch}
+                                cd ../ticdc && ./tests/scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
+                                make check_third_party_binary
+                                cd - && mkdir -p bin && mv ../ticdc/bin/* ./bin/
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tiflash --version
+                            """
+                        }
+                    }   
+                }
+                dir("ticdc") {
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'ticdc-integration')) {
+                        // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
+                        // only build binarys if not exist, use the cached binarys if exist
+                        sh label: "prepare", script: """
+                            ls -alh ./bin
+                            [ -f ./bin/cdc ] || make cdc
+                            [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
+                            [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
+                            [ -f ./bin/cdc.test ] || make integration_test_build
+                            ls -alh ./bin
+                            ./bin/cdc version
+                        """
+                    }
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") { 
+                        sh label: "prepare", script: """
+                            cp -r ../third_party_download/bin/* ./bin/
+                            ls -alh ./bin
+                        """
+                    }
+                }
+            }
+        }
+
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_GROUP'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06', 'G07', 'G08', 'G09', 'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        yamlFile POD_TEMPLATE_FILE
+                        defaultContainer 'golang'
+                    }
+                } 
+                stages {
+                    stage("Test") {
+                        options { timeout(time: 40, unit: 'MINUTES') }
+                        steps {
+                            dir('tiflow') {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
+                                    sh label: "${TEST_GROUP}", script: """
+                                        ./tests/integration_tests/run_light_it_in_ci.sh mysql ${TEST_GROUP}
+                                    """
+                                }
+                            }
+                        }
+                        post {
+                            failure {
+                                sh label: "collect logs", script: """
+                                    ls /tmp/tidb_cdc_test/
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")    
+                                    ls -alh  log-${TEST_GROUP}.tar.gz  
+                                """
+                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true 
+                            }
+                        }
+                    }
+                }
+            }        
+        }
+    }
+}

--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -1,6 +1,35 @@
+global_definitions:
+  branches: &branches
+    - ^master$
+    - ^feature/.+
+
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
   pingcap/ticdc:
+    - name: pingcap/ticdc/pull_cdc_mysql_integration_light
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false
+      # skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      context: wip/pull-cdc-mysql-integration-light
+      optional: true # change this after test passed.
+      skip_report: false
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-mysql-integration-light"
+      branches: *branches
+
+    - name: pingcap/ticdc/pull_cdc_mysql_integration_heavy
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false
+      # skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      context: wip/pull-cdc-mysql-integration-heavy
+      optional: true # change this after test passed.
+      skip_report: false
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-mysql-integration-heavy"
+      branches: *branches
+
     - name: pull-unit-test
       cluster: gcp-prow-ksyun
       decorate: true # need add this.
@@ -27,7 +56,8 @@ presubmits:
                 cpu: "16"
               limits:
                 memory: 32Gi
-                cpu: "16"            
+                cpu: "16"
+         
     - name: pull-build
       cluster: gcp-prow-ksyun
       decorate: true # need add this.
@@ -53,6 +83,7 @@ presubmits:
               limits:
                 memory: 16Gi
                 cpu: "8" 
+
     - name: pull-check
       cluster: gcp-prow-ksyun
       decorate: true # need add this.


### PR DESCRIPTION
Add two MySQL test integration testing pipelines for ticdc, related to another PR https://github.com/pingcap/ticdc/pull/1025
* pull_cdc_mysql_integration_light
* pull_cdc_mysql_integration_heavy

To make better use of resources, the tests are divided into light(4 core) and heavy(12 core) based on CPU consumption.
The naming of the pipeline should be concise and clear: cdc_${test_type}_integration_heavy, the value of test_type is mysql, kafka, or other test types.