### PR TITLE
feat(pingcap/tidb): enable job `pull-integration-realcluster-test-next-gen`

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -75,13 +75,9 @@ pipeline {
                     axis {
                         name 'SCRIPT_AND_ARGS'
                         values(
-                            'tests/integrationtest/run-tests-next-gen.sh -s bin/tidb-server -d y',
                             'tests/integrationtest/run-tests-next-gen.sh -s bin/tidb-server -d n',
-                            'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_pessimistictest',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_sessiontest',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_statisticstest',
-                            'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_txntest',
-                            'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_addindextest',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_addindextest1',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_addindextest2',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_addindextest3',
@@ -90,8 +86,13 @@ pipeline {
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_importintotest2',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_importintotest3',
                             'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_importintotest4',
-                            'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_pipelineddmltest',
-                            'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_ddltest',
+                            // 🚧 Failed or timeouted groups:
+                            // 'tests/integrationtest/run-tests-next-gen.sh -s bin/tidb-server -d y',
+                            // 'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_addindextest',
+                            // 'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_ddltest',
+                            // 'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_pessimistictest',
+                            // 'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_pipelineddmltest',
+                            // 'tests/realtikvtest/scripts/next-gen/run-tests.sh bazel_txntest',
                         )
                     }
                 }

--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -22,9 +22,8 @@ presubmits:
       name: pingcap/tidb/pull_integration_realcluster_test_next_gen
       agent: jenkins
       decorate: false # need add this.
-      # skip_if_only_changed: *skip_if_only_changed
-      optional: true
-      context: non-block/pull-integration-realcluster-test-next-gen
+      skip_if_only_changed: *skip_if_only_changed
+      context: pull-integration-realcluster-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-integration-realcluster-test-next-gen(?: .*?)?$"
       rerun_command: "/test pull-integration-realcluster-test-next-gen"
 


### PR DESCRIPTION
After removing failing test groups, now it can be turned as required if be triggered.

This pull request updates the integration test pipeline and presubmit configuration for the TiDB project. The main focus is on cleaning up the test matrix by removing or commenting out unstable test groups and updating the job configuration to better manage CI triggers and reporting.

Pipeline test matrix cleanup:

* Removed several unstable or failing test groups from the `SCRIPT_AND_ARGS` axis in `pipeline.groovy`, including `bazel_pessimistictest`, `bazel_txntest`, `bazel_addindextest`, `bazel_pipelineddmltest`, and `bazel_ddltest`, as well as the integration test with `-d y` option. These have been commented out for future reference. [[1]](diffhunk://#diff-de7893675d755e67054c7fbc4b762de79fb76cf2472fe9110f5fc8f47abb51edL78-L84) [[2]](diffhunk://#diff-de7893675d755e67054c7fbc4b762de79fb76cf2472fe9110f5fc8f47abb51edL93-R95)

Presubmit job configuration updates:

* Enabled the `skip_if_only_changed` filter and updated the job context to `pull-integration-realcluster-test-next-gen` in the presubmit YAML, while removing the `optional: true` flag and the old non-blocking context.


Test results:

- https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/pull_integration_realcluster_test_next_gen/73/ 
  > 
<img width="1147" height="157" alt="image" src="https://github.com/user-attachments/assets/f6224d1b-20fa-455d-ad69-5fe7cdfa26a6" />
