### PR TITLE
refactor(pipelines/cd/build-common): remove redundant packaging logic for non-release versions of pd, tidb, and tidb-test

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -817,11 +817,6 @@ def packageBinary() {
         sh """
         tar --exclude=${TARGET}.tar.gz -czvf ${TARGET}.tar.gz *
         """
-    //  pd,tidb,tidb-test 非release版本，和代码一起打包
-    } else if ((PRODUCT == "pd" || PRODUCT == "tidb" || PRODUCT == "tidb-test" ) && RELEASE_TAG.length() < 1) {
-        sh """
-        tar --exclude=${TARGET}.tar.gz -czvf ${TARGET}.tar.gz *
-        """
     } else if (PRODUCT == "tiem") {
         sh """
         tar --exclude=${TARGET}.tar.gz -czvf ${TARGET}.tar.gz *


### PR DESCRIPTION
Ref https://github.com/PingCAP-QE/ci/issues/3625

* Eliminated unnecessary packaging commands for non-release versions of pd, tidb, and tidb-test in the build-common.groovy script, streamlining the packageBinary function.
* For pd & tidb & tidb, all version builds do not include source code packaging by default, only when NEED_SOURCE_CODE is explicitly specified.
