### PR TITLE
feat(ticdc): ticdc add new integration pipelines

### DIFF
--- a/jobs/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/ticdc/pull_cdc_kafka_integration_light') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        githubProjectUrl("https://github.com/pingcap/ticdc")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/ticdc/pull_cdc_pulsar_integration_light') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        githubProjectUrl("https://github.com/pingcap/ticdc")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/ticdc/pull_cdc_storage_integration_light') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        githubProjectUrl("https://github.com/pingcap/ticdc")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_kafka_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_kafka_integration_light.yaml
@@ -1,0 +1,159 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - image: wurstmeister/zookeeper
+      imagePullPolicy: IfNotPresent
+      name: zookeeper
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 4Gi
+        limits:
+          cpu: 1000m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - args:
+        - cat
+      image: hub.pingcap.net/jenkins/rocky8_golang-1.23:tini
+      imagePullPolicy: Always
+      name: golang
+      resources:
+        limits:
+          cpu: "4"
+          memory: 16Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - env:
+        - name: KAFKA_CREATE_TOPICS
+          value: big-message-test:1:1
+        - name: KAFKA_BROKER_ID
+          value: "1"
+        - name: KAFKA_SSL_KEYSTORE_PASSWORD
+          value: test1234
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: localhost:2181
+        - name: KAFKA_MESSAGE_MAX_BYTES
+          value: "11534336"
+        - name: KAFKA_REPLICA_FETCH_MAX_BYTES
+          value: "11534336"
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
+        - name: ZK
+          value: zk
+        - name: KAFKA_SSL_KEYSTORE_LOCATION
+          value: /tmp/kafka.server.keystore.jks
+        - name: KAFKA_SSL_KEY_PASSWORD
+          value: test1234
+        - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+          value: test1234
+        - name: KAFKA_LISTENERS
+          value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
+        - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+          value: /tmp/kafka.server.truststore.jks
+        - name: RACK_COMMAND
+          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+      image: wurstmeister/kafka:2.12-2.4.1
+      imagePullPolicy: IfNotPresent
+      name: kafka
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 6Gi
+        limits:
+          cpu: 2000m
+          memory: 6Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - env:
+        - name: KAFKA_SERVER
+          value: 127.0.0.1:9092
+        - name: ZOOKEEPER_SERVER
+          value: 127.0.0.1:2181
+        - name: DOWNSTREAM_DB_HOST
+          value: 127.0.0.1
+        - name: USE_FLAT_MESSAGE
+          value: "true"
+        - name: DOWNSTREAM_DB_PORT
+          value: "3306"
+        - name: DB_NAME
+          value: test
+      image: rustinliu/ticdc-canal-json-adapter:latest
+      imagePullPolicy: IfNotPresent
+      name: canal-adapter
+      # TODO: add resource limit
+      # can't add resource limit now, because canal-adapter will OOM
+      # issue: https://github.com/PingCAP-QE/ci/issues/1893
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: mysql
+      image: quay.io/debezium/example-mysql:2.4
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: ""
+        - name: MYSQL_USER
+          value: mysqluser
+        - name: MYSQL_PASSWORD
+          value: mysqlpw
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "yes"
+        - name: MYSQL_TCP_PORT
+          value: "3310"
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 4Gi
+    - name: connect
+      image: quay.io/debezium/connect:2.4
+      env:
+        - name: BOOTSTRAP_SERVERS
+          value: "127.0.0.1:9092"
+        - name: GROUP_ID
+          value: "1"
+        - name: CONFIG_STORAGE_TOPIC
+          value: "my_connect_configs"
+        - name: OFFSET_STORAGE_TOPIC
+          value: "my_connect_offsets"
+        - name: STATUS_STORAGE_TOPIC
+          value: "my_connect_statuses"
+        - name: LANG
+          value: "C.UTF-8"
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 4Gi
+  volumes:
+    - emptyDir: {}
+      name: volume-0
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_pulsar_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_pulsar_integration_light.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      tty: true
+      resources:
+        limits:
+          memory: 32Gi
+          cpu: "12"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_storage_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_storage_integration_light.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      tty: true
+      resources:
+        limits:
+          memory: 16Gi
+          cpu: "6"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_light.yaml'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_kafka_integration_light.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
@@ -22,8 +22,8 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
-        // parallelsAlwaysFailFast()
+        timeout(time: 65, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
     }
     stages {
         stage('Debug info') {
@@ -58,7 +58,7 @@ pipeline {
             }
         }
         stage("prepare") {
-            options { timeout(time: 25, unit: 'MINUTES') }
+            options { timeout(time: 20, unit: 'MINUTES') }
             steps {
                 dir("third_party_download") {
                     script {
@@ -72,7 +72,7 @@ pipeline {
                                 export PD_BRANCH=${pdBranch}
                                 export TIKV_BRANCH=${tikvBranch}
                                 export TIFLASH_BRANCH=${tiflashBranch}
-                                cd ../ticdc && ./tests/scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
+                                cd ../ticdc && ./scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
                                 make check_third_party_binary
                                 cd - && mkdir -p bin && mv ../ticdc/bin/* ./bin/
                                 ls -alh ./bin
@@ -81,16 +81,18 @@ pipeline {
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
                             """
-                        }
-                    }   
+                        } 
+                    }
                 }
                 dir("ticdc") {
-                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-mysql-integration')) {
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
                         sh label: "prepare", script: """
                             ls -alh ./bin
                             [ -f ./bin/cdc ] || make cdc
+                            [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
+                            [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
                             [ -f ./bin/cdc.test ] || make integration_test_build
                             ls -alh ./bin
                             ./bin/cdc version
@@ -111,7 +113,8 @@ pipeline {
                 axes {
                     axis {
                         name 'TEST_GROUP'
-                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06', 'G07', 'G08', 'G09', 'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08',
+                            'G09', 'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
                     }
                 }
                 agent{
@@ -123,12 +126,24 @@ pipeline {
                 } 
                 stages {
                     stage("Test") {
-                        options { timeout(time: 40, unit: 'MINUTES') }
+                        options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
+                                    container("kafka") {
+                                        timeout(time: 6, unit: 'MINUTES') {
+                                            sh label: "Waiting for kafka ready", script: """
+                                                echo "Waiting for zookeeper to be ready..."
+                                                while ! nc -z localhost 2181; do sleep 10; done
+                                                echo "Waiting for kafka to be ready..."
+                                                while ! nc -z localhost 9092; do sleep 10; done
+                                                echo "Waiting for kafka-broker to be ready..."
+                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                            """
+                                        }
+                                    }
                                     sh label: "${TEST_GROUP}", script: """
-                                        ./tests/integration_tests/run_light_it_in_ci.sh mysql ${TEST_GROUP}
+                                        ./tests/integration_tests/run_light_it_in_ci.sh kafka ${TEST_GROUP}
                                     """
                                 }
                             }
@@ -145,7 +160,7 @@ pipeline {
                         }
                     }
                 }
-            }        
+            }
         }
     }
 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
@@ -8,7 +8,6 @@ final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_heavy.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-def skipRemainingStages = false
 
 pipeline {
     agent {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_light.yaml'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_pulsar_integration_light.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
@@ -23,7 +23,7 @@ pipeline {
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
-        // parallelsAlwaysFailFast()
+        parallelsAlwaysFailFast()
     }
     stages {
         stage('Debug info') {
@@ -58,7 +58,7 @@ pipeline {
             }
         }
         stage("prepare") {
-            options { timeout(time: 25, unit: 'MINUTES') }
+            options { timeout(time: 20, unit: 'MINUTES') }
             steps {
                 dir("third_party_download") {
                     script {
@@ -72,7 +72,7 @@ pipeline {
                                 export PD_BRANCH=${pdBranch}
                                 export TIKV_BRANCH=${tikvBranch}
                                 export TIFLASH_BRANCH=${tiflashBranch}
-                                cd ../ticdc && ./tests/scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
+                                cd ../ticdc && ./scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
                                 make check_third_party_binary
                                 cd - && mkdir -p bin && mv ../ticdc/bin/* ./bin/
                                 ls -alh ./bin
@@ -82,15 +82,16 @@ pipeline {
                                 ./bin/tiflash --version
                             """
                         }
-                    }   
+                    }
                 }
                 dir("ticdc") {
-                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-mysql-integration')) {
-                        // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-pulsar-integration')) { 
+                        // build cdc, pulsar_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
                         sh label: "prepare", script: """
                             ls -alh ./bin
                             [ -f ./bin/cdc ] || make cdc
+                            [ -f ./bin/cdc_pulsar_consumer ] || make pulsar_consumer
                             [ -f ./bin/cdc.test ] || make integration_test_build
                             ls -alh ./bin
                             ./bin/cdc version
@@ -111,7 +112,8 @@ pipeline {
                 axes {
                     axis {
                         name 'TEST_GROUP'
-                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06', 'G07', 'G08', 'G09', 'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08', 'G09',
+                            'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
                     }
                 }
                 agent{
@@ -128,7 +130,7 @@ pipeline {
                             dir('ticdc') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
                                     sh label: "${TEST_GROUP}", script: """
-                                        ./tests/integration_tests/run_light_it_in_ci.sh mysql ${TEST_GROUP}
+                                        ./tests/integration_tests/run_light_it_in_ci.sh pulsar ${TEST_GROUP}
                                     """
                                 }
                             }
@@ -145,7 +147,7 @@ pipeline {
                         }
                     }
                 }
-            }        
+            }
         }
     }
 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy
@@ -6,7 +6,7 @@
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_light.yaml'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_storage_integration_light.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/ticdc/latest/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
@@ -23,7 +23,7 @@ pipeline {
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
-        // parallelsAlwaysFailFast()
+        parallelsAlwaysFailFast()
     }
     stages {
         stage('Debug info') {
@@ -58,7 +58,7 @@ pipeline {
             }
         }
         stage("prepare") {
-            options { timeout(time: 25, unit: 'MINUTES') }
+            options { timeout(time: 20, unit: 'MINUTES') }
             steps {
                 dir("third_party_download") {
                     script {
@@ -72,7 +72,7 @@ pipeline {
                                 export PD_BRANCH=${pdBranch}
                                 export TIKV_BRANCH=${tikvBranch}
                                 export TIFLASH_BRANCH=${tiflashBranch}
-                                cd ../ticdc && ./tests/scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
+                                cd ../ticdc && ./scripts/download-integration-test-binaries.sh ${REFS.base_ref} && ls -alh ./bin
                                 make check_third_party_binary
                                 cd - && mkdir -p bin && mv ../ticdc/bin/* ./bin/
                                 ls -alh ./bin
@@ -82,15 +82,17 @@ pipeline {
                                 ./bin/tiflash --version
                             """
                         }
-                    }   
+                    }
                 }
                 dir("ticdc") {
-                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-mysql-integration')) {
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-storage-integration')) { 
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
                         sh label: "prepare", script: """
                             ls -alh ./bin
                             [ -f ./bin/cdc ] || make cdc
+                            [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
+                            [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
                             [ -f ./bin/cdc.test ] || make integration_test_build
                             ls -alh ./bin
                             ./bin/cdc version
@@ -111,7 +113,8 @@ pipeline {
                 axes {
                     axis {
                         name 'TEST_GROUP'
-                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06', 'G07', 'G08', 'G09', 'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08', 'G09',
+                            'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
                     }
                 }
                 agent{
@@ -128,7 +131,7 @@ pipeline {
                             dir('ticdc') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
                                     sh label: "${TEST_GROUP}", script: """
-                                        ./tests/integration_tests/run_light_it_in_ci.sh mysql ${TEST_GROUP}
+                                        ./tests/integration_tests/run_light_it_in_ci.sh storage ${TEST_GROUP}
                                     """
                                 }
                             }
@@ -145,7 +148,7 @@ pipeline {
                         }
                     }
                 }
-            }        
+            }
         }
     }
 }

--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -32,6 +32,42 @@ presubmits:
       rerun_command: "/test pull-cdc-mysql-integration-heavy"
       branches: *branches
 
+    - name: pingcap/ticdc/pull_cdc_kafka_integration_light
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false
+      # skip_if_only_changed: *skip_if_only_changed # TODO: uncomment this after the job is ready
+      context: wip/pull-cdc-kafka-integration-light # TODO: remove this after the job is ready
+      optional: true # TODO: change this after the job is ready
+      skip_report: false
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-kafka-integration-light"
+      branches: *branches
+
+    - name: pingcap/ticdc/pull_cdc_pulsar_integration_light
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false
+      # skip_if_only_changed: *skip_if_only_changed # TODO: uncomment this after the job is ready
+      context: wip/pull-cdc-pulsar-integration-light # TODO: remove this after the job is ready
+      optional: true # TODO: change this after the job is ready
+      skip_report: false
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-light)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-pulsar-integration-light"
+      branches: *branches
+
+    - name: pingcap/ticdc/pull_cdc_storage_integration_light
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false
+      # skip_if_only_changed: *skip_if_only_changed # TODO: uncomment this after the job is ready
+      context: wip/pull-cdc-storage-integration-light # TODO: remove this after the job is ready
+      optional: true # TODO: change this after the job is ready
+      skip_report: false
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-storage-integration-light"
+      branches: *branches
+
     - name: pull-unit-test
       cluster: gcp-prow-ksyun
       decorate: true # need add this.


### PR DESCRIPTION
Add the following three integration test pipeline configurations. Note that it is currently in the WIP testing phase.\
* pull-cdc-pulsar-integration-light
* pull-cdc-kafka-integration-light
* pull-cdc-storage-integration-light

Initially configure the light mode pipeline, and later distribute the tests with high load to the heavy pipeline based on actual testing conditions.