### PR TITLE
tici-test: fix ticdc download url

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
@@ -58,7 +58,7 @@ pipeline {
                                                 --pd=${otherComponentBranch} \
                                                 --tikv=${otherComponentBranch} \
                                                 --tiflash=${otherComponentBranch} \
-                                                --ticdc=${otherComponentBranch} \
+                                                --ticdc-new=${otherComponentBranch} \
                                                 --tici=${otherComponentBranch} \
                                                 --minio=${minioTag}
                                         """


### PR DESCRIPTION
previous PR https://github.com/PingCAP-QE/ci/pull/4108/files has not set ticdc download url correctly.
This PR fix it