### PR TITLE
fix(tekton/v1/tasks): fix task pingcap-get-set-release-version

### DIFF
--- a/tekton/v1/tasks/pingcap-get-set-release-version.yaml
+++ b/tekton/v1/tasks/pingcap-get-set-release-version.yaml
@@ -89,7 +89,7 @@ spec:
         #!/bin/sh
         set -e
 
-        if echo "$(params.git-refspec)" | grep -E '^refs/pull/[0-9]+:pull/[0-9]+$'; then
+        if echo "$(params.git-refspec)" | grep -E '^refs/pull/[0-9]+(/.+)?:pull/[0-9]+$'; then
           # Extract the part after the colon
           ref=$(echo "$(params.git-refspec)" | awk -F: '{print $2}')
           echo -n "$ref" > $(results.build-ref.path)


### PR DESCRIPTION
Relax git-refspec regex to allow PR suffixes in git refspec