### PR TITLE
prow: make pull_integration_ddl_test optional and manual-trigger

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -195,7 +195,9 @@ presubmits:
       labels:
         master: "0"
       decorate: false # need add this.
-      skip_if_only_changed: *skip_if_only_changed
+      always_run: false
+      optional: true
+      # skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-ddl-test
       trigger: "(?m)^/test (?:.*? )?pull-integration-ddl-test(?: .*?)?$"
       rerun_command: "/test pull-integration-ddl-test"


### PR DESCRIPTION
### What changed
- Make `pingcap/tidb/pull_integration_ddl_test` non-blocking and manual-trigger only at the prow presubmit level by setting:
  - `always_run: false`
  - `optional: true`

### How to trigger
- Comment on PR:
  - `/test pull-integration-ddl-test`

### Scope
- `ci/prow-jobs/pingcap/tidb/latest-presubmits.yaml` only.