### PR TITLE
feat(pingcap/tidb): add Git credentials ID for next gen real tikv test pipeline

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_next_gen_real_tikv_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_next_gen_real_tikv_test.groovy
@@ -21,7 +21,7 @@ pipeline {
     }
     options {
         timeout(time: 65, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
+        // parallelsAlwaysFailFast()
     }
     environment {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'

--- a/pipelines/pingcap/tidb/latest/pull_next_gen_real_tikv_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_next_gen_real_tikv_test.groovy
@@ -5,6 +5,7 @@
 
 final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_next_gen_real_tikv_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final TARGET_BRANCH_PD = "master"
@@ -185,7 +186,6 @@ EOF
                 }
                 stages {
                     stage('Test')  {
-                        options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {


### PR DESCRIPTION
* Add GIT_CREDENTIALS_ID to the pipeline configuration for improved authentication. 
* Remove timeout option from the Test stage for better flexibility and avoid groovy errors.