### PR TITLE
feat(pipelines/pingcap/tiflow): add MariaDB source for DM integration test

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
@@ -79,6 +79,23 @@ spec:
         - "--gtid-mode=ON"
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
+    - name: mariadb1
+      image: "docker.io/library/mariadb:11.3"
+      tty: true
+      resources:
+        limits:
+          memory: 4Gi
+          cpu: "2"
+      env:
+        - name: MARIADB_ROOT_PASSWORD
+          value: "123456"
+        - name: MYSQL_TCP_PORT
+          value: "3308"
+      args:
+        - "--log-bin"
+        - "--binlog-format=ROW"
+        - "--server-id=1"
+        - "--lower_case_table_names=0"
   volumes:
     - name: mysql-config-volume
       emptyDir: {}

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
@@ -80,12 +80,12 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mariadb1
-      image: "docker.io/library/mariadb:11.3"
+      image: "docker.io/library/mariadb:12.2"
       tty: true
       resources:
         limits:
-          memory: 4Gi
-          cpu: "2"
+          memory: 2Gi
+          cpu: "1"
       env:
         - name: MARIADB_ROOT_PASSWORD
           value: "123456"

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -180,6 +180,7 @@ pipeline {
                                         # TODO use wait-for-mysql-ready.sh
                                         set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                         set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3308 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                     sh label: "${TEST_GROUP}", script: """
                                         if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
@@ -195,6 +196,9 @@ pipeline {
                                             echo "run ${TEST_GROUP} test"
                                         fi
                                         export PATH=/usr/local/go/bin:\$PATH
+                                        export MARIADB_HOST1=127.0.0.1
+                                        export MARIADB_PORT1=3308
+                                        export MARIADB_PASSWORD1=123456
                                         mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
                                         make dm_integration_test_in_group GROUP="${TEST_GROUP}"
                                     """

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -178,6 +178,7 @@ pipeline {
                                         # TODO use wait-for-mysql-ready.sh
                                         set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                         set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3308 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                     sh label: "${TEST_GROUP}", script: """
                                         if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
@@ -193,6 +194,9 @@ pipeline {
                                             echo "run ${TEST_GROUP} test"
                                         fi
                                         export PATH=/usr/local/go/bin:\$PATH
+                                        export MARIADB_HOST1=127.0.0.1
+                                        export MARIADB_PORT1=3308
+                                        export MARIADB_PASSWORD1=123456
                                         mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
                                         make dm_integration_test_in_group GROUP="${TEST_GROUP}"
                                     """

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -196,9 +196,6 @@ pipeline {
                                             echo "run ${TEST_GROUP} test"
                                         fi
                                         export PATH=/usr/local/go/bin:\$PATH
-                                        export MARIADB_HOST1=127.0.0.1
-                                        export MARIADB_PORT1=3308
-                                        export MARIADB_PASSWORD1=123456
                                         mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
                                         make dm_integration_test_in_group GROUP="${TEST_GROUP}"
                                     """

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -177,9 +177,6 @@ pipeline {
                                             echo "run ${TEST_GROUP} test"
                                         fi
                                         export PATH=/usr/local/go/bin:\$PATH
-                                        export MARIADB_HOST1=127.0.0.1
-                                        export MARIADB_PORT1=3308
-                                        export MARIADB_PASSWORD1=123456
                                         mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
                                         make dm_integration_test_in_group GROUP="${TEST_GROUP}"
                                     """

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -161,6 +161,7 @@ pipeline {
                                         # TODO use wait-for-mysql-ready.sh
                                         set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                         set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3308 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                     sh label: "${TEST_GROUP}", script: """
                                         if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
@@ -176,6 +177,9 @@ pipeline {
                                             echo "run ${TEST_GROUP} test"
                                         fi
                                         export PATH=/usr/local/go/bin:\$PATH
+                                        export MARIADB_HOST1=127.0.0.1
+                                        export MARIADB_PORT1=3308
+                                        export MARIADB_PASSWORD1=123456
                                         mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
                                         make dm_integration_test_in_group GROUP="${TEST_GROUP}"
                                     """


### PR DESCRIPTION
## Summary

Add MariaDB 12.2 as a sidecar for DM integration tests (classic and next-gen).

- Add MariaDB 12.2 container (1C/2G) to `pod-pull_dm_integration_test.yaml`
- Add MariaDB health check (port 3308) and `MARIADB_HOST1`/`PORT1`/`PASSWORD1` env vars to `pull_dm_integration_test.groovy` (classic) and `pull_dm_integration_test_next_gen.groovy` (next-gen)
- Both classic and next-gen pipelines share the same pod template, so one container addition covers both

## Related

- DM-side PR: pingcap/tiflow#12599 (adds `mariadb_source` test case, currently excluded from groups until this CI PR is merged)

## Notes

- This PR should be merged before adding `mariadb_source` to a test group in tiflow.