### PR TITLE
fixi(pipelines/pingcap/tiflash): update JNLP agent image in pipeline pods

### DIFF
--- a/pipelines/pingcap/tiflash/release-7.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-7.5/pod-pull_build.yaml
@@ -19,29 +19,29 @@ spec:
           memory: "48Gi"
           cpu: "16000m"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
     - name: jnlp
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
+      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
       resources:
         requests:
           cpu: "500m"
@@ -50,27 +50,27 @@ spec:
           cpu: "500m"
           memory: "500Mi"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
     - name: util
       image: hub.pingcap.net/jenkins/ks3util
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-7.5/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-7.5/pod-pull_integration_test.yaml
@@ -2,81 +2,81 @@ apiVersion: "v1"
 kind: "Pod"
 spec:
   containers:
-  - image: "docker:18.09.6-dind"
-    imagePullPolicy: "IfNotPresent"
-    name: "dockerd"
-    resources:
-      limits:
-        memory: "32Gi"
-        cpu: "16000m"
-      requests:
-        memory: "10Gi"
-        cpu: "5000m"
-    securityContext:
-      privileged: true
-    tty: false
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - command:
-    - "cat"
-    env:
-    - name: "DOCKER_HOST"
-      value: "tcp://localhost:2375"
-    image: "hub.pingcap.net/jenkins/docker:build-essential-java"
-    imagePullPolicy: "Always"
-    name: "docker"
-    resources:
-      requests:
-        memory: "8Gi"
-        cpu: "5000m"
-    tty: true
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
-    name: "jnlp"
-    resources:
-      requests:
-        memory: "256Mi"
-        cpu: "100m"
-      limits:
-        memory: "256Mi"
-        cpu: "100m"
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
+    - image: "docker:18.09.6-dind"
+      imagePullPolicy: "IfNotPresent"
+      name: "dockerd"
+      resources:
+        limits:
+          memory: "32Gi"
+          cpu: "16000m"
+        requests:
+          memory: "10Gi"
+          cpu: "5000m"
+      securityContext:
+        privileged: true
+      tty: false
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
+    - command:
+        - "cat"
+      env:
+        - name: "DOCKER_HOST"
+          value: "tcp://localhost:2375"
+      image: "hub.pingcap.net/jenkins/docker:build-essential-java"
+      imagePullPolicy: "Always"
+      name: "docker"
+      resources:
+        requests:
+          memory: "8Gi"
+          cpu: "5000m"
+      tty: true
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
+    - image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
+      name: "jnlp"
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "256Mi"
+          cpu: "100m"
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
   volumes:
-  - emptyDir:
-      medium: ""
-    name: "volume-0"
-  - emptyDir:
-      medium: ""
-    name: "workspace-volume"
-  - emptyDir:
-      medium: ""
-    name: "volume-3"
+    - emptyDir:
+        medium: ""
+      name: "volume-0"
+    - emptyDir:
+        medium: ""
+      name: "workspace-volume"
+    - emptyDir:
+        medium: ""
+      name: "volume-3"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/release-7.5/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-7.5/pod-pull_unit-test.yaml
@@ -15,32 +15,32 @@ spec:
           memory: "32Gi"
           cpu: "12000m"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-8"
+          readOnly: false
     - name: jnlp
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
+      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
       resources:
         requests:
           cpu: "500m"
@@ -49,30 +49,30 @@ spec:
           cpu: "500m"
           memory: "500Mi"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-8"
+          readOnly: false
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tiflash/release-8.1/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.1/pod-pull_build.yaml
@@ -19,29 +19,29 @@ spec:
           memory: 48Gi
           cpu: "12"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
     - name: jnlp
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
+      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
       resources:
         requests:
           cpu: "500m"
@@ -50,27 +50,27 @@ spec:
           cpu: "500m"
           memory: "500Mi"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
     - name: util
       image: hub.pingcap.net/jenkins/ks3util
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-8.1/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.1/pod-pull_integration_test.yaml
@@ -2,81 +2,81 @@ apiVersion: "v1"
 kind: "Pod"
 spec:
   containers:
-  - image: "docker:18.09.6-dind"
-    imagePullPolicy: "IfNotPresent"
-    name: "dockerd"
-    resources:
-      limits:
-        memory: "32Gi"
-        cpu: "16000m"
-      requests:
-        memory: "10Gi"
-        cpu: "5000m"
-    securityContext:
-      privileged: true
-    tty: false
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - command:
-    - "cat"
-    env:
-    - name: "DOCKER_HOST"
-      value: "tcp://localhost:2375"
-    image: "hub.pingcap.net/jenkins/docker:build-essential-java"
-    imagePullPolicy: "Always"
-    name: "docker"
-    resources:
-      requests:
-        memory: "8Gi"
-        cpu: "5000m"
-    tty: true
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
-    name: "jnlp"    #  TODO: remove this default container
-    resources:
-      requests:
-        memory: "256Mi"
-        cpu: "100m"
-      limits:
-        memory: "256Mi"
-        cpu: "100m"
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
+    - image: "docker:18.09.6-dind"
+      imagePullPolicy: "IfNotPresent"
+      name: "dockerd"
+      resources:
+        limits:
+          memory: "32Gi"
+          cpu: "16000m"
+        requests:
+          memory: "10Gi"
+          cpu: "5000m"
+      securityContext:
+        privileged: true
+      tty: false
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
+    - command:
+        - "cat"
+      env:
+        - name: "DOCKER_HOST"
+          value: "tcp://localhost:2375"
+      image: "hub.pingcap.net/jenkins/docker:build-essential-java"
+      imagePullPolicy: "Always"
+      name: "docker"
+      resources:
+        requests:
+          memory: "8Gi"
+          cpu: "5000m"
+      tty: true
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
+    - image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
+      name: "jnlp" #  TODO: remove this default container
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "256Mi"
+          cpu: "100m"
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
   volumes:
-  - emptyDir:
-      medium: ""
-    name: "volume-0"
-  - emptyDir:
-      medium: ""
-    name: "workspace-volume"
-  - emptyDir:
-      medium: ""
-    name: "volume-3"
+    - emptyDir:
+        medium: ""
+      name: "volume-0"
+    - emptyDir:
+        medium: ""
+      name: "workspace-volume"
+    - emptyDir:
+        medium: ""
+      name: "volume-3"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/release-8.1/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.1/pod-pull_unit-test.yaml
@@ -12,32 +12,32 @@ spec:
           memory: "32Gi"
           cpu: "12000m"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
-    - name: jnlp  # TODO: remove this default container
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-8"
+          readOnly: false
+    - name: jnlp # TODO: remove this default container
+      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
       resources:
         requests:
           cpu: "500m"
@@ -46,30 +46,30 @@ spec:
           cpu: "500m"
           memory: "500Mi"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-8"
+          readOnly: false
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tiflash/release-8.2/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.2/pod-pull_build.yaml
@@ -19,29 +19,29 @@ spec:
           memory: 48Gi
           cpu: "12"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
     - name: jnlp
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
+      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
       resources:
         requests:
           cpu: "500m"
@@ -50,27 +50,27 @@ spec:
           cpu: "500m"
           memory: "500Mi"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
     - name: util
       image: hub.pingcap.net/jenkins/ks3util
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-8.2/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.2/pod-pull_integration_test.yaml
@@ -2,81 +2,81 @@ apiVersion: "v1"
 kind: "Pod"
 spec:
   containers:
-  - image: "docker:18.09.6-dind"
-    imagePullPolicy: "IfNotPresent"
-    name: "dockerd"
-    resources:
-      limits:
-        memory: "32Gi"
-        cpu: "16000m"
-      requests:
-        memory: "10Gi"
-        cpu: "5000m"
-    securityContext:
-      privileged: true
-    tty: false
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - command:
-    - "cat"
-    env:
-    - name: "DOCKER_HOST"
-      value: "tcp://localhost:2375"
-    image: "hub.pingcap.net/jenkins/docker:build-essential-java"
-    imagePullPolicy: "Always"
-    name: "docker"
-    resources:
-      requests:
-        memory: "8Gi"
-        cpu: "5000m"
-    tty: true
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
-    name: "jnlp"    #  TODO: remove this default container
-    resources:
-      requests:
-        memory: "256Mi"
-        cpu: "100m"
-      limits:
-        memory: "256Mi"
-        cpu: "100m"
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
+    - image: "docker:18.09.6-dind"
+      imagePullPolicy: "IfNotPresent"
+      name: "dockerd"
+      resources:
+        limits:
+          memory: "32Gi"
+          cpu: "16000m"
+        requests:
+          memory: "10Gi"
+          cpu: "5000m"
+      securityContext:
+        privileged: true
+      tty: false
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
+    - command:
+        - "cat"
+      env:
+        - name: "DOCKER_HOST"
+          value: "tcp://localhost:2375"
+      image: "hub.pingcap.net/jenkins/docker:build-essential-java"
+      imagePullPolicy: "Always"
+      name: "docker"
+      resources:
+        requests:
+          memory: "8Gi"
+          cpu: "5000m"
+      tty: true
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
+    - image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
+      name: "jnlp" #  TODO: remove this default container
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "256Mi"
+          cpu: "100m"
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
   volumes:
-  - emptyDir:
-      medium: ""
-    name: "volume-0"
-  - emptyDir:
-      medium: ""
-    name: "workspace-volume"
-  - emptyDir:
-      medium: ""
-    name: "volume-3"
+    - emptyDir:
+        medium: ""
+      name: "volume-0"
+    - emptyDir:
+        medium: ""
+      name: "workspace-volume"
+    - emptyDir:
+        medium: ""
+      name: "volume-3"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/release-8.2/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.2/pod-pull_unit-test.yaml
@@ -12,32 +12,32 @@ spec:
           memory: "32Gi"
           cpu: "12000m"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
-    - name: jnlp  # TODO: remove this default container
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-8"
+          readOnly: false
+    - name: jnlp # TODO: remove this default container
+      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
       resources:
         requests:
           cpu: "500m"
@@ -46,30 +46,30 @@ spec:
           cpu: "500m"
           memory: "500Mi"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-8"
+          readOnly: false
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tiflash/release-8.3/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.3/pod-pull_build.yaml
@@ -19,29 +19,29 @@ spec:
           memory: 48Gi
           cpu: "12"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
     - name: jnlp
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
+      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
       resources:
         requests:
           cpu: "500m"
@@ -50,27 +50,27 @@ spec:
           cpu: "500m"
           memory: "500Mi"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
     - name: util
       image: hub.pingcap.net/jenkins/ks3util
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-8.3/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.3/pod-pull_integration_test.yaml
@@ -2,81 +2,81 @@ apiVersion: "v1"
 kind: "Pod"
 spec:
   containers:
-  - image: "docker:18.09.6-dind"
-    imagePullPolicy: "IfNotPresent"
-    name: "dockerd"
-    resources:
-      limits:
-        memory: "32Gi"
-        cpu: "16000m"
-      requests:
-        memory: "10Gi"
-        cpu: "5000m"
-    securityContext:
-      privileged: true
-    tty: false
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - command:
-    - "cat"
-    env:
-    - name: "DOCKER_HOST"
-      value: "tcp://localhost:2375"
-    image: "hub.pingcap.net/jenkins/docker:build-essential-java"
-    imagePullPolicy: "Always"
-    name: "docker"
-    resources:
-      requests:
-        memory: "8Gi"
-        cpu: "5000m"
-    tty: true
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
-    name: "jnlp"    #  TODO: remove this default container
-    resources:
-      requests:
-        memory: "256Mi"
-        cpu: "100m"
-      limits:
-        memory: "256Mi"
-        cpu: "100m"
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
+    - image: "docker:18.09.6-dind"
+      imagePullPolicy: "IfNotPresent"
+      name: "dockerd"
+      resources:
+        limits:
+          memory: "32Gi"
+          cpu: "16000m"
+        requests:
+          memory: "10Gi"
+          cpu: "5000m"
+      securityContext:
+        privileged: true
+      tty: false
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
+    - command:
+        - "cat"
+      env:
+        - name: "DOCKER_HOST"
+          value: "tcp://localhost:2375"
+      image: "hub.pingcap.net/jenkins/docker:build-essential-java"
+      imagePullPolicy: "Always"
+      name: "docker"
+      resources:
+        requests:
+          memory: "8Gi"
+          cpu: "5000m"
+      tty: true
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
+    - image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
+      name: "jnlp" #  TODO: remove this default container
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "256Mi"
+          cpu: "100m"
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
   volumes:
-  - emptyDir:
-      medium: ""
-    name: "volume-0"
-  - emptyDir:
-      medium: ""
-    name: "workspace-volume"
-  - emptyDir:
-      medium: ""
-    name: "volume-3"
+    - emptyDir:
+        medium: ""
+      name: "volume-0"
+    - emptyDir:
+        medium: ""
+      name: "workspace-volume"
+    - emptyDir:
+        medium: ""
+      name: "volume-3"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/release-8.3/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.3/pod-pull_unit-test.yaml
@@ -12,32 +12,32 @@ spec:
           memory: "32Gi"
           cpu: "12000m"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
-    - name: jnlp  # TODO: remove this default container
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-8"
+          readOnly: false
+    - name: jnlp # TODO: remove this default container
+      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
       resources:
         requests:
           cpu: "500m"
@@ -46,30 +46,30 @@ spec:
           cpu: "500m"
           memory: "500Mi"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-8"
+          readOnly: false
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tiflash/release-8.4/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.4/pod-pull_build.yaml
@@ -19,29 +19,29 @@ spec:
           memory: 48Gi
           cpu: "12"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
     - name: jnlp
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
+      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
       resources:
         requests:
           cpu: "500m"
@@ -50,27 +50,27 @@ spec:
           cpu: "500m"
           memory: "500Mi"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
     - name: util
       image: hub.pingcap.net/jenkins/ks3util
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-8.4/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.4/pod-pull_integration_test.yaml
@@ -2,81 +2,81 @@ apiVersion: "v1"
 kind: "Pod"
 spec:
   containers:
-  - image: "docker:18.09.6-dind"
-    imagePullPolicy: "IfNotPresent"
-    name: "dockerd"
-    resources:
-      limits:
-        memory: "32Gi"
-        cpu: "16000m"
-      requests:
-        memory: "10Gi"
-        cpu: "5000m"
-    securityContext:
-      privileged: true
-    tty: false
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - command:
-    - "cat"
-    env:
-    - name: "DOCKER_HOST"
-      value: "tcp://localhost:2375"
-    image: "hub.pingcap.net/jenkins/docker:build-essential-java"
-    imagePullPolicy: "Always"
-    name: "docker"
-    resources:
-      requests:
-        memory: "8Gi"
-        cpu: "5000m"
-    tty: true
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
-  - image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
-    name: "jnlp"    #  TODO: remove this default container
-    resources:
-      requests:
-        memory: "256Mi"
-        cpu: "100m"
-      limits:
-        memory: "256Mi"
-        cpu: "100m"
-    volumeMounts:
-    - mountPath: "/home/jenkins"
-      name: "volume-0"
-      readOnly: false
-    - mountPath: "/tmp"
-      name: "volume-3"
-      readOnly: false
-    - mountPath: "/home/jenkins/agent"
-      name: "workspace-volume"
-      readOnly: false
+    - image: "docker:18.09.6-dind"
+      imagePullPolicy: "IfNotPresent"
+      name: "dockerd"
+      resources:
+        limits:
+          memory: "32Gi"
+          cpu: "16000m"
+        requests:
+          memory: "10Gi"
+          cpu: "5000m"
+      securityContext:
+        privileged: true
+      tty: false
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
+    - command:
+        - "cat"
+      env:
+        - name: "DOCKER_HOST"
+          value: "tcp://localhost:2375"
+      image: "hub.pingcap.net/jenkins/docker:build-essential-java"
+      imagePullPolicy: "Always"
+      name: "docker"
+      resources:
+        requests:
+          memory: "8Gi"
+          cpu: "5000m"
+      tty: true
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
+    - image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
+      name: "jnlp" #  TODO: remove this default container
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "256Mi"
+          cpu: "100m"
+      volumeMounts:
+        - mountPath: "/home/jenkins"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-3"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent"
+          name: "workspace-volume"
+          readOnly: false
   volumes:
-  - emptyDir:
-      medium: ""
-    name: "volume-0"
-  - emptyDir:
-      medium: ""
-    name: "workspace-volume"
-  - emptyDir:
-      medium: ""
-    name: "volume-3"
+    - emptyDir:
+        medium: ""
+      name: "volume-0"
+    - emptyDir:
+        medium: ""
+      name: "workspace-volume"
+    - emptyDir:
+        medium: ""
+      name: "volume-3"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/release-8.4/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.4/pod-pull_unit-test.yaml
@@ -12,32 +12,32 @@ spec:
           memory: "32Gi"
           cpu: "12000m"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
-    - name: jnlp  # TODO: remove this default container
-      image: "jenkins/inbound-agent:3148.v532a_7e715ee3-1"
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-8"
+          readOnly: false
+    - name: jnlp # TODO: remove this default container
+      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
       resources:
         requests:
           cpu: "500m"
@@ -46,30 +46,30 @@ spec:
           cpu: "500m"
           memory: "500Mi"
       volumeMounts:
-      - mountPath: "/home/jenkins/agent/rust"
-        name: "volume-0"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ccache"
-        name: "volume-1"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/dependency"
-        name: "volume-2"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-        name: "volume-4"
-        readOnly: false
-      - mountPath: "/home/jenkins/agent/proxy-cache"
-        name: "volume-5"
-        readOnly: false
-      - mountPath: "/tmp"
-        name: "volume-6"
-        readOnly: false
-      - mountPath: "/tmp-memfs"
-        name: "volume-7"
-        readOnly: false
-      - mountPath: "/home/jenkins"
-        name: "volume-8"
-        readOnly: false
+        - mountPath: "/home/jenkins/agent/rust"
+          name: "volume-0"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ccache"
+          name: "volume-1"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/dependency"
+          name: "volume-2"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
+          name: "volume-4"
+          readOnly: false
+        - mountPath: "/home/jenkins/agent/proxy-cache"
+          name: "volume-5"
+          readOnly: false
+        - mountPath: "/tmp"
+          name: "volume-6"
+          readOnly: false
+        - mountPath: "/tmp-memfs"
+          name: "volume-7"
+          readOnly: false
+        - mountPath: "/home/jenkins"
+          name: "volume-8"
+          readOnly: false
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true


### PR DESCRIPTION
Bump jenkins/inbound-agent to 3345.v03dee9b_f88fc-1 across TiFlash release pod configs and normalize YAML formatting for containers, volumeMounts and volumes