### PR TITLE
fix(tekton/v1/tasks): pass pushed result path as arg to Tekton tasks

### DIFF
--- a/tekton/v1/tasks/pingcap-build-binaries-darwin.yaml
+++ b/tekton/v1/tasks/pingcap-build-binaries-darwin.yaml
@@ -52,7 +52,9 @@ spec:
       results:
         - name: generated
           type: string
+      args: ["$(results.pushed.path)"]
       script: |
+        pushed_result_path="$1"
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
         git_ref="$(params.git-ref)"
@@ -81,7 +83,7 @@ spec:
         else
           echo -n "false" > $(step.results.generated.path)
           echo "🤷 no output script generated!"
-          printf '"{}"' > $(results.pushed.path)
+          printf '"{}"' > "$pushed_result_path"
         fi
     - name: prepare-remote-env-file
       image: "$(params.builder-image)"

--- a/tekton/v1/tasks/pingcap-build-binaries-linux.yaml
+++ b/tekton/v1/tasks/pingcap-build-binaries-linux.yaml
@@ -54,7 +54,9 @@ spec:
       results:
         - name: generated
           type: string
+      args: ["$(results.pushed.path)"]
       script: |
+        pushed_result_path="$1"
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
         git_ref="$(params.git-ref)"
@@ -83,7 +85,7 @@ spec:
         else
           echo -n "false" > $(step.results.generated.path)
           echo "🤷 no output script generated!"
-          printf '"{}"' > $(results.pushed.path)
+          printf '"{}"' > "$pushed_result_path"
         fi
     - name: build
       image: "$(params.builder-image)"

--- a/tekton/v1/tasks/pingcap-build-images.yaml
+++ b/tekton/v1/tasks/pingcap-build-images.yaml
@@ -52,7 +52,9 @@ spec:
       results:
         - name: generated
           type: string
+      args: ["$(results.pushed.path)"]
       script: |
+        pushed_result_path="$1"
         git clone --depth=1 --branch=main https://github.com/PingCAP-QE/artifacts.git /workspace/artifacts
 
         git_ref="$(params.git-ref)"
@@ -80,7 +82,7 @@ spec:
         else
           echo -n "false" > $(step.results.generated.path)
           echo "🤷 no output script generated!"
-          printf '"{}"' > $(results.pushed.path)
+          printf '"{}"' > "$pushed_result_path"
         fi
     - name: build-and-publish
       image: gcr.io/kaniko-project/executor:v1.24.0-debug


### PR DESCRIPTION
It will address the failures in step which also has step results definitions:

``` /tekton/scripts/script-0-gbgwt: line
31: task.results.pushed.path: not found /tekton/scripts/script-0-gbgwt:
line 31: can't create : nonexistent direc
```