### PR TITLE
docs-pdf: remove v8.3 and v8.4 as they are archived

### DIFF
--- a/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
@@ -12,4 +12,4 @@ postsubmits:
         - ^release-5\.4$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
-        - ^release-8\.[1345]$
+        - ^release-8\.[15]$

--- a/prow-jobs/pingcap/docs/docs-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-postsubmits.yaml
@@ -12,4 +12,4 @@ postsubmits:
         - ^release-5\.4$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
-        - ^release-8\.[1345]$
+        - ^release-8\.[15]$


### PR DESCRIPTION
This PR stops the PDF builds of the following versions of docs as they have been archived.

- TiDB v8.3
- TiDB v8.4