### PR TITLE
docs: change the cloud doc branch to release-8.1 for PDF outpu

### DIFF
--- a/pipelines/pingcap/docs/latest/merged_update_docs.groovy
+++ b/pipelines/pingcap/docs/latest/merged_update_docs.groovy
@@ -77,7 +77,7 @@ pipeline {
                             python3 scripts/merge_by_toc.py
                             scripts/generate_pdf.sh
                             # Generate PDF for TiDB Cloud
-                            if [ "${REFS.base_ref}" = "release-8.1" ]; then
+                            if [ "${REFS.base_ref}" = "release-8.5" ]; then
                                 python3 scripts/merge_by_toc.py TOC-tidb-cloud.md doc_cloud.md tidb-cloud
                                 scripts/generate_cloud_pdf.sh
                             fi


### PR DESCRIPTION
As the default version for new TiDB Dedicated clusters has been updated to v8.5.2, this PR updates the cloud documentation branch to release-8.5 for PDF generation.