### PR TITLE
fix(tiflash): handle ut-build cache restore in unit test prepare

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -346,9 +346,9 @@ pipeline {
                         cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'ut-build')) {
                             // Fallback for cases where build_cache_ready was not set before this stage.
                             build_cache_ready = build_cache_ready || (sh(
-                                script: "test -x tests/.build/tiflash && echo 'true' || echo 'false'",
-                                returnStdout: true
-                            ).trim() == 'true')
+                                script: "test -x tests/.build/tiflash",
+                                returnStatus: true
+                            ) == 0)
 
                             if (build_cache_ready) {
                                 println "build cache exist, restore from cache key: ${prow.getCacheKey('binary', REFS, 'ut-build')}"


### PR DESCRIPTION
## Summary
- make `Unit Test Prepare` resilient when `build_cache_ready` was not initialized before cache restore
- detect restored ut-build content by checking `tests/.build/tiflash` inside the cache block
- use `mkdir -p tests/.build` to avoid `File exists` failure

## Why
In pull_unit_test #5456, `Unit Test Prepare` failed with `mkdir: cannot create directory 'tests/.build': File exists` after cache restore. This change makes the step idempotent and tolerant to cache state mismatches.

## Replay test
https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftiflash%2Fpull_unit_test/detail/pull_unit_test/5461/pipeline/
