### PR TITLE
chore(tekton/v1): validate image tags and add tidbx images for ops bumping

### DIFF
--- a/tekton/v1/triggers/triggers/env-gcp/_/notify/notified-successful-image-delivery-cloud-tidbx.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/notify/notified-successful-image-delivery-cloud-tidbx.yaml
@@ -14,6 +14,8 @@ spec:
             body.comment.body.matches('<!--\\s*META={.+?\\s*-->')
             &&
             size(body.comment.body.split('<!--')[1].split('-->')[0].replace('META=', '').parseJSON().images) > 0
+            &&
+            body.comment.body.split('<!--')[1].split('-->')[0].replace('META=', '').parseJSON().images.all(i, i.matches('.+:v[0-9]+[.][0-9]+[.][0-9]+-(nextgen|tidb)[.][0-9]+[.][0-9]+$'))
         - name: overlays
           value:
             - key: images


### PR DESCRIPTION


Require META images to match vX.Y.Z-(nextgen|tidb).B.C tag pattern and add two tidbx tiflash image references used by the trigger notification