### PR TITLE
refactor(pipelines/tidb): use OCI artifacts and per-stage agents in br pipelines

### DIFF
--- a/.ci/replay-jenkins-build.sh
+++ b/.ci/replay-jenkins-build.sh
@@ -136,7 +136,7 @@ discover_changed_scripts() {
     fi
 
     log "collect changed pipeline files from ${base_sha}..${head_sha}"
-    git diff --name-only "$base_sha" "$head_sha" | rg '^pipelines/.*\.groovy$' || true
+    git diff --name-only "$base_sha" "$head_sha" | grep -E '^pipelines/.*\.groovy$' || true
 }
 
 setup_auth_and_crumb() {
@@ -516,7 +516,6 @@ validate_inputs() {
     require_bin curl
     require_bin jq
     require_bin git
-    require_bin rg
     require_bin base64
     require_bin sed
 

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -122,7 +122,7 @@ pipeline {
                                 }
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
-                                    if [[ "${TEST_GROUP,,}" == "G00" ]]; then
+                                    if [[ "${TEST_GROUP}" == "G00" ]]; then
                                         ./br/tests/run_group_br_tests.sh others # check all tests added to group
                                     fi
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -122,6 +122,9 @@ pipeline {
                                 }
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
+                                    if [[ "${TEST_GROUP,,}" == "G00" ]]; then
+                                        ./br/tests/run_group_br_tests.sh others # check all tests added to group
+                                    fi
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}
                                 """
                             }

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test.groovy
@@ -60,7 +60,7 @@ pipeline {
                         }
                         sh '''
                             mv tiflash tiflash_dir
-                            ln -s `pwd`/tiflash_dir/tiflash tiflash
+                            ln -s tiflash_dir/tiflash tiflash
 
                             ./tikv-server -V
                             ./pd-server -V
@@ -72,7 +72,9 @@ pipeline {
             }
             post{
                 failure {
-                    archiveArtifacts(artifacts: 'tidb/tests/integrationtest2/logs/*.log', allowEmptyArchive: true)
+                    dir(REFS.repo) {
+                        archiveArtifacts(artifacts: 'tests/integrationtest2/logs/*.log', allowEmptyArchive: true)
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-6.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_br_integration_test.groovy
@@ -8,43 +8,36 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-pull_br_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
+final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', (REFS.base_ref ==~ /^release-fts-[0-9]+$/ ? 'master' : REFS.base_ref), REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIFLASH = component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_FAKE_GCS_SERVER = 'v1.54.0'
+final OCI_TAG_KES = 'v0.14.0'
+final OCI_TAG_MINIO = 'RELEASE.2020-02-27T00-23-05Z'
 
 prow.setPRDescription(REFS)
-
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
-        // parallelsAlwaysFailFast()
+        parallelsAlwaysFailFast()
     }
     stages {
-        stage('Debug info') {
-            steps {
-                sh label: 'Debug info', script: """
-                    printenv
-                    echo "-------------------------"
-                    go env
-                    echo "-------------------------"
-                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
-                """
-                container(name: 'net-tool') {
-                    sh 'dig github.com'
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yamlFile POD_TEMPLATE_FILE
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage('Checkout') {
-            options { timeout(time: 5, unit: 'MINUTES') }
+            options { timeout(time: 15, unit: 'MINUTES') }
             steps {
-                dir("tidb") {
+                dir(REFS.repo) {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
@@ -52,26 +45,6 @@ pipeline {
                             }
                         }
                     }
-                }
-            }
-        }
-        stage('Prepare') {
-            steps {
-                dir("third_party_download") {
-                    retry(2) {
-                        sh label: "download third_party", script: """
-                            chmod +x ../tidb/br/tests/*.sh
-                            chmod +x ${WORKSPACE}/scripts/pingcap/tidb/br_integration_test_download_dependency.sh
-                            ${WORKSPACE}/scripts/pingcap/tidb/br_integration_test_download_dependency.sh release-6.1
-                            mkdir -p bin && mv third_bin/* bin/
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                        """
-                    }
-                }
-                dir('tidb') {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'br-integration-test')) {
                         // build br.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -82,10 +55,40 @@ pipeline {
                             ./bin/tidb-server -V
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
+                    dir("bin") {
+                        container("utils") {
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                            --pd=${OCI_TAG_PD} \
+                                            --pd-ctl=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tikv-ctl=${OCI_TAG_TIKV} \
+                                            --tiflash=${OCI_TAG_TIFLASH} \
+                                            --ycsb=${OCI_TAG_YCSB} \
+                                            --fake-gcs-server=${OCI_TAG_FAKE_GCS_SERVER} \
+                                            --kes=${OCI_TAG_KES} \
+                                            --minio=${OCI_TAG_MINIO} \
+                                            --brv408
+                                    """
+                                }
+                            }
+                        }
+                        sh """
+                            mv tiflash tiflash_dir
+                            ln -s tiflash_dir/tiflash tiflash
+
+                            ls -alh .
+                            ./pd-server -V
+                            ./tikv-server -V
+                            ./tiflash --version
+                        """
+                    }
+                    // cache workspace for matrix pods
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
+                        sh """
+                            touch rev-${REFS.pulls[0].sha}
                         """
                     }
                 }
@@ -111,24 +114,25 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
-                                    sh label: "TEST_GROUP ${TEST_GROUP}", script: """
-                                        #!/usr/bin/env bash
-                                        cp ${WORKSPACE}/scripts/pingcap/tidb/br-lightning_run_group_v2.sh br/tests/run_group.sh
-                                        chmod +x br/tests/*.sh
-                                        ln -s ${WORKSPACE}/tidb/bin ${WORKSPACE}/tidb/br/bin
-                                        cd br/
-                                        ./tests/run_group.sh ${TEST_GROUP}
-                                    """
+                            dir(REFS.repo) {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
+                                    sh "ls rev-${REFS.pulls[0].sha}"
                                 }
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """
+                                    #!/usr/bin/env bash
+                                    cp ${WORKSPACE}/scripts/pingcap/tidb/br-lightning_run_group_v2.sh br/tests/run_group.sh
+                                    chmod +x br/tests/*.sh
+                                    ln -s ${WORKSPACE}/tidb/bin ${WORKSPACE}/tidb/br/bin
+                                    cd br/
+                                    ./tests/run_group.sh ${TEST_GROUP}
+                                """
                             }
                         }
                         post{
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/backup_restore_test
-                                    tar -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/backup_restore_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/backup_restore_test/ -type f -name "*.log")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test.groovy
@@ -77,7 +77,7 @@ pipeline {
                         }
                         sh """
                             mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tifflash
+                            ln -s tiflash_dir/tiflash tiflash
 
                             ls -alh .
                             ./pd-server -V

--- a/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
@@ -77,7 +77,7 @@ pipeline {
                         }
                         sh """
                             mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tifflash
+                            ln -s tiflash_dir/tiflash tiflash
 
                             ls -alh .
                             ./pd-server -V

--- a/pipelines/pingcap/tidb/release-6.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_br_integration_test.groovy
@@ -8,43 +8,36 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.5/pod-pull_br_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
+final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', (REFS.base_ref ==~ /^release-fts-[0-9]+$/ ? 'master' : REFS.base_ref), REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIFLASH = component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_FAKE_GCS_SERVER = 'v1.54.0'
+final OCI_TAG_KES = 'v0.14.0'
+final OCI_TAG_MINIO = 'RELEASE.2020-02-27T00-23-05Z'
 
 prow.setPRDescription(REFS)
-
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
-        // parallelsAlwaysFailFast()
+        parallelsAlwaysFailFast()
     }
     stages {
-        stage('Debug info') {
-            steps {
-                sh label: 'Debug info', script: """
-                    printenv
-                    echo "-------------------------"
-                    go env
-                    echo "-------------------------"
-                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
-                """
-                container(name: 'net-tool') {
-                    sh 'dig github.com'
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yamlFile POD_TEMPLATE_FILE
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage('Checkout') {
-            options { timeout(time: 5, unit: 'MINUTES') }
+            options { timeout(time: 15, unit: 'MINUTES') }
             steps {
-                dir("tidb") {
+                dir(REFS.repo) {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
@@ -52,26 +45,6 @@ pipeline {
                             }
                         }
                     }
-                }
-            }
-        }
-        stage('Prepare') {
-            steps {
-                dir("third_party_download") {
-                    retry(2) {
-                        sh label: "download third_party", script: """
-                            chmod +x ../tidb/br/tests/*.sh
-                            chmod +x ${WORKSPACE}/scripts/pingcap/tidb/br_integration_test_download_dependency.sh
-                            ${WORKSPACE}/scripts/pingcap/tidb/br_integration_test_download_dependency.sh release-6.5
-                            mkdir -p bin && mv third_bin/* bin/
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                        """
-                    }
-                }
-                dir('tidb') {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'br-integration-test')) {
                         // build br.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -82,10 +55,40 @@ pipeline {
                             ./bin/tidb-server -V
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
+                    dir("bin") {
+                        container("utils") {
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                            --pd=${OCI_TAG_PD} \
+                                            --pd-ctl=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tikv-ctl=${OCI_TAG_TIKV} \
+                                            --tiflash=${OCI_TAG_TIFLASH} \
+                                            --ycsb=${OCI_TAG_YCSB} \
+                                            --fake-gcs-server=${OCI_TAG_FAKE_GCS_SERVER} \
+                                            --kes=${OCI_TAG_KES} \
+                                            --minio=${OCI_TAG_MINIO} \
+                                            --brv408
+                                    """
+                                }
+                            }
+                        }
+                        sh """
+                            mv tiflash tiflash_dir
+                            ln -s tiflash_dir/tiflash tiflash
+
+                            ls -alh .
+                            ./pd-server -V
+                            ./tikv-server -V
+                            ./tiflash --version
+                        """
+                    }
+                    // cache workspace for matrix pods
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
+                        sh """
+                            touch rev-${REFS.pulls[0].sha}
                         """
                     }
                 }
@@ -111,24 +114,25 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
-                                    sh label: "TEST_GROUP ${TEST_GROUP}", script: """
-                                        #!/usr/bin/env bash
-                                        cp ${WORKSPACE}/scripts/pingcap/tidb/br-lightning_run_group_v2.sh br/tests/run_group.sh
-                                        chmod +x br/tests/*.sh
-                                        ln -s ${WORKSPACE}/tidb/bin ${WORKSPACE}/tidb/br/bin
-                                        cd br/
-                                        ./tests/run_group.sh ${TEST_GROUP}
-                                    """
+                            dir(REFS.repo) {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
+                                    sh "ls rev-${REFS.pulls[0].sha}"
                                 }
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """
+                                    #!/usr/bin/env bash
+                                    cp ${WORKSPACE}/scripts/pingcap/tidb/br-lightning_run_group_v2.sh br/tests/run_group.sh
+                                    chmod +x br/tests/*.sh
+                                    ln -s ${WORKSPACE}/tidb/bin ${WORKSPACE}/tidb/br/bin
+                                    cd br/
+                                    ./tests/run_group.sh ${TEST_GROUP}
+                                """
                             }
                         }
                         post{
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/backup_restore_test
-                                    tar -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/backup_restore_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/backup_restore_test/ -type f -name "*.log")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
@@ -8,43 +8,36 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-prow.setPRDescription(REFS)
+final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', (REFS.base_ref ==~ /^release-fts-[0-9]+$/ ? 'master' : REFS.base_ref), REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIFLASH = component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_FAKE_GCS_SERVER = 'v1.54.0'
+final OCI_TAG_KES = 'v0.14.0'
+final OCI_TAG_MINIO = 'RELEASE.2020-02-27T00-23-05Z'
 
+prow.setPRDescription(REFS)
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
-        // parallelsAlwaysFailFast()
+        parallelsAlwaysFailFast()
     }
     stages {
-        stage('Debug info') {
-            steps {
-                sh label: 'Debug info', script: """
-                    printenv
-                    echo "-------------------------"
-                    go env
-                    echo "-------------------------"
-                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
-                """
-                container(name: 'net-tool') {
-                    sh 'dig github.com'
-
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yamlFile POD_TEMPLATE_FILE
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage('Checkout') {
-            options { timeout(time: 5, unit: 'MINUTES') }
+            options { timeout(time: 15, unit: 'MINUTES') }
             steps {
-                dir("tidb") {
+                dir(REFS.repo) {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
@@ -52,26 +45,6 @@ pipeline {
                             }
                         }
                     }
-                }
-            }
-        }
-        stage('Prepare') {
-            steps {
-                dir("third_party_download") {
-                    retry(2) {
-                        sh label: "download third_party", script: """
-                            chmod +x ../tidb/br/tests/*.sh
-                            chmod +x ${WORKSPACE}/scripts/pingcap/tidb/br_integration_test_download_dependency.sh
-                            ${WORKSPACE}/scripts/pingcap/tidb/br_integration_test_download_dependency.sh release-7.1
-                            mkdir -p bin && mv third_bin/* bin/
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiflash --version
-                        """
-                    }
-                }
-                dir('tidb') {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'br-integration-test')) {
                         // build br.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -82,10 +55,40 @@ pipeline {
                             ./bin/tidb-server -V
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
+                    dir("bin") {
+                        container("utils") {
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                            --pd=${OCI_TAG_PD} \
+                                            --pd-ctl=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tikv-ctl=${OCI_TAG_TIKV} \
+                                            --tiflash=${OCI_TAG_TIFLASH} \
+                                            --ycsb=${OCI_TAG_YCSB} \
+                                            --fake-gcs-server=${OCI_TAG_FAKE_GCS_SERVER} \
+                                            --kes=${OCI_TAG_KES} \
+                                            --minio=${OCI_TAG_MINIO} \
+                                            --brv408
+                                    """
+                                }
+                            }
+                        }
+                        sh """
+                            mv tiflash tiflash_dir
+                            ln -s tiflash_dir/tiflash tiflash
+
+                            ls -alh .
+                            ./pd-server -V
+                            ./tikv-server -V
+                            ./tiflash --version
+                        """
+                    }
+                    // cache workspace for matrix pods
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
+                        sh """
+                            touch rev-${REFS.pulls[0].sha}
                         """
                     }
                 }
@@ -111,24 +114,25 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
-                                    sh label: "TEST_GROUP ${TEST_GROUP}", script: """
-                                        #!/usr/bin/env bash
-                                        cp ${WORKSPACE}/scripts/pingcap/tidb/br-lightning_run_group_v2.sh br/tests/run_group.sh
-                                        chmod +x br/tests/*.sh
-                                        ln -s ${WORKSPACE}/tidb/bin ${WORKSPACE}/tidb/br/bin
-                                        cd br/
-                                        ./tests/run_group.sh ${TEST_GROUP}
-                                    """
+                            dir(REFS.repo) {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
+                                    sh "ls rev-${REFS.pulls[0].sha}"
                                 }
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """
+                                    #!/usr/bin/env bash
+                                    cp ${WORKSPACE}/scripts/pingcap/tidb/br-lightning_run_group_v2.sh br/tests/run_group.sh
+                                    chmod +x br/tests/*.sh
+                                    ln -s ${WORKSPACE}/tidb/bin ${WORKSPACE}/tidb/br/bin
+                                    cd br/
+                                    ./tests/run_group.sh ${TEST_GROUP}
+                                """
                             }
                         }
                         post{
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/backup_restore_test
-                                    tar -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/backup_restore_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/backup_restore_test/ -type f -name "*.log")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
@@ -82,7 +82,7 @@ pipeline {
                         }
                         sh """
                             mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tifflash
+                            ln -s tiflash_dir/tiflash tiflash
 
                             ls -alh .
                             ./pd-server -V

--- a/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
@@ -77,7 +77,7 @@ pipeline {
                         }
                         sh """
                             mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tifflash
+                            ln -s tiflash_dir/tiflash tiflash
 
                             ls -alh .
                             ./pd-server -V

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -8,42 +8,36 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-prow.setPRDescription(REFS)
+final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', (REFS.base_ref ==~ /^release-fts-[0-9]+$/ ? 'master' : REFS.base_ref), REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIFLASH = component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_FAKE_GCS_SERVER = 'v1.54.0'
+final OCI_TAG_KES = 'v0.14.0'
+final OCI_TAG_MINIO = 'RELEASE.2020-02-27T00-23-05Z'
 
+prow.setPRDescription(REFS)
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
-        // parallelsAlwaysFailFast()
+        parallelsAlwaysFailFast()
     }
     stages {
-        stage('Debug info') {
-            steps {
-                sh label: 'Debug info', script: """
-                    printenv
-                    echo "-------------------------"
-                    go env
-                    echo "-------------------------"
-                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
-                """
-                container(name: 'net-tool') {
-                    sh 'dig github.com'
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yamlFile POD_TEMPLATE_FILE
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage('Checkout') {
-            options { timeout(time: 5, unit: 'MINUTES') }
+            options { timeout(time: 15, unit: 'MINUTES') }
             steps {
-                dir("tidb") {
+                dir(REFS.repo) {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
@@ -51,34 +45,10 @@ pipeline {
                             }
                         }
                     }
-                }
-            }
-        }
-        stage('Prepare') {
-            steps {
-                dir("third_party_download") {
-                    script {
-                        // Computes the branch name for downloading binaries based on the PR target branch and title.
-                        def otherComponentBranch = component.computeBranchFromPR('other', REFS.base_ref, REFS.pulls[0].title, 'release-7.5')
-                        retry(2) {
-                            sh label: "download third_party", script: """
-                                chmod +x ../tidb/br/tests/*.sh
-                                ${WORKSPACE}/tidb/br/tests/download_integration_test_binaries.sh ${otherComponentBranch}
-                                mkdir -p bin && mv third_bin/* bin/
-                                ls -alh bin/
-                                ./bin/pd-server -V
-                                ./bin/tikv-server -V
-                                ./bin/tiflash --version
-                            """
-                        }
-                    }
-                }
-                dir('tidb') {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'br-integration-test')) {
                         sh label: "check all tests added to group", script: """
                             #!/usr/bin/env bash
                             chmod +x br/tests/*.sh
-                            ./br/tests/run_group.sh others
                         """
                         // build br.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -89,10 +59,40 @@ pipeline {
                             ./bin/tidb-server -V
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
+                    dir("bin") {
+                        container("utils") {
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                            --pd=${OCI_TAG_PD} \
+                                            --pd-ctl=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tikv-ctl=${OCI_TAG_TIKV} \
+                                            --tiflash=${OCI_TAG_TIFLASH} \
+                                            --ycsb=${OCI_TAG_YCSB} \
+                                            --fake-gcs-server=${OCI_TAG_FAKE_GCS_SERVER} \
+                                            --kes=${OCI_TAG_KES} \
+                                            --minio=${OCI_TAG_MINIO} \
+                                            --brv408
+                                    """
+                                }
+                            }
+                        }
+                        sh """
+                            mv tiflash tiflash_dir
+                            ln -s tiflash_dir/tiflash tiflash
+
+                            ls -alh .
+                            ./pd-server -V
+                            ./tikv-server -V
+                            ./tiflash --version
+                        """
+                    }
+                    // cache workspace for matrix pods
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
+                        sh """
+                            touch rev-${REFS.pulls[0].sha}
                         """
                     }
                 }
@@ -103,8 +103,7 @@ pipeline {
                 axes {
                     axis {
                         name 'TEST_GROUP'
-                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08', 'G09', 'G10', 'G11', 'G12', 'G13',
-                            'G14', 'G15', 'G16', 'G17'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08', 'G09', 'G10', 'G11', 'G12', 'G13', 'G14', 'G15', 'G16', 'G17'
                     }
                 }
                 agent{
@@ -118,21 +117,23 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
-                                    sh label: "TEST_GROUP ${TEST_GROUP}", script: """
-                                        #!/usr/bin/env bash
-                                        chmod +x br/tests/*.sh
-                                        ./br/tests/run_group.sh ${TEST_GROUP}
-                                    """
+                            dir(REFS.repo) {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
+                                    sh "ls rev-${REFS.pulls[0].sha}"
                                 }
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """
+                                    #!/usr/bin/env bash
+                                    chmod +x br/tests/*.sh
+                                    ./br/tests/run_group.sh others # check all tests added to group
+                                    ./br/tests/run_group.sh ${TEST_GROUP}
+                                """
                             }
                         }
                         post{
                             failure {
                                 sh label: "collect logs", script: """
                                     ls /tmp/backup_restore_test
-                                    tar -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/backup_restore_test/ -type f -name "*.log")
+                                    tar --warning=no-file-changed -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/backup_restore_test/ -type f -name "*.log")
                                     ls -alh  log-${TEST_GROUP}.tar.gz
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -46,10 +46,6 @@ pipeline {
                         }
                     }
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'br-integration-test')) {
-                        sh label: "check all tests added to group", script: """
-                            #!/usr/bin/env bash
-                            chmod +x br/tests/*.sh
-                        """
                         // build br.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
                         sh label: "prepare", script: """
@@ -121,10 +117,11 @@ pipeline {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                                     sh "ls rev-${REFS.pulls[0].sha}"
                                 }
-                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """
-                                    #!/usr/bin/env bash
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
-                                    ./br/tests/run_group.sh others # check all tests added to group
+                                    if [[ "${TEST_GROUP,,}" == "G00" ]]; then
+                                        ./br/tests/run_group.sh others # check all tests added to group
+                                    fi
                                     ./br/tests/run_group.sh ${TEST_GROUP}
                                 """
                             }

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -119,7 +119,7 @@ pipeline {
                                 }
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
-                                    if [[ "${TEST_GROUP,,}" == "G00" ]]; then
+                                    if [[ "${TEST_GROUP}" == "G00" ]]; then
                                         ./br/tests/run_group.sh others # check all tests added to group
                                     fi
                                     ./br/tests/run_group.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
@@ -6,7 +6,12 @@
 final K8S_NAMESPACE = "jenkins-tidb"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-8.5/pod-pull_integration_e2e_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
+final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', (REFS.base_ref ==~ /^release-fts-[0-9]+$/ ? 'master' : REFS.base_ref), REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIFLASH = component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TICDC_NEW = (REFS.base_ref == "feature/materialized_view" ? "release-8.5" : component.computeArtifactOciTagFromPR('ticdc', REFS.base_ref, REFS.pulls[0].title, 'master'))
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
@@ -16,29 +21,15 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'  // cache mirror for us-docker.pkg.dev/pingcap-testing-account/hub
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
     }
     stages {
-        stage('Debug info') {
-            steps {
-                sh label: 'Debug info', script: """
-                    printenv
-                    echo "-------------------------"
-                    go env
-                    echo "-------------------------"
-                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} bash"
-                """
-                container(name: 'net-tool') {
-                    sh 'dig github.com'
-                }
-            }
-        }
         stage('Checkout') {
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
@@ -49,40 +40,39 @@ pipeline {
                 }
             }
         }
-        stage('Prepare') {
-            steps {
-                dir('tidb') {
-                    script {
-                        def otherComponentBranch = component.computeBranchFromPR('other', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
-                        retry(3) {
-                            sh label: 'download binary', script: """
-                                cd tests/integrationtest2 && ./download_integration_test_binaries.sh ${otherComponentBranch}
-                                ls -alh third_bin/
-                                ./third_bin/tikv-server -V
-                                ./third_bin/pd-server -V
-                                ./third_bin/tiflash --version
-                                ./third_bin/cdc version
-                            """
-                        }
-                    }
-                }
-            }
-        }
         stage('Tests') {
             options { timeout(time: 45, unit: 'MINUTES') }
             steps {
-                dir('tidb') {
-                    sh label: 'test', script: """
-                        cd tests/integrationtest2 && ./run-tests.sh
-                    """
+                dir("${REFS.repo}/tests/integrationtest2") {
+                    dir("third_bin") {
+                        container("utils") {
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                            --pd=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tiflash=${OCI_TAG_TIFLASH} \
+                                            --ticdc-new=${OCI_TAG_TICDC_NEW}
+                                    """
+                                }
+                            }
+                        }
+                        sh """
+                            mv tiflash tiflash_dir
+                            ln -s tiflash_dir/tiflash tiflash
+
+                            ./tikv-server -V
+                            ./pd-server -V
+                            ./tiflash --version
+                        """
+                    }
+                    sh './run-tests.sh'
                 }
             }
             post{
                 failure {
-                    script {
-                        println "Test failed, archive the log"
-                        archiveArtifacts artifacts: 'tidb/tests/integrationtest2/logs', fingerprint: true
-                    }
+                    archiveArtifacts(artifacts: "${REFS.repo}/tests/integrationtest2/logs/*.log", allowEmptyArchive: true)
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
@@ -58,21 +58,23 @@ pipeline {
                                 }
                             }
                         }
-                        sh """
+                        sh '''
                             mv tiflash tiflash_dir
                             ln -s tiflash_dir/tiflash tiflash
 
                             ./tikv-server -V
                             ./pd-server -V
                             ./tiflash --version
-                        """
+                        '''
                     }
                     sh './run-tests.sh'
                 }
             }
             post{
                 failure {
-                    archiveArtifacts(artifacts: "${REFS.repo}/tests/integrationtest2/logs/*.log", allowEmptyArchive: true)
+                    dir(REFS.repo) {
+                        archiveArtifacts(artifacts: 'tests/integrationtest2/logs/*.log', allowEmptyArchive: true)
+                    }
                 }
             }
         }

--- a/prow-jobs/pingcap-qe/ci/periodics.yaml
+++ b/prow-jobs/pingcap-qe/ci/periodics.yaml
@@ -39,7 +39,7 @@ periodics:
           args:
             - |
               #!/usr/bin/env bash
-              set -euxo pipefail
+              set -euo pipefail
 
               script_url="https://github.com/PingCAP-QE/ci/raw/main/tools/reporters/ci/flaky-tests/main.ts"
               start_date=$(date -d "7 days ago" +%Y-%m-%d)

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
       spec:
         containers:
           - name: main
-            image: wbitt/network-multitool
+            image: ghcr.io/pingcap-qe/cd/utils/release:v2026.2.1-3-gb0438c3
             env:
               - name: JENKINS_URL
                 value: https://do.pingcap.net/jenkins-beta
@@ -39,7 +39,6 @@ presubmits:
             command: [bash, -ceo, pipefail]
             args:
               - |
-                apk add --no-cache git jq ripgrep
                 .ci/replay-jenkins-build.sh \
                   --auto-changed \
                   --base-sha "${PULL_BASE_SHA:-}" \


### PR DESCRIPTION
pipelines

add OCI_TAG_* variables for pd/tikv/tiflash and other deps (ycsb, fake-gcs-server, kes, minio) and handle ticdc special-case; replace FILE_SERVER_URL with OCI_ARTIFACT_HOST. change top-level agent to none and run a kubernetes agent per "Checkout & Prepare" stage, merge debug, checkout and prepare steps into a single stage, increase checkout timeout
to 15m, use REFS.repo for checkout dir and update caching. fix tiflash symlink typo across releases.