### PR TITLE
feat(pipelines(tidb)): add utils sidecar to br integration test pods

### DIFF
--- a/pipelines/pingcap/tidb/release-6.1/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-pull_br_integration_test.yaml
@@ -14,6 +14,16 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-pull_br_integration_test.yaml
@@ -14,6 +14,16 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-pull_br_integration_test.yaml
@@ -17,6 +17,16 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_br_integration_test.yaml
@@ -14,6 +14,16 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml
@@ -14,6 +14,16 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tidb/release-7.3/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.3/pod-pull_br_integration_test.yaml
@@ -14,6 +14,16 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tidb/release-7.4/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.4/pod-pull_br_integration_test.yaml
@@ -14,6 +14,16 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml
@@ -14,6 +14,16 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true


### PR DESCRIPTION
Add utils sidecar to br integration test pods across multiple release branches. The container provides common helper utilities and is sized with requests 256Mi memory / 100m CPU and limits 4Gi memory / 1 CPU.