### PR TITLE
feat(pingcap/tiflow): trigger dm integration test for changes in sync_diff_inspector

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -49,14 +49,15 @@ pipeline {
                 container("golang") {
                     script {
                         def pr_diff_files = component.getPrDiffFiles(GIT_FULL_REPO_NAME, REFS.pulls[0].number, GIT_CREDENTIALS_ID2)
-                        def pattern = /(^dm\/|^pkg\/|^go\.mod).*$/
+                        def pattern = /(^dm\/|^pkg\/|^sync_diff_inspector\/|^go\.mod).*$/
                         println "pr_diff_files: ${pr_diff_files}"
                         // if any diff files start with dm/ or pkg/ or file go.mod, run the dm integration test
+                        // besides, any changes in sync_diff_inspector also need to run test
                         def matched = component.patternMatchAnyFile(pattern, pr_diff_files)
                         if (matched) {
-                            println "matched, some diff files full path start with dm/ or pkg/ or go.mod, run the dm integration test"
+                            println "matched, some diff files full path start with dm/, sync_diff_inspector/ or pkg/ or go.mod, run the dm integration test"
                         } else {
-                            println "not matched, all files full path not start with dm/ or pkg/ or go.mod, current pr not releate to dm, so skip the dm integration test"
+                            println "not matched, all files full path not start with dm/, sync_diff_inspector/ or pkg/ or go.mod, current pr not releate to dm, so skip the dm integration test"
                             currentBuild.result = 'SUCCESS'
                             skipRemainingStages = true
                             return 0


### PR DESCRIPTION
As title, since dm integration test relies on sync_diff_inspector, we should trigger this test when we add some changes to sync_diff_inspector.