### PR TITLE
feat(docs): support beta release branch pattern in docs presubmits

### DIFF
--- a/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
@@ -11,4 +11,4 @@ presubmits:
       rerun_command: "/test pull-verify"
       branches:
         - ^master$
-        - ^release-\d+\.\d+$
+        - ^release-\d+\.\d+(-beta\.\d+)?$

--- a/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
@@ -11,4 +11,4 @@ presubmits:
       rerun_command: "/test pull-verify"
       branches:
         - ^master$
-        - ^release-\d+\.\d+$
+        - ^release-\d+\.\d+(-beta\.\d+)?$


### PR DESCRIPTION
Update branch regex in docs presubmit configurations to match beta release branches, allowing for optional beta version in release branch names (e.g., release-X.Y-beta.M).
* release-9.0-beta.1