### PR TITLE
chore(ci): update checkconfig image version in presubmits.yaml

### DIFF
--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -53,7 +53,7 @@ presubmits:
                 --plugin-config=../../ti-community-infra/configs/prow/config/plugins.yaml \
                 --config-path=../../ti-community-infra/configs/prow/config/config.yaml \
                 --job-config-path=flatten-prow-jobs/
-            image: ghcr.io/ti-community-infra/prow/checkconfig:v20250904-30fdc35da
+            image: ghcr.io/ti-community-infra/prow/checkconfig:v20250905-a0cfed255
             name: checkconfig
             resources: {}
           - name: verify-gitops


### PR DESCRIPTION
Update checkconfig image version in presubmits.yaml, REF https://github.com/ti-community-infra/prow/pull/21.

to resolve error reported by checkconfig:
```shell
pod spec may not use init containers
``` 

