### PR TITLE
chore(pingcap/tidb): increase timeout for CI jobs in release branches

### DIFF
--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
@@ -93,7 +93,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        options { timeout(time: 30, unit: 'MINUTES') }
+                        options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     environment {

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     environment {

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        options { timeout(time: 30, unit: 'MINUTES') }
+                        options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        options { timeout(time: 30, unit: 'MINUTES') }
+                        options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     environment {

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     environment {


### PR DESCRIPTION
Updated the timeout setting from 30 minutes to 65 minutes in the `ghpr_check2.groovy` files across multiple release branches to allow for longer job execution times.