### PR TITLE
fix(pipelines/tikv/pd): use HTTPS for tidb checkout in pipeline

### DIFF
--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -47,7 +47,7 @@ pipeline {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
                         retry(2) {
                             script {
-                                component.checkout('git@github.com:pingcap/tidb.git', 'tidb', TARGET_BRANCH_TIDB, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                                component.checkout('https://github.com/pingcap/tidb.git', 'tidb', TARGET_BRANCH_TIDB, REFS.pulls[0].title, '')
                             }
                         }
                     }


### PR DESCRIPTION
Switch to HTTPS and remove credentials so CI can checkout anonymously