### PR TITLE
fix(tiflow): Checkout base SHA for previous build

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
@@ -72,9 +72,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
@@ -72,9 +72,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
@@ -72,9 +72,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
@@ -32,7 +32,7 @@ pipeline {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -31,7 +31,7 @@ pipeline {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -31,7 +31,7 @@ pipeline {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -31,7 +31,7 @@ pipeline {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -31,7 +31,7 @@ pipeline {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
@@ -56,7 +56,7 @@ pipeline {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_ref}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -56,7 +56,7 @@ pipeline {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
                         retry(2) {
                             script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
@@ -71,9 +71,7 @@ pipeline {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
-                                git fetch origin ${REFS.base_ref}:local
-                                git checkout local
-                                git rev-parse HEAD
+                                git checkout ${REFS.base_sha}
                                 make dm_integration_test_build
                                 mv bin/dm-master.test bin/dm-master.test.previous
                                 mv bin/dm-worker.test bin/dm-worker.test.previous


### PR DESCRIPTION
Remove credentialsId from prow.checkoutRefs in release-8.5 pipelines and rely on default checkout credentials