### PR TITLE
feat(tikv/rocksdb, rust-rocksdb): enable rust-rocksdb-test and rocksdv-test job run automatically

### DIFF
--- a/prow-jobs/tikv/rocksdb/latest-presubmits.yaml
+++ b/prow-jobs/tikv/rocksdb/latest-presubmits.yaml
@@ -10,8 +10,6 @@ presubmits:
     - <<: *brancher
       name: pull-rocksdb-test-arm
       decorate: true
-      always_run: false
-      optional: true
       skip_if_only_changed: *skip_if_only_changed
       spec:
         affinity:
@@ -66,8 +64,6 @@ presubmits:
     - <<: *brancher
       name: pull-rocksdb-test-x86-debug-part1
       decorate: true
-      always_run: false
-      optional: true
       skip_if_only_changed: *skip_if_only_changed
       spec:
         affinity:
@@ -121,8 +117,6 @@ presubmits:
     - <<: *brancher
       name: pull-rocksdb-test-x86-debug-encrypted-env
       decorate: true
-      always_run: false
-      optional: true
       skip_if_only_changed: *skip_if_only_changed
       spec:
         affinity:
@@ -176,8 +170,6 @@ presubmits:
     - <<: *brancher
       name: pull-rocksdb-test-x86-debug-part2
       decorate: true
-      always_run: false
-      optional: true
       skip_if_only_changed: *skip_if_only_changed
       spec:
         affinity:
@@ -237,8 +229,6 @@ presubmits:
     - <<: *brancher
       name: pull-rocksdb-test-x86-debug-part3
       decorate: true
-      always_run: false
-      optional: true
       skip_if_only_changed: *skip_if_only_changed
       spec:
         affinity:
@@ -292,8 +282,6 @@ presubmits:
     - <<: *brancher
       name: pull-rocksdb-build-x86-release
       decorate: true
-      always_run: false
-      optional: true
       skip_if_only_changed: *skip_if_only_changed
       spec:
         affinity:

--- a/prow-jobs/tikv/rust-rocksdb/latest-presubmits.yaml
+++ b/prow-jobs/tikv/rust-rocksdb/latest-presubmits.yaml
@@ -10,8 +10,6 @@ presubmits:
     - <<: *brancher
       name: pull-rust-rocksdb-lint
       decorate: true
-      always_run: false
-      optional: true
       skip_if_only_changed: *skip_if_only_changed
       spec:
         affinity:
@@ -61,8 +59,6 @@ presubmits:
     - <<: *brancher
       name: pull-rust-rocksdb-test-x86
       decorate: true
-      always_run: false
-      optional: true
       skip_if_only_changed: *skip_if_only_changed
       spec:
         affinity:
@@ -141,8 +137,6 @@ presubmits:
       name: pull-rust-rocksdb-test-arm
       cluster: gcp-prow-ksyun
       decorate: true
-      always_run: false
-      optional: true
       skip_if_only_changed: *skip_if_only_changed
       spec:
         affinity:


### PR DESCRIPTION
Close: https://github.com/PingCAP-QE/ci/issues/4068
Close: https://github.com/PingCAP-QE/ci/issues/4103

Use prow job to run rocksdb test and rust-rocksdb test instead of the original Jenkins jobs in ci.pingcap.net. The test results of the Prow job can be viewed below：
- rocksdb-test：
<img width="1498" height="618" alt="image" src="https://github.com/user-attachments/assets/635ab89b-904c-448f-a324-c7787cb8d868" />

- rust-rocksdb-test:
<img width="1490" height="545" alt="image" src="https://github.com/user-attachments/assets/0243bc0e-a898-4f36-8cfe-bde853779e15" />



