### PR TITLE
fix(pipelines/pingcap/ticdc): fix `pull-cdc-mysql-integration-*` jobs

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -92,7 +92,6 @@ pipeline {
                         sh label: "prepare", script: """
                             ls -alh ./bin
                             [ -f ./bin/cdc ] || make cdc
-                            [ -f ./bin/cdc_mysql_consumer ] || make mysql_consumer
                             [ -f ./bin/cdc.test ] || make integration_test_build
                             ls -alh ./bin
                             ./bin/cdc version

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -89,7 +89,6 @@ pipeline {
                         sh label: "prepare", script: """
                             ls -alh ./bin
                             [ -f ./bin/cdc ] || make cdc
-                            [ -f ./bin/cdc_mysql_consumer ] || make mysql_consumer
                             [ -f ./bin/cdc.test ] || make integration_test_build
                             ls -alh ./bin
                             ./bin/cdc version


### PR DESCRIPTION
Remove mysql_consumer build step from integration pipelines.

It was introduced by #4040