### PR TITLE
refactor(br): remove CODECOV_TOKEN and timeout options on test stages of periodics jobs

### DIFF
--- a/pipelines/pingcap/tidb/release-6.1/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/periodics_br_integration_test.groovy
@@ -104,8 +104,6 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
-                        options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") { 

--- a/pipelines/pingcap/tidb/release-6.5/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/periodics_br_integration_test.groovy
@@ -104,8 +104,6 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
-                        options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") { 

--- a/pipelines/pingcap/tidb/release-7.1/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/periodics_br_integration_test.groovy
@@ -104,8 +104,6 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
-                        options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") { 

--- a/pipelines/pingcap/tidb/release-7.5/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/periodics_br_integration_test.groovy
@@ -109,7 +109,6 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") { 

--- a/pipelines/pingcap/tidb/release-8.1/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/periodics_br_integration_test.groovy
@@ -107,7 +107,6 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") { 


### PR DESCRIPTION
Eliminate CODECOV_TOKEN environment variable and timeout options from the "Test" stage in periodic BR integration test pipelines across multiple release branches (6.1, 6.5, 7.1, 7.5, and 8.1) for cleaner configuration.