### PR TITLE
chore(pipelines/tiflash): fix checkout submodule failed due to permission on branch release-9.0-beta

### DIFF
--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
@@ -79,6 +79,7 @@ pipeline {
                             git version
                             git status
                             """
+                            git.setSshKey(GIT_CREDENTIALS_ID)
                             prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()

--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_unit_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                             git version
                             git status
                             """
+                            git.setSshKey(GIT_CREDENTIALS_ID)
                             prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
@@ -104,6 +104,7 @@ pipeline {
                         git version
                         git status
                         """
+                        git.setSshKey(GIT_CREDENTIALS_ID)
                         retry(2) {
                             prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_unit_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                         git version
                         git status
                         """
+                        git.setSshKey(GIT_CREDENTIALS_ID)
                         retry(2) {
                             prow.checkoutRefs(REFS, timeout = 5, credentialsId = '', gitBaseUrl = 'https://github.com', withSubmodule=true)
                             dir("contrib/tiflash-proxy") {


### PR DESCRIPTION
Added the SSH key configuration using `git.setSshKey(GIT_CREDENTIALS_ID)` to the following scripts: merged_build.groovy, merged_unit_test.groovy, pull_integration_test.groovy, and pull_unit_test.groovy. This change enhances the security and accessibility of Git operations within the pipeline.