### PR TITLE
feat(tici): add pull-e2e-test job to presubmit configuration

### DIFF
--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -47,18 +47,6 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       always_run: false
       spec:
-        initContainers:
-          - name: cache-preparation
-            image: ghcr.io/pingcap-qe/ci/tici:v2025.4.24-7-g3a888d8
-            command: ['/bin/sh', '-c']
-            args:
-              - |
-                echo "Preparing test assets..."
-                cd /cache
-                wget -qO - https://quickwit-datasets-public.s3.amazonaws.com/hdfs-logs-multitenants.json.gz | gzip -d - > hdfs-logs-multitenants.json
-            volumeMounts:
-              - name: cache-volume
-                mountPath: /cache
         containers:
           - name: e2e
             image: ghcr.io/pingcap-qe/ci/tici:v2025.4.24-7-g3a888d8
@@ -68,15 +56,13 @@ presubmits:
                 value: /cache
             args:
               - |
+                echo "Preparing test assets..."
+                mkdir -p /cache
+                wget -qO - https://quickwit-datasets-public.s3.amazonaws.com/hdfs-logs-multitenants.json.gz | gzip -d - > /cache/hdfs-logs-multitenants.json
+                echo "Running tests..."
                 make ci-prepare-test
                 make ci-run-test
-            volumeMounts:
-              - name: cache-volume
-                mountPath: /cache
             resources:
               limits:
                 cpu: "4"
                 memory: 16Gi
-        volumes:
-          - name: cache-volume
-            emptyDir: {}

--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -39,3 +39,44 @@ presubmits:
               limits:
                 cpu: "2"
                 memory: 8Gi
+
+    - <<: *brancher
+      name: pull-e2e-test
+      decorate: true
+      decoration_config: *decoration_config
+      # skip_if_only_changed: *skip_if_only_changed
+      always_run: false
+      spec:
+        initContainers:
+          - name: cache-preparation
+            image: ghcr.io/pingcap-qe/ci/tici:v2025.4.24-7-g3a888d8
+            command: ['/bin/sh', '-c']
+            args:
+              - |
+                echo "Preparing test assets..."
+                cd /cache
+                wget -qO - https://quickwit-datasets-public.s3.amazonaws.com/hdfs-logs-multitenants.json.gz | gzip -d - > hdfs-logs-multitenants.json
+            volumeMounts:
+              - name: cache-volume
+                mountPath: /cache
+        containers:
+          - name: e2e
+            image: ghcr.io/pingcap-qe/ci/tici:v2025.4.24-7-g3a888d8
+            command: [/bin/bash, -ce]
+            env:
+              - name: ASSET_DIR
+                value: /cache
+            args:
+              - |
+                make ci-prepare-test
+                make ci-run-test
+            volumeMounts:
+              - name: cache-volume
+                mountPath: /cache
+            resources:
+              limits:
+                cpu: "4"
+                memory: 16Gi
+        volumes:
+          - name: cache-volume
+            emptyDir: {}


### PR DESCRIPTION
Introduced a new presubmit job named `pull-e2e-test` that includes an init container for preparing test assets and a main container for executing end-to-end tests. The job utilizes a cache volume for asset storage and specifies resource limits for the containers.