### PR TITLE
chore(prow-jobs/pingcap-inc/tici): increase resource limits for tici presubmit jobs

### DIFF
--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -38,6 +38,9 @@ presubmits:
                 # check format & clippy
                 make check
             resources:
+              requests:
+                cpu: "6"
+                memory: 12Gi
               limits:
                 cpu: "6"
                 memory: 12Gi
@@ -65,6 +68,9 @@ presubmits:
                 make ci-prepare-test
                 make ci-run-test
             resources:
+              requests:
+                cpu: "6"
+                memory: 12Gi
               limits:
                 cpu: "6"
                 memory: 12Gi

--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -39,8 +39,8 @@ presubmits:
                 make check
             resources:
               limits:
-                cpu: "2"
-                memory: 8Gi
+                cpu: "6"
+                memory: 12Gi
 
     - <<: *brancher
       name: pull-e2e
@@ -66,5 +66,5 @@ presubmits:
                 make ci-run-test
             resources:
               limits:
-                cpu: "2"
-                memory: 8Gi
+                cpu: "6"
+                memory: 12Gi


### PR DESCRIPTION
To avoid task timeout(45 mins) failures caused by excessively long compilation times, we need to increase some request resources.

Updated CPU and memory resource limits for the 'check' and 'ci-run-test' jobs in presubmits.yaml to enhance performance during CI runs. CPU limit changed from 2 to 6 and memory limit from 8Gi to 12Gi.