### PR TITLE
fix: increase tidb br integration test timeout duration

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
         // parallelsAlwaysFailFast()
     }
     stages {
@@ -134,7 +134,7 @@ pipeline {
                     }
                     stage("Test") {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
-                        options { timeout(time: 45, unit: 'MINUTES') }
+                        options { timeout(time: 60, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash


### PR DESCRIPTION
The pass rate of the tidb BR integration test (pull_br_integration_test) is relatively low, and a large number of builds fail due to timeout. 
Analysis of Jenkins logs reveals the following:
1. The test is forcibly terminated by the SIGTERM signal during execution (exit code 143).
2. The current timeout configuration is insufficient: total timeout is 60 minutes, and the timeout for a single test group is 45 minutes.
Adjust the timeout configuration as follows:
1. Total timeout: increased from 60 minutes to 90 minutes.
2. Test group timeout: increased from 45 minutes to 60 minutes.