### PR TITLE
ci(build-common): increase tikv build timeout to 300 minutes

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/build-common.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/build-common.groovy
@@ -970,8 +970,9 @@ def run_with_pod(String builder, Closure body) {
 }
 
 try {
+    def buildTimeoutMinutes = (PRODUCT == "tikv") ? 300 : 180
     stage("Build ${PRODUCT}") {
-        timeout(time: 180, unit: 'MINUTES') {
+        timeout(time: buildTimeoutMinutes, unit: 'MINUTES') {
             if (!ifFileCacheExists()) {
                 if (params.BUILDER_IMG && params.OS=="linux"){
                     run_with_pod(params.BUILDER_IMG,{


### PR DESCRIPTION
## Background
- recent devbuilds for TiKV hit the 180-minute limit and were aborted

## What changed
- make build timeout dynamic in `build-common`
- set timeout to `300` minutes when `PRODUCT == "tikv"`
- keep timeout at `180` minutes for other products