### PR TITLE
chore(tekton/v0): update triggers to match branches for tidb-operator repo

### DIFF
--- a/tekton/v0/triggers/triggers/pingcap/tidb-operator/git-push.yaml
+++ b/tekton/v0/triggers/triggers/pingcap/tidb-operator/git-push.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'pingcap/tidb-operator'
             &&
-            body.ref.matches('^refs/heads/(master|release-.*|feature/v2)$')
+            body.ref.matches('^refs/heads/(main|release-.*)$')
   bindings:
     - ref: github-branch-push
     - { name: component, value: $(body.repository.name) }


### PR DESCRIPTION
This pull request updates the branch filtering logic in the `git-push.yaml` Tekton trigger for the `tidb-operator` repository. The change ensures that only pushes to the `main` branch and branches matching `release-*` trigger the pipeline, and removes support for the `master` and `feature/v2` branches.

Branch filtering update:

* Updated the `body.ref.matches` regular expression to trigger only on `main` and `release-*` branches, removing `master` and `feature/v2` from the allowed branches in `git-push.yaml`.