### PR TITLE
fix(pingcap/tidb): remove pull_check_next_gen presubmit job configuration

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -19,16 +19,6 @@ presubmits:
       rerun_command: "/test pull-build-next-gen"
 
     - <<: *brancher
-      name: pingcap/tidb/pull_check_next_gen
-      agent: jenkins
-      decorate: false # need add this.
-      optional: true
-      # skip_if_only_changed: *skip_if_only_changed
-      context: non-block/pull-check-next-gen
-      trigger: "(?m)^/test (?:.*? )?pull-check-next-gen(?: .*?)?$"
-      rerun_command: "/test pull-check-next-gen"
-
-    - <<: *brancher
       name: pingcap/tidb/pull_integration_realcluster_test_next_gen
       agent: jenkins
       decorate: false # need add this.


### PR DESCRIPTION
## Why

The `integrationtest` make task running inside the `check_next_gen` job seems unnecessary (running tests/integrationtest/run-tests.sh), as it is covered by `pull_integration_realcluster_test_next-gen`.