### PR TITLE
fix(tekton/v0/tasks,tekton/v1/tasks): allow release suffix in tag regex when clean git tags

### DIFF
--- a/tekton/v0/tasks/pingcap-get-set-release-version-v2.yaml
+++ b/tekton/v0/tasks/pingcap-get-set-release-version-v2.yaml
@@ -40,7 +40,7 @@ spec:
         # - v1.2.3-(fips|cse|...), but currently we only allow "fips" and "cse" for the range in `()`.
         if git tag | grep -E "v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|fips|cse)([.][0-9]+)?)?$" > /dev/null; then
           # Only delete the none-standard tags when the repo has standard semver tags.
-          git tag | grep -vE "^v[0-9]+[.][0-9]+[.][0-9]+(-(((alpha|beta|rc)([.].+)?)|fips|cse|202[1-9][0-1][0-9][0-3][0-9]-[0-9a-f]{7,10}))?$" | xargs git tag -d || true
+          git tag | grep -vE "^v[0-9]+[.][0-9]+[.][0-9]+(-(((alpha|beta|rc|release)([.].+)?)|fips|cse|202[1-9][0-1][0-9][0-3][0-9]-[0-9a-f]{7,10}))?$" | xargs git tag -d || true
         fi
 
         # delete the date tags

--- a/tekton/v1/tasks/pingcap-get-set-release-version-v2.yaml
+++ b/tekton/v1/tasks/pingcap-get-set-release-version-v2.yaml
@@ -41,7 +41,7 @@ spec:
         # - v1.2.3-(fips|cse|...), but currently we only allow "fips" and "cse" for the range in `()`.
         if git tag | grep -E "v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|fips|cse)([.][0-9]+)?)?$" > /dev/null; then
           # Only delete the none-standard tags when the repo has standard semver tags.
-          git tag | grep -vE "^v[0-9]+[.][0-9]+[.][0-9]+(-(((alpha|beta|rc)([.].+)?)|fips|cse|202[1-9][0-1][0-9][0-3][0-9]-[0-9a-f]{7,10}))?$" | xargs git tag -d || true
+          git tag | grep -vE "^v[0-9]+[.][0-9]+[.][0-9]+(-(((alpha|beta|rc|release)([.].+)?)|fips|cse|202[1-9][0-1][0-9][0-3][0-9]-[0-9a-f]{7,10}))?$" | xargs git tag -d || true
         fi
 
         # delete the date tags


### PR DESCRIPTION
This pull request updates the logic for filtering git tags in the Tekton pipeline task scripts to include the `release` tag variant as a recognized standard. This change ensures that tags matching the `release` pattern are preserved and not deleted as non-standard tags.

Tag filtering logic update:

* In both `tekton/v0/tasks/pingcap-get-set-release-version-v2.yaml` and `tekton/v1/tasks/pingcap-get-set-release-version-v2.yaml`, the regular expression used to identify standard semver tags now includes the `release` variant, preventing accidental deletion of tags such as `v1.2.3-release`. [[1]](diffhunk://#diff-9904c8dfc5da304d83fed6591586b52d82f83f304bd7641f083791d98fb20451L43-R43) [[2]](diffhunk://#diff-73a92c7100c05352eb4ee75aaa7114a55cb9ef1ef978218f79bc2b9ad422dbacL44-R44)