### PR TITLE
ci(pipelines): replace internal mirror URL for ticdc GCP jobs

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -60,7 +60,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'hub-zot.pingcap.net/mirrors/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'us-docker.pkg.dev/pingcap-testing-account/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -60,7 +60,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'hub-zot.pingcap.net/mirrors/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'us-docker.pkg.dev/pingcap-testing-account/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -58,7 +58,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'hub-zot.pingcap.net/mirrors/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'us-docker.pkg.dev/pingcap-testing-account/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -55,7 +55,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'hub-zot.pingcap.net/mirrors/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'us-docker.pkg.dev/pingcap-testing-account/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'hub-zot.pingcap.net/mirrors/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'us-docker.pkg.dev/pingcap-testing-account/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -60,7 +60,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'hub-zot.pingcap.net/mirrors/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'us-docker.pkg.dev/pingcap-testing-account/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -61,7 +61,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'hub-zot.pingcap.net/mirrors/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${REFS.org == 'pingcap-inc' ? 'us-docker.pkg.dev/pingcap-testing-account/internal' : 'us-docker.pkg.dev/pingcap-testing-account/hub'} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \


### PR DESCRIPTION
## Summary

This PR replaces the internal mirror URL `hub-zot.pingcap.net/mirrors/internal` with `us-docker.pkg.dev/pingcap-testing-account/internal` in TiCDC pipeline configurations.

## Context

The TiCDC integration test jobs run on GCP environment, but `hub-zot.pingcap.net` is an internal network address that is not accessible from GCP. This causes download failures when fetching TiDB components for `pingcap-inc` organization PRs.

## Changes

Updated 7 pipeline files in `pipelines/pingcap/ticdc/latest/`:
- `pull_cdc_kafka_integration_heavy/pipeline.groovy`
- `pull_cdc_kafka_integration_light/pipeline.groovy`
- `pull_cdc_mysql_integration_heavy/pipeline.groovy`
- `pull_cdc_mysql_integration_light/pipeline.groovy`
- `pull_cdc_pulsar_integration_light/pipeline.groovy`
- `pull_cdc_storage_integration_heavy/pipeline.groovy`
- `pull_cdc_storage_integration_light/pipeline.groovy`

## Impact

- For `pingcap-inc` organization PRs: now uses `us-docker.pkg.dev/pingcap-testing-account/internal` (accessible from GCP)
- For external contributor PRs: continues to use `us-docker.pkg.dev/pingcap-testing-account/hub` (unchanged)
- No changes to other mirror configurations (e.g., `hub-zot.pingcap.net/mirrors/hub` comments remain as documentation)

## Testing

The change only affects the OCI artifact download location. The existing CI tests should validate the functionality.