### PR TITLE
TiCDC: Update presubmit job to skip `make check` on documentation and Dockerfile changes

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -5,6 +5,7 @@ global_definitions:
     - ^release-8\.5$
     - ^feature/.+
   skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|yaml|json)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  make_check_skip_if_only_changed: &make_check_skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
@@ -125,7 +126,7 @@ presubmits:
 
     - name: pull-check
       decorate: true # need add this.
-      skip_if_only_changed: *skip_if_only_changed
+      skip_if_only_changed: *make_check_skip_if_only_changed
       branches:
         - ^master$
         - ^release-8\.5$


### PR DESCRIPTION
This pull request updates the `skip_if_only_changed` pattern for the `pull-check` job.

The updated pattern `make_check_skip_if_only_changed` specifically excludes common non-code file extensions and Dockerfiles, ensuring that the `pull-check` job will run when relevant code changes are made.

Changes include:

*   Defined a new skip pattern `make_check_skip_if_only_changed` that is more precise.
*   Applied this new pattern to the `pull-check` job.
