### PR TITLE
fix(tiflow): align ci jobs with go1.25.8

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.15-1-g5625431-go1.25"
       tty: true
       resources:
         requests:

--- a/prow-jobs/pingcap/tiflow/common-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/common-postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
       spec:
         containers:
           - name: build
-            image: golang:1.23
+            image: golang:1.25.8
             command: [bash, -ceo, pipefail]
             args:
               - |


### PR DESCRIPTION
## Summary
- bump `pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml` to the same Go 1.25.8-capable Jenkins image already used by `tiflow` ghpr/presubmit unit paths
- bump `auto-update-ticdc-gomod` from `golang:1.23` to `golang:1.25.8`

## Why
`pingcap/tiflow@9fbde6ebeb0613eab6cbb372d6eeb44f58e868e6` currently fails in two CI jobs because the runtime toolchains are older than what the repo now requires:

- `merged_unit_test`: `compile: version "go1.25.8" does not match go tool version "go1.25.6"`
- `auto-update-ticdc-gomod`: `go.mod requires go >= 1.25.8 (running go 1.23.12; GOTOOLCHAIN=local)`

This PR keeps the fix minimal and only updates the two affected job definitions.

## Validation
- `git diff --check`
- parsed both modified YAML files locally via Ruby `YAML.load_file`
