### PR TITLE
feat(prow-jobs): add master label to all Jenkins jobs

### DIFF
--- a/prow-jobs/pingcap-inc/enterprise-extensions/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/enterprise-extensions/presubmits.yaml
@@ -2,6 +2,8 @@ presubmits:
   pingcap-inc/enterprise-extensions:
     - name: pingcap-inc/enterprise-extensions/pr-verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: true
       context: pr-verify
@@ -14,6 +16,8 @@ presubmits:
         - ^release-[8-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-inc/enterprise-extensions/le-release-7.4/pr-verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: true
       context: pr-verify

--- a/prow-jobs/pingcap-qe/tidb-test/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/latest-presubmits-next-gen.yaml
@@ -3,6 +3,8 @@ presubmits:
   PingCAP-QE/tidb-test:
     - name: pingcap-qe/tidb-test/pull_integration_jdbc_test_next_gen
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false
       optional: true
       branches:
@@ -14,6 +16,8 @@ presubmits:
 
     - name: pingcap-qe/tidb-test/pull_mysql_test_next_gen
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false
       optional: true
       run_if_changed: "mysql_test/.*"

--- a/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   PingCAP-QE/tidb-test:
     - name: pingcap-qe/tidb-test/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build
@@ -14,6 +16,8 @@ presubmits:
         - ^release-nextgen-.*$ # for next-gen release branches to verify the scripts.
     - name: pingcap-qe/tidb-test/ghpr_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|jdbc_test)/.*"
       context: ci/common-test
@@ -24,6 +28,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/ghpr_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|mybatis_test|jooq_test|tidb_jdbc_test)/.*"
       context: ci/integration-jdbc-test
@@ -34,6 +40,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/ghpr_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "randgen-test/.*"
       context: ci/integration-common-test
@@ -44,6 +52,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/ghpr_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test
@@ -54,6 +64,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test
@@ -64,6 +76,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/ghpr_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: ci/integration-nodejs-test
@@ -74,6 +88,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/ghpr_integration_python_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: ci/integration-python-orm-test
@@ -84,6 +100,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/pull_tiproxy_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -95,6 +113,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/pull_tiproxy_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -106,6 +126,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/pull_tiproxy_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -117,6 +139,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/pull_tiproxy_ruby_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -128,6 +152,8 @@ presubmits:
         - ^master$
     - name: pingcap-qe/tidb-test/pull_tiproxy_mysql_connector_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap-qe/tidb-test/release-6.0-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/release-6.0-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   PingCAP-QE/tidb-test:
     - name: pingcap-qe/tidb-test/release-6.0/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build
@@ -13,6 +15,8 @@ presubmits:
         - ^release-6\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test
@@ -23,6 +27,8 @@ presubmits:
         - ^release-6\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-6.0/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test

--- a/prow-jobs/pingcap-qe/tidb-test/release-6.1-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/release-6.1-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   PingCAP-QE/tidb-test:
     - name: pingcap-qe/tidb-test/release-6.1/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build
@@ -13,6 +15,8 @@ presubmits:
         - ^release-6\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-6.1/ghpr_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test
@@ -23,6 +27,8 @@ presubmits:
         - ^release-6\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-6.1/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test

--- a/prow-jobs/pingcap-qe/tidb-test/release-6.2-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/release-6.2-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   PingCAP-QE/tidb-test:
     - name: pingcap-qe/tidb-test/release-6.2/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build
@@ -13,6 +15,8 @@ presubmits:
         - ^release-6\.[2-6](\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test
@@ -23,6 +27,8 @@ presubmits:
         - ^release-6\.[2-6](\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-6.2/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test

--- a/prow-jobs/pingcap-qe/tidb-test/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/release-7.1-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   PingCAP-QE/tidb-test:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build
@@ -17,6 +19,8 @@ presubmits:
       branches: *branches
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|jdbc_test)/.*"
       context: ci/common-test
@@ -26,6 +30,8 @@ presubmits:
       branches: *branches
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|mybatis_test|jooq_test|tidb_jdbc_test)/.*"
       context: ci/integration-jdbc-test
@@ -35,6 +41,8 @@ presubmits:
       branches: *branches
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "randgen-test/.*"
       context: ci/integration-common-test
@@ -44,6 +52,8 @@ presubmits:
       branches: *branches
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test
@@ -53,6 +63,8 @@ presubmits:
       branches: *branches
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test

--- a/prow-jobs/pingcap-qe/tidb-test/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/release-8.5-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   PingCAP-QE/tidb-test:
     - name: pingcap-qe/tidb-test/release-8.5/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build
@@ -13,6 +15,8 @@ presubmits:
         - ^release-8\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-8.5/ghpr_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|jdbc_test)/.*"
       context: ci/common-test
@@ -23,6 +27,8 @@ presubmits:
         - ^release-8\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|mybatis_test|jooq_test|tidb_jdbc_test)/.*"
       context: ci/integration-jdbc-test
@@ -33,6 +39,8 @@ presubmits:
         - ^release-8\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "randgen-test/.*"
       context: ci/integration-common-test
@@ -43,6 +51,8 @@ presubmits:
         - ^release-8\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test
@@ -53,6 +63,8 @@ presubmits:
         - ^release-8\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test

--- a/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
@@ -2,6 +2,8 @@ presubmits:
   pingcap/docs-cn:
     - name: pingcap/docs-cn/pull_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: true
       skip_report: false

--- a/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
@@ -3,6 +3,8 @@ postsubmits:
   pingcap/docs-cn:
     - name: pingcap/docs-cn/merged_update_docs_cn
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: docs-cn/merged-ci
       max_concurrency: 5

--- a/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
@@ -2,6 +2,8 @@ presubmits:
   pingcap/docs:
     - name: pingcap/docs/pull_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: true
       skip_report: false

--- a/prow-jobs/pingcap/docs/docs-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-postsubmits.yaml
@@ -3,6 +3,8 @@ postsubmits:
   pingcap/docs:
     - name: pingcap/docs/merged_update_docs
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: docs/merged-ci
       max_concurrency: 5

--- a/prow-jobs/pingcap/docs/docs-tidb-operator-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-tidb-operator-postsubmits.yaml
@@ -3,6 +3,8 @@ postsubmits:
   pingcap/docs-tidb-operator:
     - name: pingcap/docs-tidb-operator/merged_update
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: docs-tidb-operator/merged-ci
       max_concurrency: 5

--- a/prow-jobs/pingcap/tidb-tools/presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-tools/presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb-tools:
     - name: pingcap/tidb-tools/pull_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: true
       skip_report: false

--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -10,6 +10,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/e2e-test
@@ -19,6 +21,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/common-test
@@ -28,6 +32,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-common-test
@@ -37,6 +43,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: ci/integration-jdbc-test
       skip_if_only_changed: *skip_if_only_changed
@@ -46,6 +54,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-mysql-test
@@ -55,6 +65,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/sqllogic-test
@@ -64,6 +76,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-copr-test
@@ -73,6 +87,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test
@@ -82,6 +98,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_unit_test_ddlv1
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/unit-test-ddlv1 # TODO: change to ci/ after test.
@@ -91,6 +109,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_integration_python_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-python-orm-test
@@ -100,6 +120,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-nodejs-test
@@ -109,6 +131,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_integration_br_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/integration-br-test
@@ -118,6 +142,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_integration_lightning_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/integration-lightning-test
@@ -127,6 +153,8 @@ postsubmits:
     - <<: *brancher
       name: pingcap/tidb/merged_tiflash_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/tiflash-integration-test

--- a/prow-jobs/pingcap/tidb/latest-presubmits-canary.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits-canary.yaml
@@ -12,6 +12,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/canary_ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       max_concurrency: 2
       # run_if_changed: "pkg/executor"

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -13,6 +13,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/build
@@ -22,6 +24,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/check_dev
@@ -31,6 +35,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -40,6 +46,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/mysql-test
@@ -58,6 +66,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_unit_test_ddlv1
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "pkg/(ddl|meta)/.*"
       context: pull-unit-test-ddlv1
@@ -67,6 +77,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-mysql-test
@@ -76,6 +88,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-copr-test
@@ -85,6 +99,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-jdbc-test
@@ -94,6 +110,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-e2e-test
@@ -103,6 +121,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_integration_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-e2e-test
@@ -112,6 +132,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       run_if_changed: "(br|pkg/(ddl|domain|infoschema))/.*"
@@ -121,6 +143,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_lightning_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       run_if_changed: "(lightning|pkg/(domain|statistics|ddl|infoschema)|br/pkg/(checksum|httputil|membuf|pdutil|restore/split|storage))/.*"
@@ -130,6 +154,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-common-test
@@ -139,6 +165,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-common-test
@@ -148,6 +176,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-ddl-test
@@ -157,6 +187,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-sqllogic-test
@@ -166,6 +198,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_mysql_client_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-mysql-client-test
@@ -175,6 +209,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-nodejs-test
@@ -184,6 +220,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_integration_python_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-python-orm-test
@@ -193,6 +231,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/pull_tiflash_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-tiflash-integration-test

--- a/prow-jobs/pingcap/tidb/release-6.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.1-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-6.1/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -17,6 +19,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -26,6 +30,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -35,6 +41,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -44,6 +52,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -53,6 +63,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -64,6 +76,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -75,6 +89,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -85,6 +101,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -96,6 +114,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -107,6 +127,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -118,6 +140,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -129,6 +153,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -140,6 +166,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_tiflash_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -151,6 +179,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_integration_tidb_tools_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -162,6 +192,8 @@ presubmits:
 
     - name: pingcap/tidb/release-6.1/pull_integration_binlog_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-6.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.2-presubmits.yaml
@@ -5,6 +5,8 @@ presubmits:
     #### for release-6.2 branch
     - name: pingcap/tidb/release-6.2/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -14,6 +16,8 @@ presubmits:
         - ^release-6\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.2/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -23,6 +27,8 @@ presubmits:
         - ^release-6\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.2/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -32,6 +38,8 @@ presubmits:
         - ^release-6\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.2/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -41,6 +49,8 @@ presubmits:
         - ^release-6\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.2/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test

--- a/prow-jobs/pingcap/tidb/release-6.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.3-presubmits.yaml
@@ -4,6 +4,8 @@ presubmits:
     #### for release-6.3 branch
     - name: pingcap/tidb/release-6.3/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -13,6 +15,8 @@ presubmits:
         - ^release-6\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.3/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -22,6 +26,8 @@ presubmits:
         - ^release-6\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.3/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -31,6 +37,8 @@ presubmits:
         - ^release-6\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.3/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -40,6 +48,8 @@ presubmits:
         - ^release-6\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.3/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test

--- a/prow-jobs/pingcap/tidb/release-6.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.4-presubmits.yaml
@@ -4,6 +4,8 @@ presubmits:
     #### for release-6.4 branch
     - name: pingcap/tidb/release-6.4/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -13,6 +15,8 @@ presubmits:
         - ^release-6\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.4/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -22,6 +26,8 @@ presubmits:
         - ^release-6\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.4/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -31,6 +37,8 @@ presubmits:
         - ^release-6\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.4/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -40,6 +48,8 @@ presubmits:
         - ^release-6\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.4/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test

--- a/prow-jobs/pingcap/tidb/release-6.5-20241101-v6.5.7-presubits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.5-20241101-v6.5.7-presubits.yaml
@@ -6,6 +6,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -14,6 +16,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -22,6 +26,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -30,6 +36,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -38,6 +46,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -46,6 +56,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -56,6 +68,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -66,6 +80,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -75,6 +91,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -85,6 +103,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -95,6 +115,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -105,6 +127,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -115,6 +139,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -125,6 +151,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -135,6 +163,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tidb/release-6.5-20241101-v6.5.7/pull_tiflash_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-6.5-fips-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.5-fips-presubmits.yaml
@@ -4,6 +4,8 @@ presubmits:
     #### for release-6.5 branch
     - name: pingcap/tidb/release-6.5-fips/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -13,6 +15,8 @@ presubmits:
         - ^feature/release-6.5-fips$
     - name: pingcap/tidb/release-6.5-fips/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -22,6 +26,8 @@ presubmits:
         - ^feature/release-6.5-fips$
     - name: pingcap/tidb/release-6.5-fips/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -31,6 +37,8 @@ presubmits:
         - ^feature/release-6.5-fips$
     - name: pingcap/tidb/release-6.5-fips/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -40,6 +48,8 @@ presubmits:
         - ^feature/release-6.5-fips$
     - name: pingcap/tidb/release-6.5-fips/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -49,6 +59,8 @@ presubmits:
         - ^feature/release-6.5-fips$
     - name: pingcap/tidb/release-6.5-fips/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false

--- a/prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml
@@ -10,6 +10,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-6.5/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -19,6 +21,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -28,6 +32,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -37,6 +43,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -46,6 +54,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -55,6 +65,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -66,6 +78,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -77,6 +91,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -87,6 +103,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -98,6 +116,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -109,6 +129,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -120,6 +142,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -131,6 +155,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -142,6 +168,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -153,6 +181,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_tiflash_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -164,6 +194,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_integration_tidb_tools_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -175,6 +207,8 @@ presubmits:
       skip_branches: *skip_branches
     - name: pingcap/tidb/release-6.5/pull_integration_binlog_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-6.5-with-kv-timeout-feature-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.5-with-kv-timeout-feature-presubmits.yaml
@@ -4,6 +4,8 @@ presubmits:
     #### for release-6.5-with-kv-timeout-feature branch
     - name: pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -13,6 +15,8 @@ presubmits:
         - ^tidb-6.5-with-kv-timeout-feature$
     - name: pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -22,6 +26,8 @@ presubmits:
         - ^tidb-6.5-with-kv-timeout-feature$
     - name: pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -31,6 +37,8 @@ presubmits:
         - ^tidb-6.5-with-kv-timeout-feature$
     - name: pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -40,6 +48,8 @@ presubmits:
         - ^tidb-6.5-with-kv-timeout-feature$
     - name: pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test

--- a/prow-jobs/pingcap/tidb/release-6.6-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.6-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-6.6/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -12,6 +14,8 @@ presubmits:
         - ^release-6\.[6-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.6/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -21,6 +25,8 @@ presubmits:
         - ^release-6\.[6-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.6/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -30,6 +36,8 @@ presubmits:
         - ^release-6\.[6-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.6/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -39,6 +47,8 @@ presubmits:
         - ^release-6\.[6-9](\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-6.6/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test

--- a/prow-jobs/pingcap/tidb/release-7.0-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.0-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-7.0/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -12,6 +14,8 @@ presubmits:
         - ^release-7\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.0/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -21,6 +25,8 @@ presubmits:
         - ^release-7\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.0/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -30,6 +36,8 @@ presubmits:
         - ^release-7\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.0/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -39,6 +47,8 @@ presubmits:
         - ^release-7\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.0/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test

--- a/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-7.1/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -18,6 +20,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -27,6 +31,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -36,6 +42,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -45,6 +53,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -54,6 +64,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -65,6 +77,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -76,6 +90,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -86,6 +102,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -97,6 +115,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -108,6 +128,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -119,6 +141,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -130,6 +154,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -141,6 +167,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -152,6 +180,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_tiflash_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -163,6 +193,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_integration_tidb_tools_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -174,6 +206,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.1/pull_integration_binlog_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-7.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.2-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-7.2/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -12,6 +14,8 @@ presubmits:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.2/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -21,6 +25,8 @@ presubmits:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.2/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -30,6 +36,8 @@ presubmits:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.2/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -39,6 +47,8 @@ presubmits:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.2/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test

--- a/prow-jobs/pingcap/tidb/release-7.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.3-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-7.3/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -12,6 +14,8 @@ presubmits:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.3/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -21,6 +25,8 @@ presubmits:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.3/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -30,6 +36,8 @@ presubmits:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.3/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -39,6 +47,8 @@ presubmits:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.3/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -48,6 +58,8 @@ presubmits:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.3/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false

--- a/prow-jobs/pingcap/tidb/release-7.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.4-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-7.4/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -12,6 +14,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.4/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -21,6 +25,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.4/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -30,6 +36,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.4/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -39,6 +47,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.4/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -48,6 +58,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.4/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false

--- a/prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-7.5/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -17,6 +19,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -26,6 +30,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -35,6 +41,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -44,6 +52,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -53,6 +63,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -64,6 +76,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -75,6 +89,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_mysql_client_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -86,6 +102,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -96,6 +114,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -107,6 +127,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -118,6 +140,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -129,6 +153,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -140,6 +166,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -151,6 +179,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -162,6 +192,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_tiflash_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -173,6 +205,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -184,6 +218,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_integration_python_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -195,6 +231,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_integration_tidb_tools_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -206,6 +244,8 @@ presubmits:
 
     - name: pingcap/tidb/release-7.5/pull_integration_binlog_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-7.6-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.6-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-7.6/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -13,6 +15,8 @@ presubmits:
         - ^feature/release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.6/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -22,6 +26,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.6/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -31,6 +37,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.6/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -40,6 +48,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.6/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -49,6 +59,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.6/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -60,6 +72,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-7.6/pull_lightning_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false

--- a/prow-jobs/pingcap/tidb/release-8.0-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.0-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-8.0/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -12,6 +14,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.0/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -21,6 +25,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.0/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -30,6 +36,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.0/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -39,6 +47,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.0/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -48,6 +58,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.0/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -59,6 +71,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.0/pull_lightning_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false

--- a/prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-8.1/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -18,6 +20,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -27,6 +31,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/ghpr_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -36,6 +42,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/ghpr_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -45,6 +53,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -54,6 +64,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -65,6 +77,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_lightning_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false
@@ -76,6 +90,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -87,6 +103,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_mysql_client_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -98,6 +116,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -108,6 +128,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -119,6 +141,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -130,6 +154,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -141,6 +167,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -152,6 +180,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -163,6 +193,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -174,6 +206,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_tiflash_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -185,6 +219,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -196,6 +232,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_integration_python_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -207,6 +245,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_integration_tidb_tools_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -218,6 +258,8 @@ presubmits:
 
     - name: pingcap/tidb/release-8.1/pull_integration_binlog_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-8.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.2-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-8.2/pull_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -12,6 +14,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -21,6 +25,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -30,6 +36,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -39,6 +47,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -48,6 +58,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -59,6 +71,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_lightning_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false
@@ -70,6 +84,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -81,6 +97,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_mysql_client_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -92,6 +110,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -102,6 +122,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -113,6 +135,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -124,6 +148,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -135,6 +161,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -146,6 +174,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -157,6 +187,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -168,6 +200,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_tiflash_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -179,6 +213,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.2/pull_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-8.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.3-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-8.3/pull_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -12,6 +14,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -21,6 +25,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -30,6 +36,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -39,6 +47,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -48,6 +58,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -59,6 +71,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_lightning_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false
@@ -70,6 +84,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -81,6 +97,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_mysql_client_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -92,6 +110,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -102,6 +122,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -113,6 +135,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -124,6 +148,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -135,6 +161,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -146,6 +174,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -157,6 +187,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -168,6 +200,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_tiflash_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -179,6 +213,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.3/pull_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-8.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.4-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tidb:
     - name: pingcap/tidb/release-8.4/pull_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -12,6 +14,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -21,6 +25,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -30,6 +36,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -39,6 +47,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -48,6 +58,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -59,6 +71,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_lightning_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false
@@ -70,6 +84,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -81,6 +97,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_mysql_client_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -92,6 +110,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -102,6 +122,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -113,6 +135,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -124,6 +148,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -135,6 +161,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -146,6 +174,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -157,6 +187,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -168,6 +200,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_tiflash_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -179,6 +213,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -190,6 +226,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tidb/release-8.4/pull_integration_python_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
@@ -10,6 +10,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -19,6 +21,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -28,6 +32,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -37,6 +43,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -46,6 +54,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -55,6 +65,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_unit_test_ddlv1
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "pkg/(ddl|meta)/.*"
       context: pull-unit-test-ddlv1
@@ -64,6 +76,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       run_if_changed: "(br|pkg/(ddl|domain|infoschema))/.*"
@@ -73,6 +87,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_lightning_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false
@@ -84,6 +100,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -95,6 +113,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_mysql_client_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -106,6 +126,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -116,6 +138,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -127,6 +151,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -138,6 +164,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -149,6 +177,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -160,6 +190,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -171,6 +203,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -182,6 +216,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -193,6 +229,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_integration_python_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -204,6 +242,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_integration_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -215,6 +255,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-8.5/pull_integration_tidb_tools_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-9.0-beta-presubmits.yaml
@@ -13,6 +13,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/build
@@ -22,6 +24,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/check_dev
@@ -31,6 +35,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_check2
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -40,6 +46,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/mysql-test
@@ -49,6 +57,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/unit-test
@@ -58,6 +68,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_unit_test_ddlv1
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "pkg/(ddl|meta)/.*"
       context: pull-unit-test-ddlv1
@@ -67,6 +79,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_br_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       run_if_changed: "(br|pkg/(ddl|domain|infoschema))/.*"
@@ -76,6 +90,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_lightning_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false
@@ -87,6 +103,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_integration_ddl_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -98,6 +116,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_mysql_client_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -109,6 +129,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -119,6 +141,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -130,6 +154,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -141,6 +167,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -152,6 +180,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -163,6 +193,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -174,6 +206,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -185,6 +219,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -196,6 +232,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -207,6 +245,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_integration_e2e_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -218,6 +258,8 @@ presubmits:
     - <<: *brancher
       name: pingcap/tidb/release-9.0-beta/pull_integration_tidb_tools_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tiflash/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-postsubmits.yaml
@@ -3,6 +3,8 @@ postsubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/merged_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: merged-unit-test # need change this after test pass.
       max_concurrency: 1
@@ -11,6 +13,8 @@ postsubmits:
         - ^master$
     - name: pingcap/tiflash/merged_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: merged-build # need change this after test pass.
       max_concurrency: 1
@@ -19,6 +23,8 @@ postsubmits:
         - ^master$
     - name: pingcap/tiflash/merged_build_next_gen
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: merged-build-next-gen
       max_concurrency: 1

--- a/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
@@ -12,6 +12,8 @@ presubmits:
   pingcap/tiflash:
     - <<: *brancher
       agent: jenkins
+      labels:
+        master: "0"
       context: pull-unit-next-gen
       decorate: false # need add this.
       name: pingcap/tiflash/pull_unit_next_gen
@@ -23,6 +25,8 @@ presubmits:
 
     - <<: *brancher
       agent: jenkins
+      labels:
+        master: "0"
       context: pull-integration-next-gen
       decorate: false # need add this.
       name: pingcap/tiflash/pull_integration_next_gen

--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -13,6 +13,8 @@ presubmits:
   pingcap/tiflash:
     - <<: *brancher
       agent: jenkins
+      labels:
+        master: "0"
       context: pull-unit-test
       decorate: false # need add this.
       name: pingcap/tiflash/pull_unit_test
@@ -24,6 +26,8 @@ presubmits:
 
     - <<: *brancher
       agent: jenkins
+      labels:
+        master: "0"
       context: pull-integration-test
       decorate: false # need add this.
       name: pingcap/tiflash/pull_integration_test

--- a/prow-jobs/pingcap/tiflash/release-6.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-6.1-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-6.1/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       # skip_if_only_changed: *skip_if_only_changed
@@ -21,6 +23,8 @@ presubmits:
 
     - name: pingcap/tiflash/release-6.1/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       # skip_if_only_changed: *skip_if_only_changed

--- a/prow-jobs/pingcap/tiflash/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-6.5-presubmits.yaml
@@ -2,13 +2,14 @@
 global_definitions:
   branches: &branches
     - ^release-6\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
-  skip_if_only_changed: &skip_if_only_changed
-    "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
 presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-6.5/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -20,6 +21,8 @@ presubmits:
 
     - name: pingcap/tiflash/release-6.5/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-7.1-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-7.1/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -20,6 +22,8 @@ presubmits:
 
     - name: pingcap/tiflash/release-7.1/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-7.5-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-7.5/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -20,6 +22,8 @@ presubmits:
 
     - name: pingcap/tiflash/release-7.5/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.1-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-8.1/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -20,6 +22,8 @@ presubmits:
 
     - name: pingcap/tiflash/release-8.1/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-8.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.2-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-8.2/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-unit-test
@@ -14,6 +16,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflash/release-8.2/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-8.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.3-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-8.3/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-unit-test
@@ -14,6 +16,8 @@ presubmits:
         - ^release-8\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflash/release-8.3/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-8.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.4-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-8.4/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-unit-test
@@ -14,6 +16,8 @@ presubmits:
         - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflash/release-8.4/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-8.5-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.5-postsubmits.yaml
@@ -3,6 +3,8 @@ postsubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-8.5/merged_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: merged-unit-test
       max_concurrency: 1
@@ -11,6 +13,8 @@ postsubmits:
         - ^release-8\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflash/release-8.5/merged_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       context: merged-build
       max_concurrency: 1

--- a/prow-jobs/pingcap/tiflash/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.5-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-8.5/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -20,6 +22,8 @@ presubmits:
 
     - name: pingcap/tiflash/release-8.5/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-9.0-beta-presubmits.yaml
@@ -10,6 +10,8 @@ presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/release-9.0-beta/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -21,6 +23,8 @@ presubmits:
 
     - name: pingcap/tiflash/release-9.0-beta/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflow/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-postsubmits.yaml
@@ -8,6 +8,8 @@ postsubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/merged_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -22,6 +24,8 @@ presubmits:
     # Currently we keep the Jenkins job name.
     - name: pingcap/tiflow/pull_cdc_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -33,6 +37,8 @@ presubmits:
 
     - name: pingcap/tiflow/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -44,6 +50,8 @@ presubmits:
 
     - name: pingcap/tiflow/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -55,6 +63,8 @@ presubmits:
 
     - name: pingcap/tiflow/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -66,6 +76,8 @@ presubmits:
 
     - name: pingcap/tiflow/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -77,6 +89,8 @@ presubmits:
 
     - name: pingcap/tiflow/pull_syncdiff_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -87,6 +101,8 @@ presubmits:
 
     - name: pingcap/tiflow/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-6.0-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.0-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-6.0/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-6.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.1-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-6.1/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify
@@ -17,6 +19,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       run_before_merge: true
@@ -28,6 +32,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-6.1/pull_cdc_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -39,6 +45,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-6.1/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -50,6 +58,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-6.1/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed

--- a/prow-jobs/pingcap/tiflow/release-6.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.2-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-6.2/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-6.5-20241101-v6.5.7-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.5-20241101-v6.5.7-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-6.5-20241101-v6.5.7/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify
@@ -12,6 +14,8 @@ presubmits:
         - ^release-6\.5-20241101-v6\.5\.7$ # trigger for specific hotfix branch
     - name: pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       run_before_merge: true
@@ -23,6 +27,8 @@ presubmits:
         - ^release-6\.5-20241101-v6\.5\.7$ # trigger for specific hotfix branch
     - name: pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -34,6 +40,8 @@ presubmits:
         - ^release-6\.5-20241101-v6\.5\.7$ # trigger for specific hotfix branch
     - name: pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -45,6 +53,8 @@ presubmits:
         - ^release-6\.5-20241101-v6\.5\.7$ # trigger for specific hotfix branch
     - name: pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"

--- a/prow-jobs/pingcap/tiflow/release-6.5-fips-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.5-fips-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-6.5-fips/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify
@@ -12,6 +14,8 @@ presubmits:
         - ^feature/release-6.5-fips$
     - name: pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -23,6 +27,8 @@ presubmits:
         - ^feature/release-6.5-fips$
     - name: pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -34,6 +40,8 @@ presubmits:
         - ^feature/release-6.5-fips$
     - name: pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -45,6 +53,8 @@ presubmits:
         - ^feature/release-6.5-fips$
     - name: pingcap/tiflow/release-6.5-fips/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"

--- a/prow-jobs/pingcap/tiflow/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.5-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-6.5/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify
@@ -19,6 +21,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       run_before_merge: true
@@ -32,6 +36,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-6.5/pull_cdc_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -45,6 +51,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-6.5/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -58,6 +66,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-6.5/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed

--- a/prow-jobs/pingcap/tiflow/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.1-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -19,6 +21,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.1/pull_cdc_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -30,6 +34,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -43,6 +49,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.1/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -54,6 +62,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.1/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -65,6 +75,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.1/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-7.1.0-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.1.0-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true

--- a/prow-jobs/pingcap/tiflow/release-7.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.2-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -14,6 +16,8 @@ presubmits:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/pull_cdc_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -25,6 +29,8 @@ presubmits:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -36,6 +42,8 @@ presubmits:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -47,6 +55,8 @@ presubmits:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -58,6 +68,8 @@ presubmits:
         - ^release-7\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.2/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-7.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.3-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -14,6 +16,8 @@ presubmits:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/pull_cdc_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -25,6 +29,8 @@ presubmits:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -36,6 +42,8 @@ presubmits:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -47,6 +55,8 @@ presubmits:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -58,6 +68,8 @@ presubmits:
         - ^release-7\.3(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.3/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-7.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.4-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -14,6 +16,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -25,6 +29,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -36,6 +42,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -47,6 +55,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -58,6 +68,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -69,6 +81,8 @@ presubmits:
         - ^release-7\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.4/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.5-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -19,6 +21,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -30,6 +34,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -41,6 +47,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -52,6 +60,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.5/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -63,6 +73,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.5/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -74,6 +86,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-7.5/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-7.6-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.6-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -14,6 +16,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -25,6 +29,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -36,6 +42,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -47,6 +55,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -58,6 +68,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -69,6 +81,8 @@ presubmits:
         - ^release-7\.6(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-7.6/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-8.0-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.0-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -14,6 +16,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -25,6 +29,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -36,6 +42,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -47,6 +55,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -58,6 +68,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -69,6 +81,8 @@ presubmits:
         - ^release-8\.0(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.0/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.1-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -19,6 +21,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -30,6 +34,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -41,6 +47,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -52,6 +60,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.1/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -63,6 +73,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.1/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -74,6 +86,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.1/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-8.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.2-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -14,6 +16,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -25,6 +29,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -36,6 +42,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -47,6 +55,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -58,6 +68,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -69,6 +81,8 @@ presubmits:
         - ^release-8\.2(\.\d+)?(-\d+)?(-v[\.\d]+)?$
     - name: pingcap/tiflow/release-8.2/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-8.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.3-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -18,6 +20,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -28,6 +32,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -38,6 +44,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -48,6 +56,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -58,6 +68,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.3/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -68,6 +80,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.3/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-8.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.4-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -18,6 +20,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -28,6 +32,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -38,6 +44,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -48,6 +56,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -58,6 +68,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.4/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -68,6 +80,8 @@ presubmits:
       branches: *branches
     - name: pingcap/tiflow/release-8.4/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
@@ -8,6 +8,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -19,6 +21,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -30,6 +34,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -41,6 +47,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -52,6 +60,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.5/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -63,6 +73,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.5/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -74,6 +86,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-8.5/ghpr_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify

--- a/prow-jobs/pingcap/tiflow/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-9.0-beta-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   pingcap/tiflow:
     - name: pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -20,6 +22,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -31,6 +35,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -42,6 +48,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -53,6 +61,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -64,6 +74,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-9.0-beta/pull_dm_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -75,6 +87,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-9.0-beta/pull_syncdiff_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -85,6 +99,8 @@ presubmits:
 
     - name: pingcap/tiflow/release-9.0-beta/pull_verify
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify

--- a/prow-jobs/pingcap/tiproxy/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiproxy/latest-postsubmits.yaml
@@ -3,6 +3,8 @@ postsubmits:
   pingcap/tiproxy:
     - name: pingcap/tiproxy/merged_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-mysql-test # need change this.
@@ -12,6 +14,8 @@ postsubmits:
         - .+
     - name: pingcap/tiproxy/merged_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-nodejs-test # need change this.
@@ -21,6 +25,8 @@ postsubmits:
         - .+
     - name: pingcap/tiproxy/merged_integration_python_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-python-orm-test # need change this.
@@ -30,6 +36,8 @@ postsubmits:
         - .+
     - name: pingcap/tiproxy/merged_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-sqllogic-test # need change this.
@@ -39,6 +47,8 @@ postsubmits:
         - .+
     - name: pingcap/tiproxy/merged_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-common-test # need change this.
@@ -48,6 +58,8 @@ postsubmits:
         - .+
     - name: pingcap/tiproxy/merged_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-jdbc-test # need change this.

--- a/prow-jobs/pingcap/tiproxy/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiproxy/latest-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   pingcap/tiproxy:
     - name: pingcap/tiproxy/ghpr_build
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
@@ -14,6 +16,8 @@ presubmits:
         - .+
     - name: pingcap/tiproxy/ghpr_check
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
@@ -25,6 +29,8 @@ presubmits:
         - .+
     - name: pingcap/tiproxy/ghpr_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       run_before_merge: true
@@ -36,6 +42,8 @@ presubmits:
         - .+
     - name: pingcap/tiproxy/pull_mysql_connector_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -48,6 +56,8 @@ presubmits:
         - .+
     - name: pingcap/tiproxy/pull_mysql_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-mysql-test
@@ -59,6 +69,8 @@ presubmits:
         - .+
     - name: pingcap/tiproxy/pull_integration_jdbc_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-jdbc-test # need change this.
@@ -70,6 +82,8 @@ presubmits:
         - .+
     - name: pingcap/tiproxy/pull_integration_common_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-common-test # need change this.
@@ -80,6 +94,8 @@ presubmits:
         - .+
     - name: pingcap/tiproxy/pull_integration_ruby_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-ruby-orm-test # need change this.
@@ -90,6 +106,8 @@ presubmits:
         - .+
     - name: pingcap/tiproxy/pull_integration_nodejs_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-nodejs-test
@@ -101,6 +119,8 @@ presubmits:
         - .+
     - name: pingcap/tiproxy/pull_integration_python_orm_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-python-orm-test
@@ -112,6 +132,8 @@ presubmits:
         - .+
     - name: pingcap/tiproxy/pull_sqllogic_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-sqllogic-test

--- a/prow-jobs/tikv/copr-test/latest-presubmits.yaml
+++ b/prow-jobs/tikv/copr-test/latest-presubmits.yaml
@@ -12,6 +12,8 @@ presubmits:
     - <<: *brancher
       name: tikv/copr-test/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       always_run: false

--- a/prow-jobs/tikv/migration/latest-presubmits.yaml
+++ b/prow-jobs/tikv/migration/latest-presubmits.yaml
@@ -3,6 +3,8 @@ presubmits:
   tikv/migration:
     - name: tikv/migration/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: true
       context: pull-integration-test
@@ -14,6 +16,8 @@ presubmits:
         - ^br-release-.*$
     - name: tikv/migration/pull_integration_kafka_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: true
       context: pull-integration-kafka-test
@@ -25,6 +29,8 @@ presubmits:
         - ^br-release-.*$
     - name: tikv/migration/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: true
       context: pull-unit-test

--- a/prow-jobs/tikv/pd/latest-presubmits.yaml
+++ b/prow-jobs/tikv/pd/latest-presubmits.yaml
@@ -81,6 +81,8 @@ presubmits:
     - <<: *brancher
       name: tikv/pd/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -91,6 +93,8 @@ presubmits:
     - <<: *brancher
       name: tikv/pd/pull_integration_realcluster_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: true
       optional: false

--- a/prow-jobs/tikv/pd/release-7.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-7.1-presubmits.yaml
@@ -42,6 +42,8 @@ presubmits:
 
     - name: tikv/pd/release-7.1/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-copr-test

--- a/prow-jobs/tikv/pd/release-7.5-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-7.5-presubmits.yaml
@@ -42,6 +42,8 @@ presubmits:
 
     - name: tikv/pd/release-7.5/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-copr-test

--- a/prow-jobs/tikv/pd/release-8.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-8.1-presubmits.yaml
@@ -41,6 +41,8 @@ presubmits:
 
     - name: tikv/pd/release-8.1/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-copr-test

--- a/prow-jobs/tikv/pd/release-8.5-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-8.5-presubmits.yaml
@@ -41,6 +41,8 @@ presubmits:
 
     - name: tikv/pd/release-8.5/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-copr-test

--- a/prow-jobs/tikv/pd/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-9.0-beta-presubmits.yaml
@@ -41,6 +41,8 @@ presubmits:
 
     - name: tikv/pd/release-9.0-beta/pull_integration_copr_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/tikv/tikv/latest-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/latest-presubmits.yaml
@@ -13,6 +13,8 @@ presubmits:
     - <<: *brancher
       name: tikv/tikv/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       optional: false
@@ -24,6 +26,8 @@ presubmits:
     - <<: *brancher
       name: tikv/tikv/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       always_run: false # update here after test passed

--- a/prow-jobs/tikv/tikv/release-6.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-6.1-presubmits.yaml
@@ -1,7 +1,6 @@
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 global_definitions:
-  skip_if_only_changed: &skip_if_only_changed
-    "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
   branches: &branches
     - ^release-6\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
 
@@ -9,6 +8,8 @@ presubmits:
   tikv/tikv:
     - name: tikv/tikv/release-6.1/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       always_run: false # update here after test passed
@@ -21,9 +22,11 @@ presubmits:
 
     - name: tikv/tikv/release-6.1/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
-      always_run: false  # update here after test passed
+      always_run: false # update here after test passed
       optional: true # update here after test passed
       skip_report: true # update here after test passed
       context: wip/pull-integration-test

--- a/prow-jobs/tikv/tikv/release-6.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-6.5-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   tikv/tikv:
     - name: tikv/tikv/release-6.5/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -18,6 +20,8 @@ presubmits:
 
     - name: tikv/tikv/release-6.5/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       always_run: false  # update here after test passed

--- a/prow-jobs/tikv/tikv/release-7.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-7.1-presubmits.yaml
@@ -1,7 +1,6 @@
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 global_definitions:
-  skip_if_only_changed: &skip_if_only_changed
-    "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
   branches: &branches
     - ^release-7\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
 
@@ -9,6 +8,8 @@ presubmits:
   tikv/tikv:
     - name: tikv/tikv/release-7.1/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -18,9 +19,11 @@ presubmits:
 
     - name: tikv/tikv/release-7.1/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
-      always_run: false  # update here after test passed
+      always_run: false # update here after test passed
       optional: true # update here after test passed
       skip_report: true # update here after test passed
       context: wip/pull-integration-test

--- a/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
@@ -10,6 +10,8 @@ presubmits:
   tikv/tikv:
     - name: tikv/tikv/release-7.5/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -19,6 +21,8 @@ presubmits:
 
     - name: tikv/tikv/release-7.5/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       always_run: false  # update here after test passed

--- a/prow-jobs/tikv/tikv/release-8.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.1-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   tikv/tikv:
     - name: tikv/tikv/release-8.1/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -18,6 +20,8 @@ presubmits:
 
     - name: tikv/tikv/release-8.1/pull_integration_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       always_run: false  # update here after test passed
       optional: true # update here after test passed

--- a/prow-jobs/tikv/tikv/release-8.2-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.2-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   tikv/tikv:
     - name: tikv/tikv/release-8.2/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test

--- a/prow-jobs/tikv/tikv/release-8.3-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.3-presubmits.yaml
@@ -9,6 +9,8 @@ presubmits:
   tikv/tikv:
     - name: tikv/tikv/release-8.3/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test

--- a/prow-jobs/tikv/tikv/release-8.4-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.4-presubmits.yaml
@@ -1,7 +1,6 @@
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 global_definitions:
-  skip_if_only_changed: &skip_if_only_changed
-    "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
   branches: &branches
     - ^release-8\.4(\.\d+)?(-\d+)?(-v[\.\d]+)?$
 
@@ -9,6 +8,8 @@ presubmits:
   tikv/tikv:
     - name: tikv/tikv/release-8.4/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test

--- a/prow-jobs/tikv/tikv/release-8.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.5-presubmits.yaml
@@ -1,7 +1,6 @@
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 global_definitions:
-  skip_if_only_changed: &skip_if_only_changed
-    "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
   branches: &branches
     - ^release-8\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
 
@@ -9,6 +8,8 @@ presubmits:
   tikv/tikv:
     - name: tikv/tikv/release-8.5/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test

--- a/prow-jobs/tikv/tikv/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-9.0-beta-presubmits.yaml
@@ -1,7 +1,6 @@
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 global_definitions:
-  skip_if_only_changed: &skip_if_only_changed
-    "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
   branches: &branches
     - ^release-9\.0-beta\.\d+$
     - ^release-9\.0-beta\.\d+-\d{8}-v9\.0\.0-beta\.\d+(-\d+)?$
@@ -10,6 +9,8 @@ presubmits:
   tikv/tikv:
     - name: tikv/tikv/release-9.0-beta/pull_unit_test
       agent: jenkins
+      labels:
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test


### PR DESCRIPTION
This commit adds the `master: "0"` label to all Jenkins jobs across various repositories to ensure proper resource allocation and scheduling. The change affects multiple presubmit and postsubmit configurations in repositories like enterprise-extensions, tidb-test, docs, tidb-tools, tidb, tiflash, tiflow, tiproxy, copr-test, migration, and pd. The label helps in identifying and managing jobs that should run on master nodes.