### PR TITLE
opt(pingcap/tidb): set PR description earlier in all pipelines

### DIFF
--- a/pipelines/pingcap/tidb/latest/canary-ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/canary-ghpr_unit_test.groovy
@@ -8,6 +8,7 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-canary-ghpr_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_build.groovy
@@ -8,6 +8,7 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -36,9 +37,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check.groovy
@@ -9,6 +9,7 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -34,9 +35,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -8,6 +8,7 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -35,9 +36,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -9,6 +9,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -36,9 +37,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -8,6 +8,7 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -35,9 +36,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -9,6 +9,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -36,9 +37,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
@@ -14,6 +14,7 @@ final TARGET_BRANCH_PD = "master"
 final TARGET_BRANCH_TIFLASH = "master"
 final TARGET_BRANCH_TIKV = "dedicated"
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -42,9 +43,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy
@@ -9,6 +9,7 @@ final BRANCH_ALIAS = 'latest'
 final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -37,9 +38,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_check_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_check_next_gen/pipeline.groovy
@@ -10,6 +10,7 @@ final K8S_NAMESPACE = 'jenkins-tidb'
 final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -38,9 +39,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_common_test.groovy
@@ -8,6 +8,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_e2e_test.groovy
@@ -7,6 +7,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
@@ -8,6 +8,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_integration_common_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_copr_test.groovy
@@ -8,6 +8,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
@@ -8,6 +8,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -36,9 +37,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
@@ -12,6 +12,7 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final TARGET_BRANCH_PD = "master"
 final TARGET_BRANCH_TIKV = "dedicated"
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test.groovy
@@ -7,6 +7,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
@@ -15,6 +15,7 @@ final TARGET_BRANCH_TIFLASH = "master"
 final TARGET_BRANCH_TICDC = "master"
 final TARGET_BRANCH_TIKV = "dedicated"
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
@@ -8,6 +8,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
@@ -8,6 +8,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
@@ -7,6 +7,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
@@ -7,6 +7,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -12,6 +12,7 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final TARGET_BRANCH_PD = "master"
 final TARGET_BRANCH_TIKV = "dedicated"
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
@@ -9,6 +9,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -36,9 +37,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_mysql_client_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_client_test.groovy
@@ -8,6 +8,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_mysql_client_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -36,9 +37,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pipeline.groovy
@@ -10,6 +10,7 @@ final K8S_NAMESPACE = 'jenkins-tidb'
 final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -37,9 +38,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -12,6 +12,8 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 
 final TARGET_BRANCH_PD = "master"
 final TARGET_BRANCH_TIKV = "dedicated"
+
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -39,9 +41,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_sqllogic_test.groovy
@@ -8,6 +8,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
@@ -7,6 +7,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-pull_tiflash_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
@@ -8,6 +8,7 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -35,9 +36,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1_next_gen/pipeline.groovy
@@ -9,6 +9,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -36,9 +37,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pipeline.groovy
@@ -9,6 +9,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -36,9 +37,6 @@ pipeline {
                 """
                 container(name: 'net-tool') {
                     sh 'dig github.com'
-                    script {
-                        prow.setPRDescription(REFS)
-                    }
                 }
             }
         }


### PR DESCRIPTION
This pull request refactors how the PR description is set across multiple Jenkins pipeline scripts for the `pingcap/tidb` repository. Instead of calling `prow.setPRDescription(REFS)` inside a container step, the call is now made immediately after parsing the PR references at the start of each pipeline. This change improves consistency and ensures the PR description is set earlier in the pipeline execution.

**Refactoring of PR description setting:**

* Moved the `prow.setPRDescription(REFS)` call to immediately after the `REFS` variable is initialized in all affected pipeline scripts [[1]](diffhunk://#diff-aca7042b465f87b631581ba98f2c7e07a0e746e4b280fc3a20958c8844aa15c5R11) [[2]](diffhunk://#diff-330efc710fae301d014390d100e1ec4c12e0ca09a6f6118bfdfc481706b5cc1cR11) [[3]](diffhunk://#diff-f60c20c4c851bf16c1dd9b9a06bcef450bafdf3681f727a929df4f9d12d8001aR12) [[4]](diffhunk://#diff-2ec31602787b9f78109d406f68793c25b46975c1ccf60392c646f117bbd09085R11) [[5]](diffhunk://#diff-1a06f14532e2be1eefc21763f67d1a83b63ab9740c315b30ae4132768be19121R12) [[6]](diffhunk://#diff-b56f73beeb61b056a6dd2b10e709f4e2c3fb1ce386038e2cba0e9fcaf75bf469R11) [[7]](diffhunk://#diff-a21cdc45566c47643404cef7e2759cb7618004a9f63d54995cd8c1e4a0d7aa68R12) [[8]](diffhunk://#diff-4d7bdd61804e11fe4870e15fd24fd1a9b1ec246f3aa00c09384cb8373f1a61e6R17) [[9]](diffhunk://#diff-5d07f8a0316f7735c0722f8e9c4a63832c0fdef8f6ce42ee56dac322b85304c1R12) [[10]](diffhunk://#diff-66715fe1dc4720d172cf083c0878f51b0e72c9a7b381ecad93b03a45f109dbd2R13) [[11]](diffhunk://#diff-a6861b61ddc3b83f3e4f6936f488d9e80fa000164c92dab97d94493944edb65fR11) [[12]](diffhunk://#diff-e81bb3e57b3459721e077248399744cdd97de52bb31e25eff35f68b031e9ebaaR10) [[13]](diffhunk://#diff-84e19752ef591e2f48d9e6cd7d0faa4bd0b69a07335c786fce77894a093ec431R11) [[14]](diffhunk://#diff-2d29d0cf5386913371c1dbb95edab65af0c51d2ca1a4ad9ed07b0cffe5587b37R11) [[15]](diffhunk://#diff-43ec52ea3a8dfba70c88e7dd15c028b11a23f97755b697a2fe3d9f52231e1e81R11) [[16]](diffhunk://#diff-30290e50879c98b2b0d4bd9095242cb7de09be03866928f0674f312cd397b44eR15) [[17]](diffhunk://#diff-2dd6234238eba87e6ed18c49638fb7e65442a2f03d9e7ebe95344a8a779ef1f5R10) [[18]](diffhunk://#diff-640983b64b3b07022712ee0e6f8c854f46015f1d5a3e8a9ebaed4a65d0e68078R18) [[19]](diffhunk://#diff-4c2c5dbce8f99b54d8e58f20c91bb864c8f2103e1dbd155aa6f452538a9e41caR11) [[20]](diffhunk://#diff-e645c7bc98dba354105974898bab636ce65b1af9013b269f50c3bc3d7a152f2bR11).

* Removed redundant calls to `prow.setPRDescription(REFS)` from within the `net-tool` container script block in all affected pipeline scripts, simplifying the container steps [[1]](diffhunk://#diff-330efc710fae301d014390d100e1ec4c12e0ca09a6f6118bfdfc481706b5cc1cL39-L41) [[2]](diffhunk://#diff-f60c20c4c851bf16c1dd9b9a06bcef450bafdf3681f727a929df4f9d12d8001aL37-L39) [[3]](diffhunk://#diff-2ec31602787b9f78109d406f68793c25b46975c1ccf60392c646f117bbd09085L38-L40) [[4]](diffhunk://#diff-1a06f14532e2be1eefc21763f67d1a83b63ab9740c315b30ae4132768be19121L39-L41) [[5]](diffhunk://#diff-b56f73beeb61b056a6dd2b10e709f4e2c3fb1ce386038e2cba0e9fcaf75bf469L38-L40) [[6]](diffhunk://#diff-a21cdc45566c47643404cef7e2759cb7618004a9f63d54995cd8c1e4a0d7aa68L39-L41) [[7]](diffhunk://#diff-4d7bdd61804e11fe4870e15fd24fd1a9b1ec246f3aa00c09384cb8373f1a61e6L45-L47) [[8]](diffhunk://#diff-5d07f8a0316f7735c0722f8e9c4a63832c0fdef8f6ce42ee56dac322b85304c1L40-L42) [[9]](diffhunk://#diff-66715fe1dc4720d172cf083c0878f51b0e72c9a7b381ecad93b03a45f109dbd2L41-L43) [[10]](diffhunk://#diff-43ec52ea3a8dfba70c88e7dd15c028b11a23f97755b697a2fe3d9f52231e1e81L39-L41).

This change streamlines the pipeline code, reduces duplication, and ensures the PR description is set at a consistent and logical point in the pipeline execution.