### PR TITLE
feat(prow-jobs/tikv/pd): update job `pull-check-deps`

### DIFF
--- a/prow-jobs/tikv/pd/common-presubmits.yaml
+++ b/prow-jobs/tikv/pd/common-presubmits.yaml
@@ -12,6 +12,10 @@ presubmits:
       name: pull-check-deps
       decorate: true # need add this.
       skip_if_only_changed: *skip_if_only_changed
+      branches:
+        - ^master$
+        - ^release-[8-9][.][0-9]+$
+        - ^release-7[.]5$
       spec:
         containers:
           - name: build


### PR DESCRIPTION
Enable reporting and make check-deps presubmit required

This pull request makes a targeted update to the presubmit job configuration for the PD project. The main change is that the `pull-check-deps` job is now explicitly enabled for specific branches, rather than being marked as optional or skipping reports.

Branch targeting updates:

* The `pull-check-deps` job now runs only on the `master` branch and on release branches matching `release-8.x`, `release-9.x`, and `release-7.5`, improving control over where the job is executed.
* The job is no longer marked as optional and will report results, ensuring better visibility and enforcement of dependency checks.