### PR TITLE
fix(tekton/v0/triggers): fix tag regex to match -release format for pingcap/ticdc repo

### DIFF
--- a/tekton/v0/triggers/triggers/pingcap/ticdc/git-create-tag.yaml
+++ b/tekton/v0/triggers/triggers/pingcap/ticdc/git-create-tag.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'pingcap/ticdc'
             &&
-            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+[.]release[.][0-9]+$')
+            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+-release[.][0-9]+$')
   bindings:
     - ref: github-tag-create
     - { name: component, value: $(body.repository.name) }


### PR DESCRIPTION

Accept tags of the form vX.Y.Z-release.N instead of vX.Y.Z.release.N