### PR TITLE
feat(pingcap/tidb): add flaky test analysis and reporting for bazel tests

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -168,7 +168,9 @@ pipeline {
                                         sh """
                                             logs_dir="logs_\$(echo \"\$SCRIPT_AND_ARGS\" | tr ' /' '_')"
                                             mkdir -p \$logs_dir
-                                            mv tidb/bazel-test.log bazel-*.log bazel-*.json \$logs_dir
+                                            mv tidb/bazel-test.log \$logs_dir 2>/dev/null || true
+                                            mv bazel-*.log \$logs_dir 2>/dev/null || true
+                                            mv bazel-*.json \$logs_dir 2>/dev/null || true
                                         """
                                         archiveArtifacts(artifacts: '*/bazel-*.log,*/bazel-*.json', fingerprint: false, allowEmptyArchive: true)
                                     }


### PR DESCRIPTION


Parse bazel test logs for flaky cases and send results to the cloudevents server. Archive bazel logs and JSON reports on failure.