### PR TITLE
fix(pipelines/pingcap/tidb): correct BRIETEST_TMPDIR variable usage in ghpr_check2 job

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -131,7 +131,7 @@ pipeline {
                                 """
                                 sh """
                                 export BRIETEST_TMPDIR="${WORKSPACE}/tmp"
-                                mkdir -vp "$BRIETEST_TMPDIR"
+                                mkdir -vp "\${BRIETEST_TMPDIR}"
 
                                 ${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}
                                 """


### PR DESCRIPTION
Updated the mkdir command to properly reference the BRIETEST_TMPDIR environment variable, ensuring the temporary directory is created correctly during the pipeline execution.