### PR TITLE
fix(prow-jobs): update TARGET to release-9.0-beta.2 in monitoring periodics

### DIFF
--- a/prow-jobs/pingcap/monitoring/periodics.yaml
+++ b/prow-jobs/pingcap/monitoring/periodics.yaml
@@ -106,7 +106,7 @@ periodics:
           command: [bash, -ce]
           env:
             - name: TARGET
-              value: release-9.0-beta.1 # update it to new branch name when it's finished.
+              value: release-9.0-beta.2 # update it to new branch name when it's finished.
           resources:
             limits:
               memory: 4Gi

--- a/prow-jobs/pingcap/monitoring/periodics.yaml
+++ b/prow-jobs/pingcap/monitoring/periodics.yaml
@@ -14,7 +14,7 @@ periodics:
       activeDeadlineSeconds: 3600
       containers:
         - name: check
-          image: golang:1.23.2
+          image: golang:1.23.11
           env:
             - name: TARGET
               value: master
@@ -102,7 +102,7 @@ periodics:
     spec:
       containers:
         - name: check
-          image: golang:1.23
+          image: golang:1.23.11
           command: [bash, -ce]
           env:
             - name: TARGET
@@ -133,7 +133,7 @@ periodics:
     spec:
       containers:
         - name: check
-          image: golang:1.23.2
+          image: golang:1.23.11
           command: [bash, -ce]
           env:
             - name: TARGET


### PR DESCRIPTION
This pull request updates the `prow-jobs/pingcap/monitoring/periodics.yaml` file to use a more recent version of the Go programming language and updates a branch name in the environment configuration. These changes ensure the periodic jobs are using the latest stable tools and correct target branches.

### Updates to Go image versions:
* Updated the Go image from `golang:1.23.2` to `golang:1.23.11` in three different periodic job configurations to ensure compatibility with the latest patches and improvements. [[1]](diffhunk://#diff-42023fd3a034e5c540da3b9f7b6982f48acb7ee3545326f91f6abfb65cd92d4dL17-R17) [[2]](diffhunk://#diff-42023fd3a034e5c540da3b9f7b6982f48acb7ee3545326f91f6abfb65cd92d4dL136-R136)
* Updated the Go image from `golang:1.23` to `golang:1.23.11` in another periodic job configuration.

### Environment configuration update:
* Changed the `TARGET` environment variable value from `release-9.0-beta.1` to `release-9.0-beta.2` to reflect the updated branch name.