### PR TITLE
feature(prow-jobs/pingcap/tidb): enable auto run for pull_build_next_gen job

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -22,7 +22,7 @@ presubmits:
       name: pingcap/tidb/pull_check_next_gen
       agent: jenkins
       decorate: false # need add this.
-      # skip_if_only_changed: *skip_if_only_changed
+      skip_if_only_changed: *skip_if_only_changed
       optional: true
       context: pull-check-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-check-next-gen(?: .*?)?$"
@@ -52,7 +52,7 @@ presubmits:
       name: pingcap/tidb/pull_unit_test_next_gen
       agent: jenkins
       decorate: false # need add this.
-      # skip_if_only_changed: *skip_if_only_changed
+      skip_if_only_changed: *skip_if_only_changed
       optional: true
       context: pull-unit-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-unit-test-next-gen(?: .*?)?$"
@@ -62,7 +62,7 @@ presubmits:
       name: pingcap/tidb/pull_unit_test_ddlv1_next_gen
       agent: jenkins
       decorate: false # need add this.
-      # run_if_changed: "pkg/(ddl|meta)/.*"
+      run_if_changed: "pkg/(ddl|meta)/.*"
       optional: true
       context: pull-unit-test-ddlv1-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-unit-test-ddlv1-next-gen(?: .*?)?$"
@@ -82,7 +82,7 @@ presubmits:
       name: pingcap/tidb/pull_mysql_client_test_next_gen
       agent: jenkins
       decorate: false # need add this.
-      # skip_if_only_changed: *skip_if_only_changed
+      skip_if_only_changed: *skip_if_only_changed
       optional: true
       context: pull-mysql-client-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-mysql-client-test-next-gen(?: .*?)?$"

--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -14,7 +14,7 @@ presubmits:
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       optional: true
-      context: pull-build-next-gen
+      context: non-block-pull-build-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-build-next-gen(?: .*?)?$"
       rerun_command: "/test pull-build-next-gen"
 
@@ -24,7 +24,7 @@ presubmits:
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       optional: true
-      context: pull-check-next-gen
+      context: non-block-pull-check-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-check-next-gen(?: .*?)?$"
       rerun_command: "/test pull-check-next-gen"
 
@@ -54,7 +54,7 @@ presubmits:
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       optional: true
-      context: pull-unit-test-next-gen
+      context: non-block-pull-unit-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-unit-test-next-gen(?: .*?)?$"
       rerun_command: "/test pull-unit-test-next-gen"
 
@@ -64,7 +64,7 @@ presubmits:
       decorate: false # need add this.
       run_if_changed: "pkg/(ddl|meta)/.*"
       optional: true
-      context: pull-unit-test-ddlv1-next-gen
+      context: non-block-pull-unit-test-ddlv1-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-unit-test-ddlv1-next-gen(?: .*?)?$"
       rerun_command: "/test pull-unit-test-ddlv1-next-gen"
 
@@ -82,9 +82,9 @@ presubmits:
       name: pingcap/tidb/pull_mysql_client_test_next_gen
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: *skip_if_only_changed
+      # skip_if_only_changed: *skip_if_only_changed
       optional: true
-      context: pull-mysql-client-test-next-gen
+      context: non-block-pull-mysql-client-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-mysql-client-test-next-gen(?: .*?)?$"
       rerun_command: "/test pull-mysql-client-test-next-gen"
 

--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -12,7 +12,7 @@ presubmits:
       name: pingcap/tidb/pull_build_next_gen
       agent: jenkins
       decorate: false # need add this.
-      # skip_if_only_changed: *skip_if_only_changed
+      skip_if_only_changed: *skip_if_only_changed
       optional: true
       context: pull-build-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-build-next-gen(?: .*?)?$"


### PR DESCRIPTION
This pull request updates the `context` fields in the `latest-presubmits-next-gen.yaml` file to reflect non-blocking statuses for various presubmit jobs. Additionally, it removes commented-out lines and ensures proper configuration for `skip_if_only_changed` and `run_if_changed` fields.

### Updates to presubmit job configurations:

* **Context field updates**:
  - Changed `context` values to indicate non-blocking statuses for the following jobs:
    - `pull-build-next-gen` → `non-block-pull-build-next-gen`
    - `pull-check-next-gen` → `non-block-pull-check-next-gen`
    - `pull-unit-test-next-gen` → `non-block-pull-unit-test-next-gen`
    - `pull-unit-test-ddlv1-next-gen` → `non-block-pull-unit-test-ddlv1-next-gen`
    - `pull-mysql-client-test-next-gen` → `non-block-pull-mysql-client-test-next-gen`

* **Configuration fixes**:
  - Removed commented-out `skip_if_only_changed` lines and replaced them with active configurations for relevant jobs. [[1]](diffhunk://#diff-6d136e7cf0b5751935f337e8b7065f23f4f547f7f85072637dbab6476832439eL15-R27) [[2]](diffhunk://#diff-6d136e7cf0b5751935f337e8b7065f23f4f547f7f85072637dbab6476832439eL55-R67)
  - Enabled the `run_if_changed` field for `pull-unit-test-ddlv1-next-gen` with the pattern `"pkg/(ddl|meta)/.*"`.