### PR TITLE
feat(ticdc): modify golang and net-tool cpu for mysql, kafka, pulsar and storage

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_kafka_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_kafka_integration_light.yaml
@@ -25,7 +25,7 @@ spec:
       name: golang
       resources:
         limits:
-          cpu: "4"
+          cpu: "6"
           memory: 16Gi
       tty: true
       volumeMounts:
@@ -107,7 +107,7 @@ spec:
       resources:
         limits:
           memory: 128Mi
-          cpu: 300m
+          cpu: 600m
     - name: mysql
       image: quay.io/debezium/example-mysql:2.4
       imagePullPolicy: IfNotPresent

--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_heavy.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_heavy.yaml
@@ -17,7 +17,7 @@ spec:
       resources:
         limits:
           memory: 128Mi
-          cpu: 100m
+          cpu: 600m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_mysql_integration_light.yaml
@@ -17,7 +17,7 @@ spec:
       resources:
         limits:
           memory: 128Mi
-          cpu: 100m
+          cpu: 600m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_pulsar_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_pulsar_integration_light.yaml
@@ -10,14 +10,14 @@ spec:
       resources:
         limits:
           memory: 32Gi
-          cpu: "12"
+          cpu: "6"
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:
           memory: 128Mi
-          cpu: 100m
+          cpu: 600m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pod-pull_cdc_storage_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/latest/pod-pull_cdc_storage_integration_light.yaml
@@ -10,14 +10,14 @@ spec:
       resources:
         limits:
           memory: 16Gi
-          cpu: "4"
+          cpu: "6"
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true
       resources:
         limits:
           memory: 128Mi
-          cpu: 400m
+          cpu: 600m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
After lots of tests, setting the CPU limits of `golang` and `net-tool` to 6 and 600m respectively provides good performance in CPU throttling monitoring, without occupying too much resources.