### PR TITLE
fix(tekton/v1): adjust TiDB and TiFlash build resources and timeouts

### DIFF
--- a/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-community.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-community.yaml
@@ -20,8 +20,8 @@ spec:
             - key: timeout
               expression: >-
                 {
-                'pingcap/tidb': '1h',
-                'pingcap/tiflash': '3h',
+                'pingcap/tidb': '45m',
+                'pingcap/tiflash': '2h',
                 }[body.repository.full_name]
             - key: source-ws-size
               expression: >-
@@ -32,14 +32,14 @@ spec:
             - key: builder-resources-cpu
               expression: >-
                 {
-                'pingcap/tidb': '8',
-                'pingcap/tiflash': '16',
+                'pingcap/tidb': '6',
+                'pingcap/tiflash': '12',
                 }[body.repository.full_name]
             - key: builder-resources-memory
               expression: >-
                 {
-                'pingcap/tidb': '32Gi',
-                'pingcap/tiflash': '64Gi',
+                'pingcap/tidb': '24Gi',
+                'pingcap/tiflash': '48Gi',
                 }[body.repository.full_name]
   bindings:
     - ref: github-branch-push


### PR DESCRIPTION
To make it schedule able on GCP instances:

Reduce TiDB timeout from 1h to 45m and TiFlash timeout from 3h to 2h Reduce TiDB CPU from 8 to 6 and memory from 32Gi to 24Gi Reduce TiFlash CPU from 16 to 12 and memory from 64Gi to 48Gi