### PR TITLE
fix(pipelines): stop exposing github token to PR jobs (6.1-9.0beta)

### DIFF
--- a/pipelines/pingcap/tidb/release-6.1/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_common_test.groovy
@@ -18,9 +18,6 @@ pipeline {
             defaultContainer 'golang'
         }
     }
-    environment {
-        GITHUB_TOKEN = credentials('github-bot-token')
-    }
     options {
         timeout(time: 40, unit: 'MINUTES')
         parallelsAlwaysFailFast()

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_binlog_test.groovy
@@ -22,7 +22,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_common_test.groovy
@@ -22,7 +22,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_copr_test.groovy
@@ -22,7 +22,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_ddl_test.groovy
@@ -22,7 +22,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_mysql_test.groovy
@@ -22,7 +22,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_common_test.groovy
@@ -16,9 +16,6 @@ pipeline {
             defaultContainer 'golang'
         }
     }
-    environment {
-        GITHUB_TOKEN = credentials('github-bot-token')
-    }
     options {
         timeout(time: 40, unit: 'MINUTES')
         parallelsAlwaysFailFast()

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
@@ -20,7 +20,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_copr_test.groovy
@@ -20,7 +20,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
@@ -21,7 +21,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
@@ -20,7 +20,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_tidb_tools_test.groovy
@@ -21,7 +21,6 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
-        GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_mysql_client_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_mysql_client_test.groovy
@@ -17,9 +17,6 @@ pipeline {
             defaultContainer 'golang'
         }
     }
-    environment {
-        GITHUB_TOKEN = credentials('github-bot-token')
-    }
     options {
         timeout(time: 40, unit: 'MINUTES')
         parallelsAlwaysFailFast()


### PR DESCRIPTION
    ## Summary
    - remove global `GITHUB_TOKEN = credentials('github-bot-token')` injection from the PR pipelines in this batch
    - keep non-sensitive `environment` entries such as `OCI_ARTIFACT_HOST` unchanged
    - split the full security fix into multiple PRs so each one stays within the `pull-replay-jenkins-pipelines` replay limit

    ## Batch Scope
    - `pipelines/pingcap/tidb/release-6.1`
- `pipelines/pingcap/tidb/release-9.0-beta`

    ## Risk
    These PR jobs were exposing a GitHub bot token to the full Jenkins execution environment even though the variable was not consumed later in the pipeline. A malicious PR could potentially read the token from the process environment.

    ## Verification
    - `git diff --check`
    - verified no `pull_*.groovy` file in this batch still contains `GITHUB_TOKEN = credentials(...)` or `GH_TOKEN = credentials(...)`
    - verified no empty `environment {}` blocks remain after the cleanup
