### PR TITLE
ticdc: add trigger aliases for ticdc integration jobs

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
@@ -18,7 +18,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-mysql-integration-light-next-gen
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light-next-gen|next-gen)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light-next-gen|next-gen-mysql|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-light-next-gen"
       branches: *branches
       optional: true
@@ -28,7 +28,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       # run_before_merge: true
       context: pull-cdc-mysql-integration-heavy-next-gen
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy-next-gen|next-gen)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy-next-gen|next-gen-mysql|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-heavy-next-gen"
       branches: *branches
       optional: true
@@ -38,7 +38,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       # run_before_merge: true
       context: pull-cdc-kafka-integration-light-next-gen
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light-next-gen|next-gen)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light-next-gen|next-gen-kafka|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-light-next-gen"
       branches: *branches
       optional: true
@@ -48,7 +48,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       # run_before_merge: true
       context: pull-cdc-kafka-integration-heavy-next-gen
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-heavy-next-gen|next-gen)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-heavy-next-gen|next-gen-kafka|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-heavy-next-gen"
       branches: *branches
       optional: true
@@ -59,7 +59,7 @@ presubmits:
       # run_before_merge: true
       context: pull-cdc-pulsar-integration-light-next-gen
       optional: true # TODO: change this after the job is ready
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-light-next-gen|next-gen)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-light-next-gen|next-gen-pulsar|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-pulsar-integration-light-next-gen"
       branches: *branches
 
@@ -68,7 +68,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       # run_before_merge: true
       context: pull-cdc-storage-integration-light-next-gen
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light-next-gen|next-gen)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light-next-gen|next-gen-storage|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-light-next-gen"
       branches: *branches
       optional: true
@@ -78,7 +78,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       # run_before_merge: true
       context: pull-cdc-storage-integration-heavy-next-gen
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-heavy-next-gen|next-gen)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-heavy-next-gen|next-gen-storage|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-heavy-next-gen"
       branches: *branches
       optional: true

--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-mysql-integration-light
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light|light|all)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light|light|mysql|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-light"
       branches: *branches
 
@@ -28,7 +28,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-mysql-integration-heavy
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy|heavy|all)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy|heavy|mysql|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-heavy"
       branches: *branches
 
@@ -37,7 +37,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-kafka-integration-light
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light|light|all)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light|light|kafka|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-light"
       branches: *branches
 
@@ -46,7 +46,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-kafka-integration-heavy
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-heavy|heavy|all)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-heavy|heavy|kafka|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-heavy"
       branches: *branches
 
@@ -56,7 +56,7 @@ presubmits:
       run_before_merge: true
       context: pull-cdc-pulsar-integration-light
       optional: true # TODO: change this after the job is ready
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-light|light|all)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-light|light|pulsar|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-pulsar-integration-light"
       branches: *branches
 
@@ -65,7 +65,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-storage-integration-light
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light|light|all)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light|light|storage|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-light"
       branches: *branches
 
@@ -74,7 +74,7 @@ presubmits:
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-storage-integration-heavy
-      trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-heavy|heavy|all)(?: .*?)?$"
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-heavy|heavy|storage|all)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-heavy"
       branches: *branches
 


### PR DESCRIPTION
## Summary

Add trigger aliases for TiCDC integration presubmit jobs, including next-gen scoped commands.

## Changes

- Add mysql/kafka/pulsar/storage aliases to latest presubmit triggers.
- Add next-gen-mysql/kafka/pulsar/storage aliases for next-gen presubmits.

## Testing

Not run (config change only).