### PR TITLE
refactor(pingcap/tidb): use oci download script in post-submit jobs

### DIFF
--- a/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -54,12 +54,14 @@ pipeline {
                 dir('tidb') {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                     dir('bin') {
-                        retry(3) {
-                            sh label: 'download binary', script: """
-                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                chmod +x \$script
-                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            """
+                        container('utils') {
+                            retry(3) {
+                                sh label: 'download binary', script: """
+                                    script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                    chmod +x \$script
+                                    \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                """
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -52,7 +52,9 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
                     dir('bin') {
                         container('utils') {
                             retry(3) {

--- a/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -72,16 +72,14 @@ pipeline {
         stage('Tests') {
             options { timeout(time: 30, unit: 'MINUTES') }
             steps {
-                dir('tidb') {
-                    sh label: 'test graceshutdown', script: """
-                    cd tests/graceshutdown && make
-                    ./run-tests.sh
-                    """
-                    sh label: 'test globalkilltest', script: """
-                    cd tests/globalkilltest && make
-                    cp ${WORKSPACE}/tidb/bin/tikv-server ${WORKSPACE}/tidb/bin/pd-server ./bin/
-                    PD=./bin/pd-server  TIKV=./bin/tikv-server ./run-tests.sh
-                    """
+                dir('tidb/tests/graceshutdown') {
+                    sh label: 'test graceshutdown', script: 'make && ./run-tests.sh'
+                }
+                dir('tidb/tests/globalkilltest') {
+                    sh sh label: 'test globalkilltest', script: '''
+                        make
+                        PD=${WORKSPACE}/tidb/bin/pd-server TIKV=${WORKSPACE}/tidb/bin/tikv-server ./run-tests.sh
+                    '''
                 }
             }
             post{

--- a/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -76,7 +76,7 @@ pipeline {
                     sh label: 'test graceshutdown', script: 'make && ./run-tests.sh'
                 }
                 dir('tidb/tests/globalkilltest') {
-                    sh sh label: 'test globalkilltest', script: '''
+                    sh label: 'test globalkilltest', script: '''
                         make
                         PD=${WORKSPACE}/tidb/bin/pd-server TIKV=${WORKSPACE}/tidb/bin/tikv-server ./run-tests.sh
                     '''

--- a/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -57,8 +57,8 @@ pipeline {
                         retry(3) {
                             sh label: 'download binary', script: """
                                 script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                chmod +x $script
-                                $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                chmod +x \$script
+                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
                             """
                         }
                     }

--- a/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -52,18 +52,15 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    retry(3) {
-                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
-                        sh label: 'download binary', script: """
-                            chmod +x \${WORKSPACE}/scripts/artifacts/*.sh
-                            \${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
+                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    dir('bin') {
+                        retry(3) {
+                            sh label: 'download binary', script: """
+                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                chmod +x $script
+                                $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            """
+                        }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -65,7 +65,9 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
                     dir('bin') {
                         container('utils') {
                             sh label: 'download binary', script: """

--- a/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -69,8 +69,8 @@ pipeline {
                     dir('bin') {
                         sh label: 'download binary', script: """
                             script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                            chmod +x $script
-                            $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            chmod +x \$script
+                            \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
                         """
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -65,28 +65,23 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    retry(3) {
-                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    dir('bin') {
                         sh label: 'download binary', script: """
-                        chmod +x \${WORKSPACE}/scripts/artifacts/*.sh
-                        \${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                        mv third_bin/tikv-server bin/
-                        mv third_bin/pd-server bin/
-                        ls -alh bin/
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
+                            script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                            chmod +x $script
+                            $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
                         """
                     }
                 }
                 dir('tidb-test') {
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                        sh 'cd tidb_test && ./build.sh'
+                        sh 'cd randgen-test && ./build.sh'
                         sh label: 'cache tidb-test', script: """
-                        touch ws-${BUILD_TAG}
-                        mkdir -p bin
-                        cp -r ../tidb/bin/{pd,tidb,tikv}-server bin/ && chmod +x bin/*
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp -r ../tidb/bin/{pd,tidb,tikv}-server bin/ && chmod +x bin/*
                         """
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -67,11 +67,13 @@ pipeline {
                 dir('tidb') {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                     dir('bin') {
-                        sh label: 'download binary', script: """
-                            script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                            chmod +x \$script
-                            \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                        """
+                        container('utils') {
+                            sh label: 'download binary', script: """
+                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                chmod +x \$script
+                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            """
+                        }
                     }
                 }
                 dir('tidb-test') {

--- a/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -68,6 +68,8 @@ pipeline {
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                     }
+                }
+                dir('tidb-test') {
                     dir('bin') {
                         container('utils') {
                             sh label: 'download binary', script: """
@@ -77,15 +79,10 @@ pipeline {
                             """
                         }
                     }
-                }
-                dir('tidb-test') {
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'cd tidb_test && ./build.sh'
-                        sh 'cd randgen-test && ./build.sh'
                         sh label: 'cache tidb-test', script: """
+                            cp -r ../tidb/bin/tidb-server bin/ && chmod +x bin/*
                             touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp -r ../tidb/bin/{pd,tidb,tikv}-server bin/ && chmod +x bin/*
                         """
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -73,8 +73,8 @@ pipeline {
                             retry(3) {
                                 sh label: 'download binary', script: """
                                     script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                    chmod +x $script
-                                    $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                    chmod +x \$script
+                                    \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
                                 """
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -69,15 +69,14 @@ pipeline {
             steps {
                 dir('tidb') {
                     container("golang") {
-                        retry(3) {
-                            sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            rm -rf bin && mkdir -p bin
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
-                            ls -alh bin/
-                            """
+                        dir('bin') {
+                            retry(3) {
+                                sh label: 'download binary', script: """
+                                    script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                    chmod +x $script
+                                    $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                """
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -68,8 +68,9 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    container("golang") {
-                        dir('bin') {
+                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    dir('bin') {
+                        container("utils") {
                             retry(3) {
                                 sh label: 'download binary', script: """
                                     script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"

--- a/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -68,7 +68,9 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
                     dir('bin') {
                         container("utils") {
                             retry(3) {

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -67,24 +67,21 @@ pipeline {
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                     }
-                    dir('bin') {
-                        container('utils') {
-                            retry(3) {
-                                sh label: 'download binary', script: """
-                                    script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                    chmod +x \$script
-                                    \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                """
-                            }
-                        }
-                    }
                 }
                 dir('tidb-test') {
+                    dir('bin') {
+                        container('utils') {
+                            sh label: 'download binary', script: """
+                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                chmod +x \$script
+                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            """
+                        }
+                    }
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                         sh label: 'cache tidb-test', script: """
-                        touch ws-${BUILD_TAG}
-                        mkdir -p bin
-                        cp -r ../tidb/bin/{pd,tidb,tikv}-server bin/ && chmod +x bin/*
+                            cp -r ../tidb/bin/tidb-server bin/ && chmod +x bin/*
+                            touch ws-${BUILD_TAG}
                         """
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -75,7 +75,6 @@ pipeline {
                         }
                     }
                 }
-                }
                 dir('tidb-test') {
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                         sh label: 'cache tidb-test', script: """

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -64,21 +64,17 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    retry(3) {
-                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    dir('bin') {
                         retry(3) {
                             sh label: 'download binary', script: """
-                            chmod +x \${WORKSPACE}/scripts/artifacts/*.sh
-                            \${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
+                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                chmod +x $script
+                                $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
                             """
                         }
                     }
+                }
                 }
                 dir('tidb-test') {
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -69,8 +69,8 @@ pipeline {
                         retry(3) {
                             sh label: 'download binary', script: """
                                 script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                chmod +x $script
-                                $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                chmod +x \$script
+                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
                             """
                         }
                     }

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -64,7 +64,9 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
                     dir('bin') {
                         container('utils') {
                             retry(3) {

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -66,12 +66,14 @@ pipeline {
                 dir('tidb') {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                     dir('bin') {
-                        retry(3) {
-                            sh label: 'download binary', script: """
-                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                chmod +x \$script
-                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            """
+                        container('utils') {
+                            retry(3) {
+                                sh label: 'download binary', script: """
+                                    script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                    chmod +x \$script
+                                    \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                """
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
@@ -53,35 +53,27 @@ pipeline {
         }
         stage('Prepare') {
             steps {
-                dir("third_party_download") {
-                    retry(2) {
-                        sh label: "download third_party", script: """#!/usr/bin/env bash
-                            rm -rf third_bin/
-                            rm -rf bin/
-                            chmod +x ../tidb/lightning/tests/*.sh
-                            ${WORKSPACE}/tidb/lightning/tests/download_integration_test_binaries.sh ${REFS.base_ref}
-                            mkdir -p bin && mv third_bin/* bin/
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                        """
-                    }
-                }
                 dir('tidb') {
+                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
+                    dir('bin') {
+                        container('utils') {
+                            sh label: 'download binary', script: """
+                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                chmod +x \$script
+                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            """
+                        }
+                    }
                     sh label: "check all tests added to group", script: """#!/usr/bin/env bash
-                        chmod +x lightning/tests/*.sh
-                        ./lightning/tests/run_group_lightning_tests.sh others
-                    """
-                    sh label: "prepare build", script: """#!/usr/bin/env bash
-                        [ -f ./bin/tidb-server ] || make
-                        [ -f ./bin/tidb-lightning.test ] || make build_for_lightning_integration_test
-                        ls -alh ./bin
-                        ./bin/tidb-server -V
-                    """
+                            chmod +x lightning/tests/*.sh
+                            ./lightning/tests/run_group_lightning_tests.sh others
+                        """
+                    sh '[ -f ./bin/tidb-lightning.test ] || make build_for_lightning_integration_test'
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/lightning-tests") {
-                        sh label: "prepare cache binary", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
+                        sh label: 'cache tidb-test', script: """
+                            touch ws-${BUILD_TAG}
                             ls -alh ./bin
                         """
                     }

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -65,7 +65,9 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
                     dir('bin') {
                         container('utils') {
                             retry(3) {

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -70,8 +70,8 @@ pipeline {
                         retry(3) {
                             sh label: 'download binary', script: """
                                 script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                chmod +x $script
-                                $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                chmod +x \$script
+                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
                             """
                         }
                     }

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -67,12 +67,14 @@ pipeline {
                 dir('tidb') {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                     dir('bin') {
-                        retry(3) {
-                            sh label: 'download binary', script: """
-                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                chmod +x \$script
-                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            """
+                        container('utils') {
+                            retry(3) {
+                                sh label: 'download binary', script: """
+                                    script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                    chmod +x \$script
+                                    \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                """
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -65,18 +65,15 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    retry(3) {
-                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
-                        sh label: 'download binary', script: """
-                            chmod +x \${WORKSPACE}/scripts/artifacts/*.sh
-                            \${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
+                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    dir('bin') {
+                        retry(3) {
+                            sh label: 'download binary', script: """
+                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                chmod +x $script
+                                $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            """
+                        }
                     }
                 }
                 dir('tidb-test') {

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -68,24 +68,21 @@ pipeline {
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                     }
-                    dir('bin') {
-                        container('utils') {
-                            retry(3) {
-                                sh label: 'download binary', script: """
-                                    script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                    chmod +x \$script
-                                    \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                """
-                            }
-                        }
-                    }
                 }
                 dir('tidb-test') {
+                    dir('bin') {
+                        container('utils') {
+                            sh label: 'download binary', script: """
+                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                chmod +x \$script
+                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            """
+                        }
+                    }
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                         sh label: 'cache tidb-test', script: """
-                        touch ws-${BUILD_TAG}
-                        mkdir -p bin
-                        cp -r ../tidb/bin/{pd,tidb,tikv}-server bin/ && chmod +x bin/*
+                            cp -r ../tidb/bin/tidb-server bin/ && chmod +x bin/*
+                            touch ws-${BUILD_TAG}
                         """
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
@@ -63,7 +63,9 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
                     dir('bin') {
                         sh label: 'download binary', script: """
                             script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"

--- a/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
@@ -67,8 +67,8 @@ pipeline {
                     dir('bin') {
                         sh label: 'download binary', script: """
                             script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                            chmod +x $script
-                            $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            chmod +x \$script
+                            \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
                             # chown -R 1000:1000 bin/
                         """
                     }

--- a/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
@@ -69,7 +69,7 @@ pipeline {
                             script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
                             chmod +x \$script
                             \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            # chown -R 1000:1000 bin/
+                            chown -R 1000:1000 bin/
                         """
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
@@ -67,8 +67,8 @@ pipeline {
                             retry(3) {
                                 sh label: 'download binary', script: """
                                     script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                    chmod +x $script
-                                    $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                    chmod +x \$script
+                                    \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
                                     ls -alh .
                                 """
                             }

--- a/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
@@ -61,29 +61,24 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
-                    dir('bin') {
-                        container("utils") {
-                            retry(3) {
-                                sh label: 'download binary', script: """
-                                    script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
-                                    chmod +x \$script
-                                    \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                    ls -alh .
-                                """
-                            }
-                        }
+                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                     }
                 }
                 dir('tidb-test') {
+                    dir('bin') {
+                        container('utils') {
+                            sh label: 'download binary', script: """
+                                script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                chmod +x \$script
+                                \$script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            """
+                        }
+                    }
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'cache tidb-test', script: """#!/usr/bin/env bash
-                        touch ws-${BUILD_TAG}
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
+                        sh label: 'cache tidb-test', script: """
+                            cp -r ../tidb/bin/tidb-server bin/ && chmod +x bin/*
+                            touch ws-${BUILD_TAG}
                         """
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
@@ -62,16 +62,16 @@ pipeline {
             steps {
                 dir('tidb') {
                     container("golang") {
-                        retry(3) {
-                            sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
-                            sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
-                            rm -rf bin/bin
-                            ls -alh bin/
-                            """
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
+                        dir('bin') {
+                            retry(3) {
+                                sh label: 'download binary', script: """
+                                    script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
+                                    chmod +x $script
+                                    $script --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                    ls -alh .
+                                """
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
@@ -61,9 +61,9 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    container("golang") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
-                        dir('bin') {
+                    sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
+                    dir('bin') {
+                        container("utils") {
                             retry(3) {
                                 sh label: 'download binary', script: """
                                     script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"

--- a/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
@@ -21,13 +21,7 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
+
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
@@ -21,13 +21,7 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
+
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
@@ -25,6 +25,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
@@ -31,6 +31,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: report
       image: hub.pingcap.net/jenkins/python3-requests:latest
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
@@ -41,13 +41,7 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
+
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
@@ -31,13 +31,7 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
+
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: report
       image: hub.pingcap.net/jenkins/python3-requests:latest
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_nodejs_test.yaml
@@ -21,13 +21,7 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
-    - name: report
-      image: hub.pingcap.net/jenkins/python3-requests:latest
-      tty: true
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 100m
+
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_nodejs_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
@@ -31,6 +31,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/scripts/artifacts/download_pingcap_oci_artifact.sh
+++ b/scripts/artifacts/download_pingcap_oci_artifact.sh
@@ -13,6 +13,7 @@ function fetch_file_from_oci_artifact() {
     # download file
     file="$(yq .annotations[\"org.opencontainers.image.title\"] blob.yaml)"
     blob="$repo@$(yq .digest blob.yaml)"
+    echo "🔗 blob fetching url: ${blob}" >&2
     oras blob fetch --output $file $blob
     rm blob.yaml
     echo "$file"
@@ -27,10 +28,9 @@ function download() {
         return
     fi
     echo "🚀 Downloading file with name matched regex: '${to_match_file}' from ${url}"
-
     echo "📦 == artifact information ======="
     oras manifest fetch-config "$url"
-    echo "===== artifact information =====🔚"
+    echo "================================🔚"
     local tarball_file=$(fetch_file_from_oci_artifact $url "${to_match_file}")
     mv -v "$tarball_file" "$file_path"
     echo "✅ Downloaded, saved in ${file_path}"


### PR DESCRIPTION
This pull request updates multiple CI pipeline scripts to streamline the process of downloading and preparing binaries, replacing the older artifact download script with a new OCI-based script. Additionally, minor enhancements were made to the new script for better logging and clarity.

### Pipeline updates to use the new OCI-based artifact download script:
* Replaced the `download_pingcap_artifact.sh` script with `download_pingcap_oci_artifact.sh` across multiple pipeline scripts, improving the binary download process. This includes changes to the following files:
  - `merged_e2e_test.groovy`
  - `merged_integration_common_test.groovy`
  - `merged_integration_copr_test.groovy`
  - `merged_integration_jdbc_test.groovy`
  - `merged_integration_mysql_test.groovy`
  - `merged_integration_nodejs_test.groovy`
  - `merged_integration_python_orm_test.groovy`

* Introduced a `bin` directory context in each pipeline's `Prepare` stage to better organize binary files during the download process. [[1]](diffhunk://#diff-0acea16b0d32f2b9a8ed66e8a1bd75bb975d6457d5d4c958b1b7cd23b4d73bb6L55-R67) [[2]](diffhunk://#diff-17c213e2b45a5e92c8997c08409a01fdbceaf40b80712b7b51db564b9ff533e8L68-L89) [[3]](diffhunk://#diff-968b4ab90556db2a81de172cb4dc966a63137139794bdc10be81ed3238317b3eR72-R84) [[4]](diffhunk://#diff-3ab4e2c6d3d7152407e91f4f116db51f4d9c6c696bd79d5f10af9588894830b8L67-R78) [[5]](diffhunk://#diff-c8d2f5747cba9cf5f6db92b674f51cde530def7144b469d13efaca4bab35375dL68-R78) [[6]](diffhunk://#diff-59b33aa494e6abfacd48e88f7ada1060eeb185ab027647c950255cd2f244551eL67-R81) [[7]](diffhunk://#diff-06bad8ed948ff470e5b41a84f45d7da3d200cfc38d4144b51b3611404d0ca4feL65-R77)

### Enhancements to the OCI artifact download script (`download_pingcap_oci_artifact.sh`):
* Added a log message to display the blob fetching URL for better traceability during downloads.
* Improved the formatting of artifact information logs for clarity.