### PR TITLE
fix(tekton/v1): add retries to deliver-binaries and deliver-images tasks

### DIFF
--- a/tekton/v1/pipelines/pingcap-build-package-darwin.yaml
+++ b/tekton/v1/pipelines/pingcap-build-package-darwin.yaml
@@ -189,6 +189,7 @@ spec:
         - name: message
           value: "'{}'"
     - name: deliver-binaries
+      retries: 2
       when:
         - input: $(tasks.build-binaries.results.pushed)
           operator: notin

--- a/tekton/v1/pipelines/pingcap-build-package-linux.yaml
+++ b/tekton/v1/pipelines/pingcap-build-package-linux.yaml
@@ -215,6 +215,7 @@ spec:
         - name: source
           workspace: source
     - name: deliver-binaries
+      retries: 2
       when:
         - input: $(tasks.build-binaries.results.pushed)
           operator: notin
@@ -231,6 +232,7 @@ spec:
         - name: publisher-url
           value: "$(params.publisher-url)"
     - name: deliver-images
+      retries: 2
       when:
         - input: $(tasks.build-images.results.pushed)
           operator: notin


### PR DESCRIPTION
Add retry mechanism to improve reliability of binary and image delivery
tasks
