### PR TITLE
feat(pingcap/tidb): add new vector search test presubmit job

### DIFF
--- a/jobs/pingcap/tidb/latest/pull_vector_search_test.groovy
+++ b/jobs/pingcap/tidb/latest/pull_vector_search_test.groovy
@@ -1,0 +1,37 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+pipelineJob('pingcap/tidb/pull_vector_search_test') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC", "", "Prow job spec struct data")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/pingcap/tidb")
+    }
+ 
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath('pipelines/pingcap/tidb/latest/pull_vector_search_test.groovy')
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        } 
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/pod-pull_vector_search_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_vector_search_test.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 12Gi
+          cpu: "6"
+        limits:
+          memory: 12Gi
+          cpu: "6"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+

--- a/pipelines/pingcap/tidb/latest/pull_vector_search_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_vector_search_test.groovy
@@ -1,0 +1,89 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tidb"
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_vector_search_test.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    }
+    options {
+        timeout(time: 45, unit: 'MINUTES')
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                }
+            }
+        }
+        stage('Checkout') {
+            steps {
+                dir('tidb') {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir('tidb') {
+                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
+                    }
+                    script {
+                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin', trunkBranch="master", artifactVerify=true)
+                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'pd', REFS.base_ref, REFS.pulls[0].title, 'centos7/pd-server.tar.gz', 'bin', trunkBranch="master", artifactVerify=true)
+                         // Note tiflash need extract all files in tiflash dir (extract tar.gz to tiflash dir)
+                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tiflash', REFS.base_ref, REFS.pulls[0].title, 'centos7/tiflash-server.tar.gz', 'bin', trunkBranch="master", artifactVerify=true)
+                    } 
+                }
+            }
+        }
+        stage('Tests') {
+            options { timeout(time: 30, unit: 'MINUTES') }
+            steps {
+                dir('tidb') {
+                    sh label: 'test', script: """
+                        cd tests/clusterintegrationtest/
+                        ./run_mysql_tester.sh
+                        ./run_python_tester.sh
+                        ./run_upgra
+                    """
+                }
+            }
+            post{
+                failure {
+                    script {
+                        println "Test failed, archive the log"
+                        archiveArtifacts artifacts: 'tidb/tests/integrationtest2/logs', fingerprint: true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/pull_vector_search_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_vector_search_test.groovy
@@ -80,7 +80,7 @@ pipeline {
                 failure {
                     script {
                         println "Test failed, archive the log"
-                        archiveArtifacts artifacts: 'tidb/tests/integrationtest2/logs', fingerprint: true
+                        archiveArtifacts artifacts: 'tidb/tests/clusterintegrationtest/logs', fingerprint: true
                     }
                 }
             }

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -224,3 +224,15 @@ presubmits:
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-integration-python-orm-test(?: .*?)?$"
       rerun_command: "/test pull-integration-python-orm-test"
+
+
+    - <<: *brancher
+      name: pingcap/tidb/pull_vector_search_test
+      agent: jenkins
+      decorate: false # need add this.
+      always_run: false
+      optional: true
+      context: pull-vector-search-test
+      skip_report: false
+      trigger: "(?m)^/test (?:.*? )?pull-vector-search-test(?: .*?)?$"
+      rerun_command: "/test pull-vector-search-test"


### PR DESCRIPTION
Relate to https://github.com/pingcap/tidb/pull/61009

Add new vector search test presubmit job. The test is currently in the testing phase and will not be triggered automatically; it can only be triggered manually.