### PR TITLE
chore(tekton/v0/triggers): relax tag ref regex for fake GitHub triggers

### DIFF
--- a/tekton/v0/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/tekton/v0/triggers/triggers/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -28,7 +28,7 @@ spec:
               'tikv/tikv'
             ]
             &&
-            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
+            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-.+)?$')
             &&
             header.canonical('ce-paramPlatform') in [
               'linux/amd64',

--- a/tekton/v0/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
+++ b/tekton/v0/triggers/triggers/_/fake-github/fake-github-tag-create.yaml
@@ -28,7 +28,7 @@ spec:
               'tikv/tikv'
             ]
             &&
-            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|rc)([.][0-9]+)?)?$')
+            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-.+)?$')
             &&
             ! (header.canonical('ce-paramPlatform') in [
               'linux/amd64',


### PR DESCRIPTION
Make us can trigger dev-build for next-gen tags.