### PR TITLE
refactor(tekton/v0): use intranet publisher URL in Tekton tasks and scripts

### DIFF
--- a/scripts/flow/rc/refresh-tiup.sh
+++ b/scripts/flow/rc/refresh-tiup.sh
@@ -100,8 +100,7 @@ publish_and_wait() {
 }
 
 # Example:
-#   # 1. export the publisher service to local
-#   kubectl port-forward -n apps svc/publisher-staging-mirror 8080:80
-#   # 2. run the script to publish tiup packages from oci artifact
-#   ./scripts/flow/rc/refresh-tiup.sh http://localhost:8080 <git-branch-name>
+#   # run the script to publish tiup packages from oci artifact
+#   # for staging:
+#   ./scripts/flow/rc/refresh-tiup.sh https://publisher-staging.pingcap.net <git-branch-name>
 main "$@"

--- a/tekton/v0/tasks/publish-fileserver-from-oci-artifact.yaml
+++ b/tekton/v0/tasks/publish-fileserver-from-oci-artifact.yaml
@@ -14,8 +14,8 @@ spec:
         The full url of the pushed image, contain the tag part.
         It will parse the repo from it.
     - name: publisher-url
-      description: Staging is http://publisher-staging-mirror.apps.svc, product is http://publisher-prod-mirror.apps.svc.
-      default: http://publisher-staging-mirror.apps.svc
+      description: Staging is https://publisher-staging.pingcap.net, product is https://publisher.pingcap.net.
+      default: https://publisher-staging.pingcap.net
   results:
     - name: request-ids
       type: array

--- a/tekton/v0/tasks/publish-tiup-from-oci-artifact-v2.yaml
+++ b/tekton/v0/tasks/publish-tiup-from-oci-artifact-v2.yaml
@@ -14,8 +14,8 @@ spec:
         The full url of the pushed image, contain the tag part.
         It will parse the repo from it.
     - name: publisher-url
-      description: Staging is http://publisher-staging-mirror.apps.svc, product is http://publisher-prod-mirror.apps.svc.
-      default: http://publisher-staging-mirror.apps.svc
+      description: Staging is https://publisher-staging.pingcap.net, product is https://publisher.pingcap.net.
+      default: https://publisher-staging.pingcap.net
     - name: force-version
       description: >
         Force set the version.

--- a/tekton/v0/tasks/release/pingcap-create-github-alpha-tags.yaml
+++ b/tekton/v0/tasks/release/pingcap-create-github-alpha-tags.yaml
@@ -24,6 +24,6 @@ spec:
       command:
         - /app/publisher-cli
       args:
-        - --url=http://publisher-prod-mirror.apps.svc
+        - --url=https://publisher.pingcap.net
         - tiup
         - reset-rate-limit

--- a/tekton/v0/triggers/templates/_/push-oci-artifact-to-fileserver.yaml
+++ b/tekton/v0/triggers/templates/_/push-oci-artifact-to-fileserver.yaml
@@ -18,4 +18,4 @@ spec:
           - name: artifact-url
             value: "$(tt.params.image_url)"
           - name: publisher-url
-            value: http://publisher-staging-mirror.apps.svc
+            value: https://publisher-staging.pingcap.net

--- a/tekton/v0/triggers/templates/_/push-oci-artifact-to-tiup.yaml
+++ b/tekton/v0/triggers/templates/_/push-oci-artifact-to-tiup.yaml
@@ -22,7 +22,7 @@ spec:
           - name: artifact-url
             value: "$(tt.params.image_url)"
           - name: publisher-url
-            value: http://publisher-staging-mirror.apps.svc
+            value: https://publisher-staging.pingcap.net
     - apiVersion: tekton.dev/v1beta1
       kind: TaskRun
       metadata:
@@ -37,7 +37,7 @@ spec:
           - name: artifact-url
             value: "$(tt.params.image_url)"
           - name: publisher-url
-            value: http://publisher-prod-mirror.apps.svc
+            value: https://publisher.pingcap.net
 ---
 apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
@@ -63,4 +63,4 @@ spec:
           - name: artifact-url
             value: "$(tt.params.image_url)"
           - name: publisher-url
-            value: http://publisher-staging-mirror.apps.svc
+            value: https://publisher-staging.pingcap.net


### PR DESCRIPTION
Switch publisher references from internal svc host to intranet urls:
- prod: https://publisher.pingcap.net
- staging: https://publisher-staging.pingcap.net

Also update the script example to use the staging publisher host.