### PR TITLE
ci(pipelines): centralize TiFlash layout setup

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -71,11 +71,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
@@ -79,11 +79,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -71,11 +71,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
@@ -79,11 +79,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -69,11 +69,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
@@ -76,11 +76,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
@@ -70,11 +70,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
@@ -70,11 +70,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -66,11 +66,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
@@ -76,11 +76,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
@@ -67,11 +67,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
@@ -67,11 +67,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
@@ -68,11 +68,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
@@ -78,11 +78,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -68,11 +68,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
@@ -78,11 +78,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -71,11 +71,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
@@ -79,11 +79,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -72,11 +72,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
@@ -79,11 +79,6 @@ pipeline {
                                             --etcdctl=${OCI_TAG_ETCD} \
                                             --ycsb=${OCI_TAG_YCSB} \
                                             --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-
-                                        ls -d tiflash
-                                        mv tiflash tiflash-dir
-                                        mv tiflash-dir/* .
-                                        rm -rf tiflash-dir
                                     """
                                 }
                             }

--- a/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
@@ -50,14 +50,10 @@ pipeline {
                             dir("bin") {
                                 retry(3) {
                                     sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV} --tiflash=${OCI_TAG_TIFLASH}
-                                        if [[ -d tiflash && ! -L tiflash ]]; then
-                                            mv tiflash tiflash_dir
-                                        fi
-                                        if [[ -d tiflash_dir ]]; then
-                                            rm -f tiflash
-                                            ln -s `pwd`/tiflash_dir/tiflash tiflash
-                                        fi
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                            --pd=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tiflash=${OCI_TAG_TIFLASH}
                                     """
                                 }
                             }

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -77,9 +77,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tiflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
@@ -64,9 +64,6 @@ pipeline {
                             """
                         }
                         sh '''
-                            mv tiflash tiflash_dir
-                            ln -s `pwd`/tiflash_dir/tiflash tiflash
-
                             ./tikv-server -V
                             ./tikv-worker -V
                             ./pd-server -V

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test.groovy
@@ -60,9 +60,6 @@ pipeline {
                             }
                         }
                         sh '''
-                            mv tiflash tiflash_dir
-                            ln -s `pwd`/tiflash_dir/tiflash tiflash
-
                             ./tikv-server -V
                             ./pd-server -V
                             ./tiflash --version

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
@@ -63,9 +63,6 @@ pipeline {
                         """
                     }
                     sh '''
-                        mv tiflash tiflash_dir
-                        ln -s `pwd`/tiflash_dir/tiflash tiflash
-
                         ./tikv-server -V
                         ./tikv-worker -V
                         ./pd-server -V

--- a/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
@@ -66,13 +66,6 @@ pipeline {
                                 """
                             }
                             sh '''
-                                if [[ -d tiflash && ! -L tiflash ]]; then
-                                    rm -rf tiflash_dir
-                                    mv tiflash tiflash_dir
-                                fi
-                                if [[ -f tiflash_dir/tiflash ]]; then
-                                    ln -sfn "$(pwd)/tiflash_dir/tiflash" tiflash
-                                fi
                                 ls -alh .
                                 ./tikv-server -V
                                 ./pd-server -V

--- a/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
@@ -66,9 +66,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tiflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
@@ -49,14 +49,10 @@ pipeline {
                             dir("bin") {
                                 retry(3) {
                                     sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV} --tiflash=${OCI_TAG_TIFLASH}
-                                        if [[ -d tiflash && ! -L tiflash ]]; then
-                                            mv tiflash tiflash_dir
-                                        fi
-                                        if [[ -d tiflash_dir ]]; then
-                                            rm -f tiflash
-                                            ln -s `pwd`/tiflash_dir/tiflash tiflash
-                                        fi
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                            --pd=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tiflash=${OCI_TAG_TIFLASH}
                                     """
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test.groovy
@@ -76,9 +76,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tifflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
@@ -76,9 +76,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tifflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
@@ -81,9 +81,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tifflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
@@ -76,9 +76,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tifflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
@@ -76,9 +76,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tiflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
@@ -66,9 +66,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tiflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
@@ -76,9 +76,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tiflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
@@ -66,9 +66,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tiflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
@@ -76,9 +76,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tiflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
@@ -66,9 +66,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tiflash
-
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_e2e_test.groovy
@@ -60,9 +60,6 @@ pipeline {
                             }
                         }
                         sh '''
-                            mv tiflash tiflash_dir
-                            ln -s `pwd`/tiflash_dir/tiflash tiflash
-
                             ./tikv-server -V
                             ./pd-server -V
                             ./tiflash --version

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
@@ -59,7 +59,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./ticdc_download_integration_test_binaries.sh
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
@@ -58,7 +58,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./ticdc_download_integration_test_binaries.sh
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
@@ -59,7 +59,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./ticdc_download_integration_test_binaries.sh
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
@@ -59,7 +59,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./ticdc_download_integration_test_binaries.sh
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-7.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-7.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-7.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -56,7 +56,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-7.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -56,7 +56,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-7.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-7.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-7.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-8.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-8.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-8.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-8.1
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-8.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-8.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-8.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh release-8.5
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -57,7 +57,7 @@ pipeline {
                                     # First download binary using the release branch script
                                     ./scripts/download-integration-test-binaries.sh ${REFS.base_ref}
                                     # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/lib*
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
 
                                     # Then download and replace other components with exact versions
                                     cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./

--- a/pipelines/qa/qa-release-br-integration-test.groovy
+++ b/pipelines/qa/qa-release-br-integration-test.groovy
@@ -73,8 +73,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tiflash
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/qa/qa-release-lightning-integration-test.groovy
+++ b/pipelines/qa/qa-release-lightning-integration-test.groovy
@@ -68,8 +68,6 @@ pipeline {
                             }
                         }
                         sh """
-                            mv tiflash tiflash_dir
-                            ln -s tiflash_dir/tiflash tiflash
                             ls -alh .
                             ./pd-server -V
                             ./tikv-server -V

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
@@ -53,9 +53,6 @@ pipeline {
                                     --tidb=${OCI_TAG_TIDB} \
                                     --tikv=${OCI_TAG_TIKV} \
                                     --tiflash=${OCI_TAG_TIFLASH}
-                                chmod +x tidb-server tikv-server
-                                mv tiflash tiflash_dir
-                                ln -s tiflash_dir/tiflash tiflash
                             """
                         }
                     }

--- a/scripts/artifacts/download_pingcap_oci_artifact.sh
+++ b/scripts/artifacts/download_pingcap_oci_artifact.sh
@@ -69,6 +69,27 @@ function download_and_extract_with_path() {
     echo "✅ extracted ${path_in_archive} from ${file_path} ."
 }
 
+function prepare_tiflash_layout() {
+    local extracted_dir="tiflash"
+    local normalized_dir="tiflash_dir"
+    local normalized_binary="${normalized_dir}/tiflash"
+
+    if [[ -d "${extracted_dir}" && ! -L "${extracted_dir}" ]]; then
+        rm -rf "${normalized_dir}"
+        mv -v "${extracted_dir}" "${normalized_dir}"
+    fi
+
+    if [[ ! -f "${normalized_binary}" ]]; then
+        echo "Error: expected TiFlash binary at ${normalized_binary}" >&2
+        exit 1
+    fi
+
+    chmod +x "${normalized_binary}"
+    rm -rf "${extracted_dir}"
+    ln -sfn "${normalized_binary}" "${extracted_dir}"
+    echo "✅ prepared TiFlash binary symlink layout: ${extracted_dir} -> ${normalized_binary}"
+}
+
 function compute_tag_platform_suffix() {
     local os="$(uname | tr '[:upper:]' '[:lower:]')"
     local arch="$(compute_oci_arch_suffix)"
@@ -127,7 +148,7 @@ function main() {
     if [[ -n "$TIFLASH" ]]; then
         echo "🚀 start download TiFlash"
         download_and_extract_with_path "$tiflash_oci_url" '^tiflash-v.+.tar.gz$' tiflash.tar.gz tiflash
-        chmod +x tiflash/tiflash
+        prepare_tiflash_layout
         ls -alh tiflash
         echo "🎉 download TiFlash success"
     fi

--- a/scripts/pingcap/tiflow/download_test_binaries_by_tag.sh
+++ b/scripts/pingcap/tiflow/download_test_binaries_by_tag.sh
@@ -68,11 +68,6 @@ main() {
 	(
 		cd "${BIN_DIR}"
 		"${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh" "${oci_args[@]}"
-		# Flatten tiflash directory so tiflash binary is directly in bin/
-		if [ -d tiflash ]; then
-			mv tiflash/* .
-			rm -rf tiflash
-		fi
 	)
 
 	log_green "Download SUCCESS"

--- a/scripts/pingcap/tiflow/release-6.1/ticdc_download_integration_test_binaries.sh
+++ b/scripts/pingcap/tiflow/release-6.1/ticdc_download_integration_test_binaries.sh
@@ -47,12 +47,6 @@ cd third_bin
 --ycsb="${YCSB_VERSION}" \
 --etcdctl="${ETCD_VERSION}" \
 --sync-diff-inspector="${SYNC_DIFF_VERSION}"
-
-# Flatten tiflash directory so tiflash binary is directly accessible
-if [ -d tiflash ]; then
-mv tiflash/* .
-rm -rf tiflash
-fi
 )
 
 # jq - download from GitHub releases

--- a/scripts/pingcap/tiflow/release-6.5-fips/ticdc_download_integration_test_binaries.sh
+++ b/scripts/pingcap/tiflow/release-6.5-fips/ticdc_download_integration_test_binaries.sh
@@ -49,12 +49,6 @@ color-green "Download binaries..."
         --ycsb="${YCSB_VERSION}" \
         --etcdctl="${ETCD_VERSION}" \
         --sync-diff-inspector="${SYNC_DIFF_VERSION}"
-
-    # Flatten tiflash directory so tiflash binary is directly accessible
-    if [ -d tiflash ]; then
-        mv tiflash/* .
-        rm -rf tiflash
-    fi
 )
 
 # jq - download from GitHub releases

--- a/scripts/pingcap/tiflow/release-6.5/ticdc_download_integration_test_binaries.sh
+++ b/scripts/pingcap/tiflow/release-6.5/ticdc_download_integration_test_binaries.sh
@@ -47,12 +47,6 @@ cd third_bin
 --ycsb="${YCSB_VERSION}" \
 --etcdctl="${ETCD_VERSION}" \
 --sync-diff-inspector="${SYNC_DIFF_VERSION}"
-
-# Flatten tiflash directory so tiflash binary is directly accessible
-if [ -d tiflash ]; then
-mv tiflash/* .
-rm -rf tiflash
-fi
 )
 
 # jq - download from GitHub releases

--- a/scripts/pingcap/tiflow/ticdc_integration_test_download_dependency.sh
+++ b/scripts/pingcap/tiflow/ticdc_integration_test_download_dependency.sh
@@ -63,12 +63,6 @@ function main() {
             --minio="${MINIO_VERSION}" \
             --ycsb="${YCSB_VERSION}" \
             --etcdctl="${ETCD_VERSION}"
-
-        # Flatten tiflash directory so tiflash binary is directly in third_bin/
-        if [ -d tiflash ]; then
-            mv tiflash/* .
-            rm -rf tiflash
-        fi
     )
 
     chmod a+x third_bin/*


### PR DESCRIPTION
Add prepare_tiflash_layout() to
scripts/artifacts/download_pingcap_oci_artifact.sh and remove ad-hoc tiflash flattening from multiple pipelines and helper scripts.
Normalize TiFlash binary layout to tiflash_dir/tiflash and create a symlink at tiflash.