### PR TITLE
ci(prow): migrate titan GHPR test to native presubmits

### DIFF
--- a/prow-jobs/kustomization.yaml
+++ b/prow-jobs/kustomization.yaml
@@ -155,3 +155,4 @@ configMapGenerator:
       - tikv_tikv_release-8.4-presubmits.yaml=tikv/tikv/release-8.4-presubmits.yaml
       - tikv_tikv_release-8.5-presubmits.yaml=tikv/tikv/release-8.5-presubmits.yaml
       - tikv_tikv_release-9.0-beta-presubmits.yaml=tikv/tikv/release-9.0-beta-presubmits.yaml
+      - tikv_titan_latest-presubmits.yaml=tikv/titan/latest-presubmits.yaml

--- a/prow-jobs/tikv/titan/latest-presubmits.yaml
+++ b/prow-jobs/tikv/titan/latest-presubmits.yaml
@@ -165,8 +165,6 @@ global_definitions:
 
 presubmits:
   tikv/titan:
-    # Old titan_ghpr_test also had a mac-i7 branch. We intentionally omit it here
-    # because GCP does not currently provide macOS nodes for native Prow jobs.
     - <<: *titan_presubmit_job
       name: pull-titan-format
       spec:

--- a/prow-jobs/tikv/titan/latest-presubmits.yaml
+++ b/prow-jobs/tikv/titan/latest-presubmits.yaml
@@ -1,0 +1,252 @@
+global_definitions:
+  brancher: &brancher
+    branches:
+      - ^master$
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  titan_presubmit_job: &titan_presubmit_job
+    <<: *brancher
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    always_run: false
+    optional: true
+    skip_if_only_changed: *skip_if_only_changed
+  amd64_affinity: &amd64_affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+  arm64_affinity: &arm64_affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - arm64
+  builder_container: &builder_container
+    name: builder
+    image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+    imagePullPolicy: Always
+    command: [bash, -ce]
+    resources: &build_resources
+      requests:
+        cpu: "4"
+        memory: 8Gi
+      limits:
+        cpu: "4"
+        memory: 8Gi
+  titan_test_script: &titan_test_script |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    build_type="${BUILD_TYPE:-}"
+    sanitizer="${SANITIZER:-}"
+    cmake_build_type="Debug"
+    run_tests="yes"
+    build_jobs="${MAKE_JOBS:-2}"
+    cmake_cxx_flags="${CXXFLAGS:-}"
+    run_with_sanitizer_runtime() {
+      "$@"
+    }
+    required_packages=(
+      libstdc++-devel
+      snappy-devel
+      lz4-devel
+      zlib-devel
+      libzstd-devel
+      gflags-devel
+    )
+    cmake_args=(
+      .
+      -L
+      -DWITH_SNAPPY=ON
+      -DWITH_LZ4=ON
+      -DWITH_ZLIB=ON
+      -DWITH_ZSTD=ON
+      -DROCKSDB_BUILD_SHARED=OFF
+    )
+
+    if [[ -n "${build_type}" ]]; then
+      cmake_build_type="${build_type}"
+      run_tests="no"
+    fi
+
+    if [[ -n "${sanitizer}" ]]; then
+      cmake_args+=("-DWITH_${sanitizer}=ON" "-DWITH_TITAN_TOOLS=OFF")
+      case "${sanitizer}" in
+        ASAN)
+          required_packages+=(devtoolset-8-libasan-devel)
+          ;;
+        TSAN)
+          required_packages+=(devtoolset-8-libtsan-devel)
+          ;;
+        UBSAN)
+          required_packages+=(devtoolset-8-libubsan-devel)
+          ;;
+      esac
+    fi
+
+    if [[ "${sanitizer}" == "TSAN" ]]; then
+      if ! command -v setarch >/dev/null 2>&1; then
+        echo "setarch is required for TSan runtime on this job" >&2
+        exit 1
+      fi
+      arch_name="$(uname -m)"
+      run_with_sanitizer_runtime() {
+        setarch "${arch_name}" -R "$@"
+      }
+    fi
+
+    if ! rpm -q "${required_packages[@]}" >/dev/null 2>&1; then
+      yum install -y "${required_packages[@]}"
+    fi
+
+    if [[ -f /usr/include/gflags/gflags.h ]] \
+      && grep -q 'namespace gflags' /usr/include/gflags/gflags.h \
+      && ! grep -q 'namespace google' /usr/include/gflags/gflags.h; then
+      cmake_cxx_flags="${cmake_cxx_flags:+${cmake_cxx_flags} }-DGFLAGS_NAMESPACE=gflags"
+    fi
+
+    if [[ -n "${cmake_cxx_flags}" ]]; then
+      cmake_args+=("-DCMAKE_CXX_FLAGS=${cmake_cxx_flags}")
+    fi
+
+    cmake_args+=("-DCMAKE_BUILD_TYPE=${cmake_build_type}")
+
+    if [[ -f /opt/rh/devtoolset-8/enable ]]; then
+      set +u
+      source /opt/rh/devtoolset-8/enable
+      set -u
+    fi
+
+    g++ --version
+    cmake --version
+
+    rm -rf ./tmp_dir
+    mkdir -p ./tmp_dir
+
+    cmake "${cmake_args[@]}"
+
+    VERBOSE=1 make -j"${build_jobs}"
+
+    if [[ "${run_tests}" == "yes" ]]; then
+      ctest_bin=ctest
+      if ! command -v "${ctest_bin}" >/dev/null 2>&1; then
+        ctest_bin=ctest3
+      fi
+      TEST_TMPDIR=./tmp_dir ASAN_OPTIONS=detect_leaks=0 run_with_sanitizer_runtime "${ctest_bin}" --verbose -R titan
+    fi
+  titan_format_script: &titan_format_script |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! command -v clang-format >/dev/null 2>&1; then
+      yum install -y llvm-toolset-7.0
+    fi
+    if [ -f /opt/rh/llvm-toolset-7.0/enable ]; then
+      set +u
+      source /opt/rh/llvm-toolset-7.0/enable
+      set -u
+    fi
+
+    find . \( -iname "*.h" -o -iname "*.cc" \) -print0 | xargs -0 -L1 clang-format -style=google -i
+
+    if [[ -n "$(git diff --stat)" ]]; then
+      echo "Run scripts/format-diff.sh to format your code."
+      git diff --stat
+      exit 1
+    fi
+
+presubmits:
+  tikv/titan:
+    # Old titan_ghpr_test also had a mac-i7 branch. We intentionally omit it here
+    # because GCP does not currently provide macOS nodes for native Prow jobs.
+    - <<: *titan_presubmit_job
+      name: pull-titan-format
+      spec:
+        affinity: *amd64_affinity
+        containers:
+          - <<: *builder_container
+            args:
+              - *titan_format_script
+            resources:
+              requests:
+                cpu: "2"
+                memory: 2Gi
+              limits:
+                cpu: "2"
+                memory: 2Gi
+
+    - <<: *titan_presubmit_job
+      name: pull-titan-test
+      spec:
+        affinity: *amd64_affinity
+        containers:
+          - <<: *builder_container
+            args:
+              - *titan_test_script
+
+    - <<: *titan_presubmit_job
+      name: pull-titan-sanitizer-asan
+      spec:
+        affinity: *amd64_affinity
+        containers:
+          - <<: *builder_container
+            args:
+              - *titan_test_script
+            env:
+              - name: SANITIZER
+                value: ASAN
+
+    - <<: *titan_presubmit_job
+      name: pull-titan-sanitizer-tsan
+      spec:
+        affinity: *amd64_affinity
+        containers:
+          - <<: *builder_container
+            args:
+              - *titan_test_script
+            env:
+              - name: SANITIZER
+                value: TSAN
+            securityContext:
+              privileged: true
+
+    - <<: *titan_presubmit_job
+      name: pull-titan-sanitizer-ubsan
+      spec:
+        affinity: *amd64_affinity
+        containers:
+          - <<: *builder_container
+            args:
+              - *titan_test_script
+            env:
+              - name: SANITIZER
+                value: UBSAN
+
+    - <<: *titan_presubmit_job
+      name: pull-titan-release
+      spec:
+        affinity: *amd64_affinity
+        containers:
+          - <<: *builder_container
+            args:
+              - *titan_test_script
+            env:
+              - name: BUILD_TYPE
+                value: Release
+
+    - <<: *titan_presubmit_job
+      name: pull-titan-test-arm64
+      spec:
+        affinity: *arm64_affinity
+        containers:
+          - <<: *builder_container
+            args:
+              - *titan_test_script

--- a/prow-jobs/tikv/titan/latest-presubmits.yaml
+++ b/prow-jobs/tikv/titan/latest-presubmits.yaml
@@ -8,7 +8,7 @@ global_definitions:
     decorate: true
     decoration_config:
       timeout: 3h
-    always_run: false # TODO update here after test passed 
+    always_run: false # TODO update here after test passed
     optional: true  # TODO update here after test passed
     skip_if_only_changed: *skip_if_only_changed
   amd64_affinity: &amd64_affinity

--- a/prow-jobs/tikv/titan/latest-presubmits.yaml
+++ b/prow-jobs/tikv/titan/latest-presubmits.yaml
@@ -8,8 +8,8 @@ global_definitions:
     decorate: true
     decoration_config:
       timeout: 3h
-    always_run: false
-    optional: true
+    always_run: false # TODO update here after test passed 
+    optional: true  # TODO update here after test passed
     skip_if_only_changed: *skip_if_only_changed
   amd64_affinity: &amd64_affinity
     nodeAffinity:
@@ -216,8 +216,9 @@ presubmits:
               - name: SANITIZER
                 value: TSAN
             securityContext:
+              # Required for TSAN on GCP. Without privileged mode, the TSAN job hit
+              # `ThreadSanitizer: unexpected memory mapping` during test execution.
               privileged: true
-
     - <<: *titan_presubmit_job
       name: pull-titan-sanitizer-ubsan
       spec:

--- a/prow-jobs/tikv/titan/latest-presubmits.yaml
+++ b/prow-jobs/tikv/titan/latest-presubmits.yaml
@@ -1,178 +1,36 @@
-global_definitions:
-  brancher: &brancher
-    branches:
-      - ^master$
-  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
-  titan_presubmit_job: &titan_presubmit_job
-    <<: *brancher
-    decorate: true
-    decoration_config:
-      timeout: 3h
-    always_run: false # TODO update here after test passed
-    optional: true  # TODO update here after test passed
-    skip_if_only_changed: *skip_if_only_changed
-  amd64_affinity: &amd64_affinity
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                  - amd64
-  arm64_affinity: &arm64_affinity
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                  - arm64
-  builder_container: &builder_container
-    name: builder
-    image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
-    imagePullPolicy: Always
-    command: [bash, -ce]
-    resources: &build_resources
-      requests:
-        cpu: "4"
-        memory: 8Gi
-      limits:
-        cpu: "4"
-        memory: 8Gi
-  titan_test_script: &titan_test_script |
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    build_type="${BUILD_TYPE:-}"
-    sanitizer="${SANITIZER:-}"
-    cmake_build_type="Debug"
-    run_tests="yes"
-    build_jobs="${MAKE_JOBS:-2}"
-    cmake_cxx_flags="${CXXFLAGS:-}"
-    run_with_sanitizer_runtime() {
-      "$@"
-    }
-    required_packages=(
-      libstdc++-devel
-      snappy-devel
-      lz4-devel
-      zlib-devel
-      libzstd-devel
-      gflags-devel
-    )
-    cmake_args=(
-      .
-      -L
-      -DWITH_SNAPPY=ON
-      -DWITH_LZ4=ON
-      -DWITH_ZLIB=ON
-      -DWITH_ZSTD=ON
-      -DROCKSDB_BUILD_SHARED=OFF
-    )
-
-    if [[ -n "${build_type}" ]]; then
-      cmake_build_type="${build_type}"
-      run_tests="no"
-    fi
-
-    if [[ -n "${sanitizer}" ]]; then
-      cmake_args+=("-DWITH_${sanitizer}=ON" "-DWITH_TITAN_TOOLS=OFF")
-      case "${sanitizer}" in
-        ASAN)
-          required_packages+=(devtoolset-8-libasan-devel)
-          ;;
-        TSAN)
-          required_packages+=(devtoolset-8-libtsan-devel)
-          ;;
-        UBSAN)
-          required_packages+=(devtoolset-8-libubsan-devel)
-          ;;
-      esac
-    fi
-
-    if [[ "${sanitizer}" == "TSAN" ]]; then
-      if ! command -v setarch >/dev/null 2>&1; then
-        echo "setarch is required for TSan runtime on this job" >&2
-        exit 1
-      fi
-      arch_name="$(uname -m)"
-      run_with_sanitizer_runtime() {
-        setarch "${arch_name}" -R "$@"
-      }
-    fi
-
-    if ! rpm -q "${required_packages[@]}" >/dev/null 2>&1; then
-      yum install -y "${required_packages[@]}"
-    fi
-
-    if [[ -f /usr/include/gflags/gflags.h ]] \
-      && grep -q 'namespace gflags' /usr/include/gflags/gflags.h \
-      && ! grep -q 'namespace google' /usr/include/gflags/gflags.h; then
-      cmake_cxx_flags="${cmake_cxx_flags:+${cmake_cxx_flags} }-DGFLAGS_NAMESPACE=gflags"
-    fi
-
-    if [[ -n "${cmake_cxx_flags}" ]]; then
-      cmake_args+=("-DCMAKE_CXX_FLAGS=${cmake_cxx_flags}")
-    fi
-
-    cmake_args+=("-DCMAKE_BUILD_TYPE=${cmake_build_type}")
-
-    if [[ -f /opt/rh/devtoolset-8/enable ]]; then
-      set +u
-      source /opt/rh/devtoolset-8/enable
-      set -u
-    fi
-
-    g++ --version
-    cmake --version
-
-    rm -rf ./tmp_dir
-    mkdir -p ./tmp_dir
-
-    cmake "${cmake_args[@]}"
-
-    VERBOSE=1 make -j"${build_jobs}"
-
-    if [[ "${run_tests}" == "yes" ]]; then
-      ctest_bin=ctest
-      if ! command -v "${ctest_bin}" >/dev/null 2>&1; then
-        ctest_bin=ctest3
-      fi
-      TEST_TMPDIR=./tmp_dir ASAN_OPTIONS=detect_leaks=0 run_with_sanitizer_runtime "${ctest_bin}" --verbose -R titan
-    fi
-  titan_format_script: &titan_format_script |
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    if ! command -v clang-format >/dev/null 2>&1; then
-      yum install -y llvm-toolset-7.0
-    fi
-    if [ -f /opt/rh/llvm-toolset-7.0/enable ]; then
-      set +u
-      source /opt/rh/llvm-toolset-7.0/enable
-      set -u
-    fi
-
-    find . \( -iname "*.h" -o -iname "*.cc" \) -print0 | xargs -0 -L1 clang-format -style=google -i
-
-    if [[ -n "$(git diff --stat)" ]]; then
-      echo "Run scripts/format-diff.sh to format your code."
-      git diff --stat
-      exit 1
-    fi
-
 presubmits:
   tikv/titan:
-    - <<: *titan_presubmit_job
-      name: pull-titan-format
+    - name: pull-titan-format
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      branches:
+        - ^master$
+      decoration_config:
+        timeout: 3h
+      always_run: false # TODO update here after test passed
+      optional: true # TODO update here after test passed
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       spec:
-        affinity: *amd64_affinity
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
         containers:
-          - <<: *builder_container
-            args:
-              - *titan_format_script
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/format.sh
             resources:
               requests:
                 cpu: "2"
@@ -181,35 +39,118 @@ presubmits:
                 cpu: "2"
                 memory: 2Gi
 
-    - <<: *titan_presubmit_job
-      name: pull-titan-test
+    - name: pull-titan-test
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      branches:
+        - ^master$
+      decoration_config:
+        timeout: 3h
+      always_run: false # TODO update here after test passed
+      optional: true # TODO update here after test passed
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       spec:
-        affinity: *amd64_affinity
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
         containers:
-          - <<: *builder_container
-            args:
-              - *titan_test_script
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test.sh
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
 
-    - <<: *titan_presubmit_job
-      name: pull-titan-sanitizer-asan
+    - name: pull-titan-sanitizer-asan
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      branches:
+        - ^master$
+      decoration_config:
+        timeout: 3h
+      always_run: false # TODO update here after test passed
+      optional: true # TODO update here after test passed
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       spec:
-        affinity: *amd64_affinity
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
         containers:
-          - <<: *builder_container
-            args:
-              - *titan_test_script
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test.sh
             env:
               - name: SANITIZER
                 value: ASAN
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
 
-    - <<: *titan_presubmit_job
-      name: pull-titan-sanitizer-tsan
+    - name: pull-titan-sanitizer-tsan
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      branches:
+        - ^master$
+      decoration_config:
+        timeout: 3h
+      always_run: false # TODO update here after test passed
+      optional: true # TODO update here after test passed
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       spec:
-        affinity: *amd64_affinity
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
         containers:
-          - <<: *builder_container
-            args:
-              - *titan_test_script
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test.sh
             env:
               - name: SANITIZER
                 value: TSAN
@@ -217,35 +158,133 @@ presubmits:
               # Required for TSAN on GCP. Without privileged mode, the TSAN job hit
               # `ThreadSanitizer: unexpected memory mapping` during test execution.
               privileged: true
-    - <<: *titan_presubmit_job
-      name: pull-titan-sanitizer-ubsan
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
+
+    - name: pull-titan-sanitizer-ubsan
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      branches:
+        - ^master$
+      decoration_config:
+        timeout: 3h
+      always_run: false # TODO update here after test passed
+      optional: true # TODO update here after test passed
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       spec:
-        affinity: *amd64_affinity
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
         containers:
-          - <<: *builder_container
-            args:
-              - *titan_test_script
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test.sh
             env:
               - name: SANITIZER
                 value: UBSAN
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
 
-    - <<: *titan_presubmit_job
-      name: pull-titan-release
+    - name: pull-titan-release
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      branches:
+        - ^master$
+      decoration_config:
+        timeout: 3h
+      always_run: false # TODO update here after test passed
+      optional: true # TODO update here after test passed
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       spec:
-        affinity: *amd64_affinity
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
         containers:
-          - <<: *builder_container
-            args:
-              - *titan_test_script
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test.sh
             env:
               - name: BUILD_TYPE
                 value: Release
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
 
-    - <<: *titan_presubmit_job
-      name: pull-titan-test-arm64
+    - name: pull-titan-test-arm64
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      branches:
+        - ^master$
+      decoration_config:
+        timeout: 3h
+      always_run: false # TODO update here after test passed
+      optional: true # TODO update here after test passed
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       spec:
-        affinity: *arm64_affinity
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64
         containers:
-          - <<: *builder_container
-            args:
-              - *titan_test_script
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test.sh
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi

--- a/scripts/tikv/titan/format.sh
+++ b/scripts/tikv/titan/format.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v clang-format >/dev/null 2>&1; then
+  yum install -y llvm-toolset-7.0
+fi
+
+if [[ -f /opt/rh/llvm-toolset-7.0/enable ]]; then
+  set +u
+  source /opt/rh/llvm-toolset-7.0/enable
+  set -u
+fi
+
+find . \( -iname "*.h" -o -iname "*.cc" \) -print0 | \
+  xargs -0 -L1 clang-format -style=google -i
+
+if [[ -n "$(git diff --stat)" ]]; then
+  echo "Run scripts/format-diff.sh to format your code."
+  git diff --stat
+  exit 1
+fi

--- a/scripts/tikv/titan/test.sh
+++ b/scripts/tikv/titan/test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_type="${BUILD_TYPE:-}"
+sanitizer="${SANITIZER:-}"
+cmake_build_type="Debug"
+run_tests="yes"
+build_jobs="${MAKE_JOBS:-2}"
+cmake_cxx_flags="${CXXFLAGS:-}"
+
+run_with_sanitizer_runtime() {
+  "$@"
+}
+
+required_packages=(
+  libstdc++-devel
+  snappy-devel
+  lz4-devel
+  zlib-devel
+  libzstd-devel
+  gflags-devel
+)
+
+cmake_args=(
+  .
+  -L
+  -DWITH_SNAPPY=ON
+  -DWITH_LZ4=ON
+  -DWITH_ZLIB=ON
+  -DWITH_ZSTD=ON
+  -DROCKSDB_BUILD_SHARED=OFF
+)
+
+if [[ -n "${build_type}" ]]; then
+  cmake_build_type="${build_type}"
+  run_tests="no"
+fi
+
+if [[ -n "${sanitizer}" ]]; then
+  case "${sanitizer}" in
+    ASAN)
+      cmake_args+=("-DWITH_ASAN=ON" "-DWITH_TITAN_TOOLS=OFF")
+      required_packages+=(devtoolset-8-libasan-devel)
+      ;;
+    TSAN)
+      cmake_args+=("-DWITH_TSAN=ON" "-DWITH_TITAN_TOOLS=OFF")
+      required_packages+=(devtoolset-8-libtsan-devel)
+      ;;
+    UBSAN)
+      cmake_args+=("-DWITH_UBSAN=ON" "-DWITH_TITAN_TOOLS=OFF")
+      required_packages+=(devtoolset-8-libubsan-devel)
+      ;;
+    *)
+      echo "unsupported sanitizer: ${sanitizer}" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [[ "${sanitizer}" == "TSAN" ]]; then
+  if ! command -v setarch >/dev/null 2>&1; then
+    echo "setarch is required for TSan runtime on this job" >&2
+    exit 1
+  fi
+
+  arch_name="$(uname -m)"
+  run_with_sanitizer_runtime() {
+    setarch "${arch_name}" -R "$@"
+  }
+fi
+
+if ! rpm -q "${required_packages[@]}" >/dev/null 2>&1; then
+  yum install -y "${required_packages[@]}"
+fi
+
+if [[ -f /usr/include/gflags/gflags.h ]] \
+  && grep -q 'namespace gflags' /usr/include/gflags/gflags.h \
+  && ! grep -q 'namespace google' /usr/include/gflags/gflags.h; then
+  cmake_cxx_flags="${cmake_cxx_flags:+${cmake_cxx_flags} }-DGFLAGS_NAMESPACE=gflags"
+fi
+
+if [[ -n "${cmake_cxx_flags}" ]]; then
+  cmake_args+=("-DCMAKE_CXX_FLAGS=${cmake_cxx_flags}")
+fi
+
+cmake_args+=("-DCMAKE_BUILD_TYPE=${cmake_build_type}")
+
+if [[ -f /opt/rh/devtoolset-8/enable ]]; then
+  set +u
+  source /opt/rh/devtoolset-8/enable
+  set -u
+fi
+
+g++ --version
+cmake --version
+
+rm -rf ./tmp_dir
+mkdir -p ./tmp_dir
+
+cmake "${cmake_args[@]}"
+
+VERBOSE=1 make -j"${build_jobs}"
+
+if [[ "${run_tests}" == "yes" ]]; then
+  ctest_bin=ctest
+  if ! command -v "${ctest_bin}" >/dev/null 2>&1; then
+    ctest_bin=ctest3
+  fi
+
+  TEST_TMPDIR=./tmp_dir ASAN_OPTIONS=detect_leaks=0 \
+    run_with_sanitizer_runtime "${ctest_bin}" --verbose -R titan
+fi


### PR DESCRIPTION
## Background
This PR migrates the legacy Jenkins CI job [titan_test](https://ci.pingcap.net/job/titan_ghpr_test/) to native Prow presubmit jobs on GCP. 

Issue Number: ref https://github.com/PingCAP-QE/ci/issues/4508

## Summary
- migrate the legacy titan GHPR Jenkins task to native Prow presubmit jobs on GCP
- split the old parallel job into format, test, asan, tsan, ubsan, release, and arm64 jobs

## Testing
- validated local pods in `prow-test-pods`
- `pull-titan-format`: passed
- `pull-titan-release`: passed
- `pull-titan-test`: passed
- `pull-titan-sanitizer-asan`: passed
- `pull-titan-sanitizer-tsan`: passed
- `pull-titan-sanitizer-ubsan`: passed
- `pull-titan-test-arm64`: passed