### PR TITLE
Revert "chore: upgrade tidb CI image for go1.25"

### DIFF
--- a/jenkins/pipelines/ci/tidb/tidb_ghpr_coverage.groovy
+++ b/jenkins/pipelines/ci/tidb/tidb_ghpr_coverage.groovy
@@ -10,7 +10,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12520261210"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12320241009"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-inc/enterprise-extensions/latest/pod-pr-verify.yaml
+++ b/pipelines/pingcap-inc/enterprise-extensions/latest/pod-pr-verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12520261210"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12520261210"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12520261210"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -7,7 +7,7 @@ spec:
     - name: golang
       # TODO(wuhuizuo): using standard bazel build image to shrink the image size
       # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12520261210"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
@@ -7,7 +7,7 @@ spec:
     - name: golang
       # TODO(wuhuizuo): using standard bazel build image to shrink the image size
       # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12520261210"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-periodics_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-periodics_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12520261210"
+      image: "hub.pingcap.net/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true


### PR DESCRIPTION
Reverts PingCAP-QE/ci#3986


The current changes have caused some UT and check_dev2 cases to continue failing.