### PR TITLE
opt(pingcap/tiflash): add git.setSshKey before prow.checkoutRefs in TiFlash pipelines

### DIFF
--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -85,6 +85,7 @@ pipeline {
                             git version
                             git status
                             """
+                            git.setSshKey(GIT_CREDENTIALS_ID)
                             prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()

--- a/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                             git version
                             git status
                             """
+                            git.setSshKey(GIT_CREDENTIALS_ID)
                             prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -106,6 +106,7 @@ pipeline {
                         git version
                         git status
                         """
+                        git.setSshKey(GIT_CREDENTIALS_ID)
                         retry(2) {
                             prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -105,6 +105,7 @@ pipeline {
                         git version
                         git status
                         """
+                        git.setSshKey(GIT_CREDENTIALS_ID)
                         retry(2) {
                             prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
                             dir("contrib/tiflash-proxy") {


### PR DESCRIPTION
For update private git submodules