### PR TITLE
opt(prow-jobs): skip triggering CI jobs for changes on git ignore file

### DIFF
--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -4,7 +4,7 @@ global_definitions:
       - ^master$
     # skip_branches: # skip feature branches based on released version.
     #   - ^feature/release-\d+\.\d+(.\d+)?-.+$
-  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
   decoration_config: &decoration_config
     timeout: 45m

--- a/prow-jobs/pingcap/community/presubmits.yaml
+++ b/prow-jobs/pingcap/community/presubmits.yaml
@@ -2,7 +2,7 @@ presubmits:
   pingcap/community:
     - name: pull-verify
       decorate: true
-      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       branches:
         - ^master$
       spec:

--- a/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
@@ -5,7 +5,7 @@ global_definitions:
       - ^release-6[.][1-9].*$
       - ^release-[78][.].*$
 
-  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:

--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -1,161 +1,166 @@
-# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
+global_definitions:
+  brancher: &brancher
+    branches:
+      - ^master$
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+
+# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Postsubmit
 postsubmits:
   pingcap/tidb:
-    - name: pingcap/tidb/merged_e2e_test
+    - <<: *brancher
+      name: pingcap/tidb/merged_e2e_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/e2e-test
       max_concurrency: 1
       skip_report: true
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_integration_e2e_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_integration_e2e_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: wip/integration-e2e-test
       max_concurrency: 1
       skip_report: true
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_common_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_common_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/common-test
       max_concurrency: 1
       skip_report: false
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_integration_common_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_integration_common_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-common-test
       max_concurrency: 1
       skip_report: true # TODO: change to false after failed test is fixed.
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_integration_ddl_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_integration_ddl_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-ddl-test
       max_concurrency: 1
       skip_report: false
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_integration_jdbc_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_integration_jdbc_test
       agent: jenkins
       decorate: false # need add this.
       context: ci/integration-jdbc-test
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       max_concurrency: 1
       skip_report: true
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_integration_mysql_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_integration_mysql_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-mysql-test
       max_concurrency: 1
       skip_report: false
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_sqllogic_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_sqllogic_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/sqllogic-test
       max_concurrency: 1
       skip_report: true
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_integration_copr_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_integration_copr_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-copr-test
       max_concurrency: 1
       skip_report: true
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_tiflash_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_tiflash_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/tiflash-test
       max_concurrency: 1
       skip_report: false
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_build
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_build
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/build
       max_concurrency: 1
       skip_report: false
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_unit_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_unit_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test
       max_concurrency: 1
       skip_report: false
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_unit_test_ddlv1
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_unit_test_ddlv1
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: wip/unit-test-ddlv1 # TODO: change to ci/ after test.
       max_concurrency: 1
       skip_report: true
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_integration_python_orm_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_integration_python_orm_test
       agent: jenkins
       decorate: false # need add this.
       context: ci/integration-python-orm-test
       max_concurrency: 1
       skip_report: false
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_integration_nodejs_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_integration_nodejs_test
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-nodejs-test
       max_concurrency: 1
       skip_report: true
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_mysql_client_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_mysql_client_test
       agent: jenkins
       decorate: false # need add this.
       context: ci/mysql-client-test
       max_concurrency: 1
       skip_report: false
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_integration_br_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_integration_br_test
       agent: jenkins
       decorate: false # need add this.
       context: wip/integration-br-test
       max_concurrency: 1
       skip_report: true
-      branches:
-        - ^master$
-    - name: pingcap/tidb/merged_integration_lightning_test
+
+    - <<: *brancher
+      name: pingcap/tidb/merged_integration_lightning_test
       agent: jenkins
       decorate: false # need add this.
       context: wip/integration-lightning-test
       max_concurrency: 1
       skip_report: true
-      branches:
-        - ^master$

--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -2,7 +2,7 @@ global_definitions:
   brancher: &brancher
     branches:
       - ^master$
-  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -5,7 +5,7 @@ global_definitions:
       - ^feature/.+
     skip_branches: # skip feature branches based on released version.
       - ^feature/release-\d+\.\d+(.\d+)?-.+$
-  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:

--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -6,7 +6,7 @@ global_definitions:
       - ^feature/.+
     skip_branches: # skip feature branches based on released version.
       - ^feature/release-\d+\.\d+(.\d+)?-.+$
-  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:

--- a/prow-jobs/tikv/community/presubmits.yaml
+++ b/prow-jobs/tikv/community/presubmits.yaml
@@ -2,7 +2,7 @@ presubmits:
   tikv/community:
     - name: pull-verify
       decorate: true
-      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       branches:
         - ^master$
       spec:

--- a/prow-jobs/tikv/copr-test/latest-presubmits.yaml
+++ b/prow-jobs/tikv/copr-test/latest-presubmits.yaml
@@ -5,7 +5,7 @@ global_definitions:
       - ^master$
       - ^feature/.+
       - ^release-.+
-  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
 presubmits:
   tikv/copr-test:

--- a/prow-jobs/tikv/raft-engine/presubmits.yaml
+++ b/prow-jobs/tikv/raft-engine/presubmits.yaml
@@ -1,3 +1,6 @@
+global_definitions:
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+
 presubmits:
   tikv/raft-engine:
     - name: rust-nightly

--- a/prow-jobs/tikv/tikv/latest-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/latest-presubmits.yaml
@@ -6,7 +6,7 @@ global_definitions:
       - ^feature/.+
     skip_branches:
       - ^feature/release-\d+\.\d+(.\d+)?-.+$
-  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
 presubmits:
   tikv/tikv:


### PR DESCRIPTION
This pull request makes changes to the `skip_if_only_changed` configuration across multiple Prow job configuration files. The primary update adds `.gitignore` files to the list of file types that, when modified, will not trigger specific CI jobs. Additionally, the changes introduce YAML anchors and references to reduce redundancy in some configurations.

### Updates to `skip_if_only_changed`:

* Added `.gitignore` to the `skip_if_only_changed` regex pattern in multiple files, including `prow-jobs/pingcap-inc/tici/presubmits.yaml`, `prow-jobs/pingcap/community/presubmits.yaml`, and others. This ensures that changes to `.gitignore` files do not trigger unnecessary CI jobs. [[1]](diffhunk://#diff-3c1db7bcdc72f49245c498a5dbe018a2355b56a3bbf4672768743c419486c3aeL7-R7) [[2]](diffhunk://#diff-201e72a2e194854030a794a5b8bbf9cbf0464c4ea4dfc225871c70eb822a4f23L5-R5) [[3]](diffhunk://#diff-000c3f36021710d47fe46c91d7b91db19662fe6508c646c8d9315bc79e642fecL8-R8) [[4]](diffhunk://#diff-6d136e7cf0b5751935f337e8b7065f23f4f547f7f85072637dbab6476832439eL5-R5) [[5]](diffhunk://#diff-35ccc0efb0c9d75d84787908ce4f772045178169d13836c8b429bfed39b986d6L8-R8) [[6]](diffhunk://#diff-6425cb5000ad825d1594ec6a5e4840caf8b29cbec0d199622f04544b5d6cc38fL9-R9) [[7]](diffhunk://#diff-30ab0438808b8b152ea23af14f48aaa5ef79bcdb57e58c78fd96573a7f82246aL5-R5) [[8]](diffhunk://#diff-d18d99f05cada8eed7f9813fa3a56557537ae467e4a0a8ac435946c92164eb8dL8-R8) [[9]](diffhunk://#diff-6c81344ec8a5b734e763b2af216a06208bbe6d47e818337978e601ac7db5b5f5R1-R3) [[10]](diffhunk://#diff-fa6da1100af298a0c51accb5df3a37f116a276b92ca404779fd5d7aa381b776aL9-R9)

### Configuration Simplification:

* Introduced YAML anchors (`&brancher` and `&skip_if_only_changed`) and references (`*brancher`, `*skip_if_only_changed`) in `prow-jobs/pingcap/tidb/latest-postsubmits.yaml` to avoid duplication of branch definitions and `skip_if_only_changed` logic across multiple job entries.