### PR TITLE
fix(tidb/release-8.5): port latest BR prepare flow and remove stage timeout

### DIFF
--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -36,7 +36,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir(REFS.repo) {
                     cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {


### PR DESCRIPTION
## Summary

Port the `latest` BR pull integration pipeline prepare implementation into `release-8.5`, then remove an incompatible stage timeout that caused replay failures on release artifacts.

## Root cause

After porting the `latest` prepare flow, `release-8.5` also inherited:

- `options { timeout(time: 15, unit: 'MINUTES') }` on `Checkout & Prepare`

For `release-8.5`, artifact download can take longer. During replay, Jenkins terminated the download step with:

- `script returned exit code 143`
- `Timeout has been exceeded`

## What changed

1. Ported prepare implementation from `pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy` into `release-8.5`:
- download components directly under `tidb/bin`
- cache workspace with `ws/${BUILD_TAG}` and `rev-${REFS.pulls[0].sha}` marker

2. Removed the 15-minute stage timeout from `Checkout & Prepare` in `release-8.5` to avoid premature termination of artifact download.

## Verification

- Replay reference (passed):
https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftidb%2Frelease-8.5%2Fpull_br_integration_test/detail/pull_br_integration_test/2037/pipeline/
