### PR TITLE
fix(tekton/v1): fix payload variable name for image version

### DIFF
--- a/tekton/v1/tasks/delivery/pingcap-notify-to-update-ops-tidbx.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-notify-to-update-ops-tidbx.yaml
@@ -78,7 +78,7 @@ spec:
               --arg version "$component_version" \
               --arg base_image "$image_repo" \
               --arg tag "$image_tag" \
-              '{"cluster_type": $cluster_type, "version": $component_version, "base_image": $base_image, "tag": $tag, "policy": "immediate"}' > $payload_file
+              '{"cluster_type": $cluster_type, "version": $version, "base_image": $base_image, "tag": $tag, "policy": "immediate"}' > $payload_file
 
             echo "🚀 Request to update the image for component $component@$component_version in stage $stage with: $image_repo:$image_tag"
             local response_file="/tmp/${component}-${component_version}-response.json"


### PR DESCRIPTION
This pull request makes a small fix to the payload construction in the `pingcap-notify-to-update-ops-tidbx.yaml` Tekton task, ensuring the correct variable is used for the `version` field. This helps prevent inconsistencies when the payload is sent for image update notifications.

* Fixed the payload to use the correct `$version` variable instead of `$component_version` for the `version` field in the JSON body.