### PR TITLE
fix(jobs,prow-jobs): rename job to pull_integration_realcluster_test_next_gen

### DIFF
--- a/jobs/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen.groovy
+++ b/jobs/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen.groovy
@@ -1,7 +1,7 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 final fullRepo = 'pingcap/tidb'
 final branchAlias = 'latest' // For trunk and latest release branches.
-final jobName = 'pull_integration_real_cluster_next_gen'
+final jobName = 'pull_integration_realcluster_test_next_gen'
 
 pipelineJob("${fullRepo}/${jobName}") {
     logRotator {

--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -29,7 +29,7 @@ presubmits:
       rerun_command: "/test pull-check-next-gen"
 
     - <<: *brancher
-      name: pingcap/tidb/pull_integration_real_cluster_next_gen
+      name: pingcap/tidb/pull_integration_realcluster_test_next_gen
       agent: jenkins
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed


### PR DESCRIPTION
This pull request updates the naming convention for a specific integration test job in both the Jenkins job DSL script and the Prow presubmit configuration to ensure consistency and alignment with naming standards.

### Updates to job naming:

* [`jobs/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen.groovy`](diffhunk://#diff-0b2218849b61adf414df00b459719558317f2473f12cf3f9d8bbcdac03a7c2aeL4-R4): Renamed the `jobName` variable from `pull_integration_real_cluster_next_gen` to `pull_integration_realcluster_test_next_gen` to reflect the updated naming convention.
* [`prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml`](diffhunk://#diff-6d136e7cf0b5751935f337e8b7065f23f4f547f7f85072637dbab6476832439eL32-R32): Updated the `name` field in the presubmit configuration to match the new job name, ensuring consistency across systems.