### PR TITLE
ci(tekton): extend branch regex for linux builds

### DIFF
--- a/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-community-linux.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/git-push-branch-build-community-linux.yaml
@@ -24,7 +24,7 @@ spec:
             'tikv/tikv',
             ]
             &&
-            body.ref.matches('^refs/heads/(main|master|feature/.+|release-[6-9][.][0-9]+(-beta[.][0-9]+)?|release-fts-[0-9]+)$')
+            body.ref.matches('^refs/heads/(main|master|feature/.+|release-[6-9][.][0-9]+(-beta[.][0-9]+|-[0-9]{8}-v[0-9]+[.][0-9]+[.][0-9]+)?|release-fts-[0-9]+)$')
         - name: overlays
           value:
             - key: timeout


### PR DESCRIPTION
This pull request updates the branch matching logic in the Tekton trigger configuration to support additional release branch naming patterns, specifically those that include date and version information.

**Branch filtering improvements:**

* Updated the regular expression in `git-push-branch-build-community-linux.yaml` to allow release branch names with optional date and version suffixes (e.g., `release-6.1-20240612-v6.1.0`). This makes the trigger compatible with more complex release branch naming conventions.