### PR TITLE
chore(tidb): shorten retention period for job logs to 14 days

### DIFF
--- a/jobs/pingcap/tidb/latest/pull_unit_test_next_gen.groovy
+++ b/jobs/pingcap/tidb/latest/pull_unit_test_next_gen.groovy
@@ -5,7 +5,7 @@ final jobName = 'pull_unit_test_next_gen'
 
 pipelineJob("${fullRepo}/${jobName}") {
     logRotator {
-        daysToKeep(30)
+        daysToKeep(14)
     }
     parameters {
         // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables


### PR DESCRIPTION
The retention log for the task is very large, around 7GB. Shorten the retention period to avoid frequent disk space alerts.