### PR TITLE
chore(tiflow): update golang image to 1.25 and increase resource requests for CI pod in tiflow release-8.5

### DIFF
--- a/pipelines/pingcap/tiflow/release-8.5/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-ghpr_verify.yaml
@@ -5,12 +5,12 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.25:latest"
       tty: true
       resources:
         requests:
-          memory: 12Gi
-          cpu: "4"
+          memory: 16Gi
+          cpu: "6"
         limits:
           memory: 16Gi
           cpu: "6"


### PR DESCRIPTION
Upgraded the golang image from version 1.23 to 1.25 and increased memory requests from 12Gi to 16Gi, as well as CPU requests from 4 to 6 for the pod-ghpr_verify.yaml configuration.