### PR TITLE
feat(jobs): disabled old jenkins job for running tikv clippy on Darwin machines

### DIFF
--- a/jenkins/jobs/ci/tikv/tikv/ghpr_build_clippy_darwin_amd64.groovy
+++ b/jenkins/jobs/ci/tikv/tikv/ghpr_build_clippy_darwin_amd64.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tikv-ghpr-clippy-darwin-amd64') {
+    disabled(true)
     logRotator {
         daysToKeep(90)
         numToKeep(1000)

--- a/jenkins/jobs/ci/tikv/tikv/ghpr_build_clippy_darwin_arm64.groovy
+++ b/jenkins/jobs/ci/tikv/tikv/ghpr_build_clippy_darwin_arm64.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tikv-ghpr-clippy-darwin-arm64') {
+    disabled(true)
     logRotator {
         daysToKeep(90)
         numToKeep(1000)


### PR DESCRIPTION
Deprecate jobs for running tikv clippy on Darwin machines, ref: https://github.com/PingCAP-QE/ci/issues/3338

Include jobs :
https://ci.pingcap.net/job/tikv-ghpr-clippy-darwin-amd64/
https://ci.pingcap.net/job/tikv-ghpr-clippy-darwin-arm64/

Close https://github.com/PingCAP-QE/ci/issues/3354
Close https://github.com/PingCAP-QE/ci/issues/3355