### PR TITLE
feat(ticdc): add net-tool cpu from 100m to 300m for kafka light pipelines

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_kafka_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_kafka_integration_light.yaml
@@ -107,7 +107,7 @@ spec:
       resources:
         limits:
           memory: 128Mi
-          cpu: 100m
+          cpu: 300m
     - name: mysql
       image: quay.io/debezium/example-mysql:2.4
       imagePullPolicy: IfNotPresent


### PR DESCRIPTION
In the monitoring of Kafka Light Pipelines, the CPU throttling metric for net-tool is consistently around 60%. Therefore, it is necessary to increase the CPU allocation for net-tool. This PR increases net-tool’s CPU from 100m to 300m.