### PR TITLE
fix: update checkconfig image to new version

### DIFF
--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -53,7 +53,7 @@ presubmits:
                 --plugin-config=../../ti-community-infra/configs/prow/config/plugins.yaml \
                 --config-path=../../ti-community-infra/configs/prow/config/config.yaml \
                 --job-config-path=flatten-prow-jobs/
-            image: ticommunityinfra/checkconfig:v20240614-fd27fb709
+            image: us-docker.pkg.dev/k8s-infra-prow/images/checkconfig:v20250823-25d79acb8
             name: checkconfig
             resources: {}
           - name: verify-gitops


### PR DESCRIPTION
Relate to https://github.com/PingCAP-QE/ci/pull/3708.


Resolve the error message encountered when checking presubmit config.
```shell
error loading prow config: invalid presubmit job pull-e2e: pod spec may not use init containers
```

