### PR TITLE
fix(scripts/flow/rc): fix RC flow check scripts

### DIFF
--- a/scripts/flow/rc/check-images-internal.ts
+++ b/scripts/flow/rc/check-images-internal.ts
@@ -155,6 +155,10 @@ async function checkImages(
     if (version >= "v8.4.0" && gitRepo === "pingcap/tidb-binlog") {
       continue;
     }
+    // ticdc is initilized since v9.0.0
+    if (version <= "v9.0.0" && gitRepo === "pingcap/ticdc") {
+      continue;
+    }
 
     console.group(gitRepo);
     const gitSha = await gatheringGithubGitSha(ghClient, gitRepo, branch);

--- a/scripts/flow/rc/check-images-internal.ts
+++ b/scripts/flow/rc/check-images-internal.ts
@@ -249,8 +249,10 @@ async function main(
   }
 
   console.info("🏅🏅🏅 check success!");
+  Deno.exit(0);
 }
 
-// parase cli params with `CliParams` and pass to main
-const args = parseArgs(Deno.args) as CliParams;
-await main(args);
+if (import.meta.main) {
+  const args = parseArgs(Deno.args) as CliParams;
+  await main(args);
+}

--- a/scripts/flow/rc/check-tiup.ts
+++ b/scripts/flow/rc/check-tiup.ts
@@ -220,6 +220,10 @@ async function main(
     if (version >= "v8.4.0" && ociRepo === "pingcap/tidb-binlog/package") {
       continue;
     }
+    // ticdc is initilized since v9.0.0
+    if (version <= "v9.0.0" && ociRepo === "pingcap/ticdc/package") {
+      continue;
+    }
 
     console.group(ociRepo);
     const ociInfos = {} as Record<string, OciMetadata>;

--- a/scripts/flow/rc/check-tiup.ts
+++ b/scripts/flow/rc/check-tiup.ts
@@ -269,8 +269,10 @@ async function main(
   }
 
   console.info("🏅🏅🏅 check success!");
+  Deno.exit(0);
 }
 
-// parase cli params with `CliParams` and pass to main
-const args = parseArgs(Deno.args) as CliParams;
-await main(args);
+if (import.meta.main) {
+  const args = parseArgs(Deno.args) as CliParams;
+  await main(args);
+}


### PR DESCRIPTION
This pull request introduces updates to the scripts `check-images-internal.ts` and `check-tiup.ts` to improve version handling and script execution flow. The changes include adding version-specific checks for `ticdc` initialization and ensuring proper script termination when executed directly.

### Updates to version handling:

* [`scripts/flow/rc/check-images-internal.ts`](diffhunk://#diff-bda2ba3d75043b6dba98a83474bb05cfa4d2a70bc74440c0f32f88ee9c6f6fb9R158-R161): Added a condition to skip processing `ticdc` for versions earlier than `v9.0.0`. (`[scripts/flow/rc/check-images-internal.tsR158-R161](diffhunk://#diff-bda2ba3d75043b6dba98a83474bb05cfa4d2a70bc74440c0f32f88ee9c6f6fb9R158-R161)`)
* [`scripts/flow/rc/check-tiup.ts`](diffhunk://#diff-0be4c32d0693a4c6b794b5c07c45baa7f15e5e76ffeb8cbe37d9ba30456653b9R223-R226): Added a condition to skip processing `ticdc` for versions earlier than `v9.0.0`. (`[scripts/flow/rc/check-tiup.tsR223-R226](diffhunk://#diff-0be4c32d0693a4c6b794b5c07c45baa7f15e5e76ffeb8cbe37d9ba30456653b9R223-R226)`)

### Improvements to script execution flow:

* [`scripts/flow/rc/check-images-internal.ts`](diffhunk://#diff-bda2ba3d75043b6dba98a83474bb05cfa4d2a70bc74440c0f32f88ee9c6f6fb9R252-R258): Added `Deno.exit(0)` to ensure proper script termination when executed directly and wrapped CLI parameter parsing in an `import.meta.main` check. (`[scripts/flow/rc/check-images-internal.tsR252-R258](diffhunk://#diff-bda2ba3d75043b6dba98a83474bb05cfa4d2a70bc74440c0f32f88ee9c6f6fb9R252-R258)`)
* [`scripts/flow/rc/check-tiup.ts`](diffhunk://#diff-0be4c32d0693a4c6b794b5c07c45baa7f15e5e76ffeb8cbe37d9ba30456653b9R272-R278): Added `Deno.exit(0)` to ensure proper script termination when executed directly and wrapped CLI parameter parsing in an `import.meta.main` check. (`[scripts/flow/rc/check-tiup.tsR272-R278](diffhunk://#diff-0be4c32d0693a4c6b794b5c07c45baa7f15e5e76ffeb8cbe37d9ba30456653b9R272-R278)`)