### PR TITLE
chore(pipelines/pingcap/tiflash): update context names for merged unit and build tests

### DIFF
--- a/prow-jobs/pingcap/tiflash/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: pingcap/tiflash/merged_unit_test
       agent: jenkins
       decorate: false # need add this.
-      context: wip/merged-unit-test # need change this after test pass.
+      context: merged-unit-test # need change this after test pass.
       max_concurrency: 1
       skip_report: true # need change this after test pass.
       branches:
@@ -12,7 +12,7 @@ postsubmits:
     - name: pingcap/tiflash/merged_build
       agent: jenkins
       decorate: false # need add this.
-      context: wip/merged-build # need change this after test pass.
+      context: merged-build # need change this after test pass.
       max_concurrency: 1
       skip_report: true # need change this after test pass.
       branches:


### PR DESCRIPTION
This commit modifies the context names for the merged unit test and merged build jobs in the latest-postsubmits.yaml file, changing them from 'wip/merged-unit-test' and 'wip/merged-build' to 'merged-unit-test' and 'merged-build' respectively. This change is part of the ongoing adjustments to streamline the CI process.