### PR TITLE
Update tici image

### DIFF
--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
       spec:
         containers:
           - name: e2e
-            image: ghcr.io/pingcap-qe/ci/tici:v2025.6.8-1-g5c4ef89
+            image: ghcr.io/pingcap-qe/ci/tici:v2025.6.8-1-g5c4ef89 # Use a patched CDC version to output handle.
             command: [/bin/bash, -ce]
             env:
               - name: ASSET_DIR


### PR DESCRIPTION
This image use a patched CDC version to output handle.

Related PR: https://github.com/PingCAP-QE/artifacts/pull/636