### PR TITLE
chore(prow-jobs/pingcap-inc/tici): update container images to v2025.7.13-2-gdf06f11

### DIFF
--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
       spec:
         containers:
           - name: build-debug
-            image: ghcr.io/pingcap-qe/ci/tici:v2025.6.29-4-g580a226_linux_amd64
+            image: ghcr.io/pingcap-qe/ci/tici:v2025.7.13-2-gdf06f11
             command: [/bin/bash, -ce]
             args:
               - |
@@ -53,7 +53,7 @@ presubmits:
       spec:
         containers:
           - name: e2e
-            image: ghcr.io/pingcap-qe/ci/tici:v2025.6.29-4-g580a226_linux_amd64 # Use a patched CDC version to output handle.
+            image: ghcr.io/pingcap-qe/ci/tici:v2025.7.13-2-gdf06f11
             command: [/bin/bash, -ce]
             env:
               - name: ASSET_DIR


### PR DESCRIPTION
Relate to https://github.com/PingCAP-QE/artifacts/pull/656.