### PR TITLE
fix(tiflash): Fix libclara build cache issue

### DIFF
--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -168,9 +168,10 @@ pipeline {
                             if [ -d \$libclara_cache_dir ]; then
                                 echo "libclara cache found"
                                 mkdir -p ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                cp -r \$libclara_cache_dir ${WORKSPACE}/tiflash/libs/libclara-prebuilt
+                                cp -r \$libclara_cache_dir/* ${WORKSPACE}/tiflash/libs/libclara-prebuilt/
                                 chmod +x ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
+                                chown -R 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt
+                                ls -R ${WORKSPACE}/tiflash/libs/libclara-prebuilt
                             else
                                 echo "libclara cache not found"
                             fi
@@ -355,7 +356,7 @@ pipeline {
                                         elif [ -f "${WORKSPACE}/build/libs/libclara-cmake/libclara_sharedd.so" ]; then
                                             mkdir -p "${cache_destination}_tmp"
                                             cp "${WORKSPACE}/build/libs/libclara-cmake/libclara_sharedd.so" "${cache_destination}_tmp/"
-                                            cp -r "${WORKSPACE}/build/libs/libclara-cmake/cxxbridge" "${cache_destination}_tmp/"
+                                            cp -RL "${WORKSPACE}/build/libs/libclara-cmake/cxxbridge" "${cache_destination}_tmp/"
                                             mv "${cache_destination}_tmp" "${cache_destination}"
                                             echo "Libclara cache uploaded to ${cache_destination}"
                                         else

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -212,9 +212,10 @@ pipeline {
                             if [ -d \$libclara_cache_dir ]; then
                                 echo "libclara cache found"
                                 mkdir -p ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                cp -r \$libclara_cache_dir ${WORKSPACE}/tiflash/libs/libclara-prebuilt
+                                cp -r \$libclara_cache_dir/* ${WORKSPACE}/tiflash/libs/libclara-prebuilt/
                                 chmod +x ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
+                                chown -R 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt
+                                ls -R ${WORKSPACE}/tiflash/libs/libclara-prebuilt
                             else
                                 echo "libclara cache not found"
                             fi


### PR DESCRIPTION
It turns out that cxxbridge is generating symbolic links:

```
❯ ls -la /Users/breezewish/Work/tiflash-cse/cmake-build-Debug/libs/libclara-cmake/cxxbridge/clara_fts/src
total 0
drwxr-xr-x  9 breezewish  staff  288  4 10 01:08 .
drwxr-xr-x  3 breezewish  staff   96  4 10 01:08 ..
lrwxr-xr-x  1 breezewish  staff  106  4 10 01:08 brute_searcher.rs.cc -> ../../../release/build/clara_fts-8ffc5909ded41509/out/cxxbridge/sources/clara_fts/src/brute_searcher.rs.cc
lrwxr-xr-x  1 breezewish  staff  105  4 10 01:08 brute_searcher.rs.h -> ../../../release/build/clara_fts-8ffc5909ded41509/out/cxxbridge/include/clara_fts/src/brute_searcher.rs.h
lrwxr-xr-x  1 breezewish  staff  104  4 10 01:08 index_reader.rs.cc -> ../../../release/build/clara_fts-8ffc5909ded41509/out/cxxbridge/sources/clara_fts/src/index_reader.rs.cc
lrwxr-xr-x  1 breezewish  staff  103  4 10 01:08 index_reader.rs.h -> ../../../release/build/clara_fts-8ffc5909ded41509/out/cxxbridge/include/clara_fts/src/index_reader.rs.h
lrwxr-xr-x  1 breezewish  staff  104  4 10 01:08 index_writer.rs.cc -> ../../../release/build/clara_fts-8ffc5909ded41509/out/cxxbridge/sources/clara_fts/src/index_writer.rs.cc
lrwxr-xr-x  1 breezewish  staff  103  4 10 01:08 index_writer.rs.h -> ../../../release/build/clara_fts-8ffc5909ded41509/out/cxxbridge/include/clara_fts/src/index_writer.rs.h
drwxr-xr-x  4 breezewish  staff  128  4 10 01:08 tokenizer
```

So we must copy by dereference when uploading the cache, otherwise it cannot be found.

This PR also introduce libclara cache to more pipelines, like integration_test.