### PR TITLE
feat: update ci prow presubmit check image

### DIFF
--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -53,7 +53,7 @@ presubmits:
                 --plugin-config=../../ti-community-infra/configs/prow/config/plugins.yaml \
                 --config-path=../../ti-community-infra/configs/prow/config/config.yaml \
                 --job-config-path=flatten-prow-jobs/
-            image: ticommunityinfra/checkconfig:v20230621-df5abce
+            image: ticommunityinfra/checkconfig:v20240614-fd27fb709
             name: checkconfig
             resources: {}
           - name: verify-gitops


### PR DESCRIPTION
Relate to https://github.com/PingCAP-QE/ci/pull/3708.

* Update to [v20240614-fd27fb709](https://hub.docker.com/layers/ticommunityinfra/checkconfig/v20240614-fd27fb709/images/sha256-4e5633eac93a446580b541883f90a6df934d496d9d02c25e87d5d02bb9e49058)