### PR TITLE
feat(pingcap-inc/tici): update tici pull-e2e job to pre-install tiflash from OCI

### DIFF
--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -90,7 +90,7 @@ presubmits:
       spec:
         containers:
           - name: e2e
-            image: ghcr.io/pingcap-qe/ci/tici:v2025.10.12-22-g0eba311
+            image: ghcr.io/pingcap-qe/ci/tici:v2026.3.1-1-gaebccea
             command: [/bin/bash, -ce]
             env:
               - name: ASSET_DIR

--- a/prow-jobs/pingcap/tidb-operator/release-1.x-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-operator/release-1.x-presubmits.yaml
@@ -230,7 +230,7 @@ presubmits:
               - |
                 set -ex
                 [ -f hack/run-e2e-kind.sh ] || { echo "hack/run-e2e-kind.sh not found"; exit 1; }
-                exec bash ./hack/run-e2e-kind.sh --focus='DMCluster' --nodes=1 \
+                exec bash ./hack/run-e2e-kind.sh --focus='DMCluster' --nodes=2 \
                   --kind-cp-mem=8G --kind-cp-cpu=4096 --kind-wk-mem=8G --kind-wk-cpu=4096
             env:
               - name: CODECOV_TOKEN


### PR DESCRIPTION
Depends on https://github.com/PingCAP-QE/artifacts/pull/905

test result: 
https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/pingcap-inc_tici/929/pull-e2e/2028734174122217472
<img width="823" height="444" alt="image" src="https://github.com/user-attachments/assets/240859c9-2c04-49ad-9b54-d71add981e29" />
<img width="873" height="537" alt="image" src="https://github.com/user-attachments/assets/2636ecc7-67d5-4ab2-8af9-5e2ca2457dd5" />
