### PR TITLE
chore(pingcap/tidb): remove Go version check from build pipelines

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_build/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_build/pipeline.groovy
@@ -88,25 +88,6 @@ pipeline {
                         }
                     }
                 }
-                sh label: 'Check Go version', script: """#!/usr/bin/env bash
-                    tidb_go_version=\$(grep '^go ' ${REFS.repo}/go.mod | awk '{print \$2}')
-                    plugin_audit_go_version=\$(grep '^go ' enterprise-plugin/audit/go.mod | awk '{print \$2}')
-                    plugin_whitelist_go_version=\$(grep '^go ' enterprise-plugin/whitelist/go.mod | awk '{print \$2}')
-
-                    echo "tidb go version: \$tidb_go_version"
-                    echo "enterprise-plugin audit go version: \$plugin_audit_go_version"
-                    echo "enterprise-plugin whitelist go version: \$plugin_whitelist_go_version"
-                    if [ "\$tidb_go_version" != "\$plugin_audit_go_version" ]; then
-                        echo "❌ Go version mismatch: tidb (\$tidb_go_version) != enterprise-plugin audit (\$plugin_audit_go_version)"
-                        echo "👉 Please update it in file: https://github.com/pingcap-inc/enterprise-plugin/blob/${REFS.base_ref}/audit/go.mod"
-                        exit 1
-                    fi
-                    if [ "\$tidb_go_version" != "\$plugin_whitelist_go_version" ]; then
-                        echo "❌ version mismatch: tidb (\$tidb_go_version) != enterprise-plugin whitelist (\$plugin_whitelist_go_version)"
-                        echo "👉 Please update it in file: https://github.com/pingcap-inc/enterprise-plugin/blob/${REFS.base_ref}/whitelist/go.mod"
-                        exit 1
-                    fi
-                """
                 sh label: 'Test plugins', script: """
                     mkdir -p plugin-so
 

--- a/pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy
@@ -89,23 +89,6 @@ pipeline {
                         }
                     }
                 }
-                sh label: 'Check Go version', script: """
-                    tidb_go_version=\$(grep '^go ' ${REFS.repo}/go.mod | awk '{print \$2}')
-                    plugin_audit_go_version=\$(grep '^go ' enterprise-plugin/audit/go.mod | awk '{print \$2}')
-                    plugin_whitelist_go_version=\$(grep '^go ' enterprise-plugin/whitelist/go.mod | awk '{print \$2}')
-
-                    echo "tidb go version: \$tidb_go_version"
-                    echo "enterprise-plugin audit go version: \$plugin_audit_go_version"
-                    echo "enterprise-plugin whitelist go version: \$plugin_whitelist_go_version"
-                    if [ "\$tidb_go_version" != "\$plugin_audit_go_version" ]; then
-                        echo "Go version mismatch: tidb (\$tidb_go_version) != enterprise-plugin audit (\$plugin_audit_go_version)"
-                        exit 1
-                    fi
-                    if [ "\$tidb_go_version" != "\$plugin_whitelist_go_version" ]; then
-                        echo "Go version mismatch: tidb (\$tidb_go_version) != enterprise-plugin whitelist (\$plugin_whitelist_go_version)"
-                        exit 1
-                    fi
-                """
                 sh label: 'Test plugins', script: """
                     mkdir -p plugin-so
 


### PR DESCRIPTION
Revert #3683

The original intention was to ensure that the tidb and plugin GitHub repositories use the same Go version in their go.mod files. 

This inconsistency issue manifests itself in our CI tasks on the day or the next day of each Go patch release. This isn't an environmental issue, but an engineering issue of TiDB repository!

Symptoms similar to this:
```log
[2025/08/07 06:51:03.979 +00:00] [FATAL] [terror.go:309] ["unexpected error"] [error="plugin.Open(\"plugin-so/audit-1\"): plugin was built with a different version of package runtime"]
```


**Currently, some contributors do not understand this requirement and feel that this step undermines their work. If you agree, you can add your approval. After this rollback, this consistency guarantee must be manually checked by contributors or reviewers.**
