### PR TITLE
chore(prow-jobs/pingcap-inc/tici): Run ut for tici

### DIFF
--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -38,6 +38,9 @@ presubmits:
 
                 # check format & clippy
                 make check
+
+                # Run unit tests
+                make ci-ut
             resources:
               requests:
                 cpu: "6"


### PR DESCRIPTION
Run unit tests in the `pull-verify` job of TiCI