### PR TITLE
feat(pingcap/tidb): add new CI job for integration DDL tests next-gen

### DIFF
--- a/jobs/pingcap/tidb/latest/pull_integration_ddl_test_next_gen.groovy
+++ b/jobs/pingcap/tidb/latest/pull_integration_ddl_test_next_gen.groovy
@@ -1,0 +1,42 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+final fullRepo = "pingcap/tidb"
+final branchAlias = "latest" // For trunk and latest release branches.
+final jobName = "pull_integration_ddl_test_next_gen"
+
+pipelineJob("${fullRepo}/${jobName}") {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/${fullRepo}")
+    }
+
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/${fullRepo}/${branchAlias}/${jobName}/pipeline.groovy")
+            scm {
+                git{
+                    remote {
+                        url("https://github.com/PingCAP-QE/ci.git")
+                    }
+                    branch("main")
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
@@ -1,0 +1,154 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final BRANCH_ALIAS = 'latest'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final K8S_NAMESPACE = "jenkins-tidb"
+final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+final TARGET_BRANCH_PD = "master"
+final TARGET_BRANCH_TIKV = "dedicated"
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
+        OCI_ARTIFACT_HOST = 'hub-mig.pingcap.net'
+    }
+    options {
+        timeout(time: 40, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir(REFS.repo) {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+                dir("tidb-test") {
+                    cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
+                        retry(2) {
+                            script {
+                                component.checkout('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                container("golang") {
+                    dir(REFS.repo) {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                        sh label: 'ddl-test', script: 'ls bin/ddltest || make ddltest'
+                    }
+                }
+                container("utils") {
+                    dir("${REFS.repo}/bin") {
+                        sh """#!/usr/bin/env bash -euo pipefail
+                            script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                            chmod +x \$script
+                            \${script} \
+                            --pd=${TARGET_BRANCH_PD}-next-gen \
+                            --tikv=${TARGET_BRANCH_TIKV}-next-gen
+
+                        """
+                    }
+                }
+            }
+        }
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'DDL_TEST'
+                        values '^TestSimple.*Insert$', 
+                            '^TestSimple.*Update$',
+                            '^TestSimple.*Delete$',
+                            '^TestSimple(Mixed|Inc)?$',
+                            '^TestColumn$',
+                            '^TestIndex$'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        yamlFile POD_TEMPLATE_FILE
+                        defaultContainer 'golang'
+                    }
+                }
+                stages {
+                    stage("Test") {
+                        options { timeout(time: 40, unit: 'MINUTES') }
+                        steps {
+                            dir('tidb-test') {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                    sh """
+                                        ls -alh bin/
+                                        ./bin/pd-server -V
+                                        ./bin/tikv-server -V
+                                        ./bin/tidb-server -V
+                                    """
+                                    container("golang") {
+                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+
+                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                            export log_level=debug
+                                            export PATH=`pwd`/bin:\$PATH
+                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        post{
+                            failure {
+                                script {
+                                    println "Test failed, archive the log"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pod.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
+        limits:
+          memory: 16Gi
+          cpu: "6"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -87,3 +87,13 @@ presubmits:
       context: pull-mysql-client-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-mysql-client-test-next-gen(?: .*?)?$"
       rerun_command: "/test pull-mysql-client-test-next-gen"
+
+    - <<: *brancher
+      name: pingcap/tidb/pull_integration_ddl_test_next_gen
+      agent: jenkins
+      decorate: false # need add this.
+      # skip_if_only_changed: *skip_if_only_changed
+      optional: true
+      context: pull-integration-ddl-test-next-gen
+      trigger: "(?m)^/test (?:.*? )?pull-integration-ddl-test-next-gen(?: .*?)?$"
+      rerun_command: "/test pull-integration-ddl-test-next-gen"


### PR DESCRIPTION
- Introduce pipeline and pod configuration for `pull_integration_ddl_test_next_gen`
- Register the job in `latest-presubmits-next-gen.yaml`
- Define stages for debugging, checkout, preparation, and testing

This commit enhances the CI/CD process for the TiDB project by adding a dedicated job for integration DDL tests, ensuring better testing coverage for next-gen features.


Close #3582