### PR TITLE
chore(prow-jobs/tikv/pd): make the job `pull-unit-test-next-gen` be optional

### DIFF
--- a/prow-jobs/tikv/pd/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/tikv/pd/latest-presubmits-next-gen.yaml
@@ -48,7 +48,7 @@ presubmits:
       name: pull-unit-test-next-gen
       skip_if_only_changed: *skip_if_only_changed
       optional: true # delete it when the test is stable
-      context: non-block/pull-unit-test-next-gen # delete it when the test is stable      
+      context: non-block/pull-unit-test-next-gen # delete it when the test is stable
       spec:
         containers:
           - name: test


### PR DESCRIPTION
Mark pull-unit-test-next-gen as optional and non-blocking.

It has many flaky tests which can't work well together.