### PR TITLE
refactor: use download_pingcap_oci_artifact.sh instead of download_pingcap_artifact.sh

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 70, unit: 'MINUTES')
@@ -66,10 +66,12 @@ pipeline {
                 dir('tidb') {
                     cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
+                    }
+                    container("utils") {
                         sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/* bin/
+                            ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            
+mv pd-server bin/
                             ls -alh bin/
                         """
                     }
@@ -104,14 +106,14 @@ pipeline {
                                     sh label: "print version", script: """
                                         pwd && ls -alh
                                         ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && chmod +x bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && chmod +x bin/tikv-server && ./bin/tikv-server -V
+                                        ls bin/pd-server && chmod +x bin/pd-server && ./pd-server -V
+                                        ls bin/tikv-server && chmod +x bin/tikv-server && ./tikv-server -V
                                     """
                                 }
                             }
                             dir('tidb-test/mysql_test') {
                                 sh """
-                                    mkdir -p bin
+    
                                     mv ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                                     ls -alh bin/
                                 """

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -70,7 +70,7 @@ pipeline {
                     container("utils") {
                         sh label: 'download binary', script: """
                             ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            
+
 mv pd-server bin/
                             ls -alh bin/
                         """
@@ -113,7 +113,7 @@ mv pd-server bin/
                             }
                             dir('tidb-test/mysql_test') {
                                 sh """
-    
+
                                     mv ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                                     ls -alh bin/
                                 """

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/pod-ghpr_integration_mysql_test.yaml
@@ -30,6 +30,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')
@@ -66,10 +66,12 @@ pipeline {
                 dir('tidb') {
                     cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
+                    }
+                    container("utils") {
                         sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/* bin/
+                            ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            
+mv pd-server bin/
                             ls -alh bin/
                         """
                     }
@@ -108,14 +110,14 @@ pipeline {
                                     sh label: "print version", script: """
                                         pwd && ls -alh
                                         ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && chmod +x bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && chmod +x bin/tikv-server && ./bin/tikv-server -V
+                                        ls bin/pd-server && chmod +x bin/pd-server && ./pd-server -V
+                                        ls bin/tikv-server && chmod +x bin/tikv-server && ./tikv-server -V
                                     """
                                 }
                             }
                             dir('tidb-test/mysql_test') {
                                 sh """
-                                    mkdir -p bin
+    
                                     mv ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                                     ls -alh bin/
                                 """

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -70,7 +70,7 @@ pipeline {
                     container("utils") {
                         sh label: 'download binary', script: """
                             ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            
+
 mv pd-server bin/
                             ls -alh bin/
                         """
@@ -117,7 +117,7 @@ mv pd-server bin/
                             }
                             dir('tidb-test/mysql_test') {
                                 sh """
-    
+
                                     mv ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                                     ls -alh bin/
                                 """

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/pod-ghpr_integration_mysql_test.yaml
@@ -30,6 +30,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_e2e_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_integration_common_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_integration_copr_test.yaml
@@ -18,6 +18,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_integration_ddl_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_integration_jdbc_test.yaml
@@ -31,6 +31,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_integration_mysql_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_common_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -69,13 +69,14 @@ pipeline {
                     container("golang") {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                         retry(3) {
-                            sh label: 'download thirdparty binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
+                            dir("bin") { container("utils") { sh label: 'download binary', script: """
+                                container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+
+
+
+                                ./tikv-server -V
+                                ./pd-server -V
                             """
                         }
                     }
@@ -88,8 +89,8 @@ pipeline {
                         cd randgen-test && ./build.sh && cd ..
                         mkdir -p bin
                         cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
+                        ./pd-server -V
+                        ./tikv-server -V
                         ./bin/tidb-server -V
                         """
                     }
@@ -123,8 +124,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("golang") {

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_copr_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -72,15 +72,16 @@ pipeline {
                     container("golang") {
                         retry(2) {
                             sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
                             rm -rf bin/ && mkdir -p bin/
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
+                            mkdir -p bin
+
+                            mv pd-server bin/
                             ls -alh bin/
                             chmod +x bin/*
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
+                            ./tikv-server -V
+                            ./pd-server -V
                             """
                         }
                     }
@@ -93,8 +94,8 @@ pipeline {
                 dir('tidb') {
                     sh label: 'check version', script: """
                     ls -alh bin/
-                    ./bin/tikv-server -V
-                    ./bin/pd-server -V
+                    ./tikv-server -V
+                    ./pd-server -V
                     """
                 }
                 dir('tikv-copr-test') {

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_ddl_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -71,10 +71,11 @@ pipeline {
                         sh label: 'ddl-test', script: 'ls bin/ddltest || make ddltest'
                         retry(3) {
                             sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
+                                container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+
+
+
                                 ls -alh bin/
                             """
                         }
@@ -87,8 +88,8 @@ pipeline {
                             mkdir -p bin
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
+                            ./pd-server -V
+                            ./tikv-server -V
                             ./bin/tidb-server -V
                         """
                     }
@@ -119,8 +120,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("golang") {

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_jdbc_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -69,15 +69,16 @@ pipeline {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                         retry(3) {
                             sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
+                                container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+
+
+
                                 ls -alh bin/
                                 chmod +x bin/*
                                 ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
+                                ./tikv-server -V
+                                ./pd-server -V
                             """
                         }
                     }
@@ -89,8 +90,8 @@ pipeline {
                             mkdir -p bin
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
+                            ./pd-server -V
+                            ./tikv-server -V
                             ./bin/tidb-server -V
                         """
                     }
@@ -127,8 +128,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh label: "print version", script: """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("java") {

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_e2e_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_br_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_common_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_copr_test.yaml
@@ -25,6 +25,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_ddl_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_jdbc_test.yaml
@@ -38,6 +38,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_lightning_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_mysql_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_nodejs_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_integration_python_orm_test.yaml
@@ -31,6 +31,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_e2e_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
@@ -52,18 +52,21 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
-                    retry(3) {
-                        sh label: 'download binary', script: """
-                            chmod +x \${WORKSPACE}/scripts/artifacts/*.sh
-                            \${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
-                            ls -alh bin/
-                            chmod +x bin/*
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
+                    container("golang") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
+                    dir("bin") {
+                        container("utils") {
+                            retry(3) {
+                                sh label: 'download binary', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                    ls -alh
+                                    chmod +x *
+                                    ./tikv-server -V
+                                    ./pd-server -V
+                                """
+                            }
+                        }
                     }
                 }
             }
@@ -75,8 +78,8 @@ pipeline {
                     sh label: 'check version', script: """
                     ls -alh bin/
                     ./bin/tidb-server -V
-                    ./bin/tikv-server -V
-                    ./bin/pd-server -V
+                    ./tikv-server -V
+                    ./pd-server -V
                     """
                     sh label: 'test graceshutdown', script: """
                     cd tests/graceshutdown && make

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_copr_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -71,15 +71,16 @@ pipeline {
                     container("golang") {
                         retry(2) {
                             sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
                             rm -rf bin/ && mkdir -p bin/
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
+                            mkdir -p bin
+
+                            mv pd-server bin/
                             ls -alh bin/
                             chmod +x bin/*
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
+                            ./tikv-server -V
+                            ./pd-server -V
                             """
                         }
                     }
@@ -92,8 +93,8 @@ pipeline {
                 dir('tidb') {
                     sh label: 'check version', script: """
                     ls -alh bin/
-                    ./bin/tikv-server -V
-                    ./bin/pd-server -V
+                    ./tikv-server -V
+                    ./pd-server -V
                     """
                 }
                 dir('tikv-copr-test') {

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -71,10 +71,11 @@ pipeline {
                         sh label: 'ddl-test', script: 'ls bin/ddltest || make ddltest'
                         retry(3) {
                             sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
+                                container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+
+
+
                                 ls -alh bin/
                             """
                         }
@@ -87,8 +88,8 @@ pipeline {
                             mkdir -p bin
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
+                            ./pd-server -V
+                            ./tikv-server -V
                             ./bin/tidb-server -V
                         """
                     }
@@ -119,8 +120,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("golang") {

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -68,15 +68,16 @@ pipeline {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                         retry(3) {
                             sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
+                                container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+
+
+
                                 ls -alh bin/
                                 chmod +x bin/*
                                 ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
+                                ./tikv-server -V
+                                ./pd-server -V
                             """
                         }
                     }
@@ -88,8 +89,8 @@ pipeline {
                             mkdir -p bin
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
+                            ./pd-server -V
+                            ./tikv-server -V
                             ./bin/tidb-server -V
                         """
                     }
@@ -126,8 +127,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh label: "print version", script: """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("java") {

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -69,10 +69,11 @@ pipeline {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                         retry(2) {
                             sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
+                            container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+                            mkdir -p bin
+
+                            mv pd-server bin/
                             ls -alh bin/
                             chmod +x bin/*
                             """
@@ -87,8 +88,8 @@ pipeline {
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
                             ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
+                            ./tikv-server -V
+                            ./pd-server -V
                         """
                     }
                 }
@@ -122,8 +123,8 @@ pipeline {
                                     sh label: 'print version', script: """
                                         ls -alh bin/
                                         ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                        ./tikv-server -V
+                                        ./pd-server -V
                                     """
                                     container("golang") {
                                         sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_e2e_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_br_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_common_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_copr_test.yaml
@@ -25,6 +25,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_ddl_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_jdbc_test.yaml
@@ -38,6 +38,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_lightning_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_mysql_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_nodejs_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_integration_python_orm_test.yaml
@@ -31,6 +31,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_e2e_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
@@ -52,18 +52,21 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
-                    retry(3) {
-                        sh label: 'download binary', script: """
-                            chmod +x \${WORKSPACE}/scripts/artifacts/*.sh
-                            \${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
-                            ls -alh bin/
-                            chmod +x bin/*
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
+                    container("golang") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
+                    dir("bin") {
+                        container("utils") {
+                            retry(3) {
+                                sh label: 'download binary', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                    ls -alh
+                                    chmod +x *
+                                    ./tikv-server -V
+                                    ./pd-server -V
+                                """
+                            }
+                        }
                     }
                 }
             }
@@ -75,8 +78,8 @@ pipeline {
                     sh label: 'check version', script: """
                     ls -alh bin/
                     ./bin/tidb-server -V
-                    ./bin/tikv-server -V
-                    ./bin/pd-server -V
+                    ./tikv-server -V
+                    ./pd-server -V
                     """
                     sh label: 'test graceshutdown', script: """
                     cd tests/graceshutdown && make

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_copr_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -71,15 +71,16 @@ pipeline {
                     container("golang") {
                         retry(2) {
                             sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
                             rm -rf bin/ && mkdir -p bin/
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
+                            mkdir -p bin
+
+                            mv pd-server bin/
                             ls -alh bin/
                             chmod +x bin/*
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
+                            ./tikv-server -V
+                            ./pd-server -V
                             """
                         }
                     }
@@ -92,8 +93,8 @@ pipeline {
                 dir('tidb') {
                     sh label: 'check version', script: """
                     ls -alh bin/
-                    ./bin/tikv-server -V
-                    ./bin/pd-server -V
+                    ./tikv-server -V
+                    ./pd-server -V
                     """
                 }
                 dir('tikv-copr-test') {

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -71,10 +71,11 @@ pipeline {
                         sh label: 'ddl-test', script: 'ls bin/ddltest || make ddltest'
                         retry(3) {
                             sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
+                                container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+
+
+
                                 ls -alh bin/
                             """
                         }
@@ -87,8 +88,8 @@ pipeline {
                             mkdir -p bin
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
+                            ./pd-server -V
+                            ./tikv-server -V
                             ./bin/tidb-server -V
                         """
                     }
@@ -119,8 +120,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("golang") {

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -68,15 +68,16 @@ pipeline {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                         retry(3) {
                             sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
+                                container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+
+
+
                                 ls -alh bin/
                                 chmod +x bin/*
                                 ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
+                                ./tikv-server -V
+                                ./pd-server -V
                             """
                         }
                     }
@@ -88,8 +89,8 @@ pipeline {
                             mkdir -p bin
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
+                            ./pd-server -V
+                            ./tikv-server -V
                             ./bin/tidb-server -V
                         """
                     }
@@ -126,8 +127,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh label: "print version", script: """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("java") {

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -69,10 +69,11 @@ pipeline {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                         retry(2) {
                             sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
+                            container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+                            mkdir -p bin
+
+                            mv pd-server bin/
                             ls -alh bin/
                             chmod +x bin/*
                             """
@@ -87,8 +88,8 @@ pipeline {
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
                             ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
+                            ./tikv-server -V
+                            ./pd-server -V
                         """
                     }
                 }
@@ -122,8 +123,8 @@ pipeline {
                                     sh label: 'print version', script: """
                                         ls -alh bin/
                                         ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                        ./tikv-server -V
+                                        ./pd-server -V
                                     """
                                     container("golang") {
                                         sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_e2e_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_br_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_common_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_copr_test.yaml
@@ -25,6 +25,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_ddl_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_jdbc_test.yaml
@@ -38,6 +38,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_lightning_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_mysql_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_nodejs_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_integration_python_orm_test.yaml
@@ -31,6 +31,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_e2e_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
@@ -52,18 +52,21 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
-                    retry(3) {
-                        sh label: 'download binary', script: """
-                            chmod +x \${WORKSPACE}/scripts/artifacts/*.sh
-                            \${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
-                            ls -alh bin/
-                            chmod +x bin/*
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
+                    container("golang") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
+                    dir("bin") {
+                        container("utils") {
+                            retry(3) {
+                                sh label: 'download binary', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                    ls -alh
+                                    chmod +x *
+                                    ./tikv-server -V
+                                    ./pd-server -V
+                                """
+                            }
+                        }
                     }
                 }
             }
@@ -75,8 +78,8 @@ pipeline {
                     sh label: 'check version', script: """
                     ls -alh bin/
                     ./bin/tidb-server -V
-                    ./bin/tikv-server -V
-                    ./bin/pd-server -V
+                    ./tikv-server -V
+                    ./pd-server -V
                     """
                     sh label: 'test graceshutdown', script: """
                     cd tests/graceshutdown && make

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -68,14 +68,15 @@ pipeline {
                     container("golang") {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                         retry(3) {
-                            sh label: 'download thirdparty binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
+                            dir("bin") {
+                                container("utils") {
+                                    sh label: 'download binary', script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                        ./tikv-server -V
+                                        ./pd-server -V
+                                    """
+                                }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_copr_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -68,19 +68,17 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    container("golang") {
+                                        container("golang") {
                         retry(2) {
-                            sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            rm -rf bin/ && mkdir -p bin/
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
-                            ls -alh bin/
-                            chmod +x bin/*
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                            """
+                            dir("bin") {
+                                container("utils") {
+                                    sh label: 'download binary', script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                        ./tikv-server -V
+                                        ./pd-server -V
+                                    """
+                                }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -71,10 +71,11 @@ pipeline {
                         sh label: 'ddl-test', script: 'ls bin/ddltest || make ddltest'
                         retry(3) {
                             sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
+                                container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+
+
+
                                 ls -alh bin/
                             """
                         }
@@ -87,8 +88,8 @@ pipeline {
                             mkdir -p bin
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
+                            ./pd-server -V
+                            ./tikv-server -V
                             ./bin/tidb-server -V
                         """
                     }
@@ -119,8 +120,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("golang") {

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -68,15 +68,16 @@ pipeline {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                         retry(3) {
                             sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
+                                container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+
+
+
                                 ls -alh bin/
                                 chmod +x bin/*
                                 ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
+                                ./tikv-server -V
+                                ./pd-server -V
                             """
                         }
                     }
@@ -88,8 +89,8 @@ pipeline {
                             mkdir -p bin
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
+                            ./pd-server -V
+                            ./tikv-server -V
                             ./bin/tidb-server -V
                         """
                     }
@@ -126,8 +127,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh label: "print version", script: """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("java") {

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
@@ -69,10 +69,11 @@ pipeline {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                         retry(2) {
                             sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
+                            container("utils") {
+                        sh label: 'download binary', script: "${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}"
+                            mkdir -p bin
+
+                            mv pd-server bin/
                             ls -alh bin/
                             chmod +x bin/*
                             """
@@ -87,8 +88,8 @@ pipeline {
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
                             ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
+                            ./tikv-server -V
+                            ./pd-server -V
                         """
                     }
                 }
@@ -122,8 +123,8 @@ pipeline {
                                     sh label: 'print version', script: """
                                         ls -alh bin/
                                         ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                        ./tikv-server -V
+                                        ./pd-server -V
                                     """
                                     container("golang") {
                                         sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_e2e_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_br_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_common_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_copr_test.yaml
@@ -25,6 +25,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_ddl_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_e2e_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_jdbc_test.yaml
@@ -38,6 +38,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_lightning_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_mysql_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_nodejs_test.yaml
@@ -28,6 +28,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_python_orm_test.yaml
@@ -31,6 +31,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_tidb_tools_test.yaml
@@ -32,6 +32,16 @@ spec:
         limits:
           memory: 2Gi
           cpu: "1"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_e2e_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
@@ -52,18 +52,21 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
-                    retry(3) {
-                        sh label: 'download binary', script: """
-                            chmod +x \${WORKSPACE}/scripts/artifacts/*.sh
-                            \${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
-                            ls -alh bin/
-                            chmod +x bin/*
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
+                    container("golang") {
+                        sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
+                    dir("bin") {
+                        container("utils") {
+                            retry(3) {
+                                sh label: 'download binary', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                    ls -alh
+                                    chmod +x *
+                                    ./tikv-server -V
+                                    ./pd-server -V
+                                """
+                            }
+                        }
                     }
                 }
             }
@@ -75,8 +78,8 @@ pipeline {
                     sh label: 'check version', script: """
                     ls -alh bin/
                     ./bin/tidb-server -V
-                    ./bin/tikv-server -V
-                    ./bin/pd-server -V
+                    ./tikv-server -V
+                    ./pd-server -V
                     """
                     sh label: 'test graceshutdown', script: """
                     cd tests/graceshutdown && make

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
@@ -17,8 +17,8 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
@@ -67,14 +67,16 @@ pipeline {
                 dir('tidb') {
                     container("golang") {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
+                    container("utils") {
                         retry(3) {
-                            sh label: 'download thirdparty binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
+                            dir("bin") { container("utils") { sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+
+
+
+                                ./tikv-server -V
+                                ./pd-server -V
                             """
                         }
                     }
@@ -87,8 +89,8 @@ pipeline {
                         cd randgen-test && ./build.sh && cd ..
                         mkdir -p bin
                         cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
+                        ./pd-server -V
+                        ./tikv-server -V
                         ./bin/tidb-server -V
                         """
                     }
@@ -122,8 +124,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("golang") {

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_copr_test.groovy
@@ -17,8 +17,8 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
@@ -68,18 +68,18 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    container("golang") {
+                    container("utils") {
                         retry(2) {
                             sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
                             rm -rf bin/ && mkdir -p bin/
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
+                            mkdir -p bin
+
+                            mv pd-server bin/
                             ls -alh bin/
                             chmod +x bin/*
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
+                            ./tikv-server -V
+                            ./pd-server -V
                             """
                         }
                     }
@@ -92,8 +92,8 @@ pipeline {
                 dir('tidb') {
                     sh label: 'check version', script: """
                     ls -alh bin/
-                    ./bin/tikv-server -V
-                    ./bin/pd-server -V
+                    ./tikv-server -V
+                    ./pd-server -V
                     """
                 }
                 dir('tikv-copr-test') {

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -66,17 +66,19 @@ pipeline {
                 dir('tidb') {
                     container("golang") {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
+                    container("utils") {
                         retry(3) {
                             sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+
+
+
                                 ls -alh bin/
                                 chmod +x bin/*
                                 ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
+                                ./tikv-server -V
+                                ./pd-server -V
                             """
                         }
                     }
@@ -88,8 +90,8 @@ pipeline {
                             mkdir -p bin
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
+                            ./pd-server -V
+                            ./tikv-server -V
                             ./bin/tidb-server -V
                         """
                     }
@@ -126,8 +128,8 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                                     sh label: "print version", script: """
                                         ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
+                                        ./pd-server -V
+                                        ./tikv-server -V
                                         ./bin/tidb-server -V
                                     """
                                     container("java") {

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
@@ -17,8 +17,8 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
         GITHUB_TOKEN = credentials('github-bot-token')
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
@@ -67,12 +67,14 @@ pipeline {
                 dir('tidb') {
                     container("golang") {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
+                    container("utils") {
                         retry(2) {
                             sh label: 'download binary', script: """
-                            chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                            mv third_bin/tikv-server bin/
-                            mv third_bin/pd-server bin/
+                            ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                            mkdir -p bin
+
+                            mv pd-server bin/
                             ls -alh bin/
                             chmod +x bin/*
                             """
@@ -87,8 +89,8 @@ pipeline {
                             cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
                             ls -alh bin/
                             ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
+                            ./tikv-server -V
+                            ./pd-server -V
                         """
                     }
                 }
@@ -122,8 +124,8 @@ pipeline {
                                     sh label: 'print version', script: """
                                         ls -alh bin/
                                         ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                        ./tikv-server -V
+                                        ./pd-server -V
                                     """
                                     container("golang") {
                                         sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
@@ -15,7 +15,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 75, unit: 'MINUTES')
@@ -64,30 +64,32 @@ pipeline {
                 container('nodejs') {
                     dir('tidb') {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
-                        retry(2) {
-                            sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
-                                rm -rf bin/bin
-                                ls -alh bin/
-                                chmod +x bin/*
-                            """
+                    }
+                }
+                dir('tidb') {
+                    dir("bin") {
+                        container('utils') {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+                                    ls -alh
+                                    chmod +x *
+                                """
+                            }
                         }
                     }
-                    dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                }
+                dir('tidb-test') {
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./tikv-server -V
+                            ./pd-server -V
+                        """
                     }
                 }
             }
@@ -116,8 +118,8 @@ pipeline {
                                     sh label: 'print version', script: """
                                         ls -alh bin/
                                         ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                        ./tikv-server -V
+                                        ./pd-server -V
                                     """
                                     sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
                                         export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -62,30 +62,34 @@ pipeline {
                 container("golang") {
                     dir('tidb') {
                         sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
+                    }
+                }
+                container("utils") {
+                    dir('tidb') {
                         retry(2) {
                             sh label: 'download binary', script: """
-                                chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
-                                mv third_bin/tikv-server bin/
-                                mv third_bin/pd-server bin/
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${REFS.base_ref} --tikv=${REFS.base_ref}
+
+
+
                                 rm -rf bin/bin
                                 ls -alh bin/
                                 chmod +x bin/*
                             """
                         }
                     }
-                    dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                }
+                dir('tidb-test') {
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./tikv-server -V
+                            ./pd-server -V
+                        """
                     }
                 }
             }
@@ -118,8 +122,8 @@ pipeline {
                                     sh label: 'print version', script: """
                                         ls -alh bin/
                                         ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                        ./tikv-server -V
+                                        ./pd-server -V
                                     """
                                     sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"

--- a/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
@@ -35,6 +35,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml
@@ -21,6 +21,16 @@ spec:
         limits:
           memory: 128Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
@@ -85,7 +85,7 @@ pipeline {
                         sh label: 'download tikv', script: """
                         ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tikv=${REFS.base_ref}
                         mkdir -p bin
-                        
+
                         mv pd-server bin/
                         ls -alh bin/
                         bin/pd-server -V

--- a/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
@@ -79,9 +79,15 @@ pipeline {
                     container("golang") {
                         sh label: 'pd-server', script: '[ -f bin/pd-server ] || make'
                         sh label: 'tikv-server', script: """
-                        chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                        ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --tikv=${REFS.base_ref}
-                        rm -rf third_bin/bin && mv third_bin/* bin/ && ls -alh bin/
+                        """
+                    }
+                    container("utils") {
+                        sh label: 'download tikv', script: """
+                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tikv=${REFS.base_ref}
+                        mkdir -p bin
+                        
+                        mv pd-server bin/
+                        ls -alh bin/
                         bin/pd-server -V
                         bin/tikv-server -V
                         """

--- a/pipelines/tikv/pd/release-7.1/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/release-7.1/pod-pull_integration_copr_test.yaml
@@ -35,6 +35,16 @@ spec:
         limits:
           memory: 256Mi
           cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/tikv/pd/release-7.1/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-7.1/pull_integration_copr_test.groovy
@@ -85,7 +85,7 @@ pipeline {
                         sh label: 'download tikv', script: """
                         ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tikv=${REFS.base_ref}
                         mkdir -p bin
-                        
+
                         mv pd-server bin/
                         ls -alh bin/
                         bin/pd-server -V

--- a/pipelines/tikv/pd/release-7.1/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-7.1/pull_integration_copr_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
@@ -79,9 +79,15 @@ pipeline {
                     container("golang") {
                         sh label: 'pd-server', script: '[ -f bin/pd-server ] || make'
                         sh label: 'tikv-server', script: """
-                        chmod +x ${WORKSPACE}/scripts/artifacts/*.sh
-                        ${WORKSPACE}/scripts/artifacts/download_pingcap_artifact.sh --tikv=${REFS.base_ref}
-                        rm -rf third_bin/bin && mv third_bin/* bin/ && ls -alh bin/
+                        """
+                    }
+                    container("utils") {
+                        sh label: 'download tikv', script: """
+                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tikv=${REFS.base_ref}
+                        mkdir -p bin
+                        
+                        mv pd-server bin/
+                        ls -alh bin/
                         bin/pd-server -V
                         bin/tikv-server -V
                         """


### PR DESCRIPTION
## Changes

This PR refactors all Jenkins pipeline jobs that use  to use the new  script.

### Key Changes

1. **Pod Templates (53 files)**: Added  container to all integration test pod templates
   - Image: 

2. **Pipeline Groovy Files (42 files)**:
   - Replace  with 
   - Execute download script in  with 
   - Add  environment variable
   - Remove  environment variable (no longer needed)
   - Remove  step (script permissions are set in git)
   - Update version check commands to use relative paths ( instead of )

### Affected Branches

- : release-6.5, 8.2, 8.3, 8.4, 9.0-beta
- : latest, release-7.1
- : release-6.0, 6.2

### Commits

- : Add utils container to all integration test pod templates
- : refactor: use download_pingcap_oci_artifact.sh in pipeline groovy files