### PR TITLE
chore(pipelines/pingcap/tiflash): tiflash next-gen pipeline support master branch

### DIFF
--- a/prow-jobs/pingcap/tiflash/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-postsubmits.yaml
@@ -24,4 +24,5 @@ postsubmits:
       max_concurrency: 1
       skip_report: true # need change this after test pass.
       branches:
-        - ^feature/.+
+        - ^master$
+        - ^feature/next-gen.*$

--- a/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
@@ -2,6 +2,7 @@
 global_definitions:
   brancher: &brancher
     branches:
+      - ^master$
       - ^feature/next-gen.*$
   skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 


### PR DESCRIPTION
This commit modifies the branch patterns in both `latest-postsubmits.yaml` and `latest-presubmits-next-gen.yaml` to include the `master` branch alongside the `feature/next-gen` branches. This change ensures that the CI pipelines correctly handle builds and tests for the latest developments in both the master and next-gen feature branches.