### PR TITLE
Fix tici pipeline

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
@@ -64,13 +64,9 @@ pipeline {
                                         """
                                     }
                                     sh '''
-                                        mkdir -p tiflash_dir
-                                        if [[ -f tiflash && ! -L tiflash ]]; then
-                                            if [[ ! -f tiflash_dir/tiflash ]]; then
-                                                mv tiflash tiflash_dir/
-                                            else
-                                                rm -f tiflash
-                                            fi
+                                        if [[ -d tiflash && ! -L tiflash ]]; then
+                                            rm -rf tiflash_dir
+                                            mv tiflash tiflash_dir
                                         fi
                                         if [[ -f tiflash_dir/tiflash ]]; then
                                             ln -sfn "$(pwd)/tiflash_dir/tiflash" tiflash


### PR DESCRIPTION
When rerun test with cache, tiflash link has a bug, after   https://github.com/PingCAP-QE/ci/pull/4108/files  merged

```
+ mv tiflash tiflash_dir
mv: 'tiflash' and 'tiflash_dir/tiflash' are the same file
script returned exit code 1
```