### PR TITLE
chore(pingcap/tidb): update job `pull_integration_realcluster_test_next_gen`

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -90,7 +90,6 @@ pipeline {
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_importintotest3',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_importintotest4',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_pipelineddmltest',
-                            'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_flashbacktest',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_ddltest',
                         )
                     }

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -76,7 +76,6 @@ pipeline {
                         values(
                             // 'tests/integrationtest/run-tests-next-gen.sh -s bin/tidb-server -d y',
                             'tests/integrationtest/run-tests-next-gen.sh -s bin/tidb-server -d n',
-                            'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_brietest',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_pessimistictest',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_sessiontest',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_statisticstest',


### PR DESCRIPTION
This pull request makes a small adjustment to the test pipeline by removing one of the test scripts from the integration test suite. The change streamlines the set of tests that are executed in the pipeline.

- Removed the execution of the `bazel_brietest` test script from the integration test values in `pipeline.groovy`.