### PR TITLE
Add release-nextgen branch to presubmit jobs to ensure compatibility with upcoming releases.

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
@@ -89,6 +89,7 @@ presubmits:
       skip_if_only_changed: *skip_if_only_changed
       branches:
         - ^master$
+        - ^release-nextgen-\d+$
       spec:
         containers:
           - name: check
@@ -112,6 +113,7 @@ presubmits:
       optional: true
       branches:
         - ^master$
+        - ^release-nextgen-\d+$
       spec:
         containers:
           - name: build


### PR DESCRIPTION
This PR updates the branch configuration for two presubmit jobs in the TiCDC project. The goal is to ensure these jobs run on newly created `release-nextgen-*` branches, in addition to the existing `master` branch. This will allow for better testing and validation of features being developed for the next generation of TiCDC as they are merged into these release branches.

Changes include:

*   Added `^release-nextgen-\d+$` to the `branches` field for the `check` presubmit job.
*   Added `^release-nextgen-\d+$` to the `branches` field for the `build` presubmit job.

No issues are closed by this change.
