### PR TITLE
fix(pipelines): update docker image references for Python ORM tests

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pod.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: python
-      image: "hub.pingcap.net/temp/django-tidb-test:latest"
+      image: "hub.pingcap.net/jenkins/django-tidb-test:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_python_orm_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: python
-      image: "hub.pingcap.net/temp/django-tidb-test:latest"
+      image: "hub.pingcap.net/jenkins/django-tidb-test:latest"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_python_orm_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: python
-      image: "hub.pingcap.net/temp/django-tidb-test:latest"
+      image: "hub.pingcap.net/jenkins/django-tidb-test:latest"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
Changed the Docker image reference for the Python ORM test pods in multiple YAML files from "hub.pingcap.net/temp/django-tidb-test:latest" to "hub.pingcap.net/jenkins/django-tidb-test:latest" to ensure consistency across the integration testing environment.