### PR TITLE
feat(scripts/artifacts): add support for downloading pd-ctl and fix downloading tikv-worker

### DIFF
--- a/scripts/artifacts/download_pingcap_oci_artifact.sh
+++ b/scripts/artifacts/download_pingcap_oci_artifact.sh
@@ -92,7 +92,7 @@ function main() {
     fi
     if [[ -n "$TIKV_WORKER" ]]; then
         echo "🚀 start download TiKV worker"
-        download_and_extract_with_path "$tikv_oci_url" '^tikv-worker-v.+.tar.gz$' tikv.tar.gz tikv-worker
+        download_and_extract_with_path "$tikv_worker_oci_url" '^tikv-worker-v.+.tar.gz$' tikv.tar.gz tikv-worker
         chmod +x tikv-worker
         echo "🎉 download TiKV worker success"
     fi
@@ -210,6 +210,7 @@ function parse_cli_args() {
     tidb_oci_url="${registry_host}/pingcap/tidb/package:${TIDB}_${tag_suffix}"
     tiflash_oci_url="${registry_host}/pingcap/tiflash/package:${TIFLASH}_${tag_suffix}"
     tikv_oci_url="${registry_host}/tikv/tikv/package:${TIKV}_${tag_suffix}"
+    tikv_worker_oci_url="${registry_host}/tikv/tikv/package:${TIKV_WORKER}_${tag_suffix}"
     pd_oci_url="${registry_host}/tikv/pd/package:${PD}_${tag_suffix}"
     pd_ctl_oci_url="${registry_host}/tikv/pd/package:${PD_CTL}_${tag_suffix}"
     ticdc_oci_url="${registry_host}/pingcap/tiflow/package:${TICDC}_${tag_suffix}"


### PR DESCRIPTION
## Feat: Add support for downloading pd-ctl artifact

This pull request introduces the capability to download the `pd-ctl` binary from OCI registries. This is a necessary addition to ensure that all required components for TiDB cluster management can be provisioned consistently.

The following changes have been made:

* Added a new command-line argument `-pd-ctl` (and its long form `--pd-ctl`) to specify the version of `pd-ctl` to download.
* Implemented logic within the `main` function to download and extract the `pd-ctl` artifact if the `PD_CTL` environment variable is set.
* Constructed the OCI URL for `pd-ctl` using the provided version and the configured registry host.
* Updated the `parse_cli_args` function to handle the new `-pd-ctl` argument.
* Included `PD_CTL` in the output of the script's argument parsing for better visibility.

This enhancement allows users to explicitly specify and download `pd-ctl` alongside other TiDB components, streamlining the setup and deployment process.

## Fix: Fix downloading tikv-worker artifact

This pull request fix the downloading tag of tikv-worker.

* Use the value of tikv-worker argument as the tag for downloading.

close #3842
