### PR TITLE
feat: update go1.25.8 toolchain pin for tiflow/ticdc unit jobs

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.15-1-g5625431-go1.25"
       tty: true
       resources:
         requests:

--- a/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
@@ -103,7 +103,7 @@ presubmits:
       spec:
         containers:
           - name: check
-            image: &image ghcr.io/pingcap-qe/ci/base:v2025.12.7-3-g1c0b8cf-go1.25
+            image: &image ghcr.io/pingcap-qe/ci/base:v2026.3.15-1-g5625431-go1.25
             command: [bash, -ce]
             args:
               - |

--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -150,7 +150,7 @@ presubmits:
       spec:
         containers:
           - name: check
-            image: &image ghcr.io/pingcap-qe/ci/base:v2025.12.7-3-g1c0b8cf-go1.25
+            image: &image ghcr.io/pingcap-qe/ci/base:v2026.3.15-1-g5625431-go1.25
             command: [bash, -ce]
             args:
               - |

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
       spec:
         containers:
           - name: cdc-unit-test
-            image: ghcr.io/pingcap-qe/ci/base:v2026.3.8-1-g9d412f4-go1.25
+            image: ghcr.io/pingcap-qe/ci/base:v2026.3.15-1-g5625431-go1.25
             command: [bash, -ce]
             args:
               - |


### PR DESCRIPTION
## Summary
This PR update image to mix Go patch toolchain artifacts (`go1.25.8` vs older `go tool`) that cause compile failures in PR jobs.

## Why
Some jobs are still running in environments/images that are not fully aligned to Go `1.25.8`, while repo-side changes already pull `1.25.8` artifacts. This can trigger errors like:

```text
compile: version "go1.25.8" does not match go tool version "go1.25.x"
```
## replay test

https://github.com/pingcap/ticdc/pull/4467

- https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/pingcap_ticdc/4467/pull-unit-test/2034863608625631232
- https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/pingcap_ticdc/4467/pull-unit-test/2034863608625631232

https://github.com/pingcap/tiflow/pull/12560

- https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/pingcap_tiflow/12560/pull-unit-test-cdc/2034866305454051328
- https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftiflow%2Fghpr_verify/detail/ghpr_verify/4500/pipeline/