### PR TITLE
fix(tekton/v1/triggers): try to reduce tikv binary build pod memory resource

### DIFF
--- a/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-community-linux.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-community-linux.yaml
@@ -77,7 +77,7 @@ spec:
                 'pingcap/tiflash': '48Gi',
                 'pingcap/tiflow': '24Gi',
                 'tikv/pd': '24Gi',
-                'tikv/tikv': '56Gi',
+                'tikv/tikv': '52Gi',
                 }[body.repository.full_name]
   bindings:
     - ref: github-branch-push


### PR DESCRIPTION

from 56GB to 52GB: 56GB will cause scheduling success rate low.