### PR TITLE
chore(pingcap/tidb-operator): update dind-daemon configuration in laest-presubmits.yaml

### DIFF
--- a/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
@@ -23,21 +23,16 @@ presubmits:
             emptyDir: {}
         containers:
           - name: dind-daemon
-            image: docker:28.1-dind-rootless
-            command: ["/usr/local/bin/dockerd-entrypoint.sh"]
-            args: ["--experimental"]
+            image: docker:28.1-dind
+            command: ["dockerd-entrypoint.sh"]
+            env:
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
             securityContext:
               privileged: true
-              runAsUser: 1001
-              runAsGroup: 1001
-            env:
-              - name: XDG_RUNTIME_DIR # Explicitly set for consistency
-                value: /run/user/1001
             volumeMounts:
               - name: docker-sock-dir
-                # This is where dockerd-rootless typically creates its socket,
-                # corresponding to $XDG_RUNTIME_DIR.
-                mountPath: /run/user/1001
+                mountPath: /var/run
             resources:
               requests:
                 memory: "4Gi"
@@ -56,10 +51,7 @@ presubmits:
                 apt-get update -qq && apt-get install -y -qq --no-install-recommends docker-ce-cli
                 echo "Docker CLI installed."
                 
-                # Set DOCKER_HOST to use the shared socket
-                export DOCKER_HOST="unix:///run/user/1001/docker.sock"
-                
-                echo "Waiting for Docker daemon to be responsive on ${DOCKER_HOST}..."
+                echo "Waiting for Docker daemon to be responsive..."
                 timeout_seconds=120
                 # Loop until docker info succeeds or timeout is reached
                 if ! timeout ${timeout_seconds}s bash -c " \
@@ -67,8 +59,8 @@ presubmits:
                     echo \\"Waiting for Docker... \\\$(date)\\""; sleep 5; \
                   done"; then
                   echo "Error: Docker daemon did not start within ${timeout_seconds} seconds." >&2
-                  echo "Listing contents of /run/user/1001 to help debug:" >&2
-                  ls -la /run/user/1001 || echo "Warning: Failed to list /run/user/1001" >&2
+                  echo "Listing contents of /var/run to help debug:" >&2
+                  ls -la /var/run || echo "Warning: Failed to list /var/run" >&2
                   exit 1
                 fi
                 echo "Docker daemon is responsive."
@@ -77,7 +69,7 @@ presubmits:
                 make e2e
             volumeMounts:
               - name: docker-sock-dir
-                mountPath: /run/user/1001 # Mount the shared socket directory
+                mountPath: /var/run # Mount the shared socket directory
             resources:
               requests:
                 memory: 32Gi


### PR DESCRIPTION
This commit modifies the `latest-presubmits.yaml` file to change the dind-daemon container's image to `docker:28.1-dind`, updates the command to `dockerd-entrypoint.sh`, and adjusts the environment variable settings. Additionally, it changes the mount path for the Docker socket from `/run/user/1001` to `/var/run`, streamlining the configuration for better compatibility.