### PR TITLE
Revert "Remove dind-daemon initContainer configuration"

### DIFF
--- a/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
@@ -35,6 +35,36 @@ presubmits:
                   resources:
                     requests:
                       storage: 500Gi
+        initContainers:
+          - name: dind-daemon
+            image: docker:28.1-dind
+            restartPolicy: Always
+            command:
+            - /bin/sh
+            - -c
+            - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
+            env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - name: docker-sock-dir
+                mountPath: /var/run
+              - name: data
+                mountPath: /var/lib/docker
+                subPath: docker
+            resources:
+              requests:
+                memory: "28Gi"
+                cpu: "1"
+              limits:
+                memory: "28Gi"
+                cpu: "1"
         containers:
           - name: e2e-runner
             image: ubuntu:22.04


### PR DESCRIPTION
Reverts PingCAP-QE/ci#3746.

Prow tide and sinker have been upgraded.