### PR TITLE
refactor(tekton/v1): change registry to tidbx in Tekton triggers for tidbx builds

### DIFF
--- a/tekton/v1/triggers/triggers/env-gcp/_/git-create-tag-build-ng.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/git-create-tag-build-ng.yaml
@@ -76,7 +76,7 @@ spec:
     - { name: component, value: $(extensions.component) }
     - { name: os, value: linux }
     - { name: profile, value: next-gen }
-    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/hub }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/tidbx }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
     - { name: timeout, value: $(extensions.timeout) }
 

--- a/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-ng.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-ng.yaml
@@ -76,7 +76,7 @@ spec:
     - { name: component, value: $(extensions.component) }
     - { name: os, value: linux }
     - { name: profile, value: next-gen }
-    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/hub }
+    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/tidbx }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
     - { name: timeout, value: $(extensions.timeout) }
 


### PR DESCRIPTION
This pull request updates the registry used for image builds in the Tekton pipeline configuration files for the GCP environment. The registry is changed from `hub` to `tidbx` to ensure images are pushed to the correct location.

Configuration updates:

* Updated the `registry` value in `git-create-tag-build-ng.yaml` to use `us-docker.pkg.dev/pingcap-testing-account/tidbx` instead of `hub`.
* Updated the `registry` value in `git-push-branch-build-ng.yaml` to use `us-docker.pkg.dev/pingcap-testing-account/tidbx` instead of `hub`.