### PR TITLE
refactor(pingcap/tidb): rename `merged-build` job name to `merged-tidb-build`

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -134,7 +134,7 @@ postsubmits:
       skip_report: true
 
     - <<: *brancher
-      name: merged-build
+      name: merged-tidb-build
       cluster: default
       decorate: true
       skip_if_only_changed: *skip_if_only_changed


### PR DESCRIPTION

the prow's `badge.svg` api only support `jobs` query param, so let's adjust the job name that we can use the `badge.svg` api.