### PR TITLE
feat(pipelines): Add proxy cache upload logic on master merged-build pipeline

### DIFF
--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
@@ -280,7 +280,7 @@ pipeline {
                 stage("Upload Proxy Cache") {
                     steps {
                         sh label: "upload proxy cache", script: """
-                            echo "TODO: upload proxy cache"
+                            echo "skip upload proxy cache, only upload for master branch to avoid duplicate uploads."
                         """
                     }
                 }


### PR DESCRIPTION
- Implemented logic to upload proxy cache only if the commit hash is valid and the refresh is enabled.
- Added checks to skip upload if the cache already exists or if the proxy library is not found.
- Updated messages to provide clear feedback on the upload process.