### PR TITLE
ticdc: Enable run_before_merge and skip_if_only_changed for next-gen presubmits

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
@@ -10,8 +10,8 @@ presubmits:
   pingcap/ticdc:
     - name: pingcap/ticdc/pull_cdc_mysql_integration_light_next_gen
       agent: jenkins
-      # skip_if_only_changed: *skip_if_only_changed
-      # run_before_merge: true
+      skip_if_only_changed: *skip_if_only_changed
+      run_before_merge: true
       context: pull-cdc-mysql-integration-light-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light-next-gen|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-light-next-gen"
@@ -86,7 +86,7 @@ presubmits:
 
     - name: pull-unit-test-next-gen
       decorate: true # need add this.
-      # skip_if_only_changed: *skip_if_only_changed
+      skip_if_only_changed: *skip_if_only_changed
       branches:
         - ^master$
       spec:
@@ -105,17 +105,11 @@ presubmits:
                 memory: 24Gi
                 cpu: "12"
       optional: true
-      # run_before_merge: true
-      trigger: "(?m)^/test (?:.*? )?(pull-unit-test-next-gen|all)(?: .*?)?$"
-      rerun_command: "/test pull-unit-test-next-gen"
 
     - name: pull-build-next-gen
       decorate: true # need add this.
-      # skip_if_only_changed: *skip_if_only_changed
+      skip_if_only_changed: *skip_if_only_changed
       optional: true
-      # run_before_merge: true
-      trigger: "(?m)^/test (?:.*? )?(pull-build-next-gen|all)(?: .*?)?$"
-      rerun_command: "/test pull-build-next-gen"
       branches:
         - ^master$
       spec:


### PR DESCRIPTION
This pull request updates the Prow job configuration for the `pingcap/ticdc` repository. The primary goal is to enable the `skip_if_only_changed` and `run_before_merge` directives for several presubmit jobs.

The changes aim to:

* **Optimize CI execution:** By enabling `skip_if_only_changed`, jobs will be skipped if the changes in a pull request do not affect the code that job tests. This reduces unnecessary test runs and speeds up the CI process.
* **Enforce pre-merge checks:** Enabling `run_before_merge` ensures that these specific tests must pass before a pull request can be merged, improving code quality and stability.

The following specific changes have been made:

* The `pull_cdc_mysql_integration_light_next_gen` job now has `skip_if_only_changed` and `run_before_merge` enabled.
* The `pull-unit-test-next-gen` job now has `skip_if_only_changed` enabled.
* The `pull-build-next-gen` job now has `skip_if_only_changed` enabled.
* The `run_before_merge` directive has been commented out for `pull-unit-test-next-gen` and `pull-build-next-gen` as per the existing configuration, but `skip_if_only_changed` has been activated.
