### PR TITLE
chore(ticdc): update container image from jenkins to base in ticdc presubmit jobs

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
@@ -93,7 +93,7 @@ presubmits:
       spec:
         containers:
           - name: check
-            image: &image ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.25
+            image: &image ghcr.io/pingcap-qe/ci/base:v2025.12.7-3-g1c0b8cf-go1.25
             command: [bash, -ce]
             args:
               - |

--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -88,7 +88,7 @@ presubmits:
       spec:
         containers:
           - name: check
-            image: &image ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.25
+            image: &image ghcr.io/pingcap-qe/ci/base:v2025.12.7-3-g1c0b8cf-go1.25
             command: [bash, -ce]
             args:
               - |


### PR DESCRIPTION
Changed the container image in the latest presubmit YAML files for ticdc from `ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.25` to `ghcr.io/pingcap-qe/ci/base:v2025.12.7-3-g1c0b8cf-go1.25`.