### PR TITLE
fix(presubmits): comment out skip_if_only_changed in next-gen e2e tett job configuration

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -73,7 +73,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_e2e_test_next_gen
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: *skip_if_only_changed
+      # skip_if_only_changed: *skip_if_only_changed
       optional: true
       context: pull-integration-e2e-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-integration-e2e-test-next-gen(?: .*?)?$"


### PR DESCRIPTION
pull_integration_e2e_test_next_gen is still in the WIP testing phase, can only support manual trigger testing.