### PR TITLE
feature(pingcap/tidb): enable job `pull_integration_ddl_test_next_gen` job

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
@@ -69,7 +69,7 @@ pipeline {
                                 \$script \
                                     --pd=${TARGET_BRANCH_PD}-next-gen \
                                     --tikv=${TARGET_BRANCH_TIKV}-next-gen \
-                                    --tikv-worker${TARGET_BRANCH_TIKV}-next-gen
+                                    --tikv-worker=${TARGET_BRANCH_TIKV}-next-gen
                             """
                         }
                     }

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
+        // parallelsAlwaysFailFast() // disable for debug.
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -22,7 +22,7 @@ pipeline {
     }
     options {
         timeout(time: 65, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
+        // parallelsAlwaysFailFast() // disable for debug.
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -129,6 +129,8 @@ pipeline {
                                 // run the test.
                                 // TODO: use a script for next-gen, consider merging the script.
                                 sh label: "store=${STORE} part=${PART}", script: """#!/usr/bin/env bash
+                                    set -euo pipefail
+
                                     if [ "$STORE" == "tikv" ]; then
                                         echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh

--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -92,7 +92,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_ddl_test_next_gen
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: *skip_if_only_changed
+      # skip_if_only_changed: *skip_if_only_changed
       optional: true
       context: non-block/pull-integration-ddl-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-integration-ddl-test-next-gen(?: .*?)?$"

--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -92,7 +92,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_ddl_test_next_gen
       agent: jenkins
       decorate: false # need add this.
-      # skip_if_only_changed: *skip_if_only_changed
+      skip_if_only_changed: *skip_if_only_changed
       optional: true
       context: non-block/pull-integration-ddl-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-integration-ddl-test-next-gen(?: .*?)?$"


### PR DESCRIPTION
This pull request focuses on restructuring and optimizing the CI/CD pipelines for integration and MySQL tests, as well as making small configuration adjustments. The most significant changes include removing unnecessary debug stages, improving caching and artifact handling, and ensuring better script reliability.

### Pipeline restructuring and optimization:

* Removed the `Debug info` stage from the `pull_integration_ddl_test_next_gen` pipeline, which included commands for printing environment variables, debugging commands, and network checks. This simplifies the pipeline by removing redundant steps. (`pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy`, [pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovyL32-L48](diffhunk://#diff-30290e50879c98b2b0d4bd9095242cb7de09be03866928f0674f312cd397b44eL32-L48))
* Improved the `Prepare` stage in the `pull_integration_ddl_test_next_gen` pipeline by introducing caching for `tidb` and `tidb-test` binaries, consolidating artifact downloads, and removing redundant container usage. This enhances efficiency and reduces build times. (`pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy`, [pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovyL74-R80](diffhunk://#diff-30290e50879c98b2b0d4bd9095242cb7de09be03866928f0674f312cd397b44eL74-R80))

### Script reliability improvement:

* Added `set -euo pipefail` to the MySQL test script to ensure stricter error handling, improving script reliability and maintainability. (`pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy`, [pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovyR132-R133](diffhunk://#diff-bace5d09f771329c3a3e1f6568129f82595f20ebc2866a7963be3053f86037fdR132-R133))

### Configuration adjustment:

* Enabled the `skip_if_only_changed` field in the `pull_integration_ddl_test_next_gen` presubmit configuration, ensuring that the job is skipped for irrelevant changes. (`prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml`, [prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yamlL95-R95](diffhunk://#diff-6d136e7cf0b5751935f337e8b7065f23f4f547f7f85072637dbab6476832439eL95-R95))