### PR TITLE
feat(tekton/v1/triggers): add Tekton triggers and templates for CI automation

### DIFF
--- a/tekton/v1/triggers/templates/_/build-component-all-platforms.yaml
+++ b/tekton/v1/triggers/templates/_/build-component-all-platforms.yaml
@@ -1,0 +1,299 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: build-component-all-platforms
+spec:
+  params:
+    - name: git-url
+      description: The git repository full url
+    - name: git-refspec
+      default: +refs/heads/*:refs/heads/*
+    - name: git-revision
+      description: The git revision
+    - name: git-ref
+      description: The git branch
+    - name: component
+      description: component name, tidb|tikv|pd|tiflow|tiflash, etc...
+    - name: profile
+      description: build target profile
+      default: release
+    - name: registry
+      default: hub.pingcap.net
+    - name: timeout
+      description: pipeline run timeout
+      default: 2h
+    - name: source-ws-size
+      description: workspace size for source.
+      default: 10Gi
+    - name: builder-resources-memory
+      default: 16Gi
+    - name: builder-resources-cpu
+      default: "4"
+    - name: ce-context
+      description: cloud event context.
+      default: "{}"
+    - name: force-builder-image
+      default: ""
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: bp-$(tt.params.component)-$(tt.params.profile)-linux-amd64-
+        annotations:
+          "tekton.dev/ce-context": $(tt.params.ce-context)
+          "tibuild.pingcap.net/git-repo": $(tt.params.git-url)
+          "tibuild.pingcap.net/git-ref": $(tt.params.git-ref)
+          "tibuild.pingcap.net/git-revision": $(tt.params.git-revision)
+          "tibuild.pingcap.net/component": $(tt.params.component)
+          "tibuild.pingcap.net/profile": $(tt.params.profile)
+          "tibuild.pingcap.net/platform": linux/amd64
+      spec:
+        pipelineRef:
+          name: pingcap-build-package-linux
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: git-refspec
+            value: $(tt.params.git-refspec)
+          - name: git-revision
+            value: $(tt.params.git-revision)
+          - name: git-ref
+            value: $(tt.params.git-ref)
+          - name: component
+            value: $(tt.params.component)
+          - name: profile
+            value: $(tt.params.profile)
+          - name: os
+            value: linux
+          - name: arch
+            value: amd64
+          - name: registry
+            value: $(tt.params.registry)
+          - name: force-builder-image
+            value: $(tt.params.force-builder-image)
+        podTemplate:
+          nodeSelector:
+            kubernetes.io/arch: amd64
+        taskRunSpecs:
+          - pipelineTaskName: checkout
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: checkout-ext
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: build-binaries
+            taskServiceAccountName: image-releaser
+            stepOverrides:
+              - name: build
+                resources:
+                  requests:
+                    memory: $(tt.params.builder-resources-memory)
+                    cpu: $(tt.params.builder-resources-cpu)
+          - pipelineTaskName: build-images
+            taskServiceAccountName: image-releaser
+        timeouts:
+          pipeline: $(tt.params.timeout)
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                storageClassName: hyperdisk-rwo
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: $(tt.params.source-ws-size)
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
+          # - name: cargo-home
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home
+          # - name: cypress-cache
+          #   persistentVolumeClaim:
+          #     claimName: cypress-cache
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: bp-$(tt.params.component)-$(tt.params.profile)-linux-arm64-
+        annotations:
+          "tekton.dev/ce-context": $(tt.params.ce-context)
+          "tibuild.pingcap.net/git-repo": $(tt.params.git-url)
+          "tibuild.pingcap.net/git-ref": $(tt.params.git-ref)
+          "tibuild.pingcap.net/git-revision": $(tt.params.git-revision)
+          "tibuild.pingcap.net/component": $(tt.params.component)
+          "tibuild.pingcap.net/profile": $(tt.params.profile)
+          "tibuild.pingcap.net/platform": linux/arm64
+      spec:
+        pipelineRef:
+          name: pingcap-build-package-linux
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: git-refspec
+            value: $(tt.params.git-refspec)
+          - name: git-revision
+            value: $(tt.params.git-revision)
+          - name: git-ref
+            value: $(tt.params.git-ref)
+          - name: component
+            value: $(tt.params.component)
+          - name: profile
+            value: $(tt.params.profile)
+          - name: os
+            value: linux
+          - name: arch
+            value: arm64
+          - name: registry
+            value: $(tt.params.registry)
+          - name: force-builder-image
+            value: $(tt.params.force-builder-image)
+        podTemplate:
+          nodeSelector:
+            kubernetes.io/arch: arm64
+        taskRunSpecs:
+          - pipelineTaskName: checkout
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: checkout-ext
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: build-binaries
+            taskServiceAccountName: image-releaser
+            stepOverrides:
+              - name: build
+                resources:
+                  requests:
+                    memory: $(tt.params.builder-resources-memory)
+                    cpu: $(tt.params.builder-resources-cpu)
+          - pipelineTaskName: build-images
+            taskServiceAccountName: image-releaser
+        timeouts:
+          pipeline: $(tt.params.timeout)
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                storageClassName: hyperdisk-rwo
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: $(tt.params.source-ws-size)
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
+          # - name: cargo-home
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home
+          # - name: cypress-cache
+          #   persistentVolumeClaim:
+          #     claimName: cypress-cache
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: bp-$(tt.params.component)-$(tt.params.profile)-darwin-amd64-
+        annotations:
+          "tekton.dev/ce-context": $(tt.params.ce-context)
+          "tibuild.pingcap.net/git-repo": $(tt.params.git-url)
+          "tibuild.pingcap.net/git-ref": $(tt.params.git-ref)
+          "tibuild.pingcap.net/git-revision": $(tt.params.git-revision)
+          "tibuild.pingcap.net/component": $(tt.params.component)
+          "tibuild.pingcap.net/profile": $(tt.params.profile)
+          "tibuild.pingcap.net/platform": darwin/amd64
+      spec:
+        pipelineRef:
+          name: pingcap-build-package-darwin
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: git-refspec
+            value: $(tt.params.git-refspec)
+          - name: git-revision
+            value: $(tt.params.git-revision)
+          - name: git-ref
+            value: $(tt.params.git-ref)
+          - name: component
+            value: $(tt.params.component)
+          - name: os
+            value: darwin
+          - name: arch
+            value: amd64
+          - name: profile
+            value: $(tt.params.profile)
+          - name: registry
+            value: $(tt.params.registry)
+          - name: force-builder-image
+            value: $(tt.params.force-builder-image)
+          - name: boskos-server-url
+            value: http://boskos.apps.svc
+        timeouts:
+          pipeline: $(tt.params.timeout)
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                storageClassName: hyperdisk-rwo
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: $(tt.params.source-ws-size)
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
+          - name: mac-ssh-credentials
+            secret:
+              secretName: mac-ssh-credentials
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: bp-$(tt.params.component)-$(tt.params.profile)-darwin-arm64-
+        annotations:
+          "tekton.dev/ce-context": $(tt.params.ce-context)
+          "tibuild.pingcap.net/git-repo": $(tt.params.git-url)
+          "tibuild.pingcap.net/git-ref": $(tt.params.git-ref)
+          "tibuild.pingcap.net/git-revision": $(tt.params.git-revision)
+          "tibuild.pingcap.net/component": $(tt.params.component)
+          "tibuild.pingcap.net/profile": $(tt.params.profile)
+          "tibuild.pingcap.net/platform": darwin/arm64
+      spec:
+        pipelineRef:
+          name: pingcap-build-package-darwin
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: git-refspec
+            value: $(tt.params.git-refspec)
+          - name: git-revision
+            value: $(tt.params.git-revision)
+          - name: git-ref
+            value: $(tt.params.git-ref)
+          - name: component
+            value: $(tt.params.component)
+          - name: os
+            value: darwin
+          - name: arch
+            value: arm64
+          - name: profile
+            value: $(tt.params.profile)
+          - name: registry
+            value: $(tt.params.registry)
+          - name: force-builder-image
+            value: $(tt.params.force-builder-image)
+          - name: boskos-server-url
+            value: http://boskos.apps.svc
+        timeouts:
+          pipeline: $(tt.params.timeout)
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                storageClassName: hyperdisk-rwo
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: $(tt.params.source-ws-size)
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
+          - name: mac-ssh-credentials
+            secret:
+              secretName: mac-ssh-credentials

--- a/tekton/v1/triggers/templates/_/build-component-single-platform.yaml
+++ b/tekton/v1/triggers/templates/_/build-component-single-platform.yaml
@@ -1,0 +1,118 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: build-component-single-platform
+spec:
+  params:
+    - name: git-url
+      description: The git repository full url
+    - name: git-refspec
+      default: +refs/heads/*:refs/heads/*
+    - name: git-revision
+      description: The git revision
+    - name: git-ref
+      description: The git branch
+    - name: component
+      description: component name, tidb|tikv|pd|tiflow|tiflash, etc...
+    - name: os
+      default: linux
+    - name: arch
+      default: amd64
+    - name: profile
+      description: build target profile
+      default: release
+    - name: registry
+      default: hub.pingcap.net
+    - name: timeout
+      description: pipeline run timeout
+      default: 2h
+    - name: source-ws-size
+      description: workspace size for source.
+      default: 10Gi
+    - name: builder-resources-memory
+      default: 16Gi
+    - name: builder-resources-cpu
+      default: "4"
+    - name: ce-context
+      description: cloud event context.
+      default: "{}"
+    - name: force-builder-image
+      default: ""
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: bp-$(tt.params.component)-$(tt.params.profile)-$(tt.params.os)-$(tt.params.arch)-
+        annotations:
+          "tekton.dev/ce-context": $(tt.params.ce-context)
+          "tibuild.pingcap.net/git-repo": $(tt.params.git-url)
+          "tibuild.pingcap.net/git-ref": $(tt.params.git-ref)
+          "tibuild.pingcap.net/git-revision": $(tt.params.git-revision)
+          "tibuild.pingcap.net/component": $(tt.params.component)
+          "tibuild.pingcap.net/profile": $(tt.params.profile)
+          "tibuild.pingcap.net/platform": $(tt.params.os)/$(tt.params.arch)
+      spec:
+        pipelineRef:
+          name: pingcap-build-package-$(tt.params.os)
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: git-refspec
+            value: $(tt.params.git-refspec)
+          - name: git-revision
+            value: $(tt.params.git-revision)
+          - name: git-ref
+            value: $(tt.params.git-ref)
+          - name: component
+            value: $(tt.params.component)
+          - name: profile
+            value: $(tt.params.profile)
+          - name: os
+            value: $(tt.params.os)
+          - name: arch
+            value: $(tt.params.arch)
+          - name: registry
+            value: $(tt.params.registry)
+          - name: force-builder-image
+            value: $(tt.params.force-builder-image)
+          - name: boskos-server-url # for darwin platforms
+            value: http://boskos.apps.svc
+        podTemplate:
+          nodeSelector:
+            kubernetes.io/arch: $(tt.params.arch)
+        taskRunSpecs:
+          - pipelineTaskName: checkout
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: checkout-ext
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: build-binaries
+            taskServiceAccountName: image-releaser
+            stepOverrides:
+              - name: build
+                resources:
+                  requests:
+                    memory: $(tt.params.builder-resources-memory)
+                    cpu: $(tt.params.builder-resources-cpu)
+          - pipelineTaskName: build-images
+            taskServiceAccountName: image-releaser
+        timeouts:
+          pipeline: $(tt.params.timeout)
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                storageClassName: hyperdisk-rwo
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: $(tt.params.source-ws-size)
+          # - name: cargo-home # for linux platforms
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home
+          # - name: cypress-cache # for linux platforms
+          #   persistentVolumeClaim:
+          #     claimName: cypress-cache
+          - name: mac-ssh-credentials # for darwin platforms
+            secret:
+              secretName: mac-ssh-credentials

--- a/tekton/v1/triggers/templates/_/build-component.yaml
+++ b/tekton/v1/triggers/templates/_/build-component.yaml
@@ -1,0 +1,180 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: build-component
+spec:
+  params:
+    - name: git-url
+      description: The git repository full url
+    - name: git-refspec
+      default: +refs/heads/*:refs/heads/*
+    - name: git-revision
+      description: The git revision
+    - name: git-ref
+      description: The git branch
+    - name: component
+      description: component name, tidb|tikv|pd|tiflow|tiflash, etc...
+    - name: os
+      default: linux
+    - name: profile
+      description: build target profile
+      default: release
+    - name: registry
+      default: hub.pingcap.net
+    - name: timeout
+      description: pipeline run timeout
+      default: 2h
+    - name: source-ws-size
+      description: workspace size for source.
+      default: 10Gi
+    - name: builder-resources-memory
+      default: 16Gi
+    - name: builder-resources-cpu
+      default: "4"
+    - name: ce-context
+      description: cloud event context.
+      default: '{}'
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: bp-$(tt.params.component)-$(tt.params.profile)-$(tt.params.os)-amd64-
+        annotations:
+          "tekton.dev/ce-context": $(tt.params.ce-context)
+          "tibuild.pingcap.net/git-repo": $(tt.params.git-url)
+          "tibuild.pingcap.net/git-ref": $(tt.params.git-ref)
+          "tibuild.pingcap.net/git-revision": $(tt.params.git-revision)
+          "tibuild.pingcap.net/component": $(tt.params.component)
+          "tibuild.pingcap.net/profile": $(tt.params.profile)
+          "tibuild.pingcap.net/platform": $(tt.params.os)/amd64
+      spec:
+        pipelineRef:
+          name: pingcap-build-package-linux
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: git-refspec
+            value: $(tt.params.git-refspec)
+          - name: git-revision
+            value: $(tt.params.git-revision)
+          - name: git-ref
+            value: $(tt.params.git-ref)
+          - name: component
+            value: $(tt.params.component)
+          - name: profile
+            value: $(tt.params.profile)
+          - name: os
+            value: $(tt.params.os)
+          - name: arch
+            value: amd64
+          - name: registry
+            value: $(tt.params.registry)
+        podTemplate:
+          nodeSelector:
+            kubernetes.io/arch: amd64
+        taskRunSpecs:
+          - pipelineTaskName: checkout
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: checkout-ext
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: build-binaries
+            taskServiceAccountName: image-releaser
+            stepOverrides:
+              - name: build
+                resources:
+                  requests:
+                    memory: $(tt.params.builder-resources-memory)
+                    cpu: $(tt.params.builder-resources-cpu)
+          - pipelineTaskName: build-images
+            taskServiceAccountName: image-releaser
+        timeouts:
+          pipeline: $(tt.params.timeout)
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                storageClassName: hyperdisk-rwo
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: $(tt.params.source-ws-size)
+          # - name: git-basic-auth # fetch with git-cdn.
+          #   secret:
+          #     secretName: git-credentials-basic
+          # - name: cargo-home
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home
+          # - name: cypress-cache
+          #   persistentVolumeClaim:
+          #     claimName: cypress-cache
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: bp-$(tt.params.component)-$(tt.params.profile)-$(tt.params.os)-arm64-
+        annotations:
+          "tekton.dev/ce-context": $(tt.params.ce-context)
+          "tibuild.pingcap.net/git-repo": $(tt.params.git-url)
+          "tibuild.pingcap.net/git-ref": $(tt.params.git-ref)
+          "tibuild.pingcap.net/git-revision": $(tt.params.git-revision)
+          "tibuild.pingcap.net/component": $(tt.params.component)
+          "tibuild.pingcap.net/profile": $(tt.params.profile)
+          "tibuild.pingcap.net/platform": $(tt.params.os)/arm64
+      spec:
+        pipelineRef:
+          name: pingcap-build-package-linux
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: git-refspec
+            value: $(tt.params.git-refspec)
+          - name: git-revision
+            value: $(tt.params.git-revision)
+          - name: git-ref
+            value: $(tt.params.git-ref)
+          - name: component
+            value: $(tt.params.component)
+          - name: profile
+            value: $(tt.params.profile)
+          - name: os
+            value: $(tt.params.os)
+          - name: arch
+            value: arm64
+          - name: registry
+            value: $(tt.params.registry)
+        podTemplate:
+          nodeSelector:
+            kubernetes.io/arch: arm64
+        taskRunSpecs:
+          - pipelineTaskName: checkout
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: checkout-ext
+            taskServiceAccountName: github-bot
+          - pipelineTaskName: build-binaries
+            taskServiceAccountName: image-releaser
+            stepOverrides:
+              - name: build
+                resources:
+                  requests:
+                    memory: $(tt.params.builder-resources-memory)
+                    cpu: $(tt.params.builder-resources-cpu)
+          - pipelineTaskName: build-images
+            taskServiceAccountName: image-releaser
+        timeouts:
+          pipeline: $(tt.params.timeout)
+        workspaces:
+          - name: source
+            volumeClaimTemplate:
+              spec:
+                storageClassName: hyperdisk-rwo
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: $(tt.params.source-ws-size)
+          # - name: cargo-home
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home
+          # - name: cypress-cache
+          #   persistentVolumeClaim:
+          #     claimName: cypress-cache

--- a/tekton/v1/triggers/templates/_/ci-helper-for-pr.yaml
+++ b/tekton/v1/triggers/templates/_/ci-helper-for-pr.yaml
@@ -1,0 +1,28 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: ci-helper-for-pr
+spec:
+  params:
+    - name: pr-owner
+    - name: pr-repo
+    - name: pr-number
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: TaskRun
+      metadata:
+        generateName: ci-helper-for-pr-
+      spec:
+        params:
+          - name: owner
+            value: $(tt.params.pr-owner)
+          - name: repo
+            value: $(tt.params.pr-repo)
+          - name: number
+            value: $(tt.params.pr-number)
+        taskRef:
+          name: ci-helper-for-pr
+        workspaces:
+          - name: github
+            secret:
+              secretName: github

--- a/tekton/v1/triggers/templates/kustomization.yaml
+++ b/tekton/v1/triggers/templates/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - _/build-component-all-platforms.yaml
+  - _/build-component-single-platform.yaml
+  - _/build-component.yaml
+  - _/ci-helper-for-pr.yaml
+  - pingcap/bump-placeholder-version-in-readme.yaml
+  - pingcap/sync-owners-for-hotfix-branch.yaml
+  - pingcap/tidb/update-gomod-fix-ladp-for-hotfix-branch.yaml
+  - tikv/tikv/bump-tikv-cargo-pkg-version.yaml

--- a/tekton/v1/triggers/templates/pingcap/bump-placeholder-version-in-readme.yaml
+++ b/tekton/v1/triggers/templates/pingcap/bump-placeholder-version-in-readme.yaml
@@ -1,0 +1,29 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: bump-placeholder-version-in-readme
+spec:
+  params:
+    - name: git-url
+      description: The git repository full url
+    - name: git-ref
+      description: The git branch or tag.
+    - name: rust-image
+      default: ghcr.io/pingcap-qe/cd/builders/tikv:v20231116-e1c4b43
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: TaskRun
+      metadata:
+        generateName: create-pr-to-add-release-anchor-commit-
+      spec:
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: branch
+            value: $(tt.params.git-ref)
+        taskRef:
+          name: create-pr-to-add-release-anchor-commit
+        workspaces:
+          - name: github
+            secret:
+              secretName: github

--- a/tekton/v1/triggers/templates/pingcap/sync-owners-for-hotfix-branch.yaml
+++ b/tekton/v1/triggers/templates/pingcap/sync-owners-for-hotfix-branch.yaml
@@ -1,0 +1,33 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: sync-owners-for-hotfix-branch
+spec:
+  params:
+    - name: git-url
+      description: The git repository full url
+    - name: git-ref
+      description: The git ref
+      default: main
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: TaskRun
+      metadata:
+        generateName: create-pr-to-sync-owners-for-hotfix-
+        annotations:
+          "tekton.dev/git-status": "true"
+          "tekton.dev/git-repo": $(tt.params.git-url)
+          "tekton.dev/git-revision": $(tt.params.git-ref)
+      spec:
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: branch
+            value: $(tt.params.git-ref)
+        taskRef:
+          kind: Task
+          name: create-pr-to-sync-owners
+        workspaces:
+          - name: github
+            secret:
+              secretName: github

--- a/tekton/v1/triggers/templates/pingcap/tidb/update-gomod-fix-ladp-for-hotfix-branch.yaml
+++ b/tekton/v1/triggers/templates/pingcap/tidb/update-gomod-fix-ladp-for-hotfix-branch.yaml
@@ -1,0 +1,36 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: update-pingcap-tidb-gomod-fix-ladp-for-hotfix-branch
+spec:
+  params:
+    - name: git-url
+      description: The git repository full url
+    - name: git-ref
+      description: The git ref
+      default: main
+    - name: golang-image
+      default: ghcr.io/pingcap-qe/ci/base:v20231216-14-g77d0cd2-go1.19
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: TaskRun
+      metadata:
+        generateName: create-pr-to-update-gomod-fix-ladp-for-hotfix-
+      spec:
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: branch
+            value: $(tt.params.git-ref)
+          - name: golang-image
+            value: $(tt.params.golang-image)
+        taskRef:
+          kind: Task
+          name: create-pr-to-update-gomod-fix-ladp
+        podTemplate:
+            nodeSelector:
+              kubernetes.io/arch: "amd64"
+        workspaces:
+          - name: github
+            secret:
+              secretName: github

--- a/tekton/v1/triggers/templates/tikv/tikv/bump-tikv-cargo-pkg-version.yaml
+++ b/tekton/v1/triggers/templates/tikv/tikv/bump-tikv-cargo-pkg-version.yaml
@@ -1,0 +1,34 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: bump-tikv-cargo-pkg-version
+spec:
+  params:
+    - name: git-url
+      description: The git repository full url
+    - name: git-ref
+      description: The git branch or tag.
+    - name: rust-image
+      default: ghcr.io/pingcap-qe/cd/builders/tikv:v20231116-e1c4b43
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: TaskRun
+      metadata:
+        generateName: create-pr-to-bump-tikv-version-
+      spec:
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: branch
+            value: $(tt.params.git-ref)
+          - name: rust-image
+            value: $(tt.params.rust-image)
+        taskRef:
+          name: create-pr-to-bump-tikv-version
+        workspaces:
+          - name: github
+            secret:
+              secretName: github
+          # - name: cargo-home
+          #   persistentVolumeClaim:
+          #     claimName: cargo-home

--- a/tekton/v1/triggers/triggers/_/git-create-branch-gomod-update.yaml
+++ b/tekton/v1/triggers/triggers/_/git-create-branch-gomod-update.yaml
@@ -1,0 +1,89 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: branch-create-pingcap-tidb-hotfix-lt-v7.0
+  labels:
+    type: github-branch-create
+spec:
+  interceptors:
+    - name: filter on repo owner and name
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name in ['pingcap/tidb', 'pingcap/tiflow']
+    # filter git refs that match regexp: ^release-\d+\.\d+-\d+-v\d+\.\d+\.\d+$
+    # example values of `body.ref`:
+    #   release-6.5-20231020-v6.5.5
+    #   release-6.5-20231020-v6.5.5-1
+    # regular use re2: https://github.com/google/re2/wiki/Syntax
+    - name: filter on branch names
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.ref.matches('^release-[0-9]+[.][0-9]+-[0-9]+-v[0-9]+[.][0-9]+[.][0-9]+(-.+)?$') &&
+            body.ref < 'release-7.0'
+
+  bindings:
+    - ref: github-branch-create
+    - {
+        name: golang-image,
+        value: "ghcr.io/pingcap-qe/ci/base:v20231216-50-gc125b52-go1.19",
+      }
+  template:
+    ref: update-pingcap-tidb-gomod-fix-ladp-for-hotfix-branch
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: branch-create-pingcap-tidb-hotfix-be-v7.0-v7.3
+  labels:
+    type: github-branch-create
+spec:
+  interceptors:
+    - name: combined filter on repo owner, name, and branch
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name in ['pingcap/tidb', 'pingcap/tiflow'] &&
+            body.ref.matches('^release-7[.][0-3]-[0-9]+-v[0-9]+[.][0-9]+[.][0-9]+(-.+)?$')
+  bindings:
+    - ref: github-branch-create
+    - {
+        name: golang-image,
+        value: "ghcr.io/pingcap-qe/ci/base:v20231216-50-gc125b52-go1.20",
+      }
+  template:
+    ref: update-pingcap-tidb-gomod-fix-ladp-for-hotfix-branch
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: branch-create-pingcap-tidb-hotfix-ge-v7.4
+  labels:
+    type: github-branch-create
+spec:
+  interceptors:
+    - name: combined filter on repo owner, name, and branch
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name in ['pingcap/tidb', 'pingcap/tiflow'] &&
+            body.ref.matches('^release-[0-9]+[.][0-9]+-[0-9]+-v[0-9]+[.][0-9]+[.][0-9]+(-.+)?$') &&
+            body.ref >= 'release-7.4'
+
+  bindings:
+    - ref: github-branch-create
+    - {
+        name: golang-image,
+        value: "ghcr.io/pingcap-qe/ci/base:v20231216-50-gc125b52-go1.21",
+      }
+  template:
+    ref: update-pingcap-tidb-gomod-fix-ladp-for-hotfix-branch

--- a/tekton/v1/triggers/triggers/_/git-create-branch.yaml
+++ b/tekton/v1/triggers/triggers/_/git-create-branch.yaml
@@ -1,0 +1,59 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: branch-create-product-components-hotfix
+  labels:
+    type: github-branch-create
+spec:
+  interceptors:
+    - name: filter on repo and branches
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name in [
+            'pingcap/tidb',
+            'pingcap/tiflash',
+            'pingcap/tiflow',
+            'pingcap/ticdc',
+            'pingcap/tidb-binlog',
+            'pingcap/tidb-dashboard',
+            'pingcap/tidb-tools',
+            'tikv/tikv',
+            'tikv/pd',
+            ]
+            &&
+            body.ref.matches('^release-[0-9]+[.][0-9]+-[0-9]+-v[0-9]+[.][0-9]+[.][0-9]+(-.+)?$')
+
+  bindings:
+    - ref: github-branch-create
+  template:
+    ref: sync-owners-for-hotfix-branch
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: branch-create-pingcap-org-bump-placeholder
+  labels:
+    type: github-branch-create
+    github-owner: pingcap
+spec:
+  interceptors:
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name in [
+            'pingcap/monitoring',
+            'pingcap/ng-monitoring',
+            'pingcap/tidb-binlog',
+            'pingcap/tidb-dashboard',
+            ]
+            &&
+            body.ref.matches('^release-[0-9]+[.][0-9]+(-beta[.][0-9]+)?$')
+  bindings:
+    - ref: github-branch-create
+  template:
+    ref: bump-placeholder-version-in-readme

--- a/tekton/v1/triggers/triggers/_/git-create-tag.yaml
+++ b/tekton/v1/triggers/triggers/_/git-create-tag.yaml
@@ -1,0 +1,26 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: tag-create-pingcap-org-bump-placeholder
+  labels:
+    type: github-tag-create
+spec:
+  interceptors:
+    - name: filter on repo owner and name and tags
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name in [
+            'pingcap/monitoring',
+            'pingcap/ng-monitoring',
+            'pingcap/tidb-binlog',
+            'pingcap/tidb-dashboard',
+            'pingcap/tiflow',
+            ]
+            &&
+            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta)([.][0-9]+.*)?)?$')
+  bindings:
+    - ref: github-tag-create
+  template:
+    ref: bump-placeholder-version-in-readme

--- a/tekton/v1/triggers/triggers/_/github-pr-labeled-with-lgtm.yaml
+++ b/tekton/v1/triggers/triggers/_/github-pr-labeled-with-lgtm.yaml
@@ -1,0 +1,71 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: pr-to-feature-branches-labeled-with-lgtm
+  labels:
+    type: github-pr
+spec:
+  interceptors:
+    - name: filter on repo owner and name and tags
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.action == 'labeled'
+            &&
+            body.label.name in ['lgtm']
+            &&
+            body.repository.full_name in [ 'pingcap/tidb', 'pingcap/tiflash', 'pingcap/tiflow', 'pingcap/ticdc', 'tikv/tikv', 'tikv/pd' ]
+            &&
+            body.pull_request.base.ref.startsWith('feature/')
+  bindings:
+    - ref: github-pr
+  template:
+    spec:
+      params:
+        - name: pr-owner
+        - name: pr-repo
+        - name: pr-number
+      resourcetemplates:
+        - apiVersion: tekton.dev/v1beta1
+          kind: TaskRun
+          metadata:
+            generateName: auto-add-approved-label-to-pr-on-special-branch-
+          spec:
+            params:
+              - name: owner
+                value: $(tt.params.pr-owner)
+              - name: repo
+                value: $(tt.params.pr-repo)
+              - name: number
+                value: $(tt.params.pr-number)
+            taskSpec:
+              description: CI helper for contribution pull requests
+              params:
+                - name: owner
+                  description: repo owner
+                - name: repo
+                  description: repo short name
+                - name: number
+                  description: pull request number
+              steps:
+                - name: edit-pull-request
+                  image: alpine:3.21.3
+                  script: |
+                    #!/usr/bin/env sh
+
+                    # install `gh` tool
+                    apk add github-cli
+
+                    gh auth login --with-token < $(workspaces.github.path)/token
+                    pr_url="https://github.com/$(params.owner)/$(params.repo)/pull/$(params.number)"
+                    # TODO: Judge if we can add approved label by the comments from prow approve plugin
+                    # Add label only if there are sufficient approvals from trusted users```
+                    gh pr edit --add-label approved "$pr_url"
+              workspaces:
+                - name: github
+                  description: Must includes a key `token`
+            workspaces:
+              - name: github
+                secret:
+                  secretName: github

--- a/tekton/v1/triggers/triggers/_/github-pr-labeled-with-needs-ok-to-test.yaml
+++ b/tekton/v1/triggers/triggers/_/github-pr-labeled-with-needs-ok-to-test.yaml
@@ -1,0 +1,33 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: pr-labeled-with-needs-ok-to-test
+  labels:
+    type: github-pr
+spec:
+  interceptors:
+    - name: filter on repo owner and name and tags
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.action == 'labeled'
+            &&
+            body.label.name in ['needs-ok-to-test']
+            &&
+            body.repository.full_name in [
+            'pingcap/tidb',
+            'pingcap/tidb-dashboard',
+            'pingcap/tidb-operator',
+            'pingcap/tiflow',
+            'tikv/client-go',
+            'tikv/pd',
+            'tikv/raft-engine',
+            'tikv/tikv',
+            ]
+            &&
+            body.pull_request.user.login in ['mittalrishabh', 'Tema', 'HaoW30']
+  bindings:
+    - ref: github-pr
+  template:
+    ref: ci-helper-for-pr

--- a/tekton/v1/triggers/triggers/kustomization.yaml
+++ b/tekton/v1/triggers/triggers/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - _/git-create-branch-gomod-update.yaml
+  - _/git-create-branch.yaml
+  - _/git-create-tag.yaml
+  - _/github-pr-labeled-with-lgtm.yaml
+  - _/github-pr-labeled-with-needs-ok-to-test.yaml
+  - pingcap/ticdc/git-push-branch-build.yaml
+  - pingcap/tidb/git-push-branch-build.yaml
+  - pingcap/tiflash/git-push-branch-build.yaml
+  - tidbcloud/cloud-storage-engine/git-push-branch-build.yaml
+  - tikv/pd/git-push-branch-build.yaml
+  - tikv/tikv/git-create-branch.yaml
+  - tikv/tikv/git-create-tag.yaml

--- a/tekton/v1/triggers/triggers/pingcap/ticdc/git-push-branch-build.yaml
+++ b/tekton/v1/triggers/triggers/pingcap/ticdc/git-push-branch-build.yaml
@@ -1,0 +1,31 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: github-push-ticdc-build-next-gen
+  labels:
+    type: github-branch-push
+    github-owner: pingcap
+    profile: next-gen
+spec:
+  interceptors:
+    - name: filter on repo
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name == 'pingcap/ticdc'
+            &&
+            body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+)$')
+
+  bindings:
+    - ref: github-branch-push
+    - { name: component, value: $(body.repository.name) }
+    - { name: profile, value: next-gen }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/hub }
+    - { name: timeout, value: 20m }
+    - { name: source-ws-size, value: 50Gi }
+    - { name: builder-resources-cpu, value: "4" }
+    - { name: builder-resources-memory, value: "16Gi" }
+
+  template:
+    ref: build-component

--- a/tekton/v1/triggers/triggers/pingcap/tidb/git-push-branch-build.yaml
+++ b/tekton/v1/triggers/triggers/pingcap/tidb/git-push-branch-build.yaml
@@ -1,0 +1,31 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: github-push-tidb-build-next-gen
+  labels:
+    type: github-branch-push
+    github-owner: pingcap
+    profile: next-gen
+spec:
+  interceptors:
+    - name: filter on repo
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name == 'pingcap/tidb'
+            &&
+            body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+)$')
+
+  bindings:
+    - ref: github-branch-push
+    - { name: component, value: $(body.repository.name) }
+    - { name: os, value: linux }
+    - { name: profile, value: next-gen }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/hub }
+    - { name: timeout, value: 45m }
+    - { name: source-ws-size, value: 50Gi }
+    - { name: builder-resources-cpu, value: "6" }
+    - { name: builder-resources-memory, value: 24Gi }
+  template:
+    ref: build-component

--- a/tekton/v1/triggers/triggers/pingcap/tiflash/git-push-branch-build.yaml
+++ b/tekton/v1/triggers/triggers/pingcap/tiflash/git-push-branch-build.yaml
@@ -1,0 +1,31 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: github-push-tiflash-build-next-gen
+  labels:
+    type: github-branch-push
+    github-owner: pingcap
+    profile: next-gen
+spec:
+  interceptors:
+    - name: filter on repo
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name == 'pingcap/tiflash'
+            &&
+            body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+)$')
+
+  bindings:
+    - ref: github-branch-push
+    - { name: component, value: $(body.repository.name) }
+    - { name: profile, value: next-gen }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/hub }
+    - { name: timeout, value: 2h }
+    - { name: source-ws-size, value: 100Gi }
+    - { name: builder-resources-cpu, value: "12" }
+    - { name: builder-resources-memory, value: "48Gi" }
+
+  template:
+    ref: build-component

--- a/tekton/v1/triggers/triggers/tidbcloud/cloud-storage-engine/git-push-branch-build.yaml
+++ b/tekton/v1/triggers/triggers/tidbcloud/cloud-storage-engine/git-push-branch-build.yaml
@@ -1,0 +1,31 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: github-push-cloud-storage-engine-build
+  labels:
+    type: github-branch-push
+    github-owner: tidbcloud
+    profile: next-gen
+spec:
+  interceptors:
+    - name: filter on repo
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name == 'tidbcloud/cloud-storage-engine'
+            &&
+            body.ref.matches('^refs/heads/(dedicated|release-nextgen-[0-9]+)$')
+
+  bindings:
+    - ref: github-branch-push
+    - { name: component, value: tikv }
+    - { name: profile, value: next-gen }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/hub }
+    - { name: timeout, value: 2h }
+    - { name: source-ws-size, value: 100Gi }
+    - { name: builder-resources-cpu, value: "12" }
+    - { name: builder-resources-memory, value: "48Gi" }
+
+  template:
+    ref: build-component

--- a/tekton/v1/triggers/triggers/tikv/pd/git-push-branch-build.yaml
+++ b/tekton/v1/triggers/triggers/tikv/pd/git-push-branch-build.yaml
@@ -1,0 +1,31 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: github-push-pd-build-next-gen
+  labels:
+    type: github-branch-push
+    github-owner: tikv
+    profile: next-gen
+spec:
+  interceptors:
+    - name: filter on repo
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name == 'tikv/pd'
+            &&
+            body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+)$')
+
+  bindings:
+    - ref: github-branch-push
+    - { name: component, value: $(body.repository.name) }
+    - { name: profile, value: next-gen }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/hub }
+    - { name: timeout, value: 40m }
+    - { name: source-ws-size, value: 50Gi }
+    - { name: builder-resources-cpu, value: "6" }
+    - { name: builder-resources-memory, value: "24Gi" }
+
+  template:
+    ref: build-component

--- a/tekton/v1/triggers/triggers/tikv/tikv/git-create-branch.yaml
+++ b/tekton/v1/triggers/triggers/tikv/tikv/git-create-branch.yaml
@@ -1,0 +1,24 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: branch-create-tikv-tikv
+  labels:
+    type: github-branch-create
+    github-owner: tikv
+    github-repo: tikv
+spec:
+  interceptors:
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.repository.owner.login == 'tikv'
+            &&
+            body.repository.name == 'tikv'
+            &&
+            body.ref.matches('^release-[0-9]+[.][0-9]+(-beta[.][0-9]+)?$')
+  bindings:
+    - ref: github-branch-create
+  template:
+    ref: bump-tikv-cargo-pkg-version

--- a/tekton/v1/triggers/triggers/tikv/tikv/git-create-tag.yaml
+++ b/tekton/v1/triggers/triggers/tikv/tikv/git-create-tag.yaml
@@ -1,0 +1,25 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: tag-create-tikv-tikv
+  labels:
+    type: github-tag-create
+    github-owner: tikv
+    github-repo: tikv
+spec:
+  interceptors:
+    - name: filter on repo owner and name and branches
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.repository.owner.login == 'tikv'
+            &&
+            body.repository.name == 'tikv'
+            &&
+            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?([.]pre)?)?$')
+
+  bindings:
+    - ref: github-tag-create
+  template:
+    ref: bump-tikv-cargo-pkg-version


### PR DESCRIPTION
This pull request introduces several new Tekton TriggerTemplates and a Kustomize manifest to streamline CI/CD workflows for building components, handling PRs, and automating repository maintenance tasks. The changes provide flexible templates for multi-platform and single-platform builds, helper tasks for PRs, and automation for updating documentation and syncing owner files.

**Build and CI Pipeline Templates:**

* Added `build-component-all-platforms.yaml`, `build-component-single-platform.yaml`, and `build-component.yaml` templates to support building components across multiple platforms (Linux and Darwin, amd64 and arm64) with configurable parameters for resources, workspace size, and build profiles. These templates standardize pipeline runs and resource allocation for various build scenarios. [[1]](diffhunk://#diff-f9bca15fc3e8dcd48ed51fe3c64d652666be6952ee8ef6b7e2670effe22478c3R1-R299) [[2]](diffhunk://#diff-d017170fd58f6b5f5bcf39e5a4c09fd4704cd6bc300f71dec7388e604f59b2faR1-R118) [[3]](diffhunk://#diff-dcd409d8cbdbb7016725a94e441b41b3469ab3788e5757c8376ae17c8f0b2a02R1-R180)

* Introduced `ci-helper-for-pr.yaml` TriggerTemplate to facilitate CI tasks related to pull requests, including parameterized execution and secure access to GitHub credentials.

**Repository Maintenance Automation:**

* Added `bump-placeholder-version-in-readme.yaml` and `sync-owners-for-hotfix-branch.yaml` templates to automate documentation updates and synchronize owner files for hotfix branches, improving consistency and reducing manual intervention. [[1]](diffhunk://#diff-23e99587153e95470104cf025ed9352d6307d11aa694d3fcf2214c8ac657fd8eR1-R29) [[2]](diffhunk://#diff-5504c262d1928bdf0f299d0fe49585e5aee91673944a66b4c8cf9bb0be05899bR1-R33)

**Manifest Management:**

* Created `kustomization.yaml` to aggregate the new templates and related resources, enabling easier deployment and management of Tekton pipelines using Kustomize.