### PR TITLE
chore(pipelines/cd): update tar command to include only 'bin/' directory for artifact packaging

### DIFF
--- a/jenkins/pipelines/cd/multibranch/build_pd_multi_branch.groovy
+++ b/jenkins/pipelines/cd/multibranch/build_pd_multi_branch.groovy
@@ -267,7 +267,7 @@ try {
                     release_one("pd","${githash}")
                     timeout(10) {
                         sh """
-                        tar --exclude=pd-server.tar.gz -czvf pd-server.tar.gz *
+                        tar -czvf pd-server.tar.gz bin/
                         curl -F ${filepath}=@pd-server.tar.gz ${FILE_SERVER_URL}/upload
                         curl -F ${filepath2}=@pd-server.tar.gz ${FILE_SERVER_URL}/upload
 

--- a/jenkins/pipelines/cd/multibranch/build_tidb_multi_branch.groovy
+++ b/jenkins/pipelines/cd/multibranch/build_tidb_multi_branch.groovy
@@ -377,7 +377,7 @@ try {
                     retry(3) {
                         timeout(10) {
                         sh """
-                        tar --exclude=tidb-server.tar.gz -czvf tidb-server.tar.gz *
+                        tar -czvf tidb-server.tar.gz bin/
                         bin/tidb-server -V
                         curl --fail -F  ${filepath}=@tidb-server.tar.gz ${FILE_SERVER_URL}/upload | egrep 'success'
                         curl --fail -F  ${filepath2}=@tidb-server.tar.gz ${FILE_SERVER_URL}/upload | egrep 'success'

--- a/jenkins/pipelines/cd/multibranch/build_tikv_multi_branch.groovy
+++ b/jenkins/pipelines/cd/multibranch/build_tikv_multi_branch.groovy
@@ -243,5 +243,4 @@ try {
     if(env.BRANCH_NAME == 'master'){
          upload_result_to_db()
     }
-
 }


### PR DESCRIPTION
Close https://github.com/PingCAP-QE/ci/issues/3625

Modified the tar command in build scripts for PD, TiDB, and TikV to package only the 'bin/' directory instead of all files, improving the efficiency of artifact creation. Reduce size by not packaging the source code.