### PR TITLE
fix(pipelines): make tiflash release-8.5 ut cache prepare idempotent

### DIFF
--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -305,6 +305,12 @@ pipeline {
                             chown -R 1000:1000 ./
                         """
                         cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'ut-build')) {
+                            // Fallback for cases where build_cache_ready was not set before this stage.
+                            build_cache_ready = build_cache_ready || (sh(
+                                script: "test -x tests/.build/tiflash",
+                                returnStatus: true
+                            ) == 0)
+
                             if (build_cache_ready) {
                                 println "build cache exist, restore from cache key: ${prow.getCacheKey('binary', REFS, 'ut-build')}"
                                 sh """
@@ -317,7 +323,7 @@ pipeline {
                                 sh label: "clean git repo", script: """
                                 git status
                                 git show --oneline -s
-                                mkdir tests/.build
+                                mkdir -p tests/.build
                                 cp -r ${WORKSPACE}/install/* tests/.build/
                                 rm -rf .git
                                 rm -rf contrib


### PR DESCRIPTION
## Summary
- backport the `build_cache_ready` fallback check used in `latest` to `release-8.5` pull_unit_test pipeline
- make `tests/.build` creation idempotent by changing `mkdir tests/.build` to `mkdir -p tests/.build`

## Root Cause
In `release-8.5` pull_unit_test, `build_cache_ready` may remain `false` when cache is restored, so the script enters the cache-miss branch and runs `mkdir tests/.build`. If the directory already exists from restored cache, the stage fails with `File exists`.

## Replay Test
- https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftiflash%2Frelease-8.5%2Fpull_unit_test/detail/pull_unit_test/356/pipeline/