### PR TITLE
Revert "refactor(tekton/v1/triggers/env-gcp): split builds for next-gen release branches for tiproxy to `*-ng` triggers"

### DIFF
--- a/tekton/v1/triggers/bindings/gcp-ng-build-params.yaml
+++ b/tekton/v1/triggers/bindings/gcp-ng-build-params.yaml
@@ -4,10 +4,9 @@ metadata:
   name: gcp-ng-build-params # only use in GCP clusters for nextgen builds
 spec:
   params:
-    - { name: builder-resources-cpu, value: $(extensions.resource-config.cpu) }
-    - { name: builder-resources-memory, value: $(extensions.resource-config.memory) }
-    - { name: component, value: $(extensions.component) }
-    - { name: publisher-url, value: "https://do2.pingcap.net/publisher" }
-    - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/tidbx }
-    - { name: source-ws-size, value: $(extensions.resource-config.sourceWsSize) }
-    - { name: timeout, value: $(extensions.resource-config.timeout) }
+    - name: profile
+      value: next-gen
+    - name: registry
+      value: us-docker.pkg.dev/pingcap-testing-account/tidbx
+    - name: publisher-url
+      value: "https://do2.pingcap.net/publisher"

--- a/tekton/v1/triggers/bindings/ksy-dev-build-params.yaml
+++ b/tekton/v1/triggers/bindings/ksy-dev-build-params.yaml
@@ -5,8 +5,11 @@ metadata:
 spec:
   params:
     - { name: boskos-server-url, value: http://boskos.ee-cd.svc }
-    - { name: builder-resources-cpu, value: $(extensions.resource-config.cpu) }
-    - { name: builder-resources-memory, value: $(extensions.resource-config.memory) }
+    - { name: builder-resources-cpu, value: $(extensions.resource-config.builderResourcesCpu) }
+    - {
+        name: builder-resources-memory,
+        value: $(extensions.resource-config.builderResourcesMemory),
+      }
     - { name: ce-context, value: $(extensions.ce-context) }
     - { name: component, value: $(extensions.component) }
     - { name: force-builder-image, value: $(extensions.custom-params.builder-image) }

--- a/tekton/v1/triggers/triggers/env-gcp/_/git-create-tag-build-ng.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/git-create-tag-build-ng.yaml
@@ -16,53 +16,48 @@ spec:
             'pingcap/ticdc',
             'pingcap/tidb',
             'pingcap/tiflash',
-            'pingcap/tiproxy',
-            'tidbcloud/cloud-storage-engine',
             'tikv/pd',
+            'tidbcloud/cloud-storage-engine',
             ]
             &&
             body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+-nextgen[.][0-9]{6}[.][0-9]+$')
         - name: overlays
           value:
-            - key: resource-config
+            - key: timeout
               expression: >-
                 {
-                  'pingcap/tiproxy': {
-                    'timeout': '30m',
-                    'sourceWsSize': '20Gi',
-                    'cpu': '3',
-                    'memory': '12Gi',
-                  },
-                  'pingcap/ticdc': {
-                    'timeout': '20m',
-                    'sourceWsSize': '50Gi',
-                    'cpu': '3',
-                    'memory': '12Gi',
-                  },
-                  'pingcap/tidb': {
-                    'timeout': '45m',
-                    'sourceWsSize': '50Gi',
-                    'cpu': '6',
-                    'memory': '24Gi',
-                  },
-                  'pingcap/tiflash': {
-                    'timeout': '2h',
-                    'sourceWsSize': '100Gi',
-                    'cpu': '12',
-                    'memory': '48Gi',
-                  },
-                  'tikv/pd': {
-                    'timeout': '20m',
-                    'sourceWsSize': '50Gi',
-                    'cpu': '6',
-                    'memory': '24Gi',
-                  },
-                  'tidbcloud/cloud-storage-engine': {
-                    'timeout': '30m',
-                    'sourceWsSize': '100Gi',
-                    'cpu': '12',
-                    'memory': '48Gi',
-                  },
+                'pingcap/ticdc': '20m',
+                'pingcap/tidb': '45m',
+                'pingcap/tiflash': '2h',
+                'tikv/pd': '20m',
+                'tidbcloud/cloud-storage-engine': '2h',
+                }[body.repository.full_name]
+            - key: source-ws-size
+              expression: >-
+                {
+                'pingcap/ticdc': '50Gi',
+                'pingcap/tidb': '50Gi',
+                'pingcap/tiflash': '100Gi',
+                'tikv/pd': '50Gi',
+                'tidbcloud/cloud-storage-engine': '100Gi',
+                }[body.repository.full_name]
+            - key: builder-resources-cpu
+              expression: >-
+                {
+                'pingcap/ticdc': '4',
+                'pingcap/tidb': '6',
+                'pingcap/tiflash': '12',
+                'tikv/pd': '6',
+                'tidbcloud/cloud-storage-engine': '12',
+                }[body.repository.full_name]
+            - key: builder-resources-memory
+              expression: >-
+                {
+                'pingcap/ticdc': '16Gi',
+                'pingcap/tidb': '24Gi',
+                'pingcap/tiflash': '48Gi',
+                'tikv/pd': '24Gi',
+                'tidbcloud/cloud-storage-engine': '48Gi',
                 }[body.repository.full_name]
             - key: component
               expression: >-
@@ -71,16 +66,18 @@ spec:
                 'tikv'
                 :
                 body.repository.name
-            - key: profile
-              expression: >-
-                body.repository.full_name == 'pingcap/tiproxy' ? 'release' : 'next-gen'
 
   bindings:
     - ref: github-tag-create
     - ref: gcp-ng-build-params
+    - name: builder-resources-cpu
+      value: $(extensions.builder-resources-cpu)
+    - name: builder-resources-memory
+      value: $(extensions.builder-resources-memory)
     - { name: component, value: $(extensions.component) }
-    - { name: profile, value: $(extensions.profile) }
     - { name: os, value: linux }
+    - { name: source-ws-size, value: $(extensions.source-ws-size) }
+    - { name: timeout, value: $(extensions.timeout) }
 
   template:
     ref: build-component-linux

--- a/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-ng.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-ng.yaml
@@ -13,72 +13,51 @@ spec:
         - name: filter
           value: >-
             (
-              body.repository.full_name in [
-                'pingcap/ticdc',
-                'pingcap/tidb',
-                'pingcap/tiflash',
-                'pingcap/tiproxy',
-                'tidbcloud/cloud-storage-engine',
-                'tikv/pd',
-              ] && body.ref.matches('^refs/heads/(release-nextgen-[0-9]+)$')
+              body.repository.full_name in ['pingcap/tidb', 'pingcap/tiflash', 'pingcap/ticdc', 'tikv/pd']
+              &&
+              body.ref.matches('^refs/heads/(master|release-nextgen-[0-9]+|feature/fts)$')
             ) || (
-              body.repository.full_name in [
-                'pingcap/ticdc',
-                'pingcap/tidb',
-                'pingcap/tiflash',
-                'tikv/pd',
-              ] && body.ref == 'refs/heads/master'
-            ) || (
-              body.repository.full_name in [
-                'tidbcloud/cloud-storage-engine',
-              ] && body.ref == 'dedicated'
-            ) || (
-              body.repository.full_name in [
-                'pingcap/tidb',
-                'pingcap/tiflash',
-              ] && body.ref == 'refs/heads/feature/fts'
+              body.repository.full_name in ['tidbcloud/cloud-storage-engine']
+              &&
+              body.ref.matches('^refs/heads/(dedicated|release-nextgen-[0-9]+)$')
             )
         - name: overlays
           value:
-            - key: resource-config
+            - key: timeout
               expression: >-
                 {
-                  'pingcap/tiproxy': {
-                    'timeout': '30m',
-                    'sourceWsSize': '20Gi',
-                    'cpu': '3',
-                    'memory': '12Gi',
-                  },
-                  'pingcap/ticdc': {
-                    'timeout': '20m',
-                    'sourceWsSize': '50Gi',
-                    'cpu': '3',
-                    'memory': '12Gi',
-                  },
-                  'pingcap/tidb': {
-                    'timeout': '45m',
-                    'sourceWsSize': '50Gi',
-                    'cpu': '6',
-                    'memory': '24Gi',
-                  },
-                  'pingcap/tiflash': {
-                    'timeout': '2h',
-                    'sourceWsSize': '100Gi',
-                    'cpu': '12',
-                    'memory': '48Gi',
-                  },
-                  'tikv/pd': {
-                    'timeout': '20m',
-                    'sourceWsSize': '50Gi',
-                    'cpu': '6',
-                    'memory': '24Gi',
-                  },
-                  'tidbcloud/cloud-storage-engine': {
-                    'timeout': '30m',
-                    'sourceWsSize': '100Gi',
-                    'cpu': '12',
-                    'memory': '48Gi',
-                  },
+                'pingcap/ticdc': '20m',
+                'pingcap/tidb': '45m',
+                'pingcap/tiflash': '2h',
+                'tikv/pd': '20m',
+                'tidbcloud/cloud-storage-engine': '2h',
+                }[body.repository.full_name]
+            - key: source-ws-size
+              expression: >-
+                {
+                'pingcap/ticdc': '50Gi',
+                'pingcap/tidb': '50Gi',
+                'pingcap/tiflash': '100Gi',
+                'tikv/pd': '50Gi',
+                'tidbcloud/cloud-storage-engine': '100Gi',
+                }[body.repository.full_name]
+            - key: builder-resources-cpu
+              expression: >-
+                {
+                'pingcap/ticdc': '4',
+                'pingcap/tidb': '6',
+                'pingcap/tiflash': '12',
+                'tikv/pd': '6',
+                'tidbcloud/cloud-storage-engine': '12',
+                }[body.repository.full_name]
+            - key: builder-resources-memory
+              expression: >-
+                {
+                'pingcap/ticdc': '16Gi',
+                'pingcap/tidb': '24Gi',
+                'pingcap/tiflash': '48Gi',
+                'tikv/pd': '24Gi',
+                'tidbcloud/cloud-storage-engine': '48Gi',
                 }[body.repository.full_name]
             - key: component
               expression: >-
@@ -87,16 +66,18 @@ spec:
                 'tikv'
                 :
                 body.repository.name
-            - key: profile
-              expression: >-
-                body.repository.full_name == 'pingcap/tiproxy' ? 'release' : 'next-gen'
 
   bindings:
     - ref: github-branch-push
     - ref: gcp-ng-build-params
+    - name: builder-resources-cpu
+      value: $(extensions.builder-resources-cpu)
+    - name: builder-resources-memory
+      value: $(extensions.builder-resources-memory)
     - { name: component, value: $(extensions.component) }
-    - { name: profile, value: $(extensions.profile) }
     - { name: os, value: linux }
+    - { name: source-ws-size, value: $(extensions.source-ws-size) }
+    - { name: timeout, value: $(extensions.timeout) }
 
   template:
     ref: build-component-linux

--- a/tekton/v1/triggers/triggers/env-gcp/pingcap/tiproxy/git-create-tag.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/pingcap/tiproxy/git-create-tag.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'pingcap/tiproxy'
             &&
-            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta)([.][0-9]+)?)?$')
+            body.ref.matches('^v[0-9]+[.][0-9]+[.][0-9]+(-(alpha|beta|nextgen)([.][0-9]+.*)?)?$')
   bindings:
     - ref: github-tag-create
     - ref: gcp-classic-build-params

--- a/tekton/v1/triggers/triggers/env-gcp/pingcap/tiproxy/git-push.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/pingcap/tiproxy/git-push.yaml
@@ -15,7 +15,7 @@ spec:
           value: >-
             body.repository.full_name == 'pingcap/tiproxy'
             &&
-            body.ref.matches('^refs/heads/(main|master|release-[0-9]+[.][0-9]+)$')
+            body.ref.matches('^refs/heads/(main|master|release-[0-9]+[.][0-9]+|release-nextgen-[0-9]+)$')
   bindings:
     - ref: github-branch-push
     - ref: gcp-classic-build-params

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -43,92 +43,92 @@ spec:
                   'pingcap-inc/tici': {
                     'timeout': '2h',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/ng-monitoring': {
                     'timeout': '30m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/ticdc': {
                     'timeout': '20m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tidb': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-binlog': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-dashboard': {
                     'timeout': '40m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/tidb-operator': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '2',
-                    'memory': '8Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '8Gi'
                   },
                   'pingcap/tidb-tools': {
                     'timeout': '1h',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tiflash': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'pingcap/tiflow': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tiproxy': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'tidbcloud/cloud-storage-engine': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tidbcloud/tiflash-cse': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tikv/pd': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'tikv/tikv': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   }
                 }[body.repository.full_name]
             - key: custom-params

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push.yaml
@@ -43,92 +43,92 @@ spec:
                   'pingcap-inc/tici': {
                     'timeout': '2h',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/ng-monitoring': {
                     'timeout': '30m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/ticdc': {
                     'timeout': '20m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tidb': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-binlog': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-dashboard': {
                     'timeout': '40m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/tidb-operator': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '2',
-                    'memory': '8Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '8Gi'
                   },
                   'pingcap/tidb-tools': {
                     'timeout': '1h',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tiflash': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'pingcap/tiflow': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tiproxy': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'tidbcloud/cloud-storage-engine': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tidbcloud/tiflash-cse': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tikv/pd': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'tikv/tikv': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   }
                 }[body.repository.full_name]
             - key: custom-params

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr-single-platform.yaml
@@ -43,92 +43,92 @@ spec:
                   'pingcap-inc/tici': {
                     'timeout': '2h',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/ng-monitoring': {
                     'timeout': '30m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/ticdc': {
                     'timeout': '20m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tidb': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-binlog': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-dashboard': {
                     'timeout': '40m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/tidb-operator': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '2',
-                    'memory': '8Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '8Gi'
                   },
                   'pingcap/tidb-tools': {
                     'timeout': '1h',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tiflash': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'pingcap/tiflow': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tiproxy': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'tidbcloud/cloud-storage-engine': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tidbcloud/tiflash-cse': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tikv/pd': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'tikv/tikv': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   }
                 }[body.repository.full_name]
             - key: custom-params

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr.yaml
@@ -43,92 +43,92 @@ spec:
                   'pingcap-inc/tici': {
                     'timeout': '2h',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/ng-monitoring': {
                     'timeout': '30m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/ticdc': {
                     'timeout': '20m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tidb': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-binlog': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-dashboard': {
                     'timeout': '40m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/tidb-operator': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '2',
-                    'memory': '8Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '8Gi'
                   },
                   'pingcap/tidb-tools': {
                     'timeout': '1h',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tiflash': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'pingcap/tiflow': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tiproxy': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'tidbcloud/cloud-storage-engine': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tidbcloud/tiflash-cse': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tikv/pd': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'tikv/tikv': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   }
                 }[body.repository.full_name]
             - key: custom-params

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -45,92 +45,92 @@ spec:
                   'pingcap-inc/tici': {
                     'timeout': '2h',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/ng-monitoring': {
                     'timeout': '30m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/ticdc': {
                     'timeout': '20m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tidb': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-binlog': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-dashboard': {
                     'timeout': '40m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/tidb-operator': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '2',
-                    'memory': '8Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '8Gi'
                   },
                   'pingcap/tidb-tools': {
                     'timeout': '1h',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tiflash': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'pingcap/tiflow': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tiproxy': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'tidbcloud/cloud-storage-engine': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tidbcloud/tiflash-cse': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tikv/pd': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'tikv/tikv': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   }
                 }[body.repository.full_name]
             - key: custom-params

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create.yaml
@@ -43,92 +43,92 @@ spec:
                   'pingcap-inc/tici': {
                     'timeout': '2h',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/ng-monitoring': {
                     'timeout': '30m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/ticdc': {
                     'timeout': '20m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tidb': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-binlog': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tidb-dashboard': {
                     'timeout': '40m',
                     'sourceWsSize': '8Gi',
-                    'cpu': '2',
-                    'memory': '4Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '4Gi'
                   },
                   'pingcap/tidb-operator': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '2',
-                    'memory': '8Gi'
+                    'builderResourcesCpu': '2',
+                    'builderResourcesMemory': '8Gi'
                   },
                   'pingcap/tidb-tools': {
                     'timeout': '1h',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'pingcap/tiflash': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'pingcap/tiflow': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'pingcap/tiproxy': {
                     'timeout': '30m',
                     'sourceWsSize': '10Gi',
-                    'cpu': '4',
-                    'memory': '16Gi'
+                    'builderResourcesCpu': '4',
+                    'builderResourcesMemory': '16Gi'
                   },
                   'tidbcloud/cloud-storage-engine': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tidbcloud/tiflash-cse': {
                     'timeout': '2h',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   },
                   'tikv/pd': {
                     'timeout': '40m',
                     'sourceWsSize': '50Gi',
-                    'cpu': '8',
-                    'memory': '32Gi'
+                    'builderResourcesCpu': '8',
+                    'builderResourcesMemory': '32Gi'
                   },
                   'tikv/tikv': {
                     'timeout': '2h30m',
                     'sourceWsSize': '100Gi',
-                    'cpu': '16',
-                    'memory': '64Gi'
+                    'builderResourcesCpu': '16',
+                    'builderResourcesMemory': '64Gi'
                   }
                 }[body.repository.full_name]
             - key: custom-params


### PR DESCRIPTION
Reverts PingCAP-QE/ci#4041