### PR TITLE
chore(error-log-review):  temporarily add error log reviewer to verify the approval

### DIFF
--- a/configs/error-log-review/config.yaml
+++ b/configs/error-log-review/config.yaml
@@ -23,6 +23,7 @@ repositories:
       - "BornChanger"
       - "xuhuaiyu"
       - "YuJuncen"
+      - "tiancaiamao"
 
   - name: "pingcap/pd"
     patterns:


### PR DESCRIPTION
Temporarily add error log review to verify the approver's approval status. Revert this after test passed.

