### PR TITLE
feat(pingcap/tidb): update presubmits for next-gen branches and context names

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -2,6 +2,7 @@ global_definitions:
   brancher: &brancher
     branches:
       - ^master$
+      - ^release-nextgen-\d+$
       - ^feature/next[-]gen.*
   skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
@@ -13,8 +14,7 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
-      optional: true
-      context: non-block/pull-build-next-gen
+      context: pull-build-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-build-next-gen(?: .*?)?$"
       rerun_command: "/test pull-build-next-gen"
 
@@ -23,8 +23,7 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
-      optional: true
-      context: non-block/pull-check-next-gen
+      context: pull-check-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-check-next-gen(?: .*?)?$"
       rerun_command: "/test pull-check-next-gen"
 


### PR DESCRIPTION

Add support for release-nextgen branches and make pull-build-next-gen and pull-check-next-gen contexts required instead of optional.
---
This pull request updates the `prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml` file to enhance branch targeting and modify presubmit job configurations for better alignment with the new "next-gen" workflow. The key changes include adding support for new branch patterns and updating job contexts to reflect mandatory checks.

### Branch targeting updates:
* Added support for branches matching the pattern `^release-nextgen-\d+
Add support for release-nextgen branches and make pull-build-next-gen and pull-check-next-gen contexts required instead of optional.

 in the global `brancher` configuration, enabling the inclusion of "next-gen" release branches. (`[prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yamlR5](diffhunk://#diff-6d136e7cf0b5751935f337e8b7065f23f4f547f7f85072637dbab6476832439eR5)`)

### Presubmit job configuration updates:
* Updated the `context` for the `pull-build-next-gen` job to remove the "non-block" prefix, making it a required check. (`[prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yamlL16-R17](diffhunk://#diff-6d136e7cf0b5751935f337e8b7065f23f4f547f7f85072637dbab6476832439eL16-R17)`)
* Updated the `context` for the `pull-check-next-gen` job to remove the "non-block" prefix, also making it a required check. (`[prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yamlL26-R26](diffhunk://#diff-6d136e7cf0b5751935f337e8b7065f23f4f547f7f85072637dbab6476832439eL26-R26)`)