### PR TITLE
fix(Jenkins yaml) move utils sidecar from volumes to containers in ghpr_check2 pod

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-periodics_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-periodics_integration_test.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check2.yaml
@@ -26,13 +26,6 @@ spec:
           mountPath: /share/.cache/go-build
         - name: gopathcache
           mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
@@ -43,6 +36,14 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+
+  volumes:
+    - name: gopathcache
+      persistentVolumeClaim:
+        claimName: gopathcache
+    - name: gocache
+      persistentVolumeClaim:
+        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.1/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-pull_integration_binlog_test.yaml
@@ -73,10 +73,6 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-  volumes:
-    - emptyDir:
-        medium: Memory
-      name: volume-0
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
@@ -87,6 +83,11 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+
+  volumes:
+    - emptyDir:
+        medium: Memory
+      name: volume-0
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check2.yaml
@@ -44,6 +44,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -80,16 +91,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check2.yaml
@@ -44,6 +44,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -80,16 +91,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check2.yaml
@@ -44,6 +44,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -80,16 +91,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pod-ghpr_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/pod-ghpr_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_binlog_test.yaml
@@ -73,10 +73,6 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-  volumes:
-    - emptyDir:
-        medium: Memory
-      name: volume-0
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
@@ -87,6 +83,11 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+
+  volumes:
+    - emptyDir:
+        medium: Memory
+      name: volume-0
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml
@@ -41,6 +41,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-7.0/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.0/pod-ghpr_check2.yaml
@@ -36,6 +36,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -72,16 +83,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_binlog_test.yaml
@@ -73,10 +73,6 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-  volumes:
-    - emptyDir:
-        medium: Memory
-      name: volume-0
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
@@ -87,6 +83,11 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+
+  volumes:
+    - emptyDir:
+        medium: Memory
+      name: volume-0
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-7.2/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.2/pod-ghpr_check2.yaml
@@ -41,6 +41,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-7.3/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.3/pod-ghpr_check2.yaml
@@ -41,6 +41,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-7.4/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.4/pod-ghpr_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_binlog_test.yaml
@@ -60,10 +60,6 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-  volumes:
-    - emptyDir:
-        medium: Memory
-      name: volume-0
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
@@ -74,6 +70,11 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+
+  volumes:
+    - emptyDir:
+        medium: Memory
+      name: volume-0
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-7.6/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.6/pod-ghpr_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.0/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.0/pod-ghpr_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_binlog_test.yaml
@@ -60,10 +60,6 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-  volumes:
-    - emptyDir:
-        medium: Memory
-      name: volume-0
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
@@ -74,6 +70,11 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+
+  volumes:
+    - emptyDir:
+        medium: Memory
+      name: volume-0
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.2/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.2/pod-pull_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.3/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.3/pod-pull_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.4/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.4/pod-pull_check2.yaml
@@ -38,6 +38,17 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+
   volumes:
     - name: gopathcache
       persistentVolumeClaim:
@@ -77,16 +88,6 @@ spec:
             resourceFieldRef:
               containerName: golang
               resource: requests.memory
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      tty: true
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 100m
-        limits:
-          cpu: "1"
-          memory: 4Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Some tidb pod templates incorrectly defined the `utils` sidecar under `spec.volumes`
(with container-only fields like image/tty/resources), which breaks pod deserialization
in Jenkins/Fabric8 (e.g. ImageVolumeSource parse errors).

This change moves the `utils` block to `spec.containers` across affected templates,
including release-7.5/release-8.1 ghpr_check2 and other similarly affected pod files.