### PR TITLE
chore(tiflow): increase CPU and timeout settings for CDC integration tests

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
@@ -10,7 +10,7 @@ spec:
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "6"
         limits:
           memory: 32Gi
           cpu: "6"

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 75, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
@@ -80,7 +80,7 @@ pipeline {
         }
         stage("prepare") {
             when { expression { !skipRemainingStages} }
-            options { timeout(time: 20, unit: 'MINUTES') }
+            options { timeout(time: 30, unit: 'MINUTES') }
             steps {
                 dir("third_party_download") {
                     script {


### PR DESCRIPTION


Updated the CPU request from 4 to 6 in the pod-pull_cdc_integration_test.yaml file and adjusted the timeout settings in pull_cdc_integration_test.groovy from 60 to 75 minutes and from 20 to 30 minutes for the respective stages.