### PR TITLE
fix(pingcap/tidb): make `pull-integration-realcluster-test-next-gen` job as required

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-next-gen.yaml
@@ -23,8 +23,7 @@ presubmits:
       agent: jenkins
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
-      optional: true
-      context: non-block/pull-integration-realcluster-test-next-gen
+      context: pull-integration-realcluster-test-next-gen
       trigger: "(?m)^/test (?:.*? )?pull-integration-realcluster-test-next-gen(?: .*?)?$"
       rerun_command: "/test pull-integration-realcluster-test-next-gen"
 


### PR DESCRIPTION
Reverts PingCAP-QE/ci#3710