### PR TITLE
fix(pipelines/tiflow): update binary download script references to specific release versions on hotfix branch

### DIFF
--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-7.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     
@@ -114,7 +114,7 @@ pipeline {
                                     mv tmp_bin/* bin/ && rm -rf tmp_bin
                                 else
                                     echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-7.1
                                 fi
                                 
                                 make check_third_party_binary

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-7.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-7.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     
@@ -114,7 +114,7 @@ pipeline {
                                     mv tmp_bin/* bin/ && rm -rf tmp_bin
                                 else
                                     echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-7.1
                                 fi
                                 
                                 make check_third_party_binary

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     
@@ -114,7 +114,7 @@ pipeline {
                                     mv tmp_bin/* bin/ && rm -rf tmp_bin
                                 else
                                     echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.1
                                 fi
                                 
                                 make check_third_party_binary

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     
@@ -114,7 +114,7 @@ pipeline {
                                     mv tmp_bin/* bin/ && rm -rf tmp_bin
                                 else
                                     echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.1
                                 fi
                                 
                                 make check_third_party_binary

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     
@@ -114,7 +114,7 @@ pipeline {
                                     mv tmp_bin/* bin/ && rm -rf tmp_bin
                                 else
                                     echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.1
                                 fi
                                 
                                 make check_third_party_binary

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     
@@ -114,7 +114,7 @@ pipeline {
                                     mv tmp_bin/* bin/ && rm -rf tmp_bin
                                 else
                                     echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.1
                                 fi
                                 
                                 make check_third_party_binary

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     
@@ -114,7 +114,7 @@ pipeline {
                                     mv tmp_bin/* bin/ && rm -rf tmp_bin
                                 else
                                     echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.5
                                 fi
                                 
                                 make check_third_party_binary

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     
@@ -114,7 +114,7 @@ pipeline {
                                     mv tmp_bin/* bin/ && rm -rf tmp_bin
                                 else
                                     echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.5
                                 fi
                                 
                                 make check_third_party_binary

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     
@@ -114,7 +114,7 @@ pipeline {
                                     mv tmp_bin/* bin/ && rm -rf tmp_bin
                                 else
                                     echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.5
                                 fi
                                 
                                 make check_third_party_binary

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                                     echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
                                     
                                     # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
                                     rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
                                     
@@ -114,7 +114,7 @@ pipeline {
                                     mv tmp_bin/* bin/ && rm -rf tmp_bin
                                 else
                                     echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
+                                    ./scripts/download-integration-test-binaries.sh release-8.5
                                 fi
                                 
                                 make check_third_party_binary


### PR DESCRIPTION
Updated the binary download script references in multiple integration test files to use the specific release version (release-7.1, release-8.1, release-8.5) instead of the base reference. This change ensures that the correct binaries are downloaded for the respective release branches.

This is to ensure that there are no errors when executing downloads for the hotfix branch; in fact, the hotfix branch will download dependencies with precise tags.