### PR TITLE
fix(pipelines/pingcap-qe/tidb-test): fix pipelines

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -134,7 +134,7 @@ pipeline {
                         steps {
                             dir(REFS.repo) {
                                 // restore the cache saved by previous stage.
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
+                                cache(path: './', includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     // if cache missed, it will fail(should not miss).
                                     sh 'chmod +x bin/{tidb-server,pd-server,tikv-server,tikv-worker}'
                                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -1,6 +1,5 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
-// should triggerd for master and latest release branches
 @Library('tipipeline') _
 
 final BRANCH_ALIAS = 'latest'
@@ -85,7 +84,7 @@ pipeline {
                     }
                     axis {
                         name 'STORE'
-                        values 'unistore', 'tikv'
+                        values 'unistore' //, 'tikv'
                     }
                 }
                 agent{
@@ -97,7 +96,6 @@ pipeline {
                 }
                 stages {
                     stage('Test') {
-                        options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
                                 // restore the cache saved by previous stage.


### PR DESCRIPTION
This pull request includes updates to the pipeline configuration for testing in the `tidb-test` project. The changes focus on improving caching, modifying test configurations, and cleaning up the pipeline scripts.

### Caching improvements:
* Updated the cache key in the `pull_integration_jdbc_test_next_gen` pipeline to use a workspace-specific key format (`ws/${BUILD_TAG}/tidb-test`) for better cache management. (`[pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovyL137-R137](diffhunk://#diff-eea030b5a2abb8b2e5e3a1be2362ce7712fc41dd2b252430b51432f9d9663366L137-R137)`)

### Test configuration changes:
* Modified the `STORE` axis in the `pull_mysql_test_next_gen` pipeline to temporarily exclude `tikv` from the list of values. (`[pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovyL88-R87](diffhunk://#diff-7c278a7e52ae6c08b00ca70ee8f001a39c9c3cdd1a3c6570aebe98fe4e1a08b9L88-R87)`)
* Removed the timeout option from the `Test` stage in the `pull_mysql_test_next_gen` pipeline, potentially allowing tests to run without a time limit. (`[pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovyL100](diffhunk://#diff-7c278a7e52ae6c08b00ca70ee8f001a39c9c3cdd1a3c6570aebe98fe4e1a08b9L100)`)

### Code cleanup:
* Removed an outdated comment about triggering conditions in the `pull_mysql_test_next_gen` pipeline. (`[pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovyL3](diffhunk://#diff-7c278a7e52ae6c08b00ca70ee8f001a39c9c3cdd1a3c6570aebe98fe4e1a08b9L3)`)