### PR TITLE
feat(pingcap/tidb): add CI job for MySQL client test next-gen

### DIFF
--- a/jobs/pingcap/tidb/latest/pull_mysql_client_test_next_gen.groovy
+++ b/jobs/pingcap/tidb/latest/pull_mysql_client_test_next_gen.groovy
@@ -1,0 +1,42 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+final fullRepo = 'pingcap/tidb'
+final branchAlias = 'latest' // For trunk and latest release branches.
+final jobName = 'pull_mysql_client_test_next_gen'
+
+pipelineJob("${fullRepo}/${jobName}") {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/${fullRepo}")
+    }
+
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/${fullRepo}/${branchAlias}/${jobName}/pipeline.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pipeline.groovy
@@ -1,0 +1,108 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master and latest release branches
+@Library('tipipeline') _
+
+final BRANCH_ALIAS = 'latest'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final K8S_NAMESPACE = 'jenkins-tidb'
+final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        NEXT_GEN = '1'
+    }
+    options {
+        timeout(time: 40, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir(REFS.repo) {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+                dir("tidb-test") {
+                    cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
+                        retry(2) {
+                            script {
+                                component.checkoutSupportBatch('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir(REFS.repo) {
+                    cache(path: "./bin", includes: '**/*', key: "ng-binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
+                    }
+                }
+                dir('tidb-test') {
+                    sh "git branch && git status"
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                        sh 'touch ws-${BUILD_TAG}'
+                    }
+                }
+            }
+        }
+        stage('MySQL Connector Tests') {
+            steps {
+                dir(REFS.repo) {
+                    cache(path: "./bin", includes: '**/*', key: "ng-binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                    }
+                }
+                dir('tidb-test') {
+                    sh label: 'prepare', script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin/
+                        cp ../${REFS.repo}/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    container('mysql-client-test') {
+                        sh label: "run test", script: """#!/usr/bin/env bash
+                            make mysql_client_test
+                        """
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pod.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
+        limits:
+          memory: 16Gi
+          cpu: "6"
+    - name: mysql-client-test
+      image: "hub.pingcap.net/tiproxy-team/mysql-client-test"
+      securityContext:
+        privileged: true
+      tty: true
+      resources:
+        requests:
+          memory: 1Gi
+          cpu: "4"
+        limits:
+          memory: 16Gi
+          cpu: "8"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -34,7 +34,6 @@ presubmits:
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       optional: true
-      always_run: false
       context: pull-integration-realcluster-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-integration-realcluster-test-next-gen(?: .*?)?$"
       rerun_command: "/test pull-integration-realcluster-test-next-gen"
@@ -73,8 +72,18 @@ presubmits:
       name: pingcap/tidb/pull_integration_e2e_test_next_gen
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: *skip_if_only_changed
+      # skip_if_only_changed: *skip_if_only_changed
       optional: true
       context: pull-integration-e2e-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-integration-e2e-test-next-gen(?: .*?)?$"
       rerun_command: "/test pull-integration-e2e-test-next-gen"
+
+    - <<: *brancher
+      name: pingcap/tidb/pull_mysql_client_test_next_gen
+      agent: jenkins
+      decorate: false # need add this.
+      # skip_if_only_changed: *skip_if_only_changed
+      optional: true
+      context: pull-mysql-client-test-next-gen
+      trigger: "(?m)^/test (?:.*? )?pull-mysql-client-test-next-gen(?: .*?)?$"
+      rerun_command: "/test pull-mysql-client-test-next-gen"

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -68,7 +68,6 @@ presubmits:
       name: pingcap/tidb/pull_integration_mysql_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
       optional: true
       context: pull-integration-mysql-test
       trigger: "(?m)^/test (?:.*? )?pull-integration-mysql-test(?: .*?)?$"
@@ -78,10 +77,8 @@ presubmits:
       name: pingcap/tidb/pull_integration_copr_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
       optional: true
       context: pull-integration-copr-test
-      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-integration-copr-test(?: .*?)?$"
       rerun_command: "/test pull-integration-copr-test"
 
@@ -89,10 +86,8 @@ presubmits:
       name: pingcap/tidb/pull_integration_jdbc_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
       optional: true
       context: pull-integration-jdbc-test
-      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-integration-jdbc-test(?: .*?)?$"
       rerun_command: "/test pull-integration-jdbc-test"
 
@@ -100,10 +95,8 @@ presubmits:
       name: pingcap/tidb/pull_e2e_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
       optional: true
       context: pull-e2e-test
-      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-e2e-test(?: .*?)?$"
       rerun_command: "/test pull-e2e-test"
 
@@ -147,10 +140,8 @@ presubmits:
       name: pingcap/tidb/pull_integration_common_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
       optional: true
       context: pull-integration-common-test
-      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-integration-common-test(?: .*?)?$"
       rerun_command: "/test pull-integration-common-test"
 
@@ -160,7 +151,6 @@ presubmits:
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-ddl-test
-      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-integration-ddl-test(?: .*?)?$"
       rerun_command: "/test pull-integration-ddl-test"
 
@@ -186,10 +176,8 @@ presubmits:
       name: pingcap/tidb/pull_integration_nodejs_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
       optional: true
       context: pull-integration-nodejs-test
-      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-integration-nodejs-test(?: .*?)?$"
       rerun_command: "/test pull-integration-nodejs-test"
 
@@ -197,10 +185,8 @@ presubmits:
       name: pingcap/tidb/pull_integration_python_orm_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
       optional: true
       context: pull-integration-python-orm-test
-      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-integration-python-orm-test(?: .*?)?$"
       rerun_command: "/test pull-integration-python-orm-test"
 
@@ -208,9 +194,7 @@ presubmits:
       name: pingcap/tidb/pull_tiflash_integration_test
       agent: jenkins
       decorate: false # need add this.
-      always_run: false
       optional: true
       context: pull-tiflash-integration-test
-      skip_report: false
       trigger: "(?m)^/test (?:.*? )?pull-tiflash-integration-test(?: .*?)?$"
       rerun_command: "/test pull-tiflash-integration-test"


### PR DESCRIPTION
- Add new pipeline and pod template for MySQL client test
- Register job in latest-presubmits-next-gen.yaml
- Clean up unused fields in presubmit configs

Close #3583