### PR TITLE
fix(tekton/v1): update task with heredoc and update trigger binding

### DIFF
--- a/tekton/v1/tasks/delivery/pingcap-notify-for-tidbx-images.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-notify-for-tidbx-images.yaml
@@ -31,7 +31,9 @@ spec:
         #!/usr/bin/env bash
         set -e
 
-        echo "$(params.src)" > images.yaml
+        cat > images.yaml <<'EOF'
+        $(params.src)
+        EOF
 
         for stage in dev prod; do
           github_issue_url="$(cat $(workspaces.notify-config.path)/${stage}_github_issue_url)"

--- a/tekton/v1/triggers/triggers/_/notify/notify-successful-image-delivery-tidbx.yaml
+++ b/tekton/v1/triggers/triggers/_/notify/notify-successful-image-delivery-tidbx.yaml
@@ -14,7 +14,7 @@ spec:
             body.images.exists(img, img.contains('nextgen') || img.contains('next-gen'))
 
   bindings:
-    - { name: ce-context, value: $(extensions.ce-context) } # from event-listener
-    - { name: data, value: $(body.marshalJSON()) }
+    # - { name: ce-context, value: $(extensions.ce-context) }
+    - { name: data, value: $(extensions.ce-data) } # from event-listener
   template:
     ref: notify-successful-image-delivery-tidbx


### PR DESCRIPTION
Write images.yaml using a quoted heredoc so multiline param content is written correctly. In the notify trigger, switch the data binding to $(extensions.ce-data) from body.marshalJSON() and comment out the ce-context binding provided by the event-listener.