### PR TITLE
feat(pingcap/tidb): auto handle tidb-test PR task add support for hotfix branch 

### DIFF
--- a/prow-jobs/pingcap/tidb/common-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/common-postsubmits.yaml
@@ -12,6 +12,7 @@ postsubmits:
         - ^master$
         - ^feature/release-.*$
         - ^release-[0-9]+[.][0-9]+(-beta.[0-9]+)?$
+        - ^release-[0-9]+[.][0-9]+(-[0-9]+-v[0-9]+[.][0-9]+[.][0-9]+(-[0-9]+)?)?$
       spec:
         containers:
           - name: main


### PR DESCRIPTION
When a tidb PR is associated with changes in tidb-test, the bot will automatically handle the merging of the tidb-test PR (if the tidb PR is merged). Currently, this task supports the master and release branches, and now we need to add support for the hotfix branch. example:

* release-8.5-20250606-v8.5.2
* release-8.5-20250606-v8.5.2-1