### PR TITLE
fix(libraries): update ssh-keyscan key types

### DIFF
--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -218,7 +218,7 @@ def checkoutPRWithPreMerge(gitUrl, prTargetBranch, tidbTestRefsList, credentials
     sshagent(credentials: [credentialsId]) {
         sh label: 'Know hosts', script: """#!/usr/bin/env bash
             [ -d ~/.ssh ] || mkdir ~/.ssh && chmod 0700 ~/.ssh
-            ssh-keyscan -t rsa,dsa github.com >> ~/.ssh/known_hosts
+            ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts
         """
         sh(label: 'checkout', script: """#!/usr/bin/env bash
             set -e

--- a/libraries/tipipeline/vars/git.groovy
+++ b/libraries/tipipeline/vars/git.groovy
@@ -5,7 +5,7 @@ def setSshKey(String credentialsId, String gitSshHost = 'github.com') {
             [ -d ~/.ssh ] || mkdir ~/.ssh && chmod 0700 ~/.ssh
             cp "\$SSH_KEY" ~/.ssh/id_rsa
             chmod 400 ~/.ssh/id_rsa
-            ssh-keyscan -t rsa,dsa ${gitSshHost} >> ~/.ssh/known_hosts
+            ssh-keyscan -t rsa,ecdsa,ed25519 ${gitSshHost} >> ~/.ssh/known_hosts
         """
     }
 }

--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -82,7 +82,7 @@ def checkoutPrivateRefs(refs, credentialsId, timeout = 5, gitSshHost = 'github.c
     sshagent(credentials: [credentialsId]) {
         sh label: 'Know hosts', script: """
             [ -d ~/.ssh ] || mkdir ~/.ssh && chmod 0700 ~/.ssh
-            ssh-keyscan -t rsa,dsa ${gitSshHost} >> ~/.ssh/known_hosts
+            ssh-keyscan -t rsa,ecdsa,ed25519 ${gitSshHost} >> ~/.ssh/known_hosts
         """
         // checkout base.
         sh label: 'Checkout and merge pull request(s) to target if exist', script: """#!/usr/bin/env bash


### PR DESCRIPTION
- remove `dsa`.
- add `ecdsa` and `ed25519`.


Ref: https://docs.github.com/zh/enterprise-cloud@latest/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account