### PR TITLE
opt(prow-jobs/pingcap/ticdc): refactor presubmit jobs to improve cost efficiency and scheduling speed

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -111,7 +111,6 @@ presubmits:
             args:
               - |
                 make cdc
-            env: *env
             resources: &resources
               requests:
                 memory: 12Gi
@@ -133,7 +132,6 @@ presubmits:
             args:
               - |
                 make check
-            env: *env
             resources: *resources
 
     - name: pull-error-log-review

--- a/prow-jobs/pingcap/ticdc/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/release-9.0-beta-presubmits.yaml
@@ -110,7 +110,6 @@ presubmits:
             args:
               - |
                 make cdc
-            env: *env
             resources: &resources
               requests:
                 memory: 12Gi
@@ -131,5 +130,4 @@ presubmits:
             args:
               - |
                 make check
-            env: *env
             resources: *resources


### PR DESCRIPTION
- Remove unused fields and streamline job definitions
- Add run_before_merge to integration jobs to save resource
- Reduce CPU and memory requests for unit-test and build jobs to adjust the cloud nodes.
- Standardize command definitions for containers
- Trigger unit-test job on default cluster (GCP) to improve scheduling speed