### PR TITLE
fix(tikv): fix cargo-nextest architecture mismatch in unit-test-coverage job

### DIFF
--- a/prow-jobs/tikv/tikv/latest-postsubmits.yaml
+++ b/prow-jobs/tikv/tikv/latest-postsubmits.yaml
@@ -31,7 +31,7 @@ postsubmits:
                     NEXTEST_ARCH="aarch64-unknown-linux-gnu"
                     ;;
                   *)
-                    echo "Unsupported architecture: $ARCH"
+                    echo "Unsupported architecture: $ARCH" >&2
                     exit 1
                     ;;
                 esac


### PR DESCRIPTION
## Issue
The unit-test-coverage postsubmit job of tikv/tikv encountered the following error during execution: `cannot execute binary file: Exec format error`. 
## Cause
The image supports multiple architectures, but the script hardcodes the aarch64 cargo-nextest binary, resulting in execution failure on x86_64 nodes.
## Fix
Add dynamic architecture detection to automatically select the corresponding cargo-nextest binary file based on the actual architecture of the running node.
