### PR TITLE
chore(tici): update e2e job image and set timeout to 45 minutes in presubmit configuration

### DIFF
--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -7,6 +7,7 @@ global_definitions:
   skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
   decoration_config: &decoration_config
+    timeout: 45m
     oauth_token_secret:
       name: github-token
       key: token
@@ -49,7 +50,7 @@ presubmits:
       spec:
         containers:
           - name: e2e
-            image: ghcr.io/pingcap-qe/ci/tici:v2025.4.24-7-g3a888d8
+            image: ghcr.io/pingcap-qe/ci/tici:v2025.4.24-8-gaa30e13
             command: [/bin/bash, -ce]
             env:
               - name: ASSET_DIR


### PR DESCRIPTION
* update image to find mc and minio in path
* add job timeout 45mins