### PR TITLE
fix(scripts/flow/build): refactor versioning checks and feature suffix

### DIFF
--- a/scripts/flow/build/versioning-strategy.ts
+++ b/scripts/flow/build/versioning-strategy.ts
@@ -58,27 +58,28 @@ export function compute(
     return { releaseVersion: "v" + semver.format(rv) };
   }
 
-  // Check for feature branch
-  const featureBranch = commitInBranches.find((b) =>
-    /\bfeature\/[\w.-]+$/.test(b)
-  );
-  if (featureBranch && !commitInBranches.some(isReleaseBranch)) {
-    console.info("Current commit is in a feature branch.");
-    // Extract feature name, replace '/' with '.' for version/tag
-    const suffix = featureBranch
-      .replace(/.*\bfeature\//, "feature/")
-      .replaceAll("/", ".")
-      .replaceAll("-", ".");
-    const featureVersion = `v${rv.major}.${rv.minor}.${rv.patch}-${suffix}`;
-    return {
-      releaseVersion: featureVersion,
-      newGitTag: featureVersion,
-    };
-  }
-
   // Check if the current branch is a release branch.
   if (!commitInBranches.some(isReleaseBranch)) {
     console.info("Current commit is not contained in any release branches.");
+
+    // Check for feature branch
+    const featureBranch = commitInBranches.find((b) =>
+      /\bfeature\/[\w.-]+$/.test(b)
+    );
+    if (featureBranch) {
+      console.info("Current commit is in a feature branch.");
+      // Extract feature name, replace '/' with '.' for version/tag
+      const suffix = featureBranch
+        .replace(/.*\bfeature\//, "feature/")
+        .replaceAll("/", ".")
+        .replaceAll("-", ".");
+      const featureVersion = `v${rv.major}.${rv.minor}.${rv.patch}-${suffix}`;
+      return {
+        releaseVersion: featureVersion,
+        newGitTag: featureVersion,
+      };
+    }
+
     return { releaseVersion: "v" + semver.format(rv) };
   }
 


### PR DESCRIPTION
- Move GA and release-branch checks before feature-branch handling to short-circuit earlier and remove duplicated checks.
- Replace hyphens with dots (not underscores) in feature branch suffix to fix it to match semantic versioning.