### PR TITLE
fix(tools, prow-jobs): fix test issue reopen problem

### DIFF
--- a/prow-jobs/pingcap-qe/ci/periodics.yaml
+++ b/prow-jobs/pingcap-qe/ci/periodics.yaml
@@ -28,7 +28,7 @@ periodics:
   - name: periodic-reporter-flaky-tests-tidb
     decorate: true # need add this.
     cron: "0 6 * * 5" # Run weekly at 14:00 UTC+8 (which is 6:00 UTC) every Friday
-    hidden: true
+    # hidden: true
     spec:
       activeDeadlineSeconds: 300
       containers:
@@ -53,10 +53,7 @@ periodics:
                 --to ${end_date} \
                 --threshold-ms ${PARAM_CASE_THRESHOLD_MS} \
                 --db-url=${PARAM_DSN} \
-                --issue-create \
-                --issue-reopen \
-                --issue-comment \
-                --issue-labels "${PARAM_ISSUE_LABELS}" \
+                $PARAM_ISSUE_OPS_OPTIONS --issue-labels "${PARAM_ISSUE_LABELS}" \
                 --email-to="${PARAM_EMAIL_TO}" \
                 --email-cc="${PARAM_EMAIL_CC}" \
                 --email-from="${SMTP_USER}" \
@@ -68,6 +65,8 @@ periodics:
               value: master
             - name: PARAM_CASE_THRESHOLD_MS
               value: "100000"
+            - name: PARAM_ISSUE_OPS_OPTIONS
+              value: --issue-create --issue-reopen --issue-comment
             - name: PARAM_ISSUE_LABELS
               value: "component/test,flaky-test,severity/critical"
             - name: PARAM_DSN
@@ -119,7 +118,7 @@ periodics:
   - name: periodic-reporter-flaky-tests-tidb-v85
     decorate: true # need add this.
     cron: "0 6 * * 5" # Run weekly at 14:00 UTC+8 (which is 6:00 UTC) every Friday
-    hidden: true
+    # hidden: true
     spec:
       activeDeadlineSeconds: 300
       containers:
@@ -131,6 +130,8 @@ periodics:
               value: release-8.5
             - name: PARAM_CASE_THRESHOLD_MS
               value: "100000"
+            - name: PARAM_ISSUE_OPS_OPTIONS
+              value: --issue-comment
             - name: PARAM_ISSUE_LABELS
               value: "component/test,flaky-test,severity/critical,affects-8.5"
             - name: PARAM_DSN

--- a/tools/reporters/ci/flaky-tests/core/GithubIssueManager.test.ts
+++ b/tools/reporters/ci/flaky-tests/core/GithubIssueManager.test.ts
@@ -1,0 +1,121 @@
+import { assertEquals } from "@std/assert";
+import { GithubIssueManager } from "./GithubIssueManager.ts";
+import type { CaseAgg, ReportData } from "./types.ts";
+
+type TestIssue = {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  html_url: string;
+  closed_at?: string | null;
+};
+
+function buildReport(): ReportData {
+  return {
+    window: { from: "2026-03-06", to: "2026-03-13", thresholdMs: 1000 },
+    summary: {
+      repos: 1,
+      suites: 1,
+      cases: 1,
+      flakyCases: 1,
+      thresholdedCases: 1,
+    },
+    byTeam: [],
+    bySuite: [],
+    byCase: [],
+    topFlakyCases: [],
+  };
+}
+
+function buildCase(): CaseAgg {
+  return {
+    repo: "pingcap/tidb",
+    branch: "main",
+    suite_name: "pkg/executor",
+    case_name: "TestFlakyCase",
+    flakyCount: 3,
+    thresholdedCount: 1,
+    owner: "@test-owner",
+  };
+}
+
+function createManager(client: object): GithubIssueManager {
+  const manager = new GithubIssueManager({
+    token: "test-token",
+    allowCreate: false,
+    allowReopen: true,
+    allowComment: false,
+    dryRun: false,
+    labels: [],
+    now: () => new Date("2026-03-13T12:00:00Z"),
+    verbose: false,
+  });
+  Object.defineProperty(manager, "client", {
+    value: client,
+    configurable: true,
+    writable: true,
+  });
+  return manager;
+}
+
+Deno.test("GithubIssueManager.sync reopens issues closed at least 10 days ago", async () => {
+  const issue: TestIssue = {
+    number: 123,
+    title: "Flaky test: TestFlakyCase in pkg/executor",
+    state: "closed",
+    html_url: "https://github.com/pingcap/tidb/issues/123",
+    closed_at: "2026-03-03T12:00:00Z",
+  };
+  let reopenCalls = 0;
+  const manager = createManager({
+    searchIssues: async () => [issue],
+    reopenIssue: async () => {
+      reopenCalls += 1;
+      return {
+        ...issue,
+        state: "open",
+        closed_at: null,
+      };
+    },
+  });
+  const report = buildReport();
+  const flakyCase = buildCase();
+
+  await manager.sync(report, [flakyCase], [flakyCase]);
+
+  assertEquals(reopenCalls, 1);
+  assertEquals(flakyCase.issue?.status, "reopened");
+  assertEquals(flakyCase.issue?.state, "open");
+  assertEquals(flakyCase.issue?.number, 123);
+});
+
+Deno.test("GithubIssueManager.sync keeps recently closed issues closed", async () => {
+  const issue: TestIssue = {
+    number: 456,
+    title: "Flaky test: TestFlakyCase in pkg/executor",
+    state: "closed",
+    html_url: "https://github.com/pingcap/tidb/issues/456",
+    closed_at: "2026-03-04T12:00:01Z",
+  };
+  let reopenCalls = 0;
+  const manager = createManager({
+    searchIssues: async () => [issue],
+    reopenIssue: async () => {
+      reopenCalls += 1;
+      return issue;
+    },
+  });
+  const report = buildReport();
+  const flakyCase = buildCase();
+
+  await manager.sync(report, [flakyCase], [flakyCase]);
+
+  assertEquals(reopenCalls, 0);
+  assertEquals(flakyCase.issue?.status, "closed");
+  assertEquals(flakyCase.issue?.state, "closed");
+  assertEquals(flakyCase.issue?.number, 456);
+  assertEquals(
+    flakyCase.issue?.note,
+    "skip reopen: issue closed less than 10 days ago",
+  );
+});

--- a/tools/reporters/ci/flaky-tests/core/GithubIssueManager.ts
+++ b/tools/reporters/ci/flaky-tests/core/GithubIssueManager.ts
@@ -1,5 +1,15 @@
-import { buildIssueBody, buildIssueComment, buildIssueTitle, parseRepo } from "./IssueUtils.ts";
-import type { CaseAgg, GithubIssueInfo, GithubIssueStatus, ReportData } from "./types.ts";
+import {
+  buildIssueBody,
+  buildIssueComment,
+  buildIssueTitle,
+  parseRepo,
+} from "./IssueUtils.ts";
+import type {
+  CaseAgg,
+  GithubIssueInfo,
+  GithubIssueStatus,
+  ReportData,
+} from "./types.ts";
 
 interface IssueManagerOptions {
   token?: string;
@@ -10,6 +20,7 @@ interface IssueManagerOptions {
   labels: string[];
   repoOverride?: string;
   titleIncludesRepo?: boolean;
+  now?: () => Date;
   verbose?: boolean;
 }
 
@@ -18,7 +29,11 @@ interface GitHubIssueApi {
   title: string;
   state: "open" | "closed";
   html_url: string;
+  closed_at?: string | null;
 }
+
+const ISSUE_REOPEN_MIN_CLOSED_AGE_DAYS = 10;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 class GitHubClient {
   constructor(
@@ -31,11 +46,13 @@ class GitHubClient {
     repo: string,
     title: string,
   ): Promise<GitHubIssueApi[]> {
-    const queryTitle = title.replaceAll('"', "\\\"");
+    const queryTitle = title.replaceAll('"', '\\"');
     const query = `repo:${owner}/${repo} is:issue in:title \"${queryTitle}\"`;
-    const url = `https://api.github.com/search/issues?q=${encodeURIComponent(query)}`;
-    const res = await this.request("GET", url);
-    const items = Array.isArray(res?.items) ? res.items : [];
+    const url = `https://api.github.com/search/issues?q=${
+      encodeURIComponent(query)
+    }`;
+    const res = await this.request("GET", url) as { items?: GitHubIssueApi[] };
+    const items = Array.isArray(res.items) ? res.items : [];
     return items
       .filter((i: GitHubIssueApi) => i && i.title)
       .map((i: GitHubIssueApi) => ({
@@ -43,6 +60,7 @@ class GitHubClient {
         title: i.title,
         state: i.state,
         html_url: i.html_url,
+        closed_at: i.closed_at,
       }));
   }
 
@@ -52,7 +70,9 @@ class GitHubClient {
     title: string,
     body: string,
   ): Promise<GitHubIssueApi> {
-    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues`;
+    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${
+      encodeURIComponent(repo)
+    }/issues`;
     const res = await this.request("POST", url, {
       title,
       body,
@@ -66,7 +86,9 @@ class GitHubClient {
     repo: string,
     issueNumber: number,
   ): Promise<GitHubIssueApi> {
-    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${issueNumber}`;
+    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${
+      encodeURIComponent(repo)
+    }/issues/${issueNumber}`;
     const res = await this.request("PATCH", url, { state: "open" });
     return res as GitHubIssueApi;
   }
@@ -78,7 +100,9 @@ class GitHubClient {
     labels: string[],
   ): Promise<void> {
     if (!labels || labels.length === 0) return;
-    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${issueNumber}/labels`;
+    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${
+      encodeURIComponent(repo)
+    }/issues/${issueNumber}/labels`;
     await this.request("POST", url, { labels });
   }
 
@@ -88,7 +112,9 @@ class GitHubClient {
     issueNumber: number,
     body: string,
   ): Promise<void> {
-    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${issueNumber}/comments`;
+    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${
+      encodeURIComponent(repo)
+    }/issues/${issueNumber}/comments`;
     await this.request("POST", url, { body });
   }
 
@@ -170,6 +196,7 @@ export class GithubIssueManager {
   private readonly labels: string[];
   private readonly repoOverride?: string;
   private readonly titleIncludesRepo: boolean;
+  private readonly now: () => Date;
   private readonly verbose: boolean;
 
   constructor(opts: IssueManagerOptions) {
@@ -184,6 +211,7 @@ export class GithubIssueManager {
     this.labels = opts.labels ?? [];
     this.repoOverride = opts.repoOverride;
     this.titleIncludesRepo = !!opts.titleIncludesRepo;
+    this.now = opts.now ?? (() => new Date());
     this.verbose = !!opts.verbose;
   }
 
@@ -267,25 +295,32 @@ export class GithubIssueManager {
       return;
     }
 
-    const title = buildIssueTitle(sample, { includeRepo: this.titleIncludesRepo });
+    const title = buildIssueTitle(sample, {
+      includeRepo: this.titleIncludesRepo,
+    });
     const { owner, repo } = parsed;
 
     let issue: GitHubIssueApi | null = null;
     let status: GithubIssueStatus = "missing";
     let created = false;
+    let note: string | undefined;
 
     try {
       issue = await this.findBestIssue(owner, repo, title);
       if (issue?.state === "open") {
         status = "open";
       } else if (issue?.state === "closed") {
-        if (this.allowReopen && canMutate) {
+        const reopenCheck = this.allowReopen && canMutate
+          ? this.checkReopenEligibility(issue)
+          : { eligible: false, note: undefined };
+        if (reopenCheck.eligible) {
           status = "reopened";
           if (!this.dryRun) {
             issue = await this.client!.reopenIssue(owner, repo, issue.number);
           }
         } else {
           status = "closed";
+          note = reopenCheck.note;
         }
       } else {
         if (this.allowCreate && canMutate) {
@@ -314,7 +349,7 @@ export class GithubIssueManager {
       return;
     }
 
-    const info = this.buildIssueInfo(issueRepo, issue, status);
+    const info = this.buildIssueInfo(issueRepo, issue, status, note);
     if (this.dryRun && canMutate) info.dryRun = true;
 
     for (const c of group) {
@@ -327,7 +362,9 @@ export class GithubIssueManager {
       if (this.dryRun) {
         if (this.verbose) {
           console.debug(
-            `[github] dryrun labels: ${issueRepo}#${issue.number} -> ${this.labels.join(",")}`,
+            `[github] dryrun labels: ${issueRepo}#${issue.number} -> ${
+              this.labels.join(",")
+            }`,
           );
         }
       } else {
@@ -340,8 +377,8 @@ export class GithubIssueManager {
       }
     }
 
-    const shouldComment =
-      this.allowComment && !created && issue.state === "open" &&
+    const shouldComment = this.allowComment && !created &&
+      issue.state === "open" &&
       this.allowCommentForStatus(status);
 
     if (!shouldComment) return;
@@ -380,7 +417,9 @@ export class GithubIssueManager {
     if (!issues || issues.length === 0) return null;
 
     const normalizedTitle = this.normalizeTitle(title);
-    const exact = issues.filter((i) => this.normalizeTitle(i.title) === normalizedTitle);
+    const exact = issues.filter((i) =>
+      this.normalizeTitle(i.title) === normalizedTitle
+    );
     const candidates = exact.length > 0 ? exact : issues;
 
     const open = candidates.find((i) => i.state === "open");
@@ -393,10 +432,48 @@ export class GithubIssueManager {
     return title.trim().replace(/\s+/g, " ").toLowerCase();
   }
 
+  private checkReopenEligibility(
+    issue: GitHubIssueApi,
+  ): { eligible: boolean; note?: string } {
+    const closedAt = this.parseClosedAt(issue.closed_at);
+    if (!closedAt) {
+      return {
+        eligible: false,
+        note: "skip reopen: missing closed_at timestamp",
+      };
+    }
+
+    const ageMs = this.now().getTime() - closedAt.getTime();
+    if (!Number.isFinite(ageMs) || ageMs < 0) {
+      return {
+        eligible: false,
+        note: `skip reopen: invalid closed_at timestamp ${issue.closed_at}`,
+      };
+    }
+
+    if (ageMs < ISSUE_REOPEN_MIN_CLOSED_AGE_DAYS * DAY_MS) {
+      return {
+        eligible: false,
+        note:
+          `skip reopen: issue closed less than ${ISSUE_REOPEN_MIN_CLOSED_AGE_DAYS} days ago`,
+      };
+    }
+
+    return { eligible: true };
+  }
+
+  private parseClosedAt(value?: string | null): Date | null {
+    if (!value) return null;
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return null;
+    return parsed;
+  }
+
   private buildIssueInfo(
     repo: string,
     issue: GitHubIssueApi | null,
     status: GithubIssueStatus,
+    note?: string,
   ): GithubIssueInfo {
     return {
       repo,
@@ -404,6 +481,7 @@ export class GithubIssueManager {
       url: issue?.html_url,
       state: issue?.state,
       status,
+      note,
     };
   }
 }

--- a/tools/reporters/ci/flaky-tests/docs/README.md
+++ b/tools/reporters/ci/flaky-tests/docs/README.md
@@ -114,7 +114,7 @@ Required permissions:
 - --issue-create
   - Enable creating new GitHub issues (default false).
 - --issue-reopen
-  - Enable reopening closed GitHub issues (default false).
+  - Enable reopening closed GitHub issues only when they were closed at least 10 days ago (default false).
 - --issue-comment
   - Enable adding comments to open/reopened issues (default false).
 - --issue-mutation-limit
@@ -179,7 +179,7 @@ Defaults:
 ## GitHub issue integration
 
 - When a GitHub token is provided, the reporter searches issues by title (branch is not part of the title).
-- New issues are created only with `--issue-create`; closed issues are reopened only with `--issue-reopen`.
+- New issues are created only with `--issue-create`; closed issues are reopened only with `--issue-reopen` and only after they have been closed for at least 10 days.
 - The configured labels are applied to any matched/created issue.
 - For open or reopened issues, a comment is appended with the current window’s stats only when `--issue-comment` is enabled.
 - New issues set the issue type to `Task` (silently dropped if not permitted by GitHub).


### PR DESCRIPTION
This pull request introduces a safeguard to the GitHub issue management logic for flaky test reporting: closed issues will now only be reopened if they have been closed for at least 10 days. The changes are implemented in both the application logic and the documentation, and new tests are added to ensure correct behavior. There are also some refactorings and minor improvements for clarity and maintainability.

**Flaky Test Reporter: GitHub Issue Management**

*New Reopen Policy & Logic:*
- Introduced a minimum closed age threshold (10 days) before a closed issue can be reopened, preventing premature reopenings. The logic is encapsulated in a new method, and a note is attached to cases where reopening is skipped. [[1]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aR32-R37) [[2]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL270-R323) [[3]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aR435-R484)
- Added an optional `now` parameter to the `GithubIssueManager` for testability and improved time handling. [[1]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aR23) [[2]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aR199) [[3]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aR214)

*Testing:*
- Added comprehensive tests for the new reopen policy, verifying that only issues closed for at least 10 days are reopened and others are left closed with an explanatory note. (`GithubIssueManager.test.ts`)

*Documentation:*
- Updated documentation to clarify that `--issue-reopen` only allows reopening issues closed for at least 10 days, both in the permissions and behavior sections. [[1]](diffhunk://#diff-e162c65e3a6c93d06a8c86af46500b96320812261d3c0f17d3f47911558a2b72L117-R117) [[2]](diffhunk://#diff-e162c65e3a6c93d06a8c86af46500b96320812261d3c0f17d3f47911558a2b72L182-R182)

*Job Configuration:*
- Refactored periodic job configs to use a new `PARAM_ISSUE_OPS_OPTIONS` environment variable for issue operation flags, improving flexibility in how issue operations are enabled per job. [[1]](diffhunk://#diff-627e88a7426360b8626ef9a0002f3558221924cb7e816f08afa52255839473d7L56-R56) [[2]](diffhunk://#diff-627e88a7426360b8626ef9a0002f3558221924cb7e816f08afa52255839473d7R68-R69) [[3]](diffhunk://#diff-627e88a7426360b8626ef9a0002f3558221924cb7e816f08afa52255839473d7R133-R134)
- Unhid two periodic reporter jobs by commenting out the `hidden: true` line, making them visible in the job dashboard. [[1]](diffhunk://#diff-627e88a7426360b8626ef9a0002f3558221924cb7e816f08afa52255839473d7L31-R31) [[2]](diffhunk://#diff-627e88a7426360b8626ef9a0002f3558221924cb7e816f08afa52255839473d7L122-R121)

*Minor Refactoring:*
- Improved code formatting and type annotations in `GithubIssueManager.ts` for readability and maintainability. [[1]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL1-R12) [[2]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL34-R63) [[3]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL55-R75) [[4]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL69-R91) [[5]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL81-R105) [[6]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL91-R117) [[7]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL317-R352) [[8]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL330-R367) [[9]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL343-R381) [[10]](diffhunk://#diff-bbf5b1e359b7ef42a9547f82763bbd291bf9880f90c43763a059ab1300291b5aL383-R422)