### PR TITLE
feat(tiflash): compile bench_dbms in PR pipelines

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -56,7 +56,7 @@ pipeline {
                 script {
                     // test build cache, if cache is exist, then skip the following build steps
                     try {
-                        dir("test-build-cache") { 
+                        dir("test-build-cache") {
                             cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'ut-build')){
                                 // if file README.md not exist, then build-cache-ready is false
                                 build_cache_ready = sh(script: "test -f README.md && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
@@ -87,7 +87,7 @@ pipeline {
                         container("util") {
                             withCredentials(
                                 [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) { 
+                            ) {
                                 sh "rm -rf ./*"
                                 sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
                                 sh """
@@ -191,7 +191,7 @@ pipeline {
                                 ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
                                 ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
                             """
-                        }   
+                        }
                     }
                 }
             }
@@ -201,7 +201,7 @@ pipeline {
                 expression { !build_cache_ready }
             }
             parallel {
-                stage("Cluster Manage") { 
+                stage("Cluster Manage") {
                     steps {
                     // NOTE: cluster_manager is deprecated since release-6.0 (include)
                     echo "cluster_manager is deprecated"
@@ -272,7 +272,7 @@ pipeline {
             steps {
                 dir("${WORKSPACE}/tiflash") {
                 sh """
-                    cmake --build '${WORKSPACE}/build' --target gtests_dbms gtests_libcommon gtests_libdaemon --parallel ${PARALLELISM}
+                    cmake --build '${WORKSPACE}/build' --target gtests_dbms gtests_libcommon gtests_libdaemon bench_dbms --parallel ${PARALLELISM}
                     """
                     sh """
                     cp '${WORKSPACE}/build/dbms/gtests_dbms' '${WORKSPACE}/install/tiflash/'
@@ -367,9 +367,9 @@ pipeline {
                                 rm -rf contrib
                                 du -sh ./
                                 ls -alh
-                                """ 
+                                """
                             }
-                        }     
+                        }
                     }
                 }
                 sh label: "link tiflash and tests", script: """


### PR DESCRIPTION
Previously bench_dbms is not compiled at all, and it has been broken for a while.

Now we fixed it in https://github.com/pingcap/tiflash/pull/9948 and would like to check it in CI as well.

See replay: https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftiflash%2Fpull_unit_test/detail/pull_unit_test/3428/pipeline/177/