### PR TITLE
feat(ticdc): modify golang and net-tool cpu for kafka light pipelines

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_storage_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_storage_integration_light.yaml
@@ -10,14 +10,14 @@ spec:
       resources:
         limits:
           memory: 16Gi
-          cpu: "6"
+          cpu: "4"
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:
           memory: 128Mi
-          cpu: 100m
+          cpu: 400m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
In the monitoring of Storage Light Pipelines, the CPU throttling metric for net-tool is consistently around 56%. Therefore, it is necessary to increase the CPU allocation for net-tool. The CPU usage of Golang doesn’t reach 6 cores, so the CPU resources can be reduced a bit. This PR increases net-tool’s CPU from 100m to 400m, and decreases golang's CPU from 6 to 4.

