### PR TITLE
chore(pipelines/tidb): adjust timeout from 60min to 90min in build

### DIFF
--- a/pipelines/pingcap/tidb/release-7.1/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_build.groovy
@@ -20,7 +20,7 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_build.groovy
@@ -20,7 +20,7 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_build.groovy
@@ -20,7 +20,7 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {


### PR DESCRIPTION
In cases where there are many changes in the PR and the remote cache hit rate is low, the PR build and lint time for these branches may exceed 60 minutes, so adjust the timeout.