### PR TITLE
fix(tidb): rename smoke test job to include full path 

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-periodics.yaml
+++ b/prow-jobs/pingcap/tidb/latest-periodics.yaml
@@ -129,7 +129,7 @@ periodics:
                 operator: In
                 values:
                   - "true"
-  - name: periodics_tidb_next_gen_smoke_test
+  - name: pingcap/tidb/periodics_tidb_next_gen_smoke_test
     agent: jenkins
     decorate: false # need add this.
     cron: "0 */12 * * *" # every 12 hour


### PR DESCRIPTION
Update the name of the smoke test job to use the full path 'pingcap/tidb/periodics_tidb_next_gen_smoke_test' for better clarity