### PR TITLE
docs(pdf): generate dev PDF from main branch

### DIFF
--- a/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
+++ b/pipelines/pingcap/docs-tidb-operator/latest/merged_update.groovy
@@ -80,7 +80,7 @@ pipeline {
 
                             dst="\${TENCENTCLOUD_RCLONE_CONN}:\${TENCENTCLOUD_BUCKET_ID}/pdf"
                             case "${REFS.base_ref}" in
-                                "master")
+                                "main")
                                     version="dev"
                                     ;;
                                 "release-1.6")

--- a/prow-jobs/pingcap/docs/docs-tidb-operator-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-tidb-operator-postsubmits.yaml
@@ -8,6 +8,6 @@ postsubmits:
       max_concurrency: 5
       skip_report: false
       branches:
-        - ^master$
+        - ^main$
         - ^release-1\.[3-6]$
         - ^release-2\.[0-9]+$


### PR DESCRIPTION
Change the source branch for generating the TiDB Operator `dev` PDF from `master` to `main`

