### PR TITLE
fix(error-log-review): no required pr complete approved

### DIFF
--- a/tools/error-log-review/github.go
+++ b/tools/error-log-review/github.go
@@ -18,7 +18,10 @@ const (
 	TiChiBotUserBold = "ti-chi-bot[bot]"
 
 	// Approval notification pattern
-	ApprovalNotificationPrefix = "[APPROVALNOTIFIER] This PR is **APPROVED**"
+	// Both APPROVED and NOT APPROVED are included in the approval notification
+	// [APPROVALNOTIFIER] This PR is **APPROVED**
+	// [APPROVALNOTIFIER] This PR is **NOT APPROVED**
+	ApprovalNotificationPrefix = "[APPROVALNOTIFIER]"
 	ApprovalDetailsPrefix      = "This pull-request has been approved by:"
 )
 


### PR DESCRIPTION
The current implementation only extracts approvers from ti-chi-bot comments that start with `[APPROVALNOTIFIER] This PR is **APPROVED**`. However, ti-chi-bot also posts comments with `[APPROVALNOTIFIER] This PR is **NOT APPROVED**` when a PR has received some approvals but is still waiting for additional required approvers.

These "NOT APPROVED" comments still contain the list of users who have already approved the PR, but they were being ignored by the current code.


This change aligns with the principle that **error log review approval should be independent of general PR approval**. A PR may have received approval from authorized log reviewers even if it's still waiting for other required approvals. The tool should recognize these log-specific approvals regardless of the overall PR approval status.
