### PR TITLE
ci(lib): add pod annotations helpers for kyverno labels

### DIFF
--- a/libraries/tipipeline/vars/pod_label.groovy
+++ b/libraries/tipipeline/vars/pod_label.groovy
@@ -51,7 +51,11 @@ def buildCiAnnotationsList(def refs) {
 
 def triggerUser() {
     try {
-        return getTriggerUserFromBuild(currentBuild?.rawBuild)
+        def user = getTriggerUserFromBuild(currentBuild?.rawBuild)
+        if (!user) {
+            user = env?.BUILD_USER_ID ?: env?.BUILD_USER
+        }
+        return user
     } catch (Exception e) {
         log.warning("pod_label: failed to determine trigger user: ${e.message}")
         return null


### PR DESCRIPTION
What

Add shared lib helpers to inject CI annotations into pod templates.
Support both declarative (YAML merge) and scripted (podTemplate annotations list) pipelines.
Why

Provide minimal metadata (job, refs JSON, trigger user) for Kyverno to derive labels.
Keep pipeline changes minimal while centralizing annotation logic.
Notes

No label logic in Jenkins; Kyverno handles author/org/repo/env parsing.
Safe for both declarative and scripted pipelines.

This PR is part of a paired rollout with pingcap-ci (annotations) + ee-ops (Kyverno policy); both need to be merged for labels to take effect.
https://github.com/PingCAP-QE/ee-ops/pull/1836