### PR TITLE
feat: migrate ticdc latest pipelines to GCP

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -30,7 +30,8 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'  // cache mirror for us-docker.pkg.dev/pingcap-testing-account/hub
+        // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 80, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -27,7 +27,8 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'  // cache mirror for us-docker.pkg.dev/pingcap-testing-account/hub
+        // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 80, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -31,7 +31,8 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'  // cache mirror for us-docker.pkg.dev/pingcap-testing-account/hub
+        // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 80, unit: 'MINUTES')

--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
       rerun_command: "/test pull-cdc-mysql-integration-heavy"
       branches: *branches
 
-    - <<: *jenkins_job
+    - <<: *jenkins_job1
       name: pingcap/ticdc/pull_cdc_kafka_integration_light
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
@@ -55,7 +55,7 @@ presubmits:
       rerun_command: "/test pull-cdc-kafka-integration-heavy"
       branches: *branches
 
-    - <<: *jenkins_job
+    - <<: *jenkins_job1
       name: pingcap/ticdc/pull_cdc_pulsar_integration_light
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
@@ -65,7 +65,7 @@ presubmits:
       rerun_command: "/test pull-cdc-pulsar-integration-light"
       branches: *branches
 
-    - <<: *jenkins_job
+    - <<: *jenkins_job1
       name: pingcap/ticdc/pull_cdc_storage_integration_light
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true


### PR DESCRIPTION
Migrates the Jenkins pipelines in `pipelines/pingcap/ticdc/latest` to run on GCP.

This includes updating the pipeline definitions and prow job configurations.