### PR TITLE
chore(pingcap/tidb): disable auto trigger `pull_unit_test_next_gen` job

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -42,7 +42,7 @@ presubmits:
       name: pingcap/tidb/pull_unit_test_next_gen
       agent: jenkins
       decorate: false # need add this.
-      skip_if_only_changed: *skip_if_only_changed
+      # skip_if_only_changed: *skip_if_only_changed
       optional: true
       context: non-block/pull-unit-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-unit-test-next-gen(?: .*?)?$"


### PR DESCRIPTION
This pull request makes a small change to the presubmit job configuration for `pingcap/tidb` in `prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml`. The change comments out the `skip_if_only_changed` field for the `pull_unit_test_next_gen` job, which means this job will now always run regardless of which files are changed.