### PR TITLE
Add release-8.5 branch to presubmit jobs to ensure CI coverage for the new release branch.

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -84,6 +84,7 @@ presubmits:
       skip_if_only_changed: *skip_if_only_changed
       branches:
         - ^master$
+        - ^release-8\.5$
       spec:
         containers:
           - name: check
@@ -105,6 +106,7 @@ presubmits:
       skip_if_only_changed: *skip_if_only_changed
       branches:
         - ^master$
+        - ^release-8\.5$
       spec:
         containers:
           - name: build
@@ -126,6 +128,7 @@ presubmits:
       skip_if_only_changed: *skip_if_only_changed
       branches:
         - ^master$
+        - ^release-8\.5$
       spec:
         containers:
           - name: check
@@ -139,6 +142,7 @@ presubmits:
     - name: pull-error-log-review
       branches:
         - ^master$
+        - ^release-8\.5$
       decorate: true
       decoration_config:
         timeout: 20m


### PR DESCRIPTION
This PR updates the presubmit job configuration for TiCDC.

The primary reason for this change is to ensure that presubmit tests are run against the new `release-8.5` branch. This is crucial for maintaining code quality and stability for this specific release line.

Changes include:

*   Added `^release-8\.5$` to the list of branches for which presubmit tests will be executed.
