### PR TITLE
chore(pingcap/tiflash): set imagePullPolicy to Always for Tiflash pod configurations

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
@@ -6,6 +6,7 @@ spec:
   containers:
     - name: runner
       image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      imagePullPolicy: Always
       command:
         - "/bin/bash"
         - "-c"

--- a/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
@@ -4,6 +4,7 @@ spec:
   containers:
     - name: runner
       image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      imagePullPolicy: Always
       command:
         - "cat"
       tty: true

--- a/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
@@ -6,6 +6,7 @@ spec:
   containers:
     - name: runner
       image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      imagePullPolicy: Always
       command:
         - "/bin/bash"
         - "-c"

--- a/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
@@ -4,6 +4,7 @@ spec:
   containers:
     - name: runner
       image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      imagePullPolicy: Always
       command:
         - "cat"
       tty: true


### PR DESCRIPTION
Avoid caching old images on some nodes in the cluster.