### PR TITLE
ticdc: also collect .txt .sql file in ci

### DIFF
--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -192,7 +192,7 @@ def tests(sink_type, node_label) {
                                 sh """
                                 echo "archive logs"
                                 ls /tmp/tidb_cdc_test/
-                                tar -cvzf log-${log_tar_name}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                tar -cvzf log-${log_tar_name}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                 ls -alh  log-${log_tar_name}.tar.gz
                                 """
 

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -192,7 +192,7 @@ def tests(sink_type, node_label) {
                                 sh """
                                 echo "archive logs"
                                 ls /tmp/tidb_cdc_test/
-                                tar -cvzf log-${log_tar_name}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                tar -cvzf log-${log_tar_name}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                 ls -alh  log-${log_tar_name}.tar.gz
                                 """
 

--- a/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
+++ b/jenkins/pipelines/ci/ticdc/integration_test_common.groovy
@@ -192,7 +192,7 @@ def tests(sink_type, node_label) {
                                 sh """
                                 echo "archive logs"
                                 ls /tmp/tidb_cdc_test/
-                                tar -cvzf log-${log_tar_name}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                tar -cvzf log-${log_tar_name}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                 ls -alh  log-${log_tar_name}.tar.gz
                                 """
 

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
@@ -136,7 +136,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
@@ -136,7 +136,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy.groovy
@@ -136,7 +136,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy
@@ -137,7 +137,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy
@@ -137,7 +137,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light.groovy
@@ -137,7 +137,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy
@@ -139,7 +139,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy
@@ -139,7 +139,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light.groovy
@@ -139,7 +139,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
@@ -152,7 +152,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
@@ -137,7 +137,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
@@ -137,7 +137,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
@@ -137,7 +137,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
@@ -138,7 +138,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
@@ -138,7 +138,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
@@ -138,7 +138,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
@@ -139,7 +139,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
@@ -139,7 +139,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
@@ -139,7 +139,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql" )
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
@@ -140,7 +140,7 @@ pipeline {
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/tidb_cdc_test/
-                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/ -type f -name "*.log" -o -name "*.txt" -o -name "*.sql")
+                                    tar --warning=no-file-changed  -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/tidb_cdc_test/  -type f | grep -ie '\.\(log\|txt\|sql\)$')
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true


### PR DESCRIPTION

When the CI process of TiCDC is running, it outputs some `.sql` and `.txt` files. These files are helpful for debugging, so they need to be collected.