### PR TITLE
opt(tekton/v1/pipelines): add retries to pipeline tasks for better reliability

### DIFF
--- a/tekton/v1/pipelines/pingcap-build-package-darwin.yaml
+++ b/tekton/v1/pipelines/pingcap-build-package-darwin.yaml
@@ -95,6 +95,7 @@ spec:
         - name: output
           workspace: source
     - name: checkout-ext
+      retries: 2
       runAfter:
         - checkout
       taskRef:
@@ -114,6 +115,7 @@ spec:
         - name: output
           workspace: source
     - name: get-release-ver
+      retries: 2
       runAfter:
         - checkout
       taskRef:
@@ -128,6 +130,7 @@ spec:
           workspace: source
           subPath: $(params.component)
     - name: get-binaries-builder
+      retries: 2
       taskRef:
         name: pingcap-get-builder-image
       params:
@@ -144,6 +147,7 @@ spec:
         - name: force-builder-image
           value: "$(params.force-builder-image)"
     - name: build-binaries
+      retries: 2
       runAfter:
         - checkout-ext
       taskRef:

--- a/tekton/v1/pipelines/pingcap-build-package-linux.yaml
+++ b/tekton/v1/pipelines/pingcap-build-package-linux.yaml
@@ -98,6 +98,7 @@ spec:
         - name: output
           workspace: source
     - name: checkout-ext
+      retries: 2
       runAfter:
         - checkout
       taskRef:
@@ -117,6 +118,7 @@ spec:
         - name: output
           workspace: source
     - name: get-release-ver
+      retries: 2
       runAfter:
         - checkout
       taskRef:
@@ -131,6 +133,7 @@ spec:
           workspace: source
           subPath: $(params.component)
     - name: get-binaries-builder
+      retries: 2
       taskRef:
         name: pingcap-get-builder-image
       params:
@@ -147,6 +150,7 @@ spec:
         - name: force-builder-image
           value: "$(params.force-builder-image)"
     - name: build-binaries
+      retries: 2
       runAfter:
         - checkout-ext
       taskRef:
@@ -182,6 +186,7 @@ spec:
         - name: cypress-cache
           workspace: cypress-cache
     - name: build-images
+      retries: 2
       when:
         - input: "$(params.push)"
           operator: in


### PR DESCRIPTION
Add retry mechanism with 2 attempts to multiple tasks in both Darwin and
Linux build pipelines to avoid run on GCP meet the TaintManagerEviction
on spot nodes.
