### PR TITLE
refactor(tikv/pd): migrate presubmit `build` jobs from Jenkins to Kubernetes

### DIFF
--- a/prow-jobs/tikv/pd/release-6.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-6.1-presubmits.yaml
@@ -18,6 +18,7 @@ presubmits:
     - <<: *branches
       name: pull-build-release-6.1
       agent: kubernetes
+      cluster: gcp-prow-ksyun      
       decorate: true # need add this.
       skip_if_only_changed: *skip_if_only_changed
       spec:

--- a/prow-jobs/tikv/pd/release-6.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-6.1-presubmits.yaml
@@ -1,15 +1,27 @@
+global_definitions:
+  branches: &branches
+    - ^release-6\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
+    - ^feature/release-6.1(.\d+)?-.+$
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  affinity: &affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
   tikv/pd:
-    - name: pull-build-release-6.1
+    - <<: *branches
+      name: pull-build-release-6.1
       agent: kubernetes
-      cluster: gcp-prow-ksyun
       decorate: true # need add this.
-      always_run: true
-      context: idc-jenkins-ci/build
-      branches:
-        - ^release-6\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
+      skip_if_only_changed: *skip_if_only_changed
       spec:
+        affinity: *affinity
         containers:
           - name: build
             image: hub.pingcap.net/ee/ci/base:v20230803-go1.19.12

--- a/prow-jobs/tikv/pd/release-6.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-6.1-presubmits.yaml
@@ -15,12 +15,12 @@ global_definitions:
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
   tikv/pd:
-    - <<: *branches
-      name: pull-build-release-6.1
+    - name: pull-build-release-6.1
       agent: kubernetes
       cluster: gcp-prow-ksyun
       decorate: true # need add this.
       skip_if_only_changed: *skip_if_only_changed
+      branches: *branches
       spec:
         affinity: *affinity
         containers:
@@ -47,12 +47,3 @@ presubmits:
           - name: gomod-cache
             persistentVolumeClaim:
               claimName: gomod-cache
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/arch
-                      operator: In
-                      values:
-                        - amd64

--- a/prow-jobs/tikv/pd/release-6.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-6.1-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
     - <<: *branches
       name: pull-build-release-6.1
       agent: kubernetes
-      cluster: gcp-prow-ksyun      
+      cluster: gcp-prow-ksyun
       decorate: true # need add this.
       skip_if_only_changed: *skip_if_only_changed
       spec:

--- a/prow-jobs/tikv/pd/release-6.5-fips-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-6.5-fips-presubmits.yaml
@@ -1,12 +1,38 @@
+global_definitions:
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  affinity: &affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
   tikv/pd:
-    - name: tikv/pd/release-6.5-fips/ghpr_build
-      agent: jenkins
-      decorate: false # need add this.
-      always_run: true
-      context: idc-jenkins-ci/build
-      trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
-      rerun_command: "/test build"
+    - name: pull-build-release-6.5-fips
+      agent: kubernetes
+      decorate: true # need add this.
+      skip_if_only_changed: *skip_if_only_changed
       branches:
         - ^feature/release-6.5-fips$
+      spec:
+        affinity: *affinity
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/pd:v2024.10.8-91-g6221afa-centos7-go1.19
+            command: [bash, -ce]
+            args:
+              - |
+                ENABLE_FIPS=1 WITH_RACE=1 make # build for race mode
+                ENABLE_FIPS=1 make             # build for normal mode
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "4"
+                memory: 8Gi

--- a/prow-jobs/tikv/pd/release-6.5-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-6.5-presubmits.yaml
@@ -1,18 +1,42 @@
-# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 global_definitions:
   branches: &branches
     - ^release-6\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
     - ^feature/release-6.5(.\d+)?-.+$
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  affinity: &affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
 
+# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
   tikv/pd:
-    - name: tikv/pd/release-6.5/ghpr_build
-      agent: jenkins
-      decorate: false # need add this.
-      always_run: true
-      context: idc-jenkins-ci/build
-      trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
-      rerun_command: "/test build"
+    - name: pull-build-release-6.5
+      agent: kubernetes
+      decorate: true # need add this.
+      skip_if_only_changed: *skip_if_only_changed
       branches: *branches
       skip_branches:
         - ^release-6\.5-20241101-v6\.5\.7$ # exclude release-6.5-20241101-v6.5.7 hotfix branch
+      spec:
+        affinity: *affinity
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/pd:v2024.10.8-91-g6221afa-centos7-go1.19
+            command: [bash, -ce]
+            args:
+              - |
+                WITH_RACE=1 make # build for race mode
+                make             # build for normal mode
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "4"
+                memory: 8Gi

--- a/prow-jobs/tikv/pd/release-7.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-7.1-presubmits.yaml
@@ -1,20 +1,46 @@
-# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 global_definitions:
   branches: &branches
     - ^release-7\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
     # for feature branch based on release versions
     - ^feature/release-7.1(.\d+)?-.+$
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  affinity: &affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
 
+# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
   tikv/pd:
-    - name: tikv/pd/release-7.1/ghpr_build
-      agent: jenkins
-      decorate: false # need add this.
-      always_run: true
-      context: idc-jenkins-ci/build
-      trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
-      rerun_command: "/test build"
+    - name: pull-build-release-7.1
+      agent: kubernetes
+      decorate: true # need add this.
+      skip_if_only_changed: *skip_if_only_changed
       branches: *branches
+      skip_branches:
+        - ^release-6\.5-20241101-v6\.5\.7$ # exclude release-6.5-20241101-v6.5.7 hotfix branch
+      spec:
+        affinity: *affinity
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/pd:v2024.10.8-91-g6221afa-centos7-go1.20
+            command: [bash, -ce]
+            args:
+              - |
+                WITH_RACE=1 make # build for race mode
+                make             # build for normal mode
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "4"
+                memory: 8Gi
 
     - name: tikv/pd/release-7.1/pull_integration_copr_test
       agent: jenkins

--- a/prow-jobs/tikv/pd/release-7.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-7.1-presubmits.yaml
@@ -22,8 +22,6 @@ presubmits:
       decorate: true # need add this.
       skip_if_only_changed: *skip_if_only_changed
       branches: *branches
-      skip_branches:
-        - ^release-6\.5-20241101-v6\.5\.7$ # exclude release-6.5-20241101-v6.5.7 hotfix branch
       spec:
         affinity: *affinity
         containers:

--- a/prow-jobs/tikv/pd/release-7.5-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-7.5-presubmits.yaml
@@ -3,18 +3,42 @@ global_definitions:
     - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
     # for feature branch based on release versions
     - ^feature/release-7.5(.\d+)?-.+$
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  affinity: &affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
   tikv/pd:
-    - name: tikv/pd/release-7.5/ghpr_build
-      agent: jenkins
-      decorate: false # need add this.
-      always_run: true
-      context: idc-jenkins-ci/build
-      trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
-      rerun_command: "/test build"
+    - name: pull-build-release-7.5
+      agent: kubernetes
+      decorate: true # need add this.
+      skip_if_only_changed: *skip_if_only_changed
       branches: *branches
+      spec:
+        affinity: *affinity
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/pd:v2024.10.8-91-g6221afa-centos7-go1.21
+            command: [bash, -ce]
+            args:
+              - |
+                WITH_RACE=1 make # build for race mode
+                make             # build for normal mode
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "4"
+                memory: 8Gi
 
     - name: tikv/pd/release-7.5/pull_integration_copr_test
       agent: jenkins

--- a/prow-jobs/tikv/pd/release-8.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-8.1-presubmits.yaml
@@ -1,20 +1,44 @@
 global_definitions:
   branches: &branches
     - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
-    # for feature branch based on release versions
     - ^feature/release-8.1(.\d+)?-.+$
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  affinity: &affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
   tikv/pd:
-    - name: tikv/pd/release-8.1/ghpr_build
-      agent: jenkins
-      decorate: false # need add this.
-      always_run: true
-      context: idc-jenkins-ci/build
-      trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
-      rerun_command: "/test build"
+    - name: pull-build-release-8.1
+      agent: kubernetes
+      decorate: true # need add this.
+      skip_if_only_changed: *skip_if_only_changed
       branches: *branches
+      spec:
+        affinity: *affinity
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/pd:v2024.10.8-91-g6221afa-centos7-go1.21
+            command: [bash, -ce]
+            args:
+              - |
+                WITH_RACE=1 make # build for race mode
+                make             # build for normal mode
+            resources:
+              requests:
+                cpu: "2"
+                memory: "4Gi"
+              limits:
+                cpu: "4"
+                memory: 8Gi
+
     - name: tikv/pd/release-8.1/pull_integration_copr_test
       agent: jenkins
       decorate: false # need add this.

--- a/prow-jobs/tikv/pd/release-8.5-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-8.5-presubmits.yaml
@@ -2,18 +2,42 @@ global_definitions:
   branches: &branches
     - ^release-8\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
     - ^feature/release-8.5(.\d+)?-.+$
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  affinity: &affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
   tikv/pd:
-    - name: tikv/pd/release-8.5/ghpr_build
-      agent: jenkins
-      decorate: false # need add this.
-      always_run: true
-      context: idc-jenkins-ci/build
-      trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
-      rerun_command: "/test build"
+    - name: pull-build-release-8.5
+      agent: kubernetes
+      decorate: true # need add this.
+      skip_if_only_changed: *skip_if_only_changed
       branches: *branches
+      spec:
+        affinity: *affinity
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/pd:v2025.5.11-8-g6a5de16-centos7-go1.23
+            command: [bash, -ce]
+            args:
+              - |
+                WITH_RACE=1 make # build for race mode
+                make             # build for normal mode
+            resources:
+              requests:
+                cpu: "3"
+                memory: "6Gi"
+              limits:
+                cpu: "6"
+                memory: 12Gi
 
     - name: tikv/pd/release-8.5/pull_integration_copr_test
       agent: jenkins


### PR DESCRIPTION
- Add Kubernetes-based build jobs for all PD release branches.
- Define shared global settings for resource requests, affinity, and file change skipping.
- Update images and build commands per release.
- Remove old Jenkins job definitions.