### PR TITLE
Deprecate old ci job on ci.pingcap.net

### DIFF
--- a/jenkins/jobs/ci/tiflash/ghpr_build_arm64.groovy
+++ b/jenkins/jobs/ci/tiflash/ghpr_build_arm64.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tiflash-ghpr-build-arm64') {
+    disabled(true)
     logRotator {
         daysToKeep(90)
         numToKeep(300)

--- a/jenkins/jobs/ci/tiflash/ghpr_build_release.groovy
+++ b/jenkins/jobs/ci/tiflash/ghpr_build_release.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tiflash_ghpr_build_release') {
+    disabled(true)
     logRotator {
         daysToKeep(90)
         numToKeep(300)

--- a/jenkins/jobs/ci/tikv/tikv/ghpr_build.groovy
+++ b/jenkins/jobs/ci/tikv/tikv/ghpr_build.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tikv_ghpr_build') {
+    disabled(true)
     logRotator {
         daysToKeep(90)
         numToKeep(1000)

--- a/jenkins/jobs/ci/tikv/tikv/ghpr_build_arm64.groovy
+++ b/jenkins/jobs/ci/tikv/tikv/ghpr_build_arm64.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tikv_ghpr_build_arm64') {
+    disabled(true)
     logRotator {
         daysToKeep(90)
         numToKeep(1000)

--- a/jenkins/jobs/ci/tikv/tikv/ghpr_build_release.groovy
+++ b/jenkins/jobs/ci/tikv/tikv/ghpr_build_release.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tikv_ghpr_build_release') {
+    disabled(true)
     logRotator {
         daysToKeep(90)
         numToKeep(30)

--- a/jenkins/jobs/ci/tikv/tikv/ghpr_integration_compatibility_test.groovy
+++ b/jenkins/jobs/ci/tikv/tikv/ghpr_integration_compatibility_test.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tikv_ghpr_integration_compatibility_test') {
+    disabled(true)
     logRotator {
         daysToKeep(60)
         numToKeep(500)

--- a/jenkins/jobs/ci/tikv/tikv/ghpr_integration_copr_test.groovy
+++ b/jenkins/jobs/ci/tikv/tikv/ghpr_integration_copr_test.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tikv_ghpr_integration-copr-test') {
+    disabled(true)
     logRotator {
         daysToKeep(60)
         numToKeep(500)


### PR DESCRIPTION
Deprecate ci.pingcap.net :
- https://ci.pingcap.net/job/tiflash-ghpr-build-arm64/
- https://ci.pingcap.net/job/tiflash_ghpr_build_release/
- https://ci.pingcap.net/job/tikv_ghpr_build_release/
- https://ci.pingcap.net/job/tiflash-ghpr-build-arm64/
- https://ci.pingcap.net/job/tikv_ghpr_build/
- https://ci.pingcap.net/job/tikv_ghpr_integration_compatibility_test/
- https://ci.pingcap.net/job/tikv_ghpr_integration-copr-test/