### PR TITLE
refactor(tidb/release-8.5): Increase the timeout duration for tidb unit-test and integration-br-test

### DIFF
--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 180, unit: 'MINUTES')
         // parallelsAlwaysFailFast()
     }
     stages {
@@ -112,7 +112,7 @@ pipeline {
                 stages {
                     stage("Test") {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
-                        options { timeout(time: 45, unit: 'MINUTES') }
+                        options { timeout(time: 60, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-tests") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         FILE_SERVER_URL = 'http://fileserver.pingcap.net'
     }
     options {
-        timeout(time: 90, unit: 'MINUTES')
+        timeout(time: 180, unit: 'MINUTES')
     }
     stages {
         stage('Debug info') {


### PR DESCRIPTION
increase timeout duration for tidb test:
- https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftidb%2Frelease-8.5%2Fpull_br_integration_test/detail/pull_br_integration_test/1159/pipeline
- https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftidb%2Frelease-8.5%2Fpull_unit_test/detail/pull_unit_test/3958/pipeline