### PR TITLE
fix(flow): handle hotfix tags on feature release branches

### DIFF
--- a/scripts/flow/build/versioning-strategy.test.ts
+++ b/scripts/flow/build/versioning-strategy.test.ts
@@ -348,6 +348,14 @@ Deno.test("compute", () => {
       },
     },
     {
+      description: "history style - feature release branch with hotfix tag",
+      gitVer: "v8.5.1-20250101-fecba32",
+      branches: ["feature/release-8.5-xxx"],
+      expect: {
+        version: "v8.5.1-20250101-fecba32",
+      },
+    },
+    {
       description: "feature branch - beta prerelease",
       gitVer: "v9.0.0-beta.1.pre-151-gb4c8f4dc8",
       branches: ["feature/fts"],

--- a/scripts/flow/build/versioning-strategy.ts
+++ b/scripts/flow/build/versioning-strategy.ts
@@ -34,7 +34,7 @@ function isReleaseBranch(branch: string): boolean {
     return false;
   }
   const standardRelease =
-    /\brelease-[0-9]+[.][0-9]+(?:-beta\.[0-9]+)?(?!-[0-9]{8}-v[0-9]+[.][0-9]+[.][0-9]+)/
+    /^(?:feature\/)?release-[0-9]+[.][0-9]+(?:-beta\.[0-9]+)?(?![\/.-])(?!-[0-9]{8}-v[0-9]+[.][0-9]+[.][0-9]+)/
       .test(
         branch,
       );
@@ -108,6 +108,16 @@ export function compute(
       /\bfeature\/[\w.-]+$/.test(b)
     );
     if (featureBranch) {
+      // Check if the current version is a hotfix tag (format: YYYYMMDD-shortcommit)
+      const hasHotfixTag = rv.prerelease &&
+        rv.prerelease.length === 1 &&
+        /^\d{8}-[0-9a-f]+$/.test(rv.prerelease[0].toString());
+
+      if (hasHotfixTag) {
+        console.info("Current commit is in a feature branch with hotfix tag.");
+        return { releaseVersion: "v" + semver.format(rv) };
+      }
+
       console.info("Current commit is in a feature branch.");
       // Extract feature name, replace '/' with '.' for version/tag
       const suffix = featureBranch


### PR DESCRIPTION
Allow an optional "feature/" prefix in release branch detection and add a
check for hotfix-style prerelease tags (YYYYMMDD-shortcommit). When a feature branch contains such a hotfix tag, return the formatted release version (v + semver) instead of treating it as a regular feature prerelease. This prevents appending feature suffixes to hotfixed releases.