### PR TITLE
feat(pipelines/tidb): update pull-error-log-review job configuration of tidb

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -206,7 +206,8 @@ presubmits:
       decoration_config:
         timeout: 20m
         skip_cloning: true
-      always_run: false
+      always_run: true
+      skip_report: true
       trigger: "(?m)^/test (?:.*? )?pull-error-log-review(?: .*?)?$"
       rerun_command: "/test pull-error-log-review"
       optional: true

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -207,7 +207,7 @@ presubmits:
         timeout: 20m
         skip_cloning: true
       always_run: true
-      skip_report: true
+      skip_report: true  # Temporarily enabled to verify matching rules without impacting PRs.
       trigger: "(?m)^/test (?:.*? )?pull-error-log-review(?: .*?)?$"
       rerun_command: "/test pull-error-log-review"
       optional: true

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -206,12 +206,12 @@ presubmits:
       decoration_config:
         timeout: 20m
         skip_cloning: true
-      always_run: true
+      always_run: false
       skip_report: true  # Temporarily enabled to verify matching rules without impacting PRs.
       trigger: "(?m)^/test (?:.*? )?pull-error-log-review(?: .*?)?$"
       rerun_command: "/test pull-error-log-review"
       optional: true
-      # skip_if_only_changed: *skip_if_only_changed # TODO: add this after test is checked and stable.
+      skip_if_only_changed: *skip_if_only_changed
       spec:
         containers:
           - name: check


### PR DESCRIPTION
- Changed the `always_run` property to `true` for the `pull-error-log-review` job, ensuring it runs on every trigger.
- Added `skip_report: true` to prevent reporting on this job, streamlining the CI process.

Enable automatic triggering. To verify the effectiveness of the matching rules, please note that this task currently has status reporting turned off, so task cost failures will not be reflected on the PR GitHub page and will not affect PR merging.