### PR TITLE
TiCDC: Increase memory limits for TiCDC integration test pods to 24Gi

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
@@ -25,7 +25,7 @@ spec:
       resources:
         limits:
           cpu: "6"
-          memory: 16Gi
+          memory: 24Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-test.yaml
@@ -25,7 +25,7 @@ spec:
       resources:
         limits:
           cpu: "6"
-          memory: 16Gi
+          memory: 24Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pod-test.yaml
@@ -9,7 +9,7 @@ spec:
       tty: true
       resources:
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
   affinity:
     nodeAffinity:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pod.yaml
@@ -9,7 +9,7 @@ spec:
       tty: true
       resources:
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c


### PR DESCRIPTION
## Increase Memory Limits for TiCDC Integration Tests

This pull request increases the memory resource limits for several TiCDC integration test pipelines to improve stability and prevent out-of-memory (OOM) failures during heavy workload testing.

### Why This Change Is Needed
Recent test runs have shown intermittent failures in heavy integration tests due to memory exhaustion. The current 16Gi limit is insufficient for handling peak loads during complex data replication scenarios involving Kafka and storage integrations. Increasing the memory limit to 24Gi will provide a more stable testing environment and reduce flaky test results.

### Changes Made
- Updated memory limits from `16Gi` to `24Gi` in four integration test configurations:
  - `pull_cdc_kafka_integration_heavy/pod-test.yaml`
  - `pull_cdc_kafka_integration_heavy_next_gen/pod-test.yaml`
  - `pull_cdc_storage_integration_heavy/pod-test.yaml`
  - `pull_cdc_storage_integration_heavy_next_gen/pod.yaml`

### Impact
- CPU limits remain unchanged at 6 cores
- No changes to test logic or container images
- Only resource allocation adjustments for improved reliability
- Should reduce OOM-related test failures in CI/CD pipelines

This change ensures our integration tests can run more reliably under heavy workloads, providing better confidence in TiCDC's performance and stability.
