### PR TITLE
feat(pipelines) migrate tidb release-8.5 pull_build to GCP 

### DIFF
--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_build.yaml
@@ -5,26 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12320241009"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
+        requests:
+          cpu: "8"
+          memory: 24Gi
+          ephemeral-storage: 50Gi
         limits:
           memory: 64Gi
           cpu: "16"
+          ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc # migration: keep
           mountPath: /data/
           readOnly: true
@@ -37,22 +36,11 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:
@@ -81,3 +69,10 @@ spec:
                 operator: In
                 values:
                   - amd64
+  nodeSelector:
+    ee-bigdisk: "true"
+  tolerations:
+    - key: ee-bigdisk
+      operator: Equal
+      value: "true"
+      effect: NoSchedule

--- a/prow-jobs/pingcap-inc/tidb/release-presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tidb/release-presubmits.yaml
@@ -24,6 +24,8 @@ presubmits:
       context: pull-build
       trigger: "(?m)^/test (?:.*? )?build(?: .*?)?$"
       rerun_command: "/test build"
+      labels:
+        master: "1" # run on GCP
 
     - <<: [*jenkins_job, *brancher]
       name: pingcap-inc/tidb/release-8.5/pull_check


### PR DESCRIPTION
## Summary
Migrate `pingcap-inc/tidb/release-8.5/pull_build` to GCP runtime path and align Bazel pod config with the validated setup.

verify by https://prow.tidb.net/jenkins/job/pingcap-inc/job/tidb/job/release-8.5/job/pull_build/12/
https://prow.tidb.net/jenkins/job/pingcap-inc/job/tidb/job/release-8.5/job/pull_build/14/