### PR TITLE
ci: add workspace PVC overrides for remaining migrated GCP Jenkins jobs

### DIFF
--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
@@ -138,6 +138,16 @@ spec:
           cpu: 2000m
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - emptyDir: {}
       name: volume-0
   affinity:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
@@ -138,6 +138,16 @@ spec:
           cpu: 2000m
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - emptyDir: {}
       name: volume-0
   affinity:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 32Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 24Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 24Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_build.yaml
@@ -36,6 +36,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check.yaml
@@ -34,6 +34,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check2.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check2.yaml
@@ -41,6 +41,16 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_mysql_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_mysql_test.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           memory: 6Gi
           cpu: "3"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_unit_test.yaml
@@ -38,6 +38,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc

--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_regression_test/pod.yaml
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_regression_test/pod.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           cpu: "12"
           memory: 24Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pod.yaml
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pod.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           cpu: "16"
           memory: 64Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_build.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -141,6 +141,16 @@ spec:
           cpu: 200m
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - emptyDir: {}
       name: volume-0
   affinity:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_mysql_test.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_pulsar_test.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           memory: 32Gi
           cpu: "12"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_storage_test.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
@@ -138,6 +138,16 @@ spec:
           cpu: 2000m
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - emptyDir: {}
       name: volume-0
   affinity:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-build.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-test.yaml
@@ -138,6 +138,16 @@ spec:
           cpu: 2000m
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - emptyDir: {}
       name: volume-0
   affinity:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
@@ -138,6 +138,16 @@ spec:
           cpu: 2000m
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - emptyDir: {}
       name: volume-0
   affinity:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pod-build.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pod-test.yaml
@@ -138,6 +138,16 @@ spec:
           cpu: 2000m
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - emptyDir: {}
       name: volume-0
   affinity:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 32Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pod.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 32Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 32Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pod.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 24Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pod.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 24Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pod.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 24Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pod.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pod-build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pod-test.yaml
@@ -11,6 +11,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pod.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/ghpr_build/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/ghpr_build/pod.yaml
@@ -36,6 +36,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
@@ -34,6 +34,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -46,6 +46,16 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           memory: 6Gi
           cpu: "3"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -38,6 +38,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
@@ -34,6 +34,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
@@ -38,6 +38,17 @@ spec:
           cpu: "1"
           memory: 4Gi
 
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
@@ -28,6 +28,17 @@ spec:
           cpu: "1"
           memory: 4Gi
 
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
@@ -37,6 +37,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
@@ -34,6 +34,16 @@ spec:
         - name: test-data
           mountPath: /git
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: test-data
       emptyDir: {}
   affinity:

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
@@ -38,6 +38,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
@@ -38,6 +38,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
@@ -57,5 +57,15 @@ spec:
                 values:
                   - "true"
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: mysql-config-volume
       emptyDir: {}

--- a/pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
@@ -37,6 +37,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml
@@ -37,6 +37,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_mysql_client_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_mysql_client_test.yaml
@@ -26,6 +26,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "8"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
@@ -35,6 +35,16 @@ spec:
         - name: test-data
           mountPath: /git
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: test-data
       emptyDir: {}
   affinity:

--- a/pipelines/pingcap/tidb/latest/pull_build_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_build_next_gen/pod.yaml
@@ -36,6 +36,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pod.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
@@ -46,6 +46,16 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pod.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pod.yaml
@@ -29,6 +29,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "8"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pod.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
@@ -40,6 +40,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 300Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_check.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_check.yaml
@@ -34,6 +34,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_check2.yaml
@@ -46,6 +46,16 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_common_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "4"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_e2e_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_common_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_copr_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_ddl_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_jdbc_test.yaml
@@ -37,6 +37,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_mysql_test.yaml
@@ -27,6 +27,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_nodejs_test.yaml
@@ -40,5 +40,15 @@ spec:
                 values:
                   - amd64
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: tidb-tmp
       emptyDir: {}

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_python_orm_test.yaml
@@ -37,6 +37,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_tidb_tools_test.yaml
@@ -40,6 +40,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_mysql_client_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_mysql_client_test.yaml
@@ -26,6 +26,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "8"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_mysql_test.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           memory: 6Gi
           cpu: "3"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_sqllogic_test.yaml
@@ -35,6 +35,16 @@ spec:
         - name: test-data
           mountPath: /git
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: test-data
       emptyDir: {}
   affinity:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
@@ -38,6 +38,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           memory: 4Gi
           cpu: 2000m
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           memory: 4Gi
           cpu: 2000m
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_build.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_build.yaml
@@ -24,6 +24,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
@@ -141,6 +141,16 @@ spec:
           cpu: 200m
           memory: 4Gi
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - emptyDir: {}
       name: volume-0
   affinity:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           memory: 32Gi
           cpu: "12"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           memory: 32Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml
@@ -80,6 +80,16 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: mysql-config-volume
       emptyDir: {}
   affinity:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
@@ -80,6 +80,16 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: mysql-config-volume
       emptyDir: {}
   affinity:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
@@ -43,6 +43,17 @@ spec:
         limits:
           memory: 2Gi
           cpu: "1"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-8.5/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-ghpr_verify.yaml
@@ -14,6 +14,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/main-pod.yaml
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/main-pod.yaml
@@ -21,6 +21,17 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+  volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml
@@ -36,6 +36,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
+    - name: workspace-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc


### PR DESCRIPTION
## Summary
- add explicit `workspace-volume` ephemeral `volumeClaimTemplate` overrides to the remaining migrated GCP Jenkins pod templates
- keep the workspace override in pod YAML instead of pipeline DSL
- complete phase-2 after `#4509` validated the rollout pattern on a single job

## Scope
This PR covers the remaining `agent=jenkins && labels.master=1` declarative jobs that still relied on the Jenkins kubernetes plugin default workspace `emptyDir`.

Changed pod templates by family:
- `pipelines/pingcap/tidb/latest`: 36 files
- `pipelines/pingcap/tidb/release-8.5`: 19 files
- `pipelines/pingcap-inc/tidb/release-8.5`: 7 files
- `pipelines/pingcap/ticdc/latest`: 34 files
- `pipelines/pingcap-inc/ticdc/latest`: 14 files
- `pipelines/pingcap/tiflow/latest`: 10 files
- `pipelines/pingcap/tiflow/release-8.5`: 1 file
- `pipelines/pingcap-inc/tiflow/release-8.5`: 5 files
- `pipelines/pingcap-inc/tiflash-scripts/latest`: 2 files
- `pipelines/tidbcloud/cloud-storage-engine/dedicated`: 2 files

## Sizing rule
- when a pod already had an ephemeral PVC pattern, the new `workspace-volume` reuses that pod's existing PVC sizing signal
- otherwise the workspace PVC defaults to `150Gi` with `storageClassName: hyperdisk-rwo`

Resulting distribution in this PR:
- `150Gi`: 124 pod templates
- `200Gi`: 5 pod templates
- `300Gi`: 1 pod template

## Validation
- parsed all 130 changed pod YAML files locally
- verified every changed file now contains exactly one `spec.volumes[].name=workspace-volume`
- verified every added workspace PVC resolves to `storageClassName=hyperdisk-rwo`
- verified no remaining target pod template in the rollout scope is missing the workspace PVC override
