### PR TITLE
fix(yaml) tidb/release-8.1 move utils sidecar from volumes to containers in ghpr_check2 pod

### DIFF
--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
@@ -38,6 +38,16 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +87,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
fix yaml format
Fix the pod template used by `pingcap/tidb/release-8.1/ghpr_check2` by moving the `utils` sidecar definition from `spec.volumes` to `spec.containers`.
