### PR TITLE
feat(presubmits): skip error log review for batch jobs

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -183,6 +183,10 @@ presubmits:
             command: [/bin/bash, -ce]
             args:
               - |
+                if [[ "${JOB_TYPE:-}" == "batch" ]]; then
+                  echo "JOB_TYPE is batch, skipping error log review check"
+                  exit 0
+                fi
                 wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -217,6 +217,10 @@ presubmits:
             command: [/bin/bash, -ce]
             args:
               - |
+                if [[ "${JOB_TYPE:-}" == "batch" ]]; then
+                  echo "JOB_TYPE is batch, skipping error log review check"
+                  exit 0
+                fi
                 wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \

--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -52,6 +52,10 @@ presubmits:
             command: [/bin/bash, -ce]
             args:
               - |
+                if [[ "${JOB_TYPE:-}" == "batch" ]]; then
+                  echo "JOB_TYPE is batch, skipping error log review check"
+                  exit 0
+                fi
                 wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -111,6 +111,10 @@ presubmits:
             command: [/bin/bash, -ce]
             args:
               - |
+                if [[ "${JOB_TYPE:-}" == "batch" ]]; then
+                  echo "JOB_TYPE is batch, skipping error log review check"
+                  exit 0
+                fi
                 wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \

--- a/prow-jobs/tikv/pd/latest-presubmits.yaml
+++ b/prow-jobs/tikv/pd/latest-presubmits.yaml
@@ -115,6 +115,10 @@ presubmits:
             command: [/bin/bash, -ce]
             args:
               - |
+                if [[ "${JOB_TYPE:-}" == "batch" ]]; then
+                  echo "JOB_TYPE is batch, skipping error log review check"
+                  exit 0
+                fi
                 wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \

--- a/prow-jobs/tikv/tikv/latest-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/latest-presubmits.yaml
@@ -89,6 +89,10 @@ presubmits:
             command: [/bin/bash, -ce]
             args:
               - |
+                if [[ "${JOB_TYPE:-}" == "batch" ]]; then
+                  echo "JOB_TYPE is batch, skipping error log review check"
+                  exit 0
+                fi
                 wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \


### PR DESCRIPTION
Added a conditional check in multiple presubmit job configurations to skip the error log review process if the JOB_TYPE is set to "batch". This change applies to the following job configurations: ticdc, tidb, tiflash, tiflow, pd, and tikv.

All PRs entering the batch merge have passed all required checks (including error log review check), so the modifications here will not cause any issues. It can ensure the normal merging of batch jobs without blocking.