### PR TITLE
chores(pingcap/tidb/release-8.5): update pull_integration_br_test.groovy

### DIFF
--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -126,7 +126,7 @@ pipeline {
                             }
                         }
                         post{
-                            failure {
+                            always {
                                 sh label: "collect logs", script: """
                                     ls /tmp/backup_restore_test
                                     tar --warning=no-file-changed -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/backup_restore_test/ -type f -name "*.log")


### PR DESCRIPTION
Also archive logs when aborted.

get the log to address the test timeout issue.