### PR TITLE
fix(docs,docs-cn/pull-verify): fix the invalid Git repository issue

### DIFF
--- a/pipelines/pingcap/docs-cn/latest/pull_verify.groovy
+++ b/pipelines/pingcap/docs-cn/latest/pull_verify.groovy
@@ -108,7 +108,7 @@ pipeline {
                                             script: 'git rev-parse --show-toplevel 2>/dev/null || echo ""',
                                             returnStdout: true
                                         ).trim()
-                                        
+
                                         if (!gitRepoRoot || gitRepoRoot != currentDir) {
                                             echo "Git repository invalid or root mismatch, re-checking out..."
                                             sh 'rm -rf .git'

--- a/pipelines/pingcap/docs/latest/pull_verify.groovy
+++ b/pipelines/pingcap/docs/latest/pull_verify.groovy
@@ -109,7 +109,7 @@ pipeline {
                                             script: 'git rev-parse --show-toplevel 2>/dev/null || echo ""',
                                             returnStdout: true
                                         ).trim()
-                                        
+
                                         if (!gitRepoRoot || gitRepoRoot != currentDir) {
                                             echo "Git repository invalid or root mismatch, re-checking out..."
                                             sh 'rm -rf .git'


### PR DESCRIPTION
check the Git repository; if it is invalid or the root directory does not match, delete the .git folder and perform a fresh checkout.

Handled Scenarios
- .git directory does not exist → Perform a fresh checkout
- .git directory exists but is invalid → Delete it and perform a fresh checkout
- Mismatched Git repository root directory → Delete it and perform a fresh checkout
- Incomplete or corrupted files restored from cache → Delete them and perform a fresh checkout