### PR TITLE
chore(jenkins/pipelines/devbuild): Rename the GCR image of newarch ticdc to ticdc.

### DIFF
--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -38,7 +38,7 @@ final DockerImgRepoMapping = [
 ]
 
 // image prefix with `gcr.io/pingcap-public/dbaas/`
-final GcrDockerImgRepoMapping = ["drainer":"tidb-binlog", "pump":"tidb-binlog"]
+final GcrDockerImgRepoMapping = ["drainer":"tidb-binlog", "pump":"tidb-binlog", "ticdc-newarch":"ticdc"]
 
 final FileserverDownloadURL = "https://fileserver.pingcap.net/download"
 


### PR DESCRIPTION
Rename the GCR image of newarch ticdc to ticdc due to convenient to run tests.

This commit updates the GcrDockerImgRepoMapping in the dev-build.groovy file to include a new entry for the ticdc-newarch image, enhancing the Docker image configuration for the build process.