### PR TITLE
refactor(prow-jobs/pingcap-qe/ci): switch from Ubuntu/pixi to Alpine/uv for crawl jobs

### DIFF
--- a/prow-jobs/pingcap-qe/ci/periodics.yaml
+++ b/prow-jobs/pingcap-qe/ci/periodics.yaml
@@ -50,7 +50,7 @@ periodics:
     spec:
       containers:
         - name: main
-          image: ubuntu:latest
+          image: gcr.io/google.com/cloudsdktool/google-cloud-cli:517.0.0-alpine
           env:
             - name: IDS_CSV_FILE
               value: /tmp/ids.csv
@@ -76,14 +76,11 @@ periodics:
             - pipefail
           args:
             - |
-              # Install dependencies
-              apt-get update && apt-get install -y git curl wget jq
-
-              # Set up pixi.
-              curl -fsSL https://pixi.sh/install.sh | bash
-              export PATH="$HOME/.pixi/bin:$PATH"
-              pixi install
-              # install some packages with pixi
+              # Install tools
+              apk add github-cli jq
+              curl -LsSf https://astral.sh/uv/install.sh | sh
+              source $HOME/.local/bin/env
+              uv --version
 
               # Prepare for crawl
               mkdir -p ../data/repos
@@ -94,7 +91,7 @@ periodics:
               # Crawl.
               for org in $CRAWL_ORGS; do
                 # Crawl commits in 10 years
-                timeout 3400 pixi run ../data/.ci/crawl_org_commits.sh $org ../data ../data/.ci/config 120 || echo "⌚️ timeout in 1 hour."
+                timeout 3400 uv run ../data/.ci/crawl_org_commits.sh $org ../data ../data/.ci/config 120 || echo "⌚️ timeout in 1 hour."
               done
 
               # TODO: save cache for ../data/repos
@@ -120,7 +117,6 @@ periodics:
                 git commit -m "${pr_title} [skip ci]"
                 git push --set-upstream origin "$head_branch"
                 # create a pull request
-                which gh || pixi global install gh
                 gh pr create --title "$pr_title" --body "$pr_desc" --head $head_branch --base main
                 # Assert the folder `github/<org>/<org>` not exists.
                 # Previously, we have a issue that created a duplicate level folder.
@@ -168,7 +164,7 @@ periodics:
     spec:
       containers:
         - name: main
-          image: ubuntu:latest
+          image: gcr.io/google.com/cloudsdktool/google-cloud-cli:517.0.0-alpine
           env:
             - name: CRAWL_ORGS
               value: tikv
@@ -188,19 +184,16 @@ periodics:
             - pipefail
           args:
             - |
-              # Install dependencies
-              apt-get update && apt-get install -y git curl wget jq
-
-              # Set up pixi.
-              curl -fsSL https://pixi.sh/install.sh | bash
-              export PATH="$HOME/.pixi/bin:$PATH"
-              pixi install
-              # install some packages with pixi
+              # Install tools
+              apk add github-cli jq
+              curl -LsSf https://astral.sh/uv/install.sh | sh
+              source $HOME/.local/bin/env
+              uv --version
 
               # Crawl.
               for org in $CRAWL_ORGS; do
                 # Crawl pull and issues since 2015
-                timeout 36000 pixi run ../data/.ci/crawl_org_pulls_issues.sh $org ../data 2015-01-01 || echo "⌚️ timeout in 10 hour."
+                timeout 36000 uv run ../data/.ci/crawl_org_pulls_issues.sh $org ../data 2015-01-01 || echo "⌚️ timeout in 10 hour."
               done
 
               # Publish data.
@@ -222,7 +215,6 @@ periodics:
                 git push --set-upstream origin $head_branch
 
                 # create a pull request
-                which gh || pixi global install gh
                 gh pr create --title "$pr_title" --body "$pr_desc" --head $head_branch --base main
                 # Assert the folder `github/<org>/<org>` not exists.
                 # Previously, we have a issue that created a duplicate level folder.


### PR DESCRIPTION
Use Alpine-based Google Cloud CLI image for smaller footprint and replace pixi dependency management with uv. Install github-cli directly through apk instead of using pixi global install.

I will use gcloud cli to implement cache for git clones.