### PR TITLE
chore(pingcap/tidb): add download step for test assets in vector search test setup

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_vector_search_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_vector_search_test.groovy
@@ -68,6 +68,8 @@ pipeline {
                         # wget https://ann-benchmarks.com/fashion-mnist-784-euclidean.hdf5
                         # wget https://ann-benchmarks.com/mnist-784-euclidean.hdf5
                         # Use internal file server to download test assets
+                        wget ${FILE_SERVER_URL}/download/ci-artifacts/tidb/vector-search-test/v20250521/fashion-mnist-784-euclidean.hdf5
+                        wget ${FILE_SERVER_URL}/download/ci-artifacts/tidb/vector-search-test/v20250521/mnist-784-euclidean.hdf5
                     """
                 }
             }
@@ -88,7 +90,8 @@ pipeline {
 
                         curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
                         export PATH="\$HOME/.tiup/bin:\$PATH"
-
+                        
+                        export ASSETS_DIR=\$(pwd)/../test-assets
                         cd tests/clusterintegrationtest/
 
                         uv venv --python python3.9


### PR DESCRIPTION
This commit updates the `pull_vector_search_test.groovy` file to include a new step for downloading test assets from an internal file server, enhancing the test setup process.