### PR TITLE
fix(pielines/pingcap/ticdc): fix TiCDC test images

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/rocky8_golang-1.25:tini
+      image: hub.pingcap.net/jenkins/rocky8_golang-1.23:tini
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-build.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Add utils container to pull_cdc_mysql_integration_heavy pod Downgrade golang image from 1.25 to 1.23 in pull_cdc_kafka_integration_heavy(the `tini` tag for 1.25 is not ready).