### PR TITLE
chore(tiflow): update MySQL version for sync-diff-inspector

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 128Mi
           cpu: 100m
     - name: mysql
-      image: "harbor.pingcap.net/library/mysql:8.0.43"
+      image: "hub.pingcap.net/jenkins/mysql:8.0.43"
       tty: true
       args:
         - "--server-id=1"

--- a/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
@@ -25,9 +25,13 @@ spec:
           memory: 128Mi
           cpu: 100m
     - name: mysql
-      image: hub.pingcap.net/jenkins/mysql:5.7
+      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
       tty: true
-      args: ["--server-id=1", "--log-bin", "--binlog-format=ROW"]
+      args:
+        - "--server-id=1"
+        - "--log-bin"
+        - "--binlog-format=ROW"
+        - "--default-authentication-plugin=mysql_native_password"
       env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "1"

--- a/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 128Mi
           cpu: 100m
     - name: mysql
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "harbor.pingcap.net/library/mysql:8.0.43"
       tty: true
       args:
         - "--server-id=1"


### PR DESCRIPTION
After upgrading the pod for sync-diff-inspector integration test in https://github.com/PingCAP-QE/ci/pull/3971, it always failed due to MySQL connection error. 

The error is caused by SSL problem by lower verison of MySQL, so we should upgrade it.