### PR TITLE
fix(prow-jobs/pingcap-qe/ci): fix git remote setup in periodic jobs

### DIFF
--- a/prow-jobs/pingcap-qe/ci/periodics.yaml
+++ b/prow-jobs/pingcap-qe/ci/periodics.yaml
@@ -107,7 +107,7 @@ periodics:
                 # Set git account
                 git config user.name "ti-chi-bot[bot]"
                 git config user.email "108142056+ti-chi-bot[bot]@users.noreply.github.com"
-                git remote set-url origin https://${GITHUB_TOKEN}@github.com/PingCAP-QE/gitinsight-data.git
+                git remote add origin https://${GITHUB_TOKEN}@github.com/PingCAP-QE/gitinsight-data.git
 
                 # Checkout to a new branch with timestamp
                 head_branch="auto/update-data-commits-$(date +%Y%m%d%H%M%S)"
@@ -208,7 +208,7 @@ periodics:
                 # Set git account
                 git config user.name "ti-chi-bot[bot]"
                 git config user.email "108142056+ti-chi-bot[bot]@users.noreply.github.com"
-                git remote set-url origin https://${GITHUB_TOKEN}@github.com/PingCAP-QE/gitinsight-data.git
+                git remote add origin https://${GITHUB_TOKEN}@github.com/PingCAP-QE/gitinsight-data.git
 
                 # Checkout to a new branch with timestamp
                 head_branch="auto/update-data-issues-pulls-$(date +%Y%m%d%H%M%S)"


### PR DESCRIPTION
This pull request includes changes to the `prow-jobs/pingcap-qe/ci/periodics.yaml` file to modify the git remote configuration commands.

Changes in git remote configuration:

* Updated the command to add a new git remote instead of setting the URL for an existing remote. This change ensures that the remote is added correctly if it doesn't already exist. [[1]](diffhunk://#diff-627e88a7426360b8626ef9a0002f3558221924cb7e816f08afa52255839473d7L110-R110) [[2]](diffhunk://#diff-627e88a7426360b8626ef9a0002f3558221924cb7e816f08afa52255839473d7L211-R211)