### PR TITLE
fix(monitoring): update base_ref to release-9.0-beta.2

### DIFF
--- a/prow-jobs/pingcap/monitoring/periodics.yaml
+++ b/prow-jobs/pingcap/monitoring/periodics.yaml
@@ -96,7 +96,7 @@ periodics:
     extra_refs: # Periodic job doesn't clone any repo by default, needs to be added explicitly
       - org: pingcap
         repo: monitoring
-        base_ref: release-9.0-beta.1 # update it to new branch name when it's finished.
+        base_ref: release-9.0-beta.2 # update it to new branch name when it's finished.
         skip_submodules: true
         clone_depth: 1
     spec:


### PR DESCRIPTION
This PR updates the base reference in the monitoring periodic job from `release-9.0-beta.1` to `release-9.0-beta.2` to align with the latest beta branch.