### PR TITLE
feat(pingcap/tidb): add new integration test job for BR next-gen

### DIFF
--- a/jobs/pingcap/tidb/latest/pull_br_integration_test_next_gen.groovy
+++ b/jobs/pingcap/tidb/latest/pull_br_integration_test_next_gen.groovy
@@ -1,0 +1,42 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+final fullRepo = 'pingcap/tidb'
+final branchAlias = 'latest' // For trunk and latest release branches.
+final jobName = 'pull_br_integration_test_next_gen'
+
+pipelineJob("${fullRepo}/${jobName}") {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        // priority(0) // 0 fast than 1
+        githubProjectUrl("https://github.com/${fullRepo}")
+    }
+
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/${fullRepo}/${branchAlias}/${jobName}/pipeline.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
@@ -1,0 +1,139 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+@Library('tipipeline') _
+
+final BRANCH_ALIAS = 'latest'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_FULL_REPO_NAME = 'pingcap/tidb'
+final K8S_NAMESPACE = "jenkins-tidb"
+final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+final TARGET_BRANCH_PD = "master"
+final TARGET_BRANCH_TIFLASH = "master"
+final TARGET_BRANCH_TIKV = "dedicated"
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        NEXT_GEN = '1'
+        OCI_ARTIFACT_HOST = 'hub-mig.pingcap.net'
+    }
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+        // parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            options { timeout(time: 5, unit: 'MINUTES') }
+            steps {
+                dir("tidb") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("Prepare") {
+            steps {
+                dir(REFS.repo) {
+                    sh label: 'tidb-server failpoint binary', script: 'make failpoint-enable server failpoint-disable'
+                    sh label: 'br test binary', script: 'make build_for_br_integration_test'
+                    container("utils") {
+                        dir('bin') {
+                            sh """
+                                script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                chmod +x \$script
+                                \${script} --pd=${TARGET_BRANCH_PD}-next-gen --tikv=${TARGET_BRANCH_TIKV}-next-gen --tikv-worker=${TARGET_BRANCH_TIKV}-next-gen --tiflash=${TARGET_BRANCH_TIFLASH}-next-gen
+                            """
+                        }
+                    }
+                    // cache it for other pods
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
+                        sh """
+                            touch rev-${REFS.pulls[0].sha}
+                        """
+                    }
+                }
+            }
+        }
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_GROUP'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08', 'others'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        defaultContainer 'golang'
+                        yamlFile POD_TEMPLATE_FILE
+                    }
+                }
+                stages {
+                    stage("Test") {
+                        environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+                        options { timeout(time: 45, unit: 'MINUTES') }
+                        steps {
+                            dir(REFS.repo) {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
+                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
+                                }                       
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
+                                    chmod +x br/tests/*.sh && ./br/tests/run_group_br_tests.sh ${TEST_GROUP}
+                                """
+                            }
+                        }
+                        post{
+                            failure {
+                                sh label: "collect logs", script: """
+                                    ls /tmp/backup_restore_test
+                                    tar --warning=no-file-changed -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/backup_restore_test/ -type f -name "*.log")
+                                    ls -alh  log-${TEST_GROUP}.tar.gz
+                                """
+                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
+                            }
+                            success {
+                                dir(REFS.repo) {
+                                    sh 'ls -alh /tmp/group_cover && gocovmerge /tmp/group_cover/cov.* > coverage.txt'
+                                    script {
+                                        prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.txt')
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pod.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  initContainers:
+    - name: init-mysql-config
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      command:
+        - sh
+        - -c
+        - |
+          echo "[client]" > /mysql-config/.my.cnf
+          echo "ssl-mode=DISABLED" >> /mysql-config/.my.cnf
+      volumeMounts:
+        - mountPath: "/mysql-config"
+          name: "mysql-config-volume"
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 12Gi
+          cpu: "2"
+        limits:
+          memory: 16Gi
+          cpu: "4"
+      volumeMounts:
+        - mountPath: "/home/jenkins/.my.cnf"
+          name: "mysql-config-volume"
+          subPath: ".my.cnf"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi          
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+              - key: ci-nvme-high-performance
+                operator: In
+                values:
+                  - "true"
+  volumes:
+    - name: mysql-config-volume
+      emptyDir: {}

--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -87,3 +87,13 @@ presubmits:
       context: pull-mysql-client-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-mysql-client-test-next-gen(?: .*?)?$"
       rerun_command: "/test pull-mysql-client-test-next-gen"
+
+    - <<: *brancher
+      name: pingcap/tidb/pull_br_integration_test_next_gen
+      agent: jenkins
+      decorate: false # need add this.
+      # run_if_changed: "(br|pkg/(ddl|domain|infoschema))/.*"
+      optional: true
+      context: pull-br-integration-test-next-gen
+      trigger: "(?m)^/test (?:.*? )?pull-br-integration-test-next-gen(?: .*?)?$"
+      rerun_command: "/test pull-br-integration-test-next-gen"


### PR DESCRIPTION
- Introduced a new Jenkins pipeline job for the `pull_br_integration_test_next_gen`, including its configuration in the job DSL and Prow presubmits.
- Created associated pipeline and pod specifications to facilitate the integration testing process.
- Implemented caching and resource management for Kubernetes pods to optimize performance.

This addition enhances the CI/CD capabilities for the TiDB project, ensuring robust testing for the BR integration.

Close #3581