### PR TITLE
feat(release-check): add version parsing and branch comparison for ticdc release check

### DIFF
--- a/scripts/ops/release-check-version/create_components_json.py
+++ b/scripts/ops/release-check-version/create_components_json.py
@@ -17,21 +17,20 @@ def parse_release_version(branch):
     prefix = "release-"
     if not branch.startswith(prefix):
         return None
-    version_part = branch[len(prefix):].split("-", 1)[0]
-    try:
-        return tuple(int(part) for part in version_part.split("."))
-    except ValueError:
-        return None
+    return branch[len(prefix):].split("-", 1)[0]
 
 
 def is_branch_before_release(branch, target_version):
-    version = parse_release_version(branch)
-    if version is None:
+    version_str = parse_release_version(branch)
+    if version_str is None:
         return False
-    max_len = max(len(version), len(target_version))
-    padded_version = version + (0,) * (max_len - len(version))
-    padded_target = target_version + (0,) * (max_len - len(target_version))
-    return padded_version < padded_target
+
+    target_version_str = ".".join(map(str, target_version))
+    try:
+        from packaging.version import parse, InvalidVersion
+        return parse(version_str) < parse(target_version_str)
+    except (ImportError, InvalidVersion):
+        return False
 
 
 def get_latest_commit_hash(repo, branch):


### PR DESCRIPTION
Conditionally sets the `ticdc_repo` based on the branch version, enhancing the release management logic.
* After release-8.5, use pingcap/ticdc.
* Before release-8.5, use pingcap/tiflow.