### PR TITLE
tiflow: add MariaDB source and next-gen TiDB CI for DM integration test

### DIFF
--- a/jobs/pingcap/tiflow/latest/pull_dm_compatibility_test_next_gen.groovy
+++ b/jobs/pingcap/tiflow/latest/pull_dm_compatibility_test_next_gen.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/tiflow/pull_dm_compatibility_test_next_gen') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        githubProjectUrl("https://github.com/pingcap/tiflow")
+    }
+
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test_next_gen.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/jobs/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -1,0 +1,38 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/tiflow/pull_dm_integration_test_next_gen') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    properties {
+        githubProjectUrl("https://github.com/pingcap/tiflow")
+    }
+
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test_next_gen.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test_next_gen.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  initContainers:
+    - name: init-mysql-config
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.25:latest"
+      command:
+        - sh
+        - -c
+        - |
+          echo "[client]" > /mysql-config/.my.cnf
+          echo "ssl-mode=DISABLED" >> /mysql-config/.my.cnf
+      volumeMounts:
+        - mountPath: "/mysql-config"
+          name: "mysql-config-volume"
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.25:latest"
+      tty: true
+      resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
+        limits:
+          memory: 16Gi
+          cpu: "6"
+      volumeMounts:
+        - mountPath: "/home/jenkins/.my.cnf"
+          name: "mysql-config-volume"
+          subPath: ".my.cnf"
+    - name: mysql1
+      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      tty: true
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: "2"
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: '123456'
+      args:
+        - "--ssl=ON"
+        - "--log-bin"
+        - "--binlog-format=ROW"
+        - "--enforce-gtid-consistency=ON"
+        - "--gtid-mode=ON"
+        - "--server-id=1"
+        - "--default-authentication-plugin=mysql_native_password"
+    - name: mysql2
+      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      tty: true
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: "2"
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: '123456'
+        - name: MYSQL_TCP_PORT
+          value: '3307'
+      args:
+        - "--ssl=ON"
+        - "--log-bin"
+        - "--binlog-format=ROW"
+        - "--enforce-gtid-consistency=ON"
+        - "--gtid-mode=ON"
+        - "--server-id=1"
+        - "--default-authentication-plugin=mysql_native_password"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+  volumes:
+    - name: mysql-config-volume
+      emptyDir: {}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
@@ -79,6 +79,23 @@ spec:
         - "--gtid-mode=ON"
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
+    - name: mariadb1
+      image: "docker.io/library/mariadb:11.3"
+      tty: true
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: "2"
+      env:
+        - name: MARIADB_ROOT_PASSWORD
+          value: "123456"
+        - name: MYSQL_TCP_PORT
+          value: "3308"
+      args:
+        - "--log-bin"
+        - "--binlog-format=ROW"
+        - "--server-id=1"
+        - "--lower_case_table_names=0"
   volumes:
     - name: mysql-config-volume
       emptyDir: {}

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test_next_gen.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test_next_gen.yaml
@@ -70,6 +70,23 @@ spec:
         - "--gtid-mode=ON"
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
+    - name: mariadb1
+      image: "docker.io/library/mariadb:11.3"
+      tty: true
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: "2"
+      env:
+        - name: MARIADB_ROOT_PASSWORD
+          value: "123456"
+        - name: MYSQL_TCP_PORT
+          value: "3308"
+      args:
+        - "--log-bin"
+        - "--binlog-format=ROW"
+        - "--server-id=1"
+        - "--lower_case_table_names=0"
     - name: net-tool
       image: hub.pingcap.net/jenkins/network-multitool
       tty: true

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test_next_gen.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test_next_gen.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  initContainers:
+    - name: init-mysql-config
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.25:latest"
+      command:
+        - sh
+        - -c
+        - |
+          echo "[client]" > /mysql-config/.my.cnf
+          echo "ssl-mode=DISABLED" >> /mysql-config/.my.cnf
+      volumeMounts:
+        - mountPath: "/mysql-config"
+          name: "mysql-config-volume"
+  containers:
+    - name: golang
+      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:tini"
+      tty: true
+      args:
+        - cat
+      resources:
+        requests:
+          memory: 12Gi
+          cpu: "4"
+        limits:
+          memory: 16Gi
+          cpu: "6"
+      volumeMounts:
+        - mountPath: "/home/jenkins/.my.cnf"
+          name: "mysql-config-volume"
+          subPath: ".my.cnf"
+    - name: mysql1
+      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      tty: true
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: "2"
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: "123456"
+      args:
+        - "--ssl=ON"
+        - "--log-bin"
+        - "--binlog-format=ROW"
+        - "--enforce-gtid-consistency=ON"
+        - "--gtid-mode=ON"
+        - "--server-id=1"
+        - "--default-authentication-plugin=mysql_native_password"
+    - name: mysql2
+      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      tty: true
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: "2"
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: "123456"
+        - name: MYSQL_TCP_PORT
+          value: "3307"
+      args:
+        - "--ssl=ON"
+        - "--log-bin"
+        - "--binlog-format=ROW"
+        - "--enforce-gtid-consistency=ON"
+        - "--gtid-mode=ON"
+        - "--server-id=1"
+        - "--default-authentication-plugin=mysql_native_password"
+    - name: net-tool
+      image: hub.pingcap.net/jenkins/network-multitool
+      tty: true
+      resources:
+        limits:
+          memory: 128Mi
+          cpu: 100m
+    - name: report
+      image: hub.pingcap.net/jenkins/python3-requests:latest
+      tty: true
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+  volumes:
+    - name: mysql-config-volume
+      emptyDir: {}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test_next_gen.groovy
@@ -1,0 +1,187 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test_next_gen.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+def skipRemainingStages = false
+
+final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-next-gen")
+final OCI_TAG_TIDB = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-next-gen")
+final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "dedicated-next-gen")
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/tidbx'
+        NEXT_GEN = 1
+    }
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} -c golang -- bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
+                }
+            }
+        }
+        stage('Check diff files') {
+            steps {
+                container("golang") {
+                    script {
+                        def pr_diff_files = component.getPrDiffFiles(GIT_FULL_REPO_NAME, REFS.pulls[0].number, GIT_CREDENTIALS_ID2)
+                        def pattern = /(^dm\/|^pkg\/|^go\.mod).*$/
+                        println "pr_diff_files: ${pr_diff_files}"
+                        // if any diff files start with dm/ or pkg/ or file go.mod, run the dm compatibility test
+                        def matched = component.patternMatchAnyFile(pattern, pr_diff_files)
+                        if (matched) {
+                            println "matched, some diff files full path start with dm/ or pkg/ or go.mod, run the dm compatibility test"
+                        } else {
+                            echo "not matched, all files full path not start with dm/ or pkg/ or go.mod, current pr not releate to dm, so skip the dm compatibility test"
+                            currentBuild.result = 'SUCCESS'
+                            skipRemainingStages = true
+                            return // skip the remaining stages
+                        }
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            when { expression { !skipRemainingStages} }
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir("tiflow") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("prepare") {
+            when { expression { !skipRemainingStages} }
+            options { timeout(time: 35, unit: 'MINUTES') }
+            steps {
+                dir("tiflow") {
+                    script {
+                        retry(2) {
+                            sh label: "build previous", script: """
+                                echo "build binary for previous version"
+                                git fetch origin ${REFS.base_ref}:local
+                                git checkout local
+                                git rev-parse HEAD
+                                make dm_integration_test_build
+                                mv bin/dm-master.test bin/dm-master.test.previous
+                                mv bin/dm-worker.test bin/dm-worker.test.previous
+                                ls -alh ./bin/
+                            """
+                            sh label: "build current", script: """
+                                echo "build binary for current version"
+                                // reset to current version
+                                git checkout ${REFS.pulls[0].sha}
+                                make dm_integration_test_build
+                                mv bin/dm-master.test bin/dm-master.test.current
+                                mv bin/dm-worker.test bin/dm-worker.test.current
+                                ls -alh ./bin/
+                            """
+                        }
+                    }
+                    // download next-gen tidb components via OCI artifacts
+                    container("utils") {
+                        dir("bin") {
+                            script {
+                                retry(2) {
+                                    sh label: "download next-gen tidb components", script: """
+                                        export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                        chmod +x \$script
+                                        \$script \
+                                            --tidb=${OCI_TAG_TIDB} \
+                                            --minio=RELEASE.2025-07-23T15-54-02Z
+                                        ls -alh
+                                    """
+                                }
+                            }
+                        }
+                    }
+                    // download mydumper and gh-ost
+                    sh label: "download extra tools", script: """
+                        wget --no-verbose --retry-connrefused --waitretry=1 -t 3 -O /tmp/mydumper.tar.gz http://download.pingcap.org/tidb-enterprise-tools-latest-linux-amd64.tar.gz
+                        tar -xz -C /tmp -f /tmp/mydumper.tar.gz tidb-enterprise-tools-latest-linux-amd64/bin/mydumper
+                        mv /tmp/tidb-enterprise-tools-latest-linux-amd64/bin/mydumper ./bin/
+                        rm -rf /tmp/mydumper.tar.gz /tmp/tidb-enterprise-tools-latest-linux-amd64
+
+                        wget --no-verbose --retry-connrefused --waitretry=1 -t 3 -O /tmp/gh-ost.tar.gz https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz
+                        tar -xz -C ./bin -f /tmp/gh-ost.tar.gz
+                        rm -f /tmp/gh-ost.tar.gz
+                        chmod +x ./bin/gh-ost ./bin/mydumper
+                    """
+                    sh label: "verify binaries", script: """
+                        ls -alh ./bin
+                        ./bin/tidb-server -V
+                        ./bin/mydumper -V
+                    """
+                }
+            }
+        }
+        stage("Test") {
+            when { expression { !skipRemainingStages} }
+            options { timeout(time: 20, unit: 'MINUTES') }
+            steps {
+                dir('tiflow') {
+                        timeout(time: 10, unit: 'MINUTES') {
+                            sh label: "wait mysql ready", script: """
+                                pwd && ls -alh
+                                set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                            """
+                        }
+                        sh label: "test", script: """
+                            export MYSQL_HOST1=127.0.0.1
+                            export MYSQL_PORT1=3306
+                            export MYSQL_HOST2=127.0.0.1
+                            export MYSQL_PORT2=3307
+                            export PATH=/usr/local/go/bin:\$PATH
+                            make dm_compatibility_test CASE=""
+                        """
+                }
+            }
+            post {
+                failure {
+                    sh label: "collect logs", script: """
+                        ls /tmp/dm_test
+                        tar -cvzf log.tar.gz \$(find /tmp/dm_test/ -type f -name "*.log")
+                        ls -alh  log.tar.gz
+                    """
+                    archiveArtifacts artifacts: "log.tar.gz", allowEmptyArchive: true
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -178,6 +178,7 @@ pipeline {
                                         # TODO use wait-for-mysql-ready.sh
                                         set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                         set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3308 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                     sh label: "${TEST_GROUP}", script: """
                                         if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
@@ -193,6 +194,9 @@ pipeline {
                                             echo "run ${TEST_GROUP} test"
                                         fi
                                         export PATH=/usr/local/go/bin:\$PATH
+                                        export MARIADB_HOST1=127.0.0.1
+                                        export MARIADB_PORT1=3308
+                                        export MARIADB_PASSWORD1=123456
                                         mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
                                         make dm_integration_test_in_group GROUP="${TEST_GROUP}"
                                     """

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -1,0 +1,238 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test_next_gen.yaml'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+def skipRemainingStages = false
+
+final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-next-gen")
+final OCI_TAG_TIDB = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-next-gen")
+final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "dedicated-next-gen")
+
+pipeline {
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/tidbx'
+        NEXT_GEN = 1
+    }
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Debug info') {
+            steps {
+                sh label: 'Debug info', script: """
+                    printenv
+                    echo "-------------------------"
+                    go env
+                    echo "-------------------------"
+                    echo "debug command: kubectl -n ${K8S_NAMESPACE} exec -ti ${NODE_NAME} -c golang -- bash"
+                """
+                container(name: 'net-tool') {
+                    sh 'dig github.com'
+                    script {
+                        prow.setPRDescription(REFS)
+                    }
+                }
+            }
+        }
+        stage('Check diff files') {
+            steps {
+                container("golang") {
+                    script {
+                        def pr_diff_files = component.getPrDiffFiles(GIT_FULL_REPO_NAME, REFS.pulls[0].number, GIT_CREDENTIALS_ID2)
+                        def pattern = /(^dm\/|^pkg\/|^sync_diff_inspector\/|^go\.mod).*$/
+                        println "pr_diff_files: ${pr_diff_files}"
+                        // if any diff files start with dm/ or pkg/ or file go.mod, run the dm integration test
+                        // besides, any changes in sync_diff_inspector also need to run test
+                        def matched = component.patternMatchAnyFile(pattern, pr_diff_files)
+                        if (matched) {
+                            println "matched, some diff files full path start with dm/, sync_diff_inspector/ or pkg/ or go.mod, run the dm integration test"
+                        } else {
+                            println "not matched, all files full path not start with dm/, sync_diff_inspector/ or pkg/ or go.mod, current pr not releate to dm, so skip the dm integration test"
+                            currentBuild.result = 'SUCCESS'
+                            skipRemainingStages = true
+                            return 0
+                        }
+                    }
+                }
+            }
+        }
+        stage('Checkout') {
+            when { expression { !skipRemainingStages} }
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir("tiflow") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
+                            script {
+                                prow.checkoutRefs(REFS)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        stage("prepare") {
+            when { expression { !skipRemainingStages} }
+            options { timeout(time: 20, unit: 'MINUTES') }
+            steps {
+                dir("third_party_download") {
+                    container("utils") {
+                        dir("bin") {
+                            script {
+                                retry(2) {
+                                    sh label: "download next-gen tidb components", script: """
+                                        export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                        chmod +x \$script
+                                        \$script \
+                                            --pd=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tidb=${OCI_TAG_TIDB} \
+                                            --minio=RELEASE.2025-07-23T15-54-02Z
+                                        ls -alh
+                                    """
+                                }
+                            }
+                        }
+                    }
+                    sh label: "verify binaries", script: """
+                        ls -alh ./bin
+                        ./bin/tidb-server -V
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                    """
+                    // download gh-ost
+                    sh label: "download gh-ost", script: """
+                        wget --no-verbose --retry-connrefused --waitretry=1 -t 3 -O ./bin/gh-ost.tar.gz https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz
+                        tar -xz -C ./bin -f ./bin/gh-ost.tar.gz
+                        rm -f ./bin/gh-ost.tar.gz
+                        chmod +x ./bin/gh-ost
+                    """
+                }
+                dir("tiflow") {
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test-ng')) {
+                        // build dm-master.test for integration test
+                        // only build binarys if not exist, use the cached binarys if exist
+                        sh label: "prepare", script: """
+                            if [[ ! -f "bin/sync_diff_inspector" || ! -f "bin/dm-master.test" || ! -f "bin/dm-test-tools/check_master_online" || ! -f "bin/dm-test-tools/check_worker_online" ]]; then
+                                echo "Building binaries..."
+                                make dm_integration_test_build
+                                mkdir -p bin/dm-test-tools && cp -r ./dm/tests/bin/* ./bin/dm-test-tools
+                            else
+                                echo "Binaries already exist, skipping build..."
+                            fi
+                            ls -alh ./bin
+                            ls -alh ./bin/dm-test-tools
+                            which ./bin/dm-master.test
+                            which ./bin/dm-syncer.test
+                            which ./bin/dm-worker.test
+                            which ./bin/dmctl.test
+                            which ./bin/dm-test-tools/check_master_online
+                            which ./bin/dm-test-tools/check_worker_online
+                        """
+                    }
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm-ng") {
+                        sh label: "prepare", script: """
+                            cp -r ../third_party_download/bin/* ./bin/
+                            ls -alh ./bin
+                            ls -alh ./bin/dm-test-tools
+                        """
+                    }
+                }
+            }
+        }
+
+        stage('Tests') {
+            when { expression { !skipRemainingStages} }
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_GROUP'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06', 'G07', 'G08',
+                            'G09', 'G10', 'G11', 'TLS_GROUP'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        label "dm-it-ng-${UUID.randomUUID().toString()}"
+                        namespace K8S_NAMESPACE
+                        yamlFile POD_TEMPLATE_FILE
+                        defaultContainer 'golang'
+                    }
+                }
+                stages {
+                    stage("Test") {
+                        options { timeout(time: 50, unit: 'MINUTES') }
+                        environment {
+                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
+                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
+                        }
+                        steps {
+                            container("mysql1") {
+                                sh label: "copy mysql certs", script: """
+                                    mkdir ${WORKSPACE}/mysql-ssl
+                                    cp -r /var/lib/mysql/*.pem ${WORKSPACE}/mysql-ssl/
+                                    ls -alh ${WORKSPACE}/mysql-ssl/
+                                """
+                            }
+
+                            dir('tiflow') {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm-ng") {
+                                    timeout(time: 10, unit: 'MINUTES') {
+                                        sh label: "wait mysql ready", script: """
+                                            pwd && ls -alh
+                                            # TODO use wait-for-mysql-ready.sh
+                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        """
+                                    }
+                                    sh label: "${TEST_GROUP}", script: """
+                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                            echo "run tls test"
+                                            echo "copy mysql certs"
+                                            sudo mkdir -p /var/lib/mysql
+                                            sudo chmod 777 /var/lib/mysql
+                                            sudo chown -R 1000:1000 /var/lib/mysql
+                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                            sudo chown -R 1000:1000 /var/lib/mysql/*
+                                            ls -alh /var/lib/mysql/
+                                        else
+                                            echo "run ${TEST_GROUP} test"
+                                        fi
+                                        export PATH=/usr/local/go/bin:\$PATH
+                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                    """
+                                }
+                            }
+                        }
+                        post {
+                            failure {
+                                sh label: "collect logs", script: """
+                                    ls /tmp/dm_test
+                                    tar -cvzf log-${TEST_GROUP}.tar.gz \$(find /tmp/dm_test/ -type f -name "*.log")
+                                    ls -alh  log-${TEST_GROUP}.tar.gz
+                                """
+                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -198,6 +198,7 @@ pipeline {
                                             # TODO use wait-for-mysql-ready.sh
                                             set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                             set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3308 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                         """
                                     }
                                     sh label: "${TEST_GROUP}", script: """
@@ -214,6 +215,9 @@ pipeline {
                                             echo "run ${TEST_GROUP} test"
                                         fi
                                         export PATH=/usr/local/go/bin:\$PATH
+                                        export MARIADB_HOST1=127.0.0.1
+                                        export MARIADB_PORT1=3308
+                                        export MARIADB_PASSWORD1=123456
                                         mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
                                         make dm_integration_test_in_group GROUP="${TEST_GROUP}"
                                     """

--- a/prow-jobs/pingcap/tiflow/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits-next-gen.yaml
@@ -1,0 +1,27 @@
+global_definitions:
+  branches: &branches
+    - ^master$
+    - ^release-nextgen-\d+$
+    - ^feature/.+
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|yaml|json)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+
+# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
+presubmits:
+  pingcap/tiflow:
+    - name: pingcap/tiflow/pull_dm_integration_test_next_gen
+      agent: jenkins
+      decorate: false
+      context: pull-dm-integration-test-next-gen
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test-next-gen|dm-next-gen|next-gen)(?: .*?)?$"
+      rerun_command: "/test pull-dm-integration-test-next-gen"
+      branches: *branches
+      optional: true
+
+    - name: pingcap/tiflow/pull_dm_compatibility_test_next_gen
+      agent: jenkins
+      decorate: false
+      context: pull-dm-compatibility-test-next-gen
+      trigger: "(?m)^/test (?:.*? )?(pull-dm-compatibility-test-next-gen|dm-next-gen|next-gen)(?: .*?)?$"
+      rerun_command: "/test pull-dm-compatibility-test-next-gen"
+      branches: *branches
+      optional: true


### PR DESCRIPTION
## Summary                                          
  - Add a dedicated MariaDB container to the latest TiFlow DM integration pod
  - Wait for the MariaDB service before running DM integration groups                                                                                                                                     
  - Export MariaDB env vars for the new `dm/tests/mariadb2tidb` case                                                                                                                                      
  - **Add DM integration test and compatibility test CI jobs targeting next-gen TiDB**                                                                                                                    
  - Next-gen jobs download TiDB/PD/TiKV binaries from OCI registry (`hub-zot.pingcap.net/mirrors/tidbx`) with `master-next-gen` / `dedicated-next-gen` tags                                               
  - Next-gen jobs are set as `optional: true` initially, triggered via `/test dm-next-gen`                                                                                                                
                                                                                                                                                                                                          
 ## Files changed (classic DM CI)                                                                                                                                                                        
                                                                                                                                                                                                          
  | File | Change |                                                                                                                                                                                       
  |------|--------|                                                 
  | `pipelines/.../pod-pull_dm_integration_test.yaml` | Add `mariadb1` container |
  | `pipelines/.../pull_dm_integration_test.groovy` | Wait for MariaDB, export env vars |                                                                                                                 
                                                                                                                                                                                                          
 ## Files added (next-gen DM CI)                                                                                                                                                                         
                                                                                                                                                                                                          
  | File | Purpose |                                                
  |------|---------|                                                
  | `prow-jobs/.../latest-presubmits-next-gen.yaml` | Prow trigger definitions |                                                                                                                          
  | `jobs/.../pull_dm_integration_test_next_gen.groovy` | Job DSL for integration test |                                                                                                                  
  | `jobs/.../pull_dm_compatibility_test_next_gen.groovy` | Job DSL for compatibility test |                                                                                                              
  | `pipelines/.../pull_dm_integration_test_next_gen.groovy` | Integration test pipeline (OCI download + MariaDB) |                                                                                       
  | `pipelines/.../pull_dm_compatibility_test_next_gen.groovy` | Compatibility test pipeline (OCI download) |                                                                                             
  | `pipelines/.../pod-pull_dm_integration_test_next_gen.yaml` | Pod template (utils + MariaDB containers) |                                                                                              
  | `pipelines/.../pod-pull_dm_compatibility_test_next_gen.yaml` | Pod template (utils container) |                                                                                                       
                                                                                                                                                                                                          
  ## Note                                                                                                                                                                                                 
  - Keep this PR as draft until the corresponding TiFlow DM change is merged
  - This change is intended to support the new MariaDB compatibility integration case in TiFlow DM                                                                                                        
                                                                                                                                                                                                          
  ## Test plan                                                                                                                                                                                            
  - [ ] Trigger `/test pull-dm-integration-test` on a tiflow PR to validate MariaDB changes                                                                                                               
  - [ ] Trigger `/test pull-dm-integration-test-next-gen` on a tiflow PR to validate next-gen pipeline                                                                                                    
  - [ ] Trigger `/test pull-dm-compatibility-test-next-gen` on a tiflow PR to validate next-gen pipeline                                                                                                  
  - [ ] Verify next-gen TiDB binaries are downloaded correctly                                                                                                                                            
  - [ ] Verify DM test groups pass with next-gen TiDB downstream