### PR TITLE
chore(pingcap/tidb-operator): add new e2e presubmit on branch feature/v2

### DIFF
--- a/prow-jobs/kustomization.yaml
+++ b/prow-jobs/kustomization.yaml
@@ -27,6 +27,7 @@ configMapGenerator:
       - pingcap_tidb-binlog_latest-presubmits.yaml=pingcap/tidb-binlog/latest-presubmits.yaml
       - pingcap_tidb-engine-ext_latest-presubmits.yaml=pingcap/tidb-engine-ext/latest-presubmits.yaml
       - pingcap_tidb-engine-ext_release-6.1-latest-presubmits.yaml=pingcap/tidb-engine-ext/release-6.1-latest-presubmits.yaml
+      - pingcap_tidb-operator_latest-presubmits.yaml=pingcap/tidb-operator/latest-presubmits.yaml
       - pingcap_tidb-test_latest-presubmits.yaml=pingcap/tidb-test/latest-presubmits.yaml
       - pingcap_tidb-test_release-6.0-presubmits.yaml=pingcap/tidb-test/release-6.0-presubmits.yaml
       - pingcap_tidb-test_release-6.1-presubmits.yaml=pingcap/tidb-test/release-6.1-presubmits.yaml

--- a/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
@@ -18,32 +18,71 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       branches: *branches
       spec:
+        volumes:
+          - name: docker-sock-dir
+            emptyDir: {}
         containers:
-          - name: e2e
+          - name: dind-daemon
             image: docker:28.1-dind-rootless
-            command: [bash, -ce]
-            args:
-              - |
-                set -e
-                # Start rootless Docker daemon
-                echo "Starting dockerd-rootless.sh..."
-                dockerd-rootless.sh &
-                
-                # Wait for Docker to start.
-                echo "Waiting for Docker to start..."
-                timeout 60s sh -c 'until docker info > /dev/null 2>&1; do echo "Waiting for Docker to start $(date)..."; sleep 1; done'
-                echo "Docker started."
-
-                # Run the original command
-                make e2e
             securityContext:
               privileged: true
               runAsUser: 1001
               runAsGroup: 1001
+            env:
+              - name: XDG_RUNTIME_DIR # Explicitly set for consistency
+                value: /run/user/1001
+            volumeMounts:
+              - name: docker-sock-dir
+                # This is where dockerd-rootless typically creates its socket,
+                # corresponding to $XDG_RUNTIME_DIR.
+                mountPath: /run/user/1001
+            resources:
+              requests:
+                memory: "4Gi"
+                cpu: "1"
+              limits:
+                memory: "4Gi"
+                cpu: "1"
+
+          - name: e2e-runner
+            image: golang:1.23-bullseye
+            command: ["/bin/bash", "-ce"]
+            args:
+              - |
+                set -ex pipefail
+                
+                apt-get update -qq && apt-get install -y -qq --no-install-recommends docker-ce-cli
+                echo "Docker CLI installed."
+                
+                # Set DOCKER_HOST to use the shared socket
+                export DOCKER_HOST="unix:///run/user/1001/docker.sock"
+                
+                echo "Waiting for Docker daemon to be responsive on ${DOCKER_HOST}..."
+                timeout_seconds=120
+                # Loop until docker info succeeds or timeout is reached
+                if ! timeout ${timeout_seconds}s bash -c " \
+                  until docker info > /dev/null 2>&1; do \
+                    echo \\"Waiting for Docker... \\\$(date)\\""; sleep 5; \
+                  done"; then
+                  echo "Error: Docker daemon did not start within ${timeout_seconds} seconds." >&2
+                  echo "Listing contents of /run/user/1001 to help debug:" >&2
+                  ls -la /run/user/1001 || echo "Warning: Failed to list /run/user/1001" >&2
+                  exit 1
+                fi
+                echo "Docker daemon is responsive."
+                
+                echo "Running 'make e2e'..."
+                make e2e
+            securityContext:
+              runAsUser: 1001
+              runAsGroup: 1001
+            volumeMounts:
+              - name: docker-sock-dir
+                mountPath: /run/user/1001 # Mount the shared socket directory
             resources:
               requests:
                 memory: 32Gi
-                cpu: "8"
+                cpu: "6"
               limits:
                 memory: 32Gi
-                cpu: "8"
+                cpu: "6"

--- a/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
@@ -20,11 +20,26 @@ presubmits:
       spec:
         containers:
           - name: e2e
-            image: ghcr.io/pingcap-qe/ci/base:v2024.10.8-32-ge807718-go1.23
+            image: docker:28.1-dind-rootless
             command: [bash, -ce]
             args:
               - |
+                set -e
+                # Start rootless Docker daemon
+                echo "Starting dockerd-rootless.sh..."
+                dockerd-rootless.sh &
+                
+                # Wait for Docker to start.
+                echo "Waiting for Docker to start..."
+                timeout 60s sh -c 'until docker info > /dev/null 2>&1; do echo "Waiting for Docker to start $(date)..."; sleep 1; done'
+                echo "Docker started."
+
+                # Run the original command
                 make e2e
+            securityContext:
+              privileged: true
+              runAsUser: 1001
+              runAsGroup: 1001
             resources:
               requests:
                 memory: 32Gi

--- a/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
@@ -1,0 +1,37 @@
+global_definitions:
+  branches: &branches
+    - ^feature/v2$
+  skip_if_only_changed: &skip_if_only_changed
+    "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  decoration_config: &decoration_config
+    timeout: 45m
+    oauth_token_secret:
+      name: github-token
+      key: token
+
+
+# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
+presubmits:
+  pingcap/tidb-operator:
+    - name: pull-e2e
+      decorate: true # need add this.
+      decoration_config: *decoration_config
+      always_run: false
+      optional: true
+      # skip_if_only_changed: *skip_if_only_changed
+      branches: *branches
+      spec:
+        containers:
+          - name: e2e
+            image: ghcr.io/pingcap-qe/ci/base:v2024.10.8-32-ge807718-go1.23
+            command: [bash, -ce]
+            args:
+              - |
+                make e2e
+            resources:
+              requests:
+                memory: 32Gi
+                cpu: "8"
+              limits:
+                memory: 32Gi
+                cpu: "8"

--- a/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
         containers:
           - name: dind-daemon
             image: docker:28.1-dind-rootless
+            command: ["docker-entrypoint.sh"]
             securityContext:
               privileged: true
               runAsUser: 1001

--- a/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
@@ -5,9 +5,6 @@ global_definitions:
     "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
   decoration_config: &decoration_config
     timeout: 45m
-    oauth_token_secret:
-      name: github-token
-      key: token
 
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit


### PR DESCRIPTION
This commit introduces a new presubmit job configuration for the `tidb-operator` in the `latest-presubmits.yaml` file. The configuration includes job specifications, resource requests, and decoration settings, enhancing the CI pipeline for the `tidb-operator` repository.