### PR TITLE
fix(tekton/v1): add `publisher-url` parameter to Tekton triggers

### DIFF
--- a/tekton/v1/triggers/templates/_/build-component-all-platforms.yaml
+++ b/tekton/v1/triggers/templates/_/build-component-all-platforms.yaml
@@ -34,7 +34,7 @@ spec:
       default: "{}"
     - name: force-builder-image
       default: ""
-    - name: tiup_mirror
+    - name: publisher-url
       default: "https://publisher.pingcap.net"
   resourcetemplates:
     - apiVersion: tekton.dev/v1
@@ -73,6 +73,8 @@ spec:
             value: $(tt.params.registry)
           - name: force-builder-image
             value: $(tt.params.force-builder-image)
+          - name: publisher-url
+            value: $(tt.params.publisher-url)
         taskRunTemplate:
           podTemplate:
             nodeSelector:
@@ -151,6 +153,8 @@ spec:
             value: $(tt.params.registry)
           - name: force-builder-image
             value: $(tt.params.force-builder-image)
+          - name: publisher-url
+            value: $(tt.params.publisher-url)
         taskRunTemplate:
           podTemplate:
             nodeSelector:
@@ -231,6 +235,8 @@ spec:
             value: $(tt.params.force-builder-image)
           - name: boskos-server-url
             value: http://boskos.apps.svc
+          - name: publisher-url
+            value: $(tt.params.publisher-url)
         timeouts:
           pipeline: $(tt.params.timeout)
         workspaces:
@@ -287,6 +293,8 @@ spec:
             value: $(tt.params.force-builder-image)
           - name: boskos-server-url
             value: http://boskos.apps.svc
+          - name: publisher-url
+            value: $(tt.params.publisher-url)
         timeouts:
           pipeline: $(tt.params.timeout)
         workspaces:

--- a/tekton/v1/triggers/templates/_/build-component-single-platform.yaml
+++ b/tekton/v1/triggers/templates/_/build-component-single-platform.yaml
@@ -38,7 +38,7 @@ spec:
       default: "{}"
     - name: force-builder-image
       default: ""
-    - name: tiup_mirror
+    - name: publisher-url
       default: "https://publisher.pingcap.net"
   resourcetemplates:
     - apiVersion: tekton.dev/v1
@@ -79,6 +79,8 @@ spec:
             value: $(tt.params.force-builder-image)
           - name: boskos-server-url # for darwin platforms
             value: http://boskos.apps.svc
+          - name: publisher-url
+            value: $(tt.params.publisher-url)
         taskRunTemplate:
           podTemplate:
             nodeSelector:

--- a/tekton/v1/triggers/templates/_/build-component.yaml
+++ b/tekton/v1/triggers/templates/_/build-component.yaml
@@ -34,7 +34,7 @@ spec:
     - name: ce-context
       description: cloud event context.
       default: "{}"
-    - name: tiup_mirror
+    - name: publisher-url
       default: "https://publisher.pingcap.net"
   resourcetemplates:
     - apiVersion: tekton.dev/v1
@@ -71,8 +71,8 @@ spec:
             value: amd64
           - name: registry
             value: $(tt.params.registry)
-          - name: tiup_mirror
-            value: $(tt.params.tiup_mirror)
+          - name: publisher-url
+            value: $(tt.params.publisher-url)
         taskRunTemplate:
           podTemplate:
             nodeSelector:
@@ -149,8 +149,8 @@ spec:
             value: arm64
           - name: registry
             value: $(tt.params.registry)
-          - name: tiup_mirror
-            value: $(tt.params.tiup_mirror)
+          - name: publisher-url
+            value: $(tt.params.publisher-url)
         taskRunTemplate:
           podTemplate:
             nodeSelector:

--- a/tekton/v1/triggers/triggers/env-gcp/_/git-create-tag-build-ng.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/git-create-tag-build-ng.yaml
@@ -79,7 +79,7 @@ spec:
     - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/tidbx }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
     - { name: timeout, value: $(extensions.timeout) }
-    - { name: tiup_mirror, value: "http://publisher" }
+    - { name: publisher-url, value: "http://publisher" }
 
   template:
     ref: build-component

--- a/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-ng.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-ng.yaml
@@ -79,7 +79,7 @@ spec:
     - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/tidbx }
     - { name: source-ws-size, value: $(extensions.source-ws-size) }
     - { name: timeout, value: $(extensions.timeout) }
-    - { name: tiup_mirror, value: "http://publisher" }
+    - { name: publisher-url, value: "http://publisher" }
 
   template:
     ref: build-component


### PR DESCRIPTION
Add tiup_mirror parameter (default https://publisher.pingcap.net) to build-component templates and propagate it to taskRun env. Override value to http://publisher in env-gcp triggers.