### PR TITLE
fix(scripts/pingcap/community): use correct key for aliases in OWNERS file

### DIFF
--- a/scripts/pingcap/community/prow-owners-updater.ts
+++ b/scripts/pingcap/community/prow-owners-updater.ts
@@ -174,9 +174,7 @@ class RepoUpdater {
           `# The members of 'sig-community-*' are synced from memberships defined in repository: https://github.com/${this.owner}/community.`,
         );
       }
-      yamlContentLines.push(yaml.stringify(
-        JSON.parse(JSON.stringify(ownersMap.owners[scope])),
-      ));
+      yamlContentLines.push(yaml.stringify(ownersMap.owners[scope]));
       const yamlContent = yamlContentLines.join("\n");
 
       const filePath = scope.startsWith("/")
@@ -191,9 +189,7 @@ class RepoUpdater {
       const fileContent = [
         `# See the OWNERS docs at https://www.kubernetes.dev/docs/guide/owners/#owners_aliases`,
         `# The members of 'sig-community-*' are synced from memberships defined in repository: https://github.com/${this.owner}/community.`,
-        yaml.stringify(
-          JSON.parse(JSON.stringify({ aliases: ownersMap.aliases })),
-        ),
+        yaml.stringify({ aliases: ownersMap.aliases }),
       ].join("\n");
 
       updateFileAndContents["OWNERS_ALIASES"] = fileContent;

--- a/scripts/pingcap/community/prow-owners-updater.ts
+++ b/scripts/pingcap/community/prow-owners-updater.ts
@@ -192,7 +192,7 @@ class RepoUpdater {
         `# See the OWNERS docs at https://www.kubernetes.dev/docs/guide/owners/#owners_aliases`,
         `# The members of 'sig-community-*' are synced from memberships defined in repository: https://github.com/${this.owner}/community.`,
         yaml.stringify(
-          JSON.parse(JSON.stringify({ alias: ownersMap.aliases })),
+          JSON.parse(JSON.stringify({ aliases: ownersMap.aliases })),
         ),
       ].join("\n");
 

--- a/scripts/pingcap/community/update-prow-owners.ts
+++ b/scripts/pingcap/community/update-prow-owners.ts
@@ -22,8 +22,6 @@ async function main(
 ) {
   const owners = await CommunityParser.GetAllOwners(inputs);
 
-  console.log("parsed");
-
   // Create a new Octokit instance using the provided token
   const octokit = new Octokit({ auth: github_private_token });
 


### PR DESCRIPTION
…

The key `alias` is incorrect, the correct key is `aliases`. This commit fixes the key to `aliases`.