### PR TITLE
refactor(pipelines/pingcap/tidb): use ephemeral PVC workspace volume for release-8.5 pull_build

### DIFF
--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
@@ -46,6 +46,16 @@ spec:
               requests:
                 storage: 150Gi
             storageClassName: hyperdisk-rwo
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/release-8.5/pull_build.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_build.groovy
@@ -15,7 +15,6 @@ pipeline {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             defaultContainer 'golang'
-            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
         }
     }
     options {

--- a/pipelines/pingcap/tidb/release-8.5/pull_build.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_build.groovy
@@ -15,6 +15,7 @@ pipeline {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             defaultContainer 'golang'
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
         }
     }
     options {


### PR DESCRIPTION
## Summary
- override the Jenkins kubernetes default workspace volume for `pingcap/tidb/release-8.5/pull_build`
- keep the pod definition in YAML instead of configuring `workspaceVolume` in the pipeline DSL
- define `spec.volumes[].name=workspace-volume` as an ephemeral `volumeClaimTemplate`
- keep this PR scoped to a single high-IO migrated GCP job for phase-1 validation

## Why
Migrated Jenkins jobs on GCP currently rely on the kubernetes plugin default workspace volume when `workspaceVolume` is not set explicitly. For large build jobs, that means the workspace lives on node-local ephemeral storage and can be constrained by small-space nodes.

For declarative Jenkins pipelines in this repo, keeping pod configuration in the pod YAML is the better maintenance model. This PR therefore validates the rollout pattern by overriding `workspace-volume` directly in the pod template YAML for one representative job first.

## Validation
- validated `pipelines/pingcap/tidb/release-8.5/pull_build.groovy` via `.ci/verify-jenkins-pipeline-file.sh`
- parsed `pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml` locally and verified `workspace-volume` resolves to an ephemeral PVC with `storageClassName=hyperdisk-rwo` and `storage=150Gi`
- verified the pod YAML still survives the same annotation-style round-trip that `pod_label.withCiLabels(...)` performs
