### PR TITLE
chore(prow-jobs/pingcap-inc/tici): update container images to  v2025.6.29-2-g2b88550

### DIFF
--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
       spec:
         containers:
           - name: build-debug
-            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2024.10.8-139-g74d1fec-centos7-devtoolset10
+            image: ghcr.io/pingcap-qe/ci/tici:v2025.6.29-2-g2b88550
             command: [/bin/bash, -ce]
             args:
               - |
@@ -52,7 +52,7 @@ presubmits:
       spec:
         containers:
           - name: e2e
-            image: ghcr.io/pingcap-qe/ci/tici:v2025.6.8-1-g5c4ef89 # Use a patched CDC version to output handle.
+            image: ghcr.io/pingcap-qe/ci/tici:v2025.6.29-2-g2b88550 # Use a patched CDC version to output handle.
             command: [/bin/bash, -ce]
             env:
               - name: ASSET_DIR


### PR DESCRIPTION
Updated the container images in presubmits.yaml for both the build-debug and e2e jobs to the latest versions (v2025.6.29-2-g2b88550). This ensures that the jobs utilize the most recent features and fixes available in the CI environment.