### PR TITLE
fix(pingcap/tidb): increate 8.5 lightning test request memory

### DIFF
--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml
@@ -9,10 +9,10 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 16Gi
+          memory: 32Gi
           cpu: "4"
         limits:
-          memory: 16Gi
+          memory: 32Gi
           cpu: "4"
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool


### PR DESCRIPTION
https://github.com/pingcap/tidb/issues/62666
<img width="1980" height="902" alt="img_v3_02om_d2bc7bc8-1b9e-44ee-af42-594fda8564cg" src="https://github.com/user-attachments/assets/209707a9-bba0-4459-8aaa-019b011568ea" />
