### PR TITLE
chore(ticdc): update presubmit job configurations to modify triggers

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -2,6 +2,8 @@ global_definitions:
   branches: &branches
     - ^master$
     - ^feature/.+
+  skip_if_only_changed: &skip_if_only_changed
+    "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
@@ -10,11 +12,11 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       always_run: false
-      # skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: wip/pull-cdc-mysql-integration-light
-      optional: true # change this after test passed.
+      optional: false
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-light"
       branches: *branches
 
@@ -22,11 +24,11 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       always_run: false
-      # skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: wip/pull-cdc-mysql-integration-heavy
-      optional: true # change this after test passed.
+      optional: false
       skip_report: false
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-heavy"
       branches: *branches
 


### PR DESCRIPTION
These two test pipelines have passed testing and can now enable conditional triggers, requiring tests to be run before merging the PR.

Refactor the latest-presubmits.yaml to introduce a reusable skip_if_only_changed pattern and update the trigger expressions for the MySQL integration jobs to allow for 'all' tests. Additionally, set the optional flag to false for both integration jobs.