### PR TITLE
fix(prow-jobs/ti-community-infra/configs): update checkconfig image to `v20251023-c4199afa4`

### DIFF
--- a/prow-jobs/ti-community-infra/configs/presubmits.yaml
+++ b/prow-jobs/ti-community-infra/configs/presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
         - ^main$
       spec:
         containers:
-          - image: ticommunityinfra/checkconfig:v20221227-b4eaee6696
+          - image: ghcr.io/ti-community-infra/prow/checkconfig:v20251023-c4199afa4
             command:
               - /ko-app/checkconfig
             args:


### PR DESCRIPTION

to support check plugin config for cherry-pick-approved plugin