### PR TITLE
feat(tekton/v1/task): add gitInsteadOf parameter to configure Git URL rewrites

### DIFF
--- a/tekton/v1/tasks/git-clone.yaml
+++ b/tekton/v1/tasks/git-clone.yaml
@@ -249,7 +249,6 @@ spec:
           -submodules="${PARAM_SUBMODULES}" \
           -depth="${PARAM_DEPTH}" \
           -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
-
         cd "${CHECKOUT_DIR}"
         RESULT_SHA="$(git rev-parse HEAD)"
         EXIT_CODE="$?"


### PR DESCRIPTION
Add support for configuring Git's `insteadof` to rewrite URLs during cloning operations, allowing users to specify multiple mappings separated by commas in the format `insteadof1 => new1,insteadof2 => new2`