### PR TITLE
chore(owners): update OWNERS files for ticdc and tiflash projects

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,11 +5,14 @@ aliases:
     - lilin90
     - Oreoxmt
     - qiancai
+
   sig-approvers-tidb-tools: # approvers for CI scope of tidb-tools project.
     - Benjamin2037
+
   sig-approvers-ee: # approvers for engineering efficiency scopes.
     - wuhuizuo
     - purelind
+
   sig-approvers-raft-engine: # approvers for raft-engine project.
     - LykxSassinator
     - zhangjinpeng87
@@ -17,6 +20,14 @@ aliases:
   sig-reviewers-security: # reviewers for security scopes.
     - TopScrew
     - xiabee
+
+  sig-approvers-ticdc: # approvers for ticdc project.
+    - asddongmen
+    - wlwilliamx
+
+  sig-approvers-tiflash: # approvers for tiflash project.
+    - Lloyd-Pottiger
+    - JaySon-Huang
 
   emeritus_reviewers: # emeritus reviewers will be keeped here, but will not be used.
     - lijie0123 # ee reviewer

--- a/pipelines/pingcap/ticdc/OWNERS
+++ b/pipelines/pingcap/ticdc/OWNERS
@@ -1,0 +1,3 @@
+# See the OWNERS ticdc at https://go.k8s.io/owners
+approvers:
+  - sig-approvers-ticdc

--- a/pipelines/pingcap/tiflash/OWNERS
+++ b/pipelines/pingcap/tiflash/OWNERS
@@ -1,0 +1,3 @@
+# See the OWNERS tiflash at https://go.k8s.io/owners
+approvers:
+  - sig-approvers-tiflash


### PR DESCRIPTION
- Added approvers for the ticdc project in OWNERS file.
- Added approvers for the tiflash project in OWNERS file.
- Updated global OWNERS_ALIASES to include new approver groups for ticdc and tiflash.