### PR TITLE
fix(scripts/pingcap/community): handle 404 error in getFileContent and return undefined

### DIFF
--- a/scripts/pingcap/community/prow-owners-updater.ts
+++ b/scripts/pingcap/community/prow-owners-updater.ts
@@ -151,14 +151,21 @@ class RepoUpdater {
   }
 
   async getFileContent(path: string) {
-    const contentResponse = await this.octokit.rest.repos.getContent({
-      owner: this.owner,
-      repo: this.repo,
-      ref: this.ref,
-      path,
-    });
-    const fileContent = contentResponse.data as { content: string };
-    return atob(fileContent.content);
+    try {
+      const contentResponse = await this.octokit.rest.repos.getContent({
+        owner: this.owner,
+        repo: this.repo,
+        ref: this.ref,
+        path,
+      });
+      const fileContent = contentResponse.data as { content: string };
+      return atob(fileContent.content);
+    } catch (err) {
+      if (err instanceof RequestError && err.status === 404) {
+        return undefined;
+      }
+      throw err;
+    }
   }
 
   async toUpdateFileAndContents(ownersMap: ProwRepoOwners) {

--- a/scripts/pingcap/community/prow-owners-updater.ts
+++ b/scripts/pingcap/community/prow-owners-updater.ts
@@ -158,8 +158,13 @@ class RepoUpdater {
         ref: this.ref,
         path,
       });
-      const fileContent = contentResponse.data as { content: string };
-      return atob(fileContent.content);
+      if (
+        Array.isArray(contentResponse.data) ||
+        !("content" in contentResponse.data)
+      ) {
+        throw new Error(`The path "${path}" is not a file.`);
+      }
+      return atob(contentResponse.data.content);
     } catch (err) {
       if (err instanceof RequestError && err.status === 404) {
         return undefined;


### PR DESCRIPTION
This pull request improves the robustness of the `getFileContent` method in `prow-owners-updater.ts` by adding error handling for missing files. Now, if a requested file does not exist, the method returns `undefined` instead of throwing an error.

Error handling improvements:

* Updated `getFileContent` in `scripts/pingcap/community/prow-owners-updater.ts` to catch `RequestError` exceptions with a 404 status and return `undefined` for missing files, ensuring smoother handling of absent files. [[1]](diffhunk://#diff-2ed7e110944d601280252ef0eff96a4f51e0a68610b0799b65db910f8380e31fR154) [[2]](diffhunk://#diff-2ed7e110944d601280252ef0eff96a4f51e0a68610b0799b65db910f8380e31fR163-R168)