### PR TITLE
fix(tikv): resolving the test issue for unit-test-coverage job

### DIFF
--- a/prow-jobs/tikv/tikv/latest-postsubmits.yaml
+++ b/prow-jobs/tikv/tikv/latest-postsubmits.yaml
@@ -106,7 +106,7 @@ postsubmits:
                     if [ ${UPLOAD_RC} -ne 0 ]; then
                       echo "Warning: Coverage upload failed, but tests passed"
                     fi
-                    exit 0
+                    exit ${UPLOAD_RC}
                   fi
             env:
               - name: CODECOV_TOKEN


### PR DESCRIPTION
- Add --test-threads to increase the test concurrency.
- Resolving the capacity issue by using the volumeClaimTemplate of the ephemeral volume to create independent storage space for the Pod, avoiding restrictions imposed by the node's ephemeral-storage resource.
- filter out the data of dependencies to reduce the size of the generated lcov.info file to upload to codecov.io successfully.