### PR TITLE
fix(tekton/v1/tasks): fix image build task for more common stories

### DIFF
--- a/tekton/v1/tasks/pingcap-build-images.yaml
+++ b/tekton/v1/tasks/pingcap-build-images.yaml
@@ -119,7 +119,8 @@ spec:
         fi
 
         if [ -z "$DOCKER_CONFIG_JSON" ] && [ -z "$GSA_JSON" ]; then
-          echo "⚠️ Warning: No Docker config JSON or Google Service Account JSON found in $CREDS_DIR"
+          echo "❌ Error: No Docker config JSON or Google Service Account JSON found in $CREDS_DIR"
+          exit 1
         fi
 
         # Building


### PR DESCRIPTION
- Add `CREDS_DIR` env and script logic to locate docker credentials and GSA key, populate /kaniko/.docker/config.json and set `GOOGLE_APPLICATION_CREDENTIALS`
- Move common container image into stepTemplate and remove per-step image fields. 
