### PR TITLE
chore (tiflash): Libclara support (1)

### DIFF
--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -350,7 +350,7 @@ pipeline {
                                     def cache_destination = "/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-${libclara_suffix}"
 
                                     sh label: "upload libclara cache", script: """
-                                        if [ -f "${cache_destination}" ]; then
+                                        if [ -d "${cache_destination}" ]; then
                                             echo "Libclara cache already exists at ${cache_destination}, skip uploading"
                                         elif [ -f "${WORKSPACE}/build/libs/libclara-cmake/libclara_sharedd.so" ]; then
                                             mkdir -p "${cache_destination}_tmp"

--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -11,10 +11,16 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
 final dependency_dir = "/home/jenkins/agent/dependency"
 final proxy_cache_dir = "/home/jenkins/agent/proxy-cache/refactor-pipelines"
+
 Boolean proxy_cache_ready = false
-Boolean update_proxy_cache = true
-Boolean update_ccache = true
 String proxy_commit_hash = null
+Boolean update_proxy_cache = true
+
+Boolean libclara_cache_ready = false
+String libclara_commit_hash = null
+Boolean update_libclara_cache = true
+
+Boolean update_ccache = true
 
 pipeline {
     agent {
@@ -63,7 +69,7 @@ pipeline {
                             container("util") {
                                 withCredentials(
                                     [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) { 
+                                ) {
                                     sh "rm -rf ./*"
                                     sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
                                     sh """
@@ -84,6 +90,10 @@ pipeline {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"
                             }
+
+                            libclara_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H" -- libs/libclara').trim()
+                            println "libclara_commit_hash: ${libclara_commit_hash}"
+
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -96,7 +106,7 @@ pipeline {
             parallel {
                 stage("Ccache") {
                     steps {
-                        script { 
+                        script {
                             dir("tiflash") {
                                 sh label: "copy ccache if exist", script: """
                                 ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
@@ -143,7 +153,29 @@ pipeline {
                                 echo "proxy cache not found"
                             fi
                             """
-                        }   
+                        }
+                    }
+                }
+                stage("Libclara Cache") {
+                    steps {
+                        script {
+                            libclara_cache_ready = sh(script: "test -d /home/jenkins/agent/libclara-cache/${libclara_commit_hash}-amd64-linux-debug && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
+                            println "libclara_cache_ready: ${libclara_cache_ready}"
+
+                            sh label: "copy libclara if exist", script: """
+                            libclara_suffix="amd64-linux-debug"
+                            libclara_cache_dir="/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-\${libclara_suffix}"
+                            if [ -d \$libclara_cache_dir ]; then
+                                echo "libclara cache found"
+                                mkdir -p ${WORKSPACE}/tiflash/libs/libclara-prebuilt
+                                cp -r \$libclara_cache_dir ${WORKSPACE}/tiflash/libs/libclara-prebuilt
+                                chmod +x ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
+                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
+                            else
+                                echo "libclara cache not found"
+                            fi
+                            """
+                        }
                     }
                 }
                 stage("Cargo-Cache") {
@@ -182,6 +214,7 @@ pipeline {
                     def compatible_flag = ""
                     def openssl_root_dir = ""
                     def prebuilt_dir_flag = ""
+                    def libclara_flag = ""
                     if (proxy_cache_ready) {
                         // only for toolchain is llvm
                         prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy/'"
@@ -190,6 +223,9 @@ pipeline {
                         cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release/
                         """
                     }
+                    if (libclara_cache_ready) {
+                        libclara_flag = "-DLIBCLARA_CXXBRIDGE_DIR='${WORKSPACE}/tiflash/libs/libclara-prebuilt/cxxbridge' -DLIBCLARA_LIBRARY='${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so'"
+                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -197,7 +233,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
+                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} ${libclara_flag} \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -207,6 +243,7 @@ pipeline {
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
                             -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
+                            -DUSE_INTERNAL_LIBCLARA=${!libclara_cache_ready} \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -215,7 +252,7 @@ pipeline {
         }
         stage("Build TiFlash") {
             steps {
-                dir("${WORKSPACE}/tiflash") {  
+                dir("${WORKSPACE}/tiflash") {
                     sh """
                     cmake --build '${WORKSPACE}/build' --target tiflash --parallel 12
                     """
@@ -284,7 +321,7 @@ pipeline {
                                 if (proxy_commit_hash && proxy_commit_hash =~ /^[0-9a-f]{40}$/) {
                                     def proxy_suffix = "amd64-linux-llvm"
                                     def cache_destination = "/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-${proxy_suffix}"
-                                    
+
                                     sh label: "upload proxy cache", script: """
                                         if [ -f "${cache_destination}" ]; then
                                             echo "Proxy cache already exists at ${cache_destination}, skip uploading"
@@ -300,6 +337,36 @@ pipeline {
                                 }
                             } else {
                                 echo "Skip because proxy cache refresh is disabled"
+                            }
+                        }
+                    }
+                }
+                stage("Upload Libclara Cache") {
+                    steps {
+                        script {
+                            if (update_libclara_cache) {
+                                if (libclara_commit_hash && libclara_commit_hash =~ /^[0-9a-f]{40}$/) {
+                                    def libclara_suffix = "amd64-linux-debug"
+                                    def cache_destination = "/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-${libclara_suffix}"
+
+                                    sh label: "upload libclara cache", script: """
+                                        if [ -f "${cache_destination}" ]; then
+                                            echo "Libclara cache already exists at ${cache_destination}, skip uploading"
+                                        elif [ -f "${WORKSPACE}/build/libs/libclara-cmake/libclara_sharedd.so" ]; then
+                                            mkdir -p "${cache_destination}_tmp"
+                                            cp "${WORKSPACE}/build/libs/libclara-cmake/libclara_sharedd.so" "${cache_destination}_tmp/"
+                                            cp -r "${WORKSPACE}/build/libs/libclara-cmake/cxxbridge" "${cache_destination}_tmp/"
+                                            mv "${cache_destination}_tmp" "${cache_destination}"
+                                            echo "Libclara cache uploaded to ${cache_destination}"
+                                        else
+                                            echo "Libclara library not found in local build, cache not updated"
+                                        fi
+                                    """
+                                } else {
+                                    echo "Skip uploading libclara cache because commit hash '${libclara_commit_hash}' is not valid"
+                                }
+                            } else {
+                                echo "Skip because libclara cache refresh is disabled"
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
       command:
         - "/bin/bash"
         - "-c"
@@ -19,27 +19,30 @@ spec:
           memory: 48Gi
           cpu: "12"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/libclara-cache"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-8"
+          readOnly: false
     - name: util
       image: hub.pingcap.net/jenkins/ks3util
       args: ["sleep", "infinity"]
@@ -84,8 +87,13 @@ spec:
         readOnly: false
         server: "10.2.12.82"
     - name: "volume-6"
-      emptyDir: {}
+      nfs:
+        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
+        readOnly: false
+        server: "10.2.12.82"
     - name: "volume-7"
+      emptyDir: {}
+    - name: "volume-8"
       emptyDir:
         medium: Memory
   affinity:
@@ -101,4 +109,3 @@ spec:
                 operator: In
                 values:
                   - "true"
-

--- a/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
       command:
         - "cat"
       tty: true
@@ -12,27 +12,30 @@ spec:
           memory: "32Gi"
           cpu: "12000m"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/libclara-cache"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-8"
+          readOnly: false
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true
@@ -77,8 +80,13 @@ spec:
         readOnly: true
         server: "10.2.12.82"
     - name: "volume-6"
-      emptyDir: {}
+      nfs:
+        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
+        readOnly: true
+        server: "10.2.12.82"
     - name: "volume-7"
+      emptyDir: {}
+    - name: "volume-8"
       emptyDir:
         medium: Memory
   affinity:

--- a/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
       command:
         - "/bin/bash"
         - "-c"
@@ -19,27 +19,30 @@ spec:
           memory: 48Gi
           cpu: "12"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/libclara-cache"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-8"
+          readOnly: false
     - name: util
       image: hub.pingcap.net/jenkins/ks3util
       args: ["sleep", "infinity"]
@@ -84,8 +87,13 @@ spec:
         readOnly: true
         server: "10.2.12.82"
     - name: "volume-6"
-      emptyDir: {}
+      nfs:
+        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
+        readOnly: true
+        server: "10.2.12.82"
     - name: "volume-7"
+      emptyDir: {}
+    - name: "volume-8"
       emptyDir:
         medium: Memory
   affinity:
@@ -101,4 +109,3 @@ spec:
                 operator: In
                 values:
                   - "true"
-

--- a/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
       command:
         - "cat"
       tty: true
@@ -13,30 +13,33 @@ spec:
           memory: "32Gi"
           cpu: "12000m"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/libclara-cache"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-8"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-9"
+          readOnly: false
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true
@@ -81,11 +84,16 @@ spec:
         readOnly: true
         server: "10.2.12.82"
     - name: "volume-6"
-      emptyDir: {}
+      nfs:
+        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
+        readOnly: true
+        server: "10.2.12.82"
     - name: "volume-7"
+      emptyDir: {}
+    - name: "volume-8"
       emptyDir:
         medium: Memory
-    - name: "volume-8"
+    - name: "volume-9"
       emptyDir: {}
   affinity:
     nodeAffinity:


### PR DESCRIPTION
This PR makes CI in https://github.com/pingcap/tiflash/pull/10081 compile:

1. Use -v2 image ([source](https://github.com/pingcap/tiflash/pull/10096)), which now supports dev tools used by CI, and protobuf-compiler required by TiFlash libclara
2. Mount libclara-cache directory
3. Utilize libclara-cache in PR build, and build libclara-cache after PR is merged.

A working CI to compile with libclara is: https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftiflash%2Fpull_unit_test/detail/pull_unit_test/4044/pipeline

However due to libclara PR is not merged, the cache is not available yet.