### PR TITLE
chore(pingcap/tidb): refactor vector search test for parallel test

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_vector_search_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_vector_search_test.groovy
@@ -52,62 +52,101 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
+                    sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'vector-search-test')) {
+                        script {
+                            component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin', trunkBranch="master", artifactVerify=true)
+                            component.fetchAndExtractArtifact(FILE_SERVER_URL, 'pd', REFS.base_ref, REFS.pulls[0].title, 'centos7/pd-server.tar.gz', 'bin', trunkBranch="master", artifactVerify=true)
+                            // Note tiflash need extract all files in tiflash dir (extract tar.gz to tiflash dir)
+                            component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tiflash', REFS.base_ref, REFS.pulls[0].title, 'centos7/tiflash.tar.gz', '', trunkBranch="master", artifactVerify=false, useBranchInArtifactUrl=true)
+                            sh label: 'move tiflash', script: 'mv tiflash/* bin/ && rm -rf tiflash'
+                        } 
                     }
-                    script {
-                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin', trunkBranch="master", artifactVerify=true)
-                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'pd', REFS.base_ref, REFS.pulls[0].title, 'centos7/pd-server.tar.gz', 'bin', trunkBranch="master", artifactVerify=true)
-                         // Note tiflash need extract all files in tiflash dir (extract tar.gz to tiflash dir)
-                         component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tiflash', REFS.base_ref, REFS.pulls[0].title, 'centos7/tiflash.tar.gz', '', trunkBranch="master", artifactVerify=false, useBranchInArtifactUrl=true)
-                         sh label: 'move tiflash', script: 'mv tiflash/* bin/ && rm -rf tiflash'
-                    } 
                 }
                 dir('test-assets') {
-                    sh label: 'download test assets', script: """
+                    cache(path: "./", includes: '**/*', key: "test-assets/tidb/vector-search-test") {
+                        sh label: 'download test assets', script: """
                         # wget https://ann-benchmarks.com/fashion-mnist-784-euclidean.hdf5
                         # wget https://ann-benchmarks.com/mnist-784-euclidean.hdf5
                         # Use internal file server to download test assets
-                        wget ${FILE_SERVER_URL}/download/ci-artifacts/tidb/vector-search-test/v20250521/fashion-mnist-784-euclidean.hdf5
-                        wget ${FILE_SERVER_URL}/download/ci-artifacts/tidb/vector-search-test/v20250521/mnist-784-euclidean.hdf5
-                    """
+                        wget -q ${FILE_SERVER_URL}/download/ci-artifacts/tidb/vector-search-test/v20250521/fashion-mnist-784-euclidean.hdf5
+                        wget -q ${FILE_SERVER_URL}/download/ci-artifacts/tidb/vector-search-test/v20250521/mnist-784-euclidean.hdf5
+                        """
+                    }
                 }
             }
         }
         stage('Tests') {
-            options { timeout(time: 45, unit: 'MINUTES') }
-            steps {
-                dir('tidb') {
-                    sh label: 'print version', script: """
-                        bin/tidb-server -V
-                        bin/tikv-server -V
-                        bin/pd-server -V
-                        bin/tiflash --version
-                    """
-                    sh label: 'test', script: """
-                        export PATH="\$HOME/.local/bin:\$PATH"
-                        curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.7.3/uv-installer.sh | sh
-
-                        curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
-                        export PATH="\$HOME/.tiup/bin:\$PATH"
-                        
-                        export ASSETS_DIR=\$(pwd)/../test-assets
-                        cd tests/clusterintegrationtest/
-
-                        uv venv --python python3.9
-                        source .venv/bin/activate
-                        uv pip install -r requirements.txt
-                        ./run_mysql_tester.sh
-                        ./run_python_tester.sh
-                        ./run_upgrade_test.sh
-                    """
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_SCRIPT'
+                        values 'run_mysql_tester.sh', 'run_python_tester.sh', 'run_upgrade_test.sh'
+                    }
                 }
-            }
-            post{
-                failure {
-                    script {
-                        println "Test failed, archive the log"
-                        archiveArtifacts artifacts: 'tidb/tests/clusterintegrationtest/logs', fingerprint: true
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        defaultContainer 'golang'
+                        yamlFile POD_TEMPLATE_FILE
+                    }
+                }
+                stages {
+                    stage('Restore cache') {
+                        steps {
+                            dir("tidb") {
+                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
+                                    sh 'ls -lh'
+                                }
+                            }
+                            dir('tidb') {
+                                cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'vector-search-test')) {
+                                    sh label: 'print version', script: """
+                                        bin/tidb-server -V
+                                        bin/tikv-server -V
+                                        bin/pd-server -V
+                                        bin/tiflash --version
+                                    """
+                                }
+                            }
+                            dir('test-assets') {
+                                cache(path: "./", includes: '**/*', key: "test-assets/tidb/vector-search-test") {
+                                sh label: 'print assets', script: """
+                                        ls -alh
+                                    """
+                                }
+                            }
+                        }
+                    }
+                    stage("Test") {
+                        options { timeout(time: 45, unit: 'MINUTES') }
+                        steps {
+                            dir('tidb') {
+                                sh label: "TEST_SCRIPT ${TEST_SCRIPT}", script: """#!/usr/bin/env bash
+                                    export PATH="\$HOME/.local/bin:\$PATH"
+                                    curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.7.3/uv-installer.sh | sh
+
+                                    curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
+                                    export PATH="\$HOME/.tiup/bin:\$PATH"
+                                    
+                                    export ASSETS_DIR=\$(pwd)/../test-assets
+                                    cd tests/clusterintegrationtest/
+
+                                    uv venv --python python3.9
+                                    source .venv/bin/activate
+                                    uv pip install -r requirements.txt
+                                    ./${TEST_SCRIPT}
+                                """
+                            }
+                        }
+                        post{
+                            failure {
+                                script {
+                                    println "Test failed, archive the log"
+                                    archiveArtifacts artifacts: 'tidb/tests/clusterintegrationtest/logs', fingerprint: true
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This commit refactors the `pull_vector_search_test.groovy` file to enhance the setup process by reorganizing the caching mechanism for binaries and test assets. The changes include moving the cache steps to improve efficiency and adding a matrix for test scripts, allowing for better management of test execution. Additionally, the download commands for test assets have been updated to suppress output for cleaner logs.