### PR TITLE
feat(scripts/flow/build): add feature branch prerelease support to versioning strategy

### DIFF
--- a/scripts/flow/build/versioning-strategy.md
+++ b/scripts/flow/build/versioning-strategy.md
@@ -34,4 +34,3 @@ The table below maps the input git version and branches to the expected version 
 | History style - hotfix without tag | v8.5.1-2-g1234567 | release-8.5-20250101-v8.5.1 | v8.5.1-2-g1234567 | |
 | History style - hotfix with tag | v8.5.1-20250101-fecba32 | release-8.5-20250101-v8.5.1 | v8.5.1-20250101-fecba32 | |
 | **Feature branch - prerelease** | v9.0.0-beta.1.pre-151-gb4c8f4dc8 | feature/fts | v9.0.0-feature.fts | v9.0.0-feature.fts |
-

--- a/scripts/flow/build/versioning-strategy.md
+++ b/scripts/flow/build/versioning-strategy.md
@@ -33,3 +33,5 @@ The table below maps the input git version and branches to the expected version 
 | New style - commits after GA | v9.0.0-2-g1234567 | release-9.0 | v9.0.1-pre | v9.0.1 |
 | History style - hotfix without tag | v8.5.1-2-g1234567 | release-8.5-20250101-v8.5.1 | v8.5.1-2-g1234567 | |
 | History style - hotfix with tag | v8.5.1-20250101-fecba32 | release-8.5-20250101-v8.5.1 | v8.5.1-20250101-fecba32 | |
+| **Feature branch - prerelease** | v9.0.0-beta.1.pre-151-gb4c8f4dc8 | feature/fts | v9.0.0-feature.fts | v9.0.0-feature.fts |
+

--- a/scripts/flow/build/versioning-strategy.test.ts
+++ b/scripts/flow/build/versioning-strategy.test.ts
@@ -242,6 +242,24 @@ Deno.test("compute", () => {
         version: "v8.5.1-20250101-fecba32",
       },
     },
+    {
+      description: "feature branch - beta prerelease",
+      gitVer: "v9.0.0-beta.1.pre-151-gb4c8f4dc8",
+      branches: ["feature/fts"],
+      expect: {
+        version: "v9.0.0-feature.fts",
+        newBuildTag: "v9.0.0-feature.fts",
+      },
+    },
+    {
+      description: "feature branch - alpha prerelease",
+      gitVer: "v8.5.0-alpha-2-g1234567",
+      branches: ["feature/fts"],
+      expect: {
+        version: "v8.5.0-feature.fts",
+        newBuildTag: "v8.5.0-feature.fts",
+      },
+    },
   ];
 
   for (const { description, gitVer, branches, expect } of tests) {

--- a/scripts/flow/build/versioning-strategy.ts
+++ b/scripts/flow/build/versioning-strategy.ts
@@ -47,6 +47,24 @@ export function compute(
 ): builtControl {
   const rv = semver.parse(rawVersion.trim());
 
+  // Check for feature branch
+  const featureBranch = commitInBranches.find((b) =>
+    /^feature\/[\w.-]+$/.test(b)
+  );
+  if (featureBranch) {
+    // Extract feature name, replace '/' with '.' for version/tag
+    const featureName = featureBranch.replace(/^feature\//, "").replace(
+      /[^\w.-]/g,
+      ".",
+    );
+    const featureVersion =
+      `v${rv.major}.${rv.minor}.${rv.patch}-feature.${featureName}`;
+    return {
+      releaseVersion: featureVersion,
+      newGitTag: featureVersion,
+    };
+  }
+
   // Check if the current branch is a release branch.
   if (!commitInBranches.some(isReleaseBranch)) {
     console.info("Current commit is not contained in any release branches.");

--- a/scripts/flow/build/versioning-strategy.ts
+++ b/scripts/flow/build/versioning-strategy.ts
@@ -53,12 +53,8 @@ export function compute(
   );
   if (featureBranch) {
     // Extract feature name, replace '/' with '.' for version/tag
-    const featureName = featureBranch.replace(/^feature\//, "").replace(
-      /[^\w.-]/g,
-      ".",
-    );
-    const featureVersion =
-      `v${rv.major}.${rv.minor}.${rv.patch}-feature.${featureName}`;
+    const suffix = featureBranch.replaceAll("/", ".").replaceAll("-", "_");
+    const featureVersion = `v${rv.major}.${rv.minor}.${rv.patch}-${suffix}`;
     return {
       releaseVersion: featureVersion,
       newGitTag: featureVersion,


### PR DESCRIPTION
This pull request adds support for feature branch prerelease versioning in the build versioning strategy. Now, if a commit is on a feature branch, the computed version and tag will reflect the feature name, improving clarity and traceability for feature branch builds. The changes are documented, tested, and implemented in the core logic.

**Feature branch versioning support:**

* Updated `versioning-strategy.md` to document the new feature branch prerelease versioning scheme in the mapping table.
* Added logic to `versioning-strategy.ts` to detect feature branches and generate version/tag strings using the feature name, e.g., `v9.0.0-feature.fts`.

**Test coverage:**

* Added new test cases in `versioning-strategy.test.ts` for feature branch beta and alpha prerelease scenarios to ensure correct behavior.