### PR TITLE
TiCDC: Increase memory limits for TiCDC Pulsar integration tests to improve stability

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pod-test.yaml
@@ -9,7 +9,7 @@ spec:
       tty: true
       resources:
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
   affinity:
     nodeAffinity:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pod.yaml
@@ -9,7 +9,7 @@ spec:
       tty: true
       resources:
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c


### PR DESCRIPTION
# Increase Memory Limits for TiCDC Pulsar Integration Tests

This pull request increases the memory limits for two TiCDC Pulsar integration test pipelines to improve stability and prevent potential out-of-memory (OOM) failures during test execution.

## Changes Made

*   Increased memory limit from `16Gi` to `24Gi` for the test container in the `pull_cdc_pulsar_integration_light` pipeline.
*   Increased memory limit from `16Gi` to `24Gi` for the test container in the `pull_cdc_pulsar_integration_light_next_gen` pipeline.

## Why This Change is Necessary

Recent test runs have shown that the Pulsar integration tests, which involve complex data streaming scenarios, can sometimes exceed the previous 16Gi memory allocation under heavy load. This increase ensures that the tests have sufficient headroom to run reliably without being terminated due to memory constraints, leading to more consistent and accurate test results.
