### PR TITLE
chore(pipelines/tidb): reduce log retention period for integration tests from 30 to 7 days

### DIFF
--- a/jobs/pingcap/tidb/latest/periodics_integration_test.groovy
+++ b/jobs/pingcap/tidb/latest/periodics_integration_test.groovy
@@ -1,7 +1,7 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('pingcap/tidb/periodics_integration_test') {
     logRotator {
-        daysToKeep(30)
+        daysToKeep(7)
     }
     parameters {
         stringParam("TARGET_BRANCH", "master", "Target branch to verify")


### PR DESCRIPTION
 Reduce log retention period for integration tests from 30 to 7 days, avoid generating too many archives that take up disk space.