### PR TITLE
chore(tiflow): update container images and resource requests for integration tests

### DIFF
--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
@@ -24,9 +24,6 @@ spec:
       imagePullPolicy: Always
       name: golang
       resources:
-        requests:
-          cpu: "4"
-          memory: 16Gi
         limits:
           cpu: "4"
           memory: 16Gi
@@ -67,9 +64,6 @@ spec:
       imagePullPolicy: IfNotPresent
       name: kafka
       resources:
-        requests:
-          cpu: 2000m
-          memory: 6Gi
         limits:
           cpu: 2000m
           memory: 6Gi

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
@@ -111,13 +111,6 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        requests:
-          cpu: 200m
-          memory: 4Gi
     - name: mysql
       image: quay.io/debezium/example-mysql:2.4
       imagePullPolicy: IfNotPresent

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
@@ -9,10 +9,10 @@ spec:
       name: zookeeper
       resources:
         requests:
-          cpu: 2000m
+          cpu: 1000m
           memory: 4Gi
         limits:
-          cpu: 2000m
+          cpu: 1000m
           memory: 4Gi
       tty: true
       volumeMounts:
@@ -20,10 +20,13 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.23
+      image: hub.pingcap.net/jenkins/rocky8_golang-1.23:tini
       imagePullPolicy: Always
       name: golang
       resources:
+        requests:
+          cpu: "4"
+          memory: 16Gi
         limits:
           cpu: "4"
           memory: 16Gi
@@ -65,10 +68,10 @@ spec:
       name: kafka
       resources:
         requests:
-          cpu: 4000m
+          cpu: 2000m
           memory: 6Gi
         limits:
-          cpu: 4000m
+          cpu: 2000m
           memory: 6Gi
       tty: true
       volumeMounts:
@@ -108,6 +111,13 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
     - name: mysql
       image: quay.io/debezium/example-mysql:2.4
       imagePullPolicy: IfNotPresent

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,9 +5,12 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
         limits:
           memory: 32Gi
           cpu: "6"
@@ -17,6 +20,13 @@ spec:
       resources:
         limits:
           memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
           cpu: 100m
   affinity:
     nodeAffinity:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml
@@ -21,13 +21,6 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml
@@ -8,9 +8,6 @@ spec:
       image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
-        requests:
-          memory: 12Gi
-          cpu: "4"
         limits:
           memory: 32Gi
           cpu: "6"

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_pulsar_test.yaml
@@ -8,9 +8,6 @@ spec:
       image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
-        requests:
-          memory: 32Gi
-          cpu: "12"
         limits:
           memory: 32Gi
           cpu: "12"

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:pulsar-test"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml
@@ -8,9 +8,6 @@ spec:
       image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
-        requests:
-          memory: 12Gi
-          cpu: "4"
         limits:
           memory: 16Gi
           cpu: "6"

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml
@@ -21,13 +21,6 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml
@@ -5,9 +5,12 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
         limits:
           memory: 16Gi
           cpu: "6"
@@ -17,6 +20,13 @@ spec:
       resources:
         limits:
           memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
           cpu: 100m
   affinity:
     nodeAffinity:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml
@@ -20,9 +20,6 @@ spec:
       image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
-        requests:
-          memory: 12Gi
-          cpu: "4"
         limits:
           memory: 16Gi
           cpu: "6"

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml
@@ -3,14 +3,33 @@ kind: Pod
 spec:
   securityContext:
     fsGroup: 1000
+  initContainers:
+    - name: init-mysql-config
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      command:
+        - sh
+        - -c
+        - |
+          echo "[client]" > /mysql-config/.my.cnf
+          echo "ssl-mode=DISABLED" >> /mysql-config/.my.cnf
+      volumeMounts:
+        - mountPath: "/mysql-config"
+          name: "mysql-config-volume"
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
         limits:
           memory: 16Gi
           cpu: "6"
+      volumeMounts:
+        - mountPath: "/home/jenkins/.my.cnf"
+          name: "mysql-config-volume"
+          subPath: ".my.cnf"
     - name: mysql1
       image: 'hub.pingcap.net/jenkins/mysql:5.7'
       tty: true
@@ -56,6 +75,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  volumes:
+    - name: mysql-config-volume
+      emptyDir: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -65,3 +94,4 @@ spec:
                 operator: In
                 values:
                   - amd64
+

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml
@@ -75,13 +75,6 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
   volumes:
     - name: mysql-config-volume
       emptyDir: {}

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml
@@ -3,16 +3,35 @@ kind: Pod
 spec:
   securityContext:
     fsGroup: 1000
+  initContainers:
+    - name: init-mysql-config
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      command:
+        - sh
+        - -c
+        - |
+          echo "[client]" > /mysql-config/.my.cnf
+          echo "ssl-mode=DISABLED" >> /mysql-config/.my.cnf
+      volumeMounts:
+        - mountPath: "/mysql-config"
+          name: "mysql-config-volume"
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-tini:1.23"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:tini"
       tty: true
       args:
         - cat
       resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
         limits:
           memory: 16Gi
           cpu: "6"
+      volumeMounts:
+        - mountPath: "/home/jenkins/.my.cnf"
+          name: "mysql-config-volume"
+          subPath: ".my.cnf"
     - name: mysql1
       image: "hub.pingcap.net/jenkins/mysql:5.7"
       tty: true
@@ -58,6 +77,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+  volumes:
+    - name: mysql-config-volume
+      emptyDir: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml
@@ -77,13 +77,6 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
   volumes:
     - name: mysql-config-volume
       emptyDir: {}

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml
@@ -22,9 +22,6 @@ spec:
       args:
         - cat
       resources:
-        requests:
-          memory: 12Gi
-          cpu: "4"
         limits:
           memory: 16Gi
           cpu: "6"

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_engine_integration_test.yaml
@@ -65,13 +65,6 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
   volumes:
     - name: "volume-docker"
       emptyDir: {}

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_engine_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
         limits:
@@ -26,6 +26,9 @@ spec:
         - name: DOCKER_REGISTRY_MIRROR
           value: "https://registry-mirror.pingcap.net/"
       resources:
+        requests:
+          memory: 8Gi
+          cpu: "4"
         limits:
           memory: 16Gi
           cpu: "6"
@@ -61,6 +64,13 @@ spec:
       resources:
         limits:
           memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
           cpu: 100m
   volumes:
     - name: "volume-docker"

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_engine_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_engine_integration_test.yaml
@@ -26,9 +26,6 @@ spec:
         - name: DOCKER_REGISTRY_MIRROR
           value: "https://registry-mirror.pingcap.net/"
       resources:
-        requests:
-          memory: 8Gi
-          cpu: "4"
         limits:
           memory: 16Gi
           cpu: "6"
@@ -47,9 +44,6 @@ spec:
       command:
         - "cat"
       resources:
-        requests:
-          memory: 8Gi
-          cpu: "4"
         limits:
           memory: 16Gi
           cpu: "6"

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_verify.yaml
@@ -5,18 +5,35 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
       tty: true
       resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
         limits:
           memory: 16Gi
           cpu: "6"
+    - name: codecov
+      image: python:3.11.10-bullseye
+      tty: true
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: 2000m
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:
           memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
           cpu: 100m
   affinity:
     nodeAffinity:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_verify.yaml
@@ -28,13 +28,6 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
-  Changed golang container images from centos7 to rocky8 across multiple test configurations.
- Adjusted CPU and memory requests for golang and added new report containers with specified resources in various test YAML files.
- Introduced init containers for MySQL configuration in DM compatibility and integration tests.