### PR TITLE
chore(pipelines/pingcap/tiflash): update cache keys for next-gen integration and unit tests

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -60,10 +60,10 @@ pipeline {
                     // test build cache, if cache is exist, then skip the following build steps
                     try {
                         dir("test-build-cache") {
-                            cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'it-build')){
+                            cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'it-build-next-gen')){
                                 // if file README.md not exist, then build-cache-ready is false
                                 build_cache_ready = sh(script: "test -f README.md && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                                println "build_cache_ready: ${build_cache_ready}, build cache key: ${prow.getCacheKey('tiflash', REFS, 'it-build')}"
+                                println "build_cache_ready: ${build_cache_ready}, build cache key: ${prow.getCacheKey('tiflash', REFS, 'it-build-next-gen')}"
                                 println "skip build..."
                                 // if build cache not ready, then throw error to avoid cache empty directory
                                 // for the same cache key, if throw error, will skip the cache step
@@ -414,7 +414,7 @@ pipeline {
                     sh label: "change permission", script: """
                         chown -R 1000:1000 ./
                     """
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'it-build')){
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'it-build-next-gen')){
                        dir('tests/.build') {
                             sh label: "archive tiflash binary", script: """
                             cp -r ${WORKSPACE}/install/* ./
@@ -455,8 +455,8 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir("${WORKSPACE}/tiflash") {
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'it-build')){
-                                    println "restore from cache key: ${prow.getCacheKey('tiflash', REFS, 'it-build')}"
+                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'it-build-next-gen')){
+                                    println "restore from cache key: ${prow.getCacheKey('tiflash', REFS, 'it-build-next-gen')}"
                                     sh label: "debug info", script: """
                                     printenv
                                     pwd && ls -alh

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -59,10 +59,10 @@ pipeline {
                     // test build cache, if cache is exist, then skip the following build steps
                     try {
                         dir("test-build-cache") {
-                            cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'ut-build')){
+                            cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'ut-build-next-gen')){
                                 // if file README.md not exist, then build-cache-ready is false
                                 build_cache_ready = sh(script: "test -f README.md && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                                println "build_cache_ready: ${build_cache_ready}, build cache key: ${prow.getCacheKey('tiflash', REFS, 'ut-build')}"
+                                println "build_cache_ready: ${build_cache_ready}, build cache key: ${prow.getCacheKey('tiflash', REFS, 'ut-build-next-gen')}"
                                 println "skip build..."
                                 // if build cache not ready, then throw error to avoid cache empty directory
                                 // for the same cache key, if throw error, will skip the cache step
@@ -388,9 +388,9 @@ pipeline {
                         sh label: "change permission", script: """
                             chown -R 1000:1000 ./
                         """
-                        cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'ut-build')) {
+                        cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'ut-build-next-gen')) {
                             if (build_cache_ready) {
-                                println "build cache exist, restore from cache key: ${prow.getCacheKey('tiflash', REFS, 'ut-build')}"
+                                println "build cache exist, restore from cache key: ${prow.getCacheKey('tiflash', REFS, 'ut-build-next-gen')}"
                                 sh """
                                 du -sh ./
                                 ls -alh ./


### PR DESCRIPTION
This commit modifies the cache keys in the integration and unit test pipelines to use 'it-build-next-gen' and 'ut-build-next-gen' respectively. This change ensures that the caching mechanism is aligned with the next-gen branch, improving the efficiency of the build process.