### PR TITLE
fix(pingcap/tidb): add `-next-gen` flag to pluginpkg commands for plugins

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy
@@ -96,11 +96,11 @@ pipeline {
 
                     # compile go plugin: audit
                     pushd enterprise-plugin/audit && go mod tidy && popd
-                    pushd ${REFS.repo} && go run ./cmd/pluginpkg -pkg-dir ../enterprise-plugin/audit -out-dir ../plugin-so && popd
+                    pushd ${REFS.repo} && go run ./cmd/pluginpkg -next-gen -pkg-dir ../enterprise-plugin/audit -out-dir ../plugin-so && popd
 
                     # compile go plugin: whitelist
                     pushd enterprise-plugin/whitelist && go mod tidy && popd
-                    pushd ${REFS.repo} && go run ./cmd/pluginpkg -pkg-dir ../enterprise-plugin/whitelist -out-dir ../plugin-so && popd
+                    pushd ${REFS.repo} && go run ./cmd/pluginpkg -next-gen -pkg-dir ../enterprise-plugin/whitelist -out-dir ../plugin-so && popd
 
                     # test them.
                     make server -C ${REFS.repo}


### PR DESCRIPTION
This pull request updates the pipeline configuration to use the next-generation plugin packaging approach for compiling Go plugins. The changes ensure that the `pluginpkg` command includes the `-next-gen` flag when processing plugins.

Pipeline configuration updates:

* [`pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy`](diffhunk://#diff-5d07f8a0316f7735c0722f8e9c4a63832c0fdef8f6ce42ee56dac322b85304c1L99-R103): Updated the `pluginpkg` command to include the `-next-gen` flag for both the `audit` and `whitelist` Go plugins, reflecting a shift to the next-generation plugin packaging method.