### PR TITLE
ci(pipelines): enable ci label inject for all ticdc cdc jobs

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -36,7 +36,7 @@ pipeline {
             agent {
                 kubernetes {
                     namespace K8S_NAMESPACE
-                    yamlFile POD_TEMPLATE_FILE_BUILD
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
                     defaultContainer 'golang'
                 }
             }
@@ -102,7 +102,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -36,7 +36,7 @@ pipeline {
             agent {
                 kubernetes {
                     namespace K8S_NAMESPACE
-                    yamlFile POD_TEMPLATE_FILE_BUILD
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
                     defaultContainer 'golang'
                 }
             }
@@ -102,7 +102,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -36,7 +36,7 @@ pipeline {
             agent {
                 kubernetes {
                     namespace K8S_NAMESPACE
-                    yamlFile POD_TEMPLATE_FILE_BUILD
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
                     defaultContainer 'golang'
                 }
             }
@@ -100,7 +100,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -33,7 +33,7 @@ pipeline {
             agent {
                 kubernetes {
                     namespace K8S_NAMESPACE
-                    yamlFile POD_TEMPLATE_FILE_BUILD
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
                     defaultContainer 'golang'
                 }
             }
@@ -97,7 +97,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
@@ -33,7 +33,7 @@ pipeline {
             agent {
                 kubernetes {
                     namespace K8S_NAMESPACE
-                    yamlFile POD_TEMPLATE_FILE_BUILD
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
                     defaultContainer 'golang'
                 }
             }
@@ -99,7 +99,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -33,7 +33,7 @@ pipeline {
             agent {
                 kubernetes {
                     namespace K8S_NAMESPACE
-                    yamlFile POD_TEMPLATE_FILE_BUILD
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
                     defaultContainer 'golang'
                 }
             }
@@ -99,7 +99,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -36,7 +36,7 @@ pipeline {
             agent {
                 kubernetes {
                     namespace K8S_NAMESPACE
-                    yamlFile POD_TEMPLATE_FILE_BUILD
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
                     defaultContainer 'golang'
                 }
             }
@@ -102,7 +102,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -37,7 +37,7 @@ pipeline {
             agent {
                 kubernetes {
                     namespace K8S_NAMESPACE
-                    yamlFile POD_TEMPLATE_FILE_BUILD
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
                     defaultContainer 'golang'
                 }
             }
@@ -103,7 +103,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE_BUILD
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
             defaultContainer 'golang'
         }
     }
@@ -104,7 +104,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE_BUILD
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
             defaultContainer 'golang'
         }
     }
@@ -104,7 +104,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
@@ -12,7 +12,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             defaultContainer 'golang'
         }
     }
@@ -98,7 +98,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
@@ -16,7 +16,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE_BUILD
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
             defaultContainer 'golang'
         }
     }
@@ -102,7 +102,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE_BUILD
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
             defaultContainer 'golang'
         }
     }
@@ -102,7 +102,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE_BUILD
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
             defaultContainer 'golang'
         }
     }
@@ -104,7 +104,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE_BUILD
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
             defaultContainer 'golang'
         }
     }
@@ -103,7 +103,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
                     }
                 }


### PR DESCRIPTION
## What

Enable CI annotation injection for all non-next-gen ticdc CDC pipelines by switching to the proven pattern:

- `yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)`
- `yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)`

Updated 15 pipeline files:
- latest: 8 classic CDC pipelines
- release-9.0-beta: 7 classic CDC pipelines