### PR TITLE
tekton: avoid dirty tidb-operator version during image builds

### DIFF
--- a/tekton/v1/pipelines/pingcap-build-package-linux.yaml
+++ b/tekton/v1/pipelines/pingcap-build-package-linux.yaml
@@ -155,7 +155,7 @@ spec:
         - name: builder-image
           value: "$(tasks.get-binaries-builder.results.image-url)"
         - name: release-dir
-          value: build
+          value: /workspace/release/$(params.component)
         - name: push
           value: "$(params.push)"
         - name: registry
@@ -193,7 +193,7 @@ spec:
         - name: git-sha
           value: $(tasks.checkout.results.commit)
         - name: release-dir
-          value: build
+          value: /workspace/release/$(params.component)
         - name: build
           value: "false"
         - name: registry


### PR DESCRIPTION
## Summary
- move the package `release-dir` outside the checked-out source repo in the linux package pipeline
- avoid creating an untracked `build/` directory inside component repos before kaniko image builds
- fix the `tidb-operator` image version showing `-dirty` when built through the tekton package pipeline

## Root cause
`pingcap-build-images` runs in the checked-out repo root and the generated image build script unconditionally creates `RELEASE_WS` before invoking kaniko. The linux package pipeline currently passes `release-dir=build`, so the repo gets an untracked `build/` directory. For `tidb-operator >= 2.0`, image builds use `context: .` plus `image/Dockerfile`, and the Dockerfile runs `./hack/build.sh` inside the repo. `tidb-operator` derives `dirty` from VCS state, so the untracked `build/` directory turns the version into `-dirty`.

## Validation
- `yq e '.' tekton/v1/pipelines/pingcap-build-package-linux.yaml >/dev/null`
- `git diff --check`
- local repro in `pingcap/tidb-operator`:
  - clean tree => clean version metadata
  - creating only an untracked `build/` directory => dirty version metadata
