### PR TITLE
chore(jenkins/pipelines/devbuild): update gethash image tag in dev-build

### DIFF
--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -120,7 +120,7 @@ pipeline{
 spec:
   containers:
   - name: gethash
-    image: hub.pingcap.net/jenkins/gethash:latest
+    image: hub.pingcap.net/jenkins/gethash:v20250526
     imagePullPolicy: Always
     command: ["sleep", "infinity"]
 '''


### PR DESCRIPTION
This commit changes the image tag for the gethash container in the dev-build.groovy file from 'latest' to 'v20250526', ensuring the use of a specific version for improved stability and predictability in the build process.

* gethash.py from https://github.com/PingCAP-QE/ci/blob/main/scripts/artifacts/gethash.py
* support gitRef like commit/xxx in gethash.py