### PR TITLE
fix(pipelines): add keyspace-name flag to tidb-server startup command for build-next-gen job

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy
@@ -104,7 +104,7 @@ pipeline {
 
                     # test them.
                     make server -C ${REFS.repo}
-                    ./${REFS.repo}/bin/tidb-server -plugin-dir=./plugin-so -plugin-load=audit-1,whitelist-1 | tee ./loading-plugin.log &
+                    ./${REFS.repo}/bin/tidb-server -keyspace-name=test-ks -plugin-dir=./plugin-so -plugin-load=audit-1,whitelist-1 | tee ./loading-plugin.log &
 
                     sleep 30
                     ps aux | grep tidb-server


### PR DESCRIPTION
Ref #3381