### PR TITLE
fix(prow-jobs/pingcap-inc/tici): fix `pull-verify` job

### DIFF
--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -27,6 +27,7 @@ presubmits:
             command: [/bin/bash, -ce]
             args:
               - |
+                set -ex
                 # Verify Rust environment
                 echo "Rust version: $(rustc --version)"
                 echo "Cargo version: $(cargo --version)"


### PR DESCRIPTION
Add `set -ex` to make the script can fail fast.