### PR TITLE
fix(ci/jenkins/cd): update TikV arm_go_pod_image version

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -673,7 +673,7 @@ fi
 rm -rf ${TARGET}/build-release || true
 """
 
-buildsh["tikv"] = """
+buildsh["tikv"] = """#!/usr/bin/env bash
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
 if [ ${RELEASE_TAG}x != ''x ];then
     for a in \$(git tag --contains ${GIT_HASH}); do echo \$a && git tag -d \$a;done
@@ -957,7 +957,6 @@ def run_with_pod(String builder, Closure body) {
             ],
             volumes: [
                     emptyDirVolume(mountPath: '/tmp', memory: false),
-                    emptyDirVolume(mountPath: '/home/jenkins', memory: false),
                     persistentVolumeClaim(mountPath:'/var/cache/cargohome', claimName: cargo_pvc)
                     ],
     ) {


### PR DESCRIPTION
This pull request makes a small update to the ARM build environment for TiKV by updating the Docker image version used in the `run_with_arm_go_pod` function.

- Updated the `arm_go_pod_image` for TiKV from version `v20230804` to `v2025.11.7` in `build-common.groovy`.