### PR TITLE
refactor(cd): migrate to push devbuild images to GAR

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/docker-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/docker-common.groovy
@@ -178,14 +178,14 @@ def release_images() {
         def sync_dest_image_name = item
         // End debugging
 
-           docker.withRegistry("https://hub.pingcap.net", "harbor-pingcap") {
-               sh """
-               # Push to Internal Harbor First, then sync to DockerHub
-               # pingcap/tidb:v5.2.3 will be pushed to hub.pingcap.net/image-sync/pingcap/tidb:v5.2.3
-               docker tag ${imagePlaceHolder} ${harbor_tmp_image_name}
-               docker push ${harbor_tmp_image_name}
-               """
-           }
+        docker.withRegistry("https://hub.pingcap.net", "harbor-pingcap") {
+            sh """
+            # Push to Internal Harbor First, then sync to DockerHub
+            # pingcap/tidb:v5.2.3 will be pushed to hub.pingcap.net/image-sync/pingcap/tidb:v5.2.3
+            docker tag ${imagePlaceHolder} ${harbor_tmp_image_name}
+            docker push ${harbor_tmp_image_name}
+            """
+        }
 
         sync_image_params = [
                 string(name: 'triggered_by_upstream_ci', value: "docker-common-nova"),
@@ -204,6 +204,14 @@ def release_images() {
        }
        if (item.startsWith("uhub.service.ucloud.cn/")) {
            docker.withRegistry("https://uhub.service.ucloud.cn", "ucloud-registry") {
+               sh """
+               docker tag ${imagePlaceHolder} ${item}
+               docker push ${item}
+               """
+           }
+       }
+       if (item.startsWith("us-docker.pkg.dev/pingcap-testing-account/")) {
+           docker.withRegistry("https://us-docker.pkg.dev", "pingcap-testing-account") {
                sh """
                docker tag ${imagePlaceHolder} ${item}
                docker push ${item}

--- a/jenkins/pipelines/cd/atom-jobs/manifest-multiarch-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/manifest-multiarch-common.groovy
@@ -1,15 +1,24 @@
 node("delivery") {
     container("delivery") {
         stage("build multi-arch") {
-            withCredentials([usernamePassword(credentialsId: 'harbor-pingcap', usernameVariable: 'harborUser', passwordVariable: 'harborPassword')]) {
-                sh """
-            printenv harborPassword | docker login -u ${harborUser} --password-stdin hub.pingcap.net
-            export DOCKER_CLI_EXPERIMENTAL=enabled
-            docker manifest create ${MULTI_ARCH_IMAGE}  -a ${AMD64_IMAGE} -a ${ARM64_IMAGE}
-            docker manifest push ${MULTI_ARCH_IMAGE}
-            """
+            if (params.MULTI_ARCH_IMAGE.startsWith("us-docker.pkg.dev/pingcap-testing-account/")) {
+                docker.withRegistry("https://us-docker.pkg.dev", "pingcap-testing-account") {
+                    sh """
+                        export DOCKER_CLI_EXPERIMENTAL=enabled
+                        docker manifest create ${MULTI_ARCH_IMAGE}  -a ${AMD64_IMAGE} -a ${ARM64_IMAGE}
+                        docker manifest push ${MULTI_ARCH_IMAGE}
+                    """
+                }
+            } else {
+                docker.withRegistry("https://hub.pingcap.net", "harbor-pingcap") {
+                    sh """
+                        export DOCKER_CLI_EXPERIMENTAL=enabled
+                        docker manifest create ${MULTI_ARCH_IMAGE}  -a ${AMD64_IMAGE} -a ${ARM64_IMAGE}
+                        docker manifest push ${MULTI_ARCH_IMAGE}
+                    """
+                }
             }
+            println "multi arch image: ${MULTI_ARCH_IMAGE}"
         }
     }
-    println "multi arch image: ${MULTI_ARCH_IMAGE}"
 }

--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -17,6 +17,7 @@ final ProductForBuildMapping = [
 ]
 
 // image prefix with `hub.pingcap.net/devbuild/` for no hotfix build and `hub.pingcap.net/` for hotfix build.
+// TODO: image prefix with `us-docker.pkg.dev/pingcap-testing-account/dev/` for no hotfix build and `hub.pingcap.net/` for hotfix build.
 final DockerImgRepoMapping = [
     "tidb-binlog": "pingcap/tidb-binlog/image",
     "drainer":"pingcap/tidb-binlog/image",
@@ -211,6 +212,7 @@ spec:
                     def date = new Date()
                     PipelineStartAt =new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").format(date)
                     Image = "hub.pingcap.net/devbuild/$ProductForDocker:$Version-$BUILD_NUMBER"
+                    // TODO: Image = "us-docker.pkg.dev/pingcap-testing-account/dev/$ProductForDocker:$Version-$BUILD_NUMBER"
                     if (params.TargetImg!=""){
                         Image = params.TargetImg
                     }


### PR DESCRIPTION
- Push images to GAR for us-docker.pkg.dev paths in docker-common.groovy for dev builds.
- Create multi-arch manifests in GAR for matching image paths.
- Update default dev build image prefix to use GAR instead of Harbor.