### PR TITLE
chore(tiflow): remove sync_diff_inspector version check in CDC test pipelines

### DIFF
--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -127,7 +127,6 @@ pipeline {
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
-                                ./bin/sync_diff_inspector --version
                             """
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -127,7 +127,6 @@ pipeline {
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
-                                ./bin/sync_diff_inspector --version
                             """
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -127,7 +127,6 @@ pipeline {
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
-                                ./bin/sync_diff_inspector --version
                             """
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -127,7 +127,6 @@ pipeline {
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
-                                ./bin/sync_diff_inspector --version
                             """
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
@@ -114,7 +114,7 @@ pipeline {
                                         cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh dm/tests/
                                         chmod +x dm/tests/download_test_binaries_by_tag.sh
                                         # First download binary using the release branch script
-                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-9.0-beta
+                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-9.0-beta.1
                                         rm -rf bin/tidb-server
                                         mv bin tmp_bin
                                         # Then download and replace other components with exact versions
@@ -123,7 +123,7 @@ pipeline {
                                         cd -
                                     else
                                         echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-9.0-beta
+                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-9.0-beta.1
                                         cd -
                                     fi
                                     # Verify all required binaries

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                         cp ${WORKSPACE}/scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ${WORKSPACE}/tiflow/dm/tests/
                                         chmod +x ${WORKSPACE}/tiflow/dm/tests/download_test_binaries_by_tag.sh
                                         # First download binary using the release branch script
-                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-9.0-beta
+                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-9.0-beta.1
                                         rm -rf bin/tidb-server bin/pd-* bin/tikv-server
                                         mv bin tmp_bin
                                         # Then download and replace other components with exact versions
@@ -105,7 +105,7 @@ pipeline {
                                         cd -
                                     else
                                         echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-9.0-beta
+                                        cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-9.0-beta.1
                                         cd -
                                     fi
                                     # Verify all required binaries


### PR DESCRIPTION
Remove unnecessary version check for sync_diff_inspector in multiple CDC integration test pipelines for the release-9.0-beta.M branch.