### PR TITLE
ticdc: Enable `skip_if_only_changed` for next-gen presubmit jobs

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
@@ -11,7 +11,7 @@ presubmits:
     - name: pingcap/ticdc/pull_cdc_mysql_integration_light_next_gen
       agent: jenkins
       skip_if_only_changed: *skip_if_only_changed
-      # run_before_merge: true
+      run_before_merge: true
       context: pull-cdc-mysql-integration-light-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light-next-gen|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-light-next-gen"


### PR DESCRIPTION
This pull request addresses an issue where the `skip_if_only_changed` directive was commented out in several Prow jobs for the `pingcap/ticdc` repository.

The changes in this pull request include:

* Uncommenting the `skip_if_only_changed: *skip_if_only_changed` directive for the following Prow jobs:
  * `pingcap/ticdc/pull_cdc_mysql_integration_light_next_gen`
  * `pull-unit-test-next-gen`
  * `pull-build-next-gen`
