### PR TITLE
ticdc: Remove redundant skip_if_only_changed from mysql integration test

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
@@ -10,7 +10,7 @@ presubmits:
   pingcap/ticdc:
     - name: pingcap/ticdc/pull_cdc_mysql_integration_light_next_gen
       agent: jenkins
-      skip_if_only_changed: *skip_if_only_changed
+      # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-mysql-integration-light-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light-next-gen|next-gen)(?: .*?)?$"


### PR DESCRIPTION
This PR addresses an issue where the `pull-cdc-mysql-integration-light-next-gen` presubmit job was being skipped incorrectly due to the `skip_if_only_changed` directive.

The `skip_if_only_changed` directive is intended to prevent jobs from running if only certain files have been modified, which is not the desired behavior for this specific integration test. By commenting out this directive, we ensure that the `pull-cdc-mysql-integration-light-next-gen` job will always run when triggered, regardless of the files changed.

Changes:

*   Commented out the `skip_if_only_changed` directive for the `pull-cdc-mysql-integration-light-next-gen` presubmit job.
