### PR TITLE
feat(scripts/flow/build): add versioning strategy script

### DIFF
--- a/scripts/flow/build/versioning-strategy.md
+++ b/scripts/flow/build/versioning-strategy.md
@@ -1,0 +1,35 @@
+# Versioning Strategy and Build Git Tag Documentation
+
+This document describes the versioning strategy and build git tag generation.
+The table below maps the input git version and branches to the expected version and new build tag.
+
+## Versioning Strategy Table
+
+| Description                                                                 | Git Show Version                  | Commit in Branches                     | Release version            | New Build Tag       |
+|-----------------------------------------------------------------------------|------------------------------|----------------------------------------|----------------------------|----------------------|
+| History style - init alpha tag on master branch                             | v8.5.0-alpha                 | master                                 | v8.5.0-alpha               |                      |
+| History style - new commit on master branch                                 | v8.5.0-alpha-2-g1234567      | master                                 | v8.5.0-alpha-2-g1234567    |                      |
+| History style - create new release branch but no new commit after alpha tag | v8.5.0-alpha                 | master, release-8.5                    | v8.5.0-alpha               | v8.5.0               |
+| History style - create new release branch with new commits after alpha tag  | v8.5.0-alpha-2-g1234567      | master, release-8.5                    | v8.5.0-alpha-2-g1234567    | v8.5.0               |
+| History style - added GA tag                                                | v8.5.0                       | release-8.5                            | v8.5.0                     |                      |
+| History style - has new commits after GA tag                                | v8.5.0-2-g1234567            | release-8.5                            | v8.5.1-pre                 | v8.5.1               |
+| New style - create alpha tag                                                | v9.0.0-alpha                 | master                                 | v9.0.0-alpha               |                      |
+| New style - new commits after alpha tag (current state)                     | v9.0.0-alpha-2-g1234567      | master                                 | v9.0.0-alpha-2-g1234567    |                      |
+| New style - create beta pre tag on master branch                            | v9.0.0-beta.0.pre            | master                                 | v9.0.0-beta.0.pre          |                      |
+| New style - new commits after beta pre tag on master branch                 | v9.0.0-beta.0.pre-2-g1234567 | master                                 | v9.0.0-beta.0.pre-2-g1234567|                      |
+| New style - created beta release branch with no new comments after beta pre tag | v9.0.0-beta.0.pre            | master, release-9.0-beta.0             | v9.0.0-beta.0.pre          | v9.0.0-beta.0        |
+| New style - created beta release branch after new comments after beta pre tag | v9.0.0-beta.0.pre-2-g1234567 | master, release-9.0-beta.0             | v9.0.0-beta.0.pre-2-g1234567| v9.0.0-beta.0        |
+| New style - release beta version                                            | v9.0.0-beta.0                | release-9.0-beta.0                     | v9.0.0-beta.0              |                      |
+| New style - new commits after released beta version, we will do nothing for it | v9.0.0-beta.0-2-g1234567     | release-9.0-beta.0                     | v9.0.0-beta.0-2-g1234567   |                      |
+| New style - create rc pre tag on master branch                              | v9.0.0-rc.0.pre              | master                                 | v9.0.0-rc.0.pre            |                      |
+| New style - some new commits after rc pre taged on master branch            | v9.0.0-rc.0.pre-2-g1234567   | master                                 | v9.0.0-rc.0.pre-2-g1234567 |                      |
+| New style - checkout release-X.Y branch after rc pre taged                  | v9.0.0-rc.0.pre              | master, release-9.0                    | v9.0.0-rc.0.pre            | v9.0.0-rc.0          |
+| New style - some new commits after rc pre taged on release-X.Y branch       | v9.0.0-rc.0.pre-2-g1234567   | release-9.0                            | v9.0.0-rc.0.pre-2-g1234567 | v9.0.0-rc.0          |
+| New style - create rc tag on release-X.Y branch                             | v9.0.0-rc.0                  | release-9.0                            | v9.0.0-rc.0                |                      |
+| New style - new commits after a rc version released on release-X.Y branch   | v9.0.0-rc.0-2-g1234567       | release-9.0                            | v9.0.0-rc.0-2-g1234567     | v9.0.0-rc.1          |
+| New style - prepare the GA release on release-X.Y branch                    | v9.0.0-pre                   | release-9.0                            | v9.0.0-pre                 | v9.0.0               |
+| New style - new commits after GA pre tag created on release-X.Y branch      | v9.0.0-pre-2-g1234567        | release-9.0                            | v9.0.0-pre-2-g1234567      | v9.0.0               |
+| New style - release GA version on release-X.Y branch                        | v9.0.0                       | release-9.0                            | v9.0.0                     |                      |
+| New style - new commits after released GA version on release-X.Y branch     | v9.0.0-2-g1234567            | release-9.0                            | v9.0.1-pre                 | v9.0.1               |
+| History style - hotfix branch without hotfix tags                           | v8.5.1-2-g1234567            | release-8.5-20250101-v8.5.1            | v8.5.1-2-g1234567          |                      |
+| History style - hotfix branch with hotfix tag                               | v8.5.1-20250101-fecba32      | release-8.5-20250101-v8.5.1            | v8.5.1-20250101-fecba32    |                      |

--- a/scripts/flow/build/versioning-strategy.test.ts
+++ b/scripts/flow/build/versioning-strategy.test.ts
@@ -1,0 +1,265 @@
+import { assertEquals } from "jsr:@std/assert@1.0.11";
+import { compute } from "./versioning-strategy.ts";
+
+Deno.test("compute", () => {
+  const tests: {
+    description?: string;
+    gitVer: string;
+    branches: string[];
+    expect: { version: string; newBuildTag?: string };
+  }[] = [
+    {
+      description: "history style - init alpha tag on master branch",
+      gitVer: "v8.5.0-alpha",
+      branches: ["master"],
+      expect: {
+        version: "v8.5.0-alpha",
+      },
+    },
+    {
+      description: "history style - new commit on master branch",
+      gitVer: "v8.5.0-alpha-2-g1234567",
+      branches: ["master"],
+      expect: {
+        version: "v8.5.0-alpha-2-g1234567",
+      },
+    },
+    {
+      description:
+        "history style - create new release branch but no new commit after alpha tag",
+      gitVer: "v8.5.0-alpha",
+      branches: ["master", "release-8.5"],
+      expect: {
+        version: "v8.5.0-alpha",
+        newBuildTag: "v8.5.0",
+      },
+    },
+    {
+      description:
+        "history style - create new release branch with new commits after alpha tag",
+      gitVer: "v8.5.0-alpha-2-g1234567",
+      branches: ["master", "release-8.5"],
+      expect: {
+        version: "v8.5.0-alpha-2-g1234567",
+        newBuildTag: "v8.5.0",
+      },
+    },
+    {
+      description: "history style - added GA tag",
+      gitVer: "v8.5.0",
+      branches: ["release-8.5"],
+      expect: {
+        version: "v8.5.0",
+      },
+    },
+    {
+      description: "history style - has new commits after GA tag",
+      gitVer: "v8.5.0-2-g1234567",
+      branches: ["release-8.5"],
+      expect: {
+        version: "v8.5.1-pre",
+        newBuildTag: "v8.5.1",
+      },
+    },
+    {
+      description: "new style - create alpha tag",
+      gitVer: "v9.0.0-alpha",
+      branches: ["master"],
+      expect: {
+        version: "v9.0.0-alpha",
+      },
+    },
+    {
+      description: "new style - new commits after alpha tag (current state)",
+      gitVer: "v9.0.0-alpha-2-g1234567",
+      branches: ["master"],
+      expect: {
+        version: "v9.0.0-alpha-2-g1234567",
+      },
+    },
+    {
+      description: "new style - create beta pre tag on master branch",
+      gitVer: "v9.0.0-beta.0.pre",
+      branches: ["master"],
+      expect: {
+        version: "v9.0.0-beta.0.pre",
+        // will not create new tag for it.
+      },
+    },
+    {
+      description:
+        "new style - new commits after beta pre tag on master branch",
+      gitVer: "v9.0.0-beta.0.pre-2-g1234567",
+      branches: ["master"],
+      expect: {
+        version: "v9.0.0-beta.0.pre-2-g1234567",
+        // will not create new tag for it.
+      },
+    },
+    {
+      description:
+        "new style - created beta release branch with no new comments after beta pre tag`",
+      gitVer: "v9.0.0-beta.0.pre",
+      branches: ["master", "release-9.0-beta.0"],
+      expect: {
+        version: "v9.0.0-beta.0.pre",
+        newBuildTag: "v9.0.0-beta.0",
+      },
+    },
+    {
+      description:
+        "new style - created beta release branch after new comments after beta pre tag`",
+      gitVer: "v9.0.0-beta.0.pre-2-g1234567",
+      branches: ["master", "release-9.0-beta.0"],
+      expect: {
+        version: "v9.0.0-beta.0.pre-2-g1234567",
+        newBuildTag: "v9.0.0-beta.0",
+      },
+    },
+    {
+      description: "new style - release beta version`",
+      gitVer: "v9.0.0-beta.0",
+      branches: ["release-9.0-beta.0"],
+      expect: {
+        version: "v9.0.0-beta.0",
+      },
+    },
+    {
+      description:
+        "new style - new commits after released beta version, we will do nothing for it",
+      gitVer: "v9.0.0-beta.0-2-g1234567",
+      branches: ["release-9.0-beta.0"],
+      expect: {
+        version: "v9.0.0-beta.0-2-g1234567",
+      },
+    },
+    {
+      description: "new style - create rc pre tag on master branch",
+      gitVer: "v9.0.0-rc.0.pre",
+      branches: ["master"],
+      expect: {
+        version: "v9.0.0-rc.0.pre",
+        // will not create new tag for it.
+      },
+    },
+    {
+      description:
+        "new style - some new commits after rc pre taged on master branch",
+      gitVer: "v9.0.0-rc.0.pre-2-g1234567",
+      branches: ["master"],
+      expect: {
+        version: "v9.0.0-rc.0.pre-2-g1234567",
+        // no tag to create.
+      },
+    },
+    {
+      description: "new style - checkout release-X.Y branch after rc pre taged",
+      gitVer: "v9.0.0-rc.0.pre",
+      branches: ["master", "release-9.0"],
+      expect: {
+        version: "v9.0.0-rc.0.pre",
+        newBuildTag: "v9.0.0-rc.0", // prepare for rc releasing (saving builds).
+      },
+    },
+    {
+      description:
+        "new style - some new commits after rc pre taged on release-X.Y branch",
+      gitVer: "v9.0.0-rc.0.pre-2-g1234567",
+      branches: ["release-9.0"],
+      expect: {
+        version: "v9.0.0-rc.0.pre-2-g1234567",
+        newBuildTag: "v9.0.0-rc.0", // prepare for rc releasing (saving builds).
+      },
+    },
+    {
+      description: "new style - create rc tag on release-X.Y branch",
+      gitVer: "v9.0.0-rc.0",
+      branches: ["release-9.0"],
+      expect: {
+        version: "v9.0.0-rc.0",
+      },
+    },
+    {
+      description:
+        "new style - new commits after a rc version released on release-X.Y branch",
+      gitVer: "v9.0.0-rc.0-2-g1234567",
+      branches: ["release-9.0"],
+      expect: {
+        version: "v9.0.0-rc.0-2-g1234567",
+        newBuildTag: "v9.0.0-rc.1", // bump the rc number
+      },
+    },
+    {
+      description: "new style - prepare the GA release on release-X.Y branch",
+      gitVer: "v9.0.0-pre", // 'p' is before 'r' char, so git describe will show information woth this tag.
+      branches: ["release-9.0"],
+      expect: {
+        version: "v9.0.0-pre",
+        newBuildTag: "v9.0.0",
+      },
+    },
+    {
+      description:
+        "new style - new commits after GA pre tag created on release-X.Y branch",
+      gitVer: "v9.0.0-pre-2-g1234567",
+      branches: ["release-9.0"],
+      expect: {
+        version: "v9.0.0-pre-2-g1234567",
+        newBuildTag: "v9.0.0",
+      },
+    },
+    {
+      description: "new style - release GA version on release-X.Y branch",
+      gitVer: "v9.0.0",
+      branches: ["release-9.0"],
+      expect: {
+        version: "v9.0.0",
+      },
+    },
+    {
+      description:
+        "new style - new commits after released GA version on release-X.Y branch",
+      gitVer: "v9.0.0-2-g1234567",
+      branches: ["release-9.0"],
+      expect: {
+        version: "v9.0.1-pre",
+        newBuildTag: "v9.0.1",
+      },
+    },
+    {
+      description: "history style - hotfix branch without hotfix tags",
+      gitVer: "v8.5.1-2-g1234567",
+      branches: ["release-8.5-20250101-v8.5.1"],
+      expect: {
+        version: "v8.5.1-2-g1234567",
+      },
+    },
+    {
+      description: "history style - hotfix branch with hotfix tag",
+      gitVer: "v8.5.1-20250101-fecba32",
+      branches: ["release-8.5-20250101-v8.5.1"],
+      expect: {
+        version: "v8.5.1-20250101-fecba32",
+      },
+    },
+  ];
+
+  for (const { description, gitVer, branches, expect } of tests) {
+    console.group("🧪 ", description);
+    console.debug("🚀", `gitVer: ${gitVer} & branches: ${branches}`);
+    const result = compute(gitVer, branches);
+    console.debug("🛬️", result);
+    assertEquals(
+      result.releaseVersion,
+      expect.version,
+      "assert failed on version",
+    );
+    assertEquals(
+      result.newGitTag,
+      expect.newBuildTag,
+      "assert failed on newTag",
+    );
+    console.debug("🎉");
+    console.groupEnd();
+  }
+});

--- a/scripts/flow/build/versioning-strategy.ts
+++ b/scripts/flow/build/versioning-strategy.ts
@@ -1,0 +1,177 @@
+import * as semver from "jsr:@std/semver@1.0.4";
+import { parseArgs } from "jsr:@std/cli@1.0.14/parse-args";
+
+interface builtControl {
+  // tell the build system what version we should name for release.
+  releaseVersion: string;
+  // tell the build system what git tag we should create for building.
+  newGitTag?: string | null;
+}
+
+/**
+ * Determine if the given branch is a release branch.
+ * @param {string} branch - The branch name to check.
+ * @returns {boolean} True if the branch is a release branch, false otherwise.
+ */
+function isReleaseBranch(branch: string): boolean {
+  return /\brelease-[0-9]+[.][0-9]+(?!-[0-9]{8}-v[0-9]+[.][0-9]+[.][0-9]+)/
+    .test(branch);
+}
+
+/**
+ * Determine if the given version is a GA version.
+ * @param {string} version - The version to check.
+ * @returns {boolean} true if the version is a GA version, false otherwise.
+ */
+function isGaVer(version: semver.SemVer): boolean {
+  if (!version.prerelease || version.prerelease.length === 0) {
+    return true;
+  }
+
+  if (version.prerelease.length === 1 && version.prerelease[0] == "fips") {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Computes the release version and new git tag based on the raw version and commit branches.
+ * @param {string} rawVersion The raw version string.
+ * @param {string[]} commitInBranches The branches the commit is in.
+ * @returns {builtControl} The computed release version and new git tag.
+ */
+export function compute(
+  rawVersion: string,
+  commitInBranches: string[],
+): builtControl {
+  const releaseVersion = semver.parse(rawVersion.trim());
+
+  // Check if the current branch is a release branch.
+  if (!commitInBranches.some(isReleaseBranch)) {
+    console.info("Current commit is not contained in any release branches.");
+    return { releaseVersion: "v" + semver.format(releaseVersion) };
+  }
+
+  // If it's a GA version, return it directly
+  if (isGaVer(releaseVersion)) {
+    console.info("it's a normal GA version.");
+    return { releaseVersion: "v" + semver.format(releaseVersion) };
+  }
+
+  const preRelease = (releaseVersion.prerelease || []).join(".");
+  let newGitTag = undefined;
+  if (preRelease.startsWith("alpha")) {
+    newGitTag =
+      `v${releaseVersion.major}.${releaseVersion.minor}.${releaseVersion.patch}`;
+  } else if (releaseVersion.prerelease![0] == "beta") {
+    if (
+      releaseVersion.prerelease!.length > 2 &&
+      releaseVersion.prerelease![2].toString().startsWith("pre")
+    ) {
+      // for: v1.1.1-beta.0.pre | v1.1.1-beta.0.pre-2-g1234567
+      newGitTag =
+        `v${releaseVersion.major}.${releaseVersion.minor}.${releaseVersion.patch}-${
+          releaseVersion.prerelease?.slice(0, 2).join(".")
+        }`;
+    } else {
+      console.warn("I will do nothing for this beta version:", rawVersion);
+    }
+  } else if (releaseVersion.prerelease![0] == "rc") {
+    if (
+      releaseVersion.prerelease!.length == 2 &&
+      typeof releaseVersion.prerelease![1] === "string"
+    ) {
+      console.info("Now i will increase the rc number.");
+      const rcIndexStr = releaseVersion.prerelease![1].toString().split("-")[0];
+      const newRCIndex = parseInt(rcIndexStr) + 1;
+      newGitTag =
+        `v${releaseVersion.major}.${releaseVersion.minor}.${releaseVersion.patch}-${
+          releaseVersion.prerelease![0]
+        }.${newRCIndex}`;
+    } else if (
+      releaseVersion.prerelease!.length > 2 &&
+      releaseVersion.prerelease![2].toString().startsWith("pre")
+    ) {
+      // for: v1.1.1-rc.0.pre | v1.1.1-rc.0.pre-2-g1234567
+      newGitTag =
+        `v${releaseVersion.major}.${releaseVersion.minor}.${releaseVersion.patch}-${
+          releaseVersion.prerelease?.slice(0, 2).join(".")
+        }`;
+    } else {
+      console.warn("I will do nothing for this rc version:", rawVersion);
+    }
+  } else if (preRelease.startsWith("pre")) {
+    newGitTag =
+      `v${releaseVersion.major}.${releaseVersion.minor}.${releaseVersion.patch}`;
+  } else {
+    // Handle the case where there are new commits after a GA tag
+    newGitTag = `v${releaseVersion.major}.${releaseVersion.minor}.${
+      releaseVersion.patch + 1
+    }`;
+    releaseVersion.patch++;
+    releaseVersion.prerelease = ["pre"];
+  }
+
+  if (newGitTag) {
+    console.info(`Computed new tag: ${newGitTag}`);
+  }
+
+  return { releaseVersion: "v" + semver.format(releaseVersion), newGitTag };
+}
+
+/**
+ * Main function to execute the versioning strategy.
+ */
+function main() {
+  const flags = parseArgs(Deno.args, {
+    string: [
+      "git_version",
+      "git_version_file",
+      "contain_branches",
+      "contain_branches_file",
+      "save_release_version_file",
+      "save_build_git_tag_file",
+    ],
+    default: {
+      save_release_version_file: "release_version.txt",
+      save_build_git_tag_file: "build_git_tag.txt",
+    },
+  });
+
+  // check the flags
+  const argsValid = (flags["git_version"] || flags["git_version_file"]) &&
+    (flags["contain_branches"] || flags["contain_branches_file"]);
+
+  if (!argsValid) {
+    console.error("Invalid arguments");
+    // print help message
+    console.error(`
+      Usage: deno run versioning-strategy.ts --git_version=<version> --contain_branches=<branch>
+      Options:
+        --git_version=<version>         The current git version
+        --git_version_file=<file>       The file containing the current git version
+        --contain_branches=<branch>     The branch to contain
+        --contain_branches_file=<file>  The file containing the branches to contain
+        --save_release_version_file=<file>  The file to save the release version (default: release_version.txt)
+        --save_build_git_tag_file=<file>    The file to save the build git tag (default: build_git_tag.txt)
+    `);
+    Deno.exit(1);
+  }
+
+  const rawVersion = flags.git_version ||
+    Deno.readTextFileSync(flags.git_version_file!);
+  const currentBranch = flags.contain_branches ||
+    Deno.readTextFileSync(flags.contain_branches_file!);
+  const ret = compute(rawVersion, currentBranch.split("\n"));
+
+  // Save results for next step
+  Deno.writeTextFileSync(flags.save_release_version_file, ret.releaseVersion);
+  if (ret.newGitTag) {
+    Deno.writeTextFileSync(flags.save_build_git_tag_file, ret.newGitTag);
+  }
+}
+
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Usage


you can run it by one method of them:

- run with file params:
  ```bash
  deno run --allow-read --allow-write scripts/flow/build/versioning-strategy.ts --git_version_file release_version.txt --contain_branches_file branches.txt
  ```
- run with literal params:
```bash
  deno run --allow-write scripts/flow/build/versioning-strategy.ts --git_version=v9.0.0-beta.0-2-g12235 --contain_branches=release-9.0
```