### PR TITLE
fix(pipelines/pingcap/ticdc/latest): increase memory limits for TiCDC integration test pods to prevent out-of-memory failures

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pod-test.yaml
@@ -9,7 +9,7 @@ spec:
       tty: true
       resources:
         limits:
-          memory: 8Gi
+          memory: 16Gi
           cpu: "4"
   affinity:
     nodeAffinity:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pod.yaml
@@ -9,7 +9,7 @@ spec:
       tty: true
       resources:
         limits:
-          memory: 8Gi
+          memory: 16Gi
           cpu: "4"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c


### PR DESCRIPTION
## Increase memory resources for TiCDC integration test pipelines

### Why this change?
Recent test runs have shown that some TiCDC integration tests are experiencing out-of-memory (OOM) issues and performance degradation, particularly during heavy workload scenarios. To ensure test stability and reliability, we need to increase the memory allocation for both build and test pods across various integration test pipelines.

### Changes:
- **Test pods**: Memory allocation adjusted based on test intensity:
  - **Light tests**: Memory increased from 8Gi to 16Gi
    - MySQL integration light

- **Next-gen pipelines**: Memory allocations updated consistently with their legacy counterparts
  - Build pods: 8Gi → 16Gi

### Impact:
- Improved test stability by preventing OOM failures
- Better performance for memory-intensive integration tests
- Consistent resource allocation across all TiCDC integration test pipelines
- No changes to CPU allocations - all remain at current levels

These changes will help ensure our integration tests run reliably and provide accurate results for pull request validation.
