### PR TITLE
chore(Jenkins) temp hotfix cache

### DIFF
--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_build.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_build.groovy
@@ -37,6 +37,24 @@ pipeline {
             }
         }
 
+        stage("Hotfix deps URL (temporary CI workaround)") {
+            steps {
+                dir(REFS.repo) {
+                    sh '''
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i '/bazel-cache\\.pingcap\\.net:8080/d' "$f"
+                      sed -i '/ats\\.apps\\.svc/d' "$f"
+                      sed -i '/cache\\.hawkingrei\\.com/d' "$f"
+                      sed -i '/mirror\\.bazel\\.build/d' "$f"
+                    done
+                    grep -nE 'bazel-cache\\.pingcap\\.net:8080|ats\\.apps\\.svc|cache\\.hawkingrei\\.com|mirror\\.bazel\\.build' WORKSPACE DEPS.bzl || true
+                    '''
+                }
+            }
+        }
+
         stage("Build tidb-server community edition"){
             steps {
                 dir(REFS.repo) {


### PR DESCRIPTION
temp hotfix cache, remove deprecate bazel hard code in source code
will remove after pingcap-inc/tidb code fixed