### PR TITLE
ci: fix workspace pvc rollout for tiflow-related jobs

### DIFF
--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_regression_test/pipeline.groovy
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_regression_test/pipeline.groovy
@@ -12,6 +12,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 2
         }

--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_regression_test/pod.yaml
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_regression_test/pod.yaml
@@ -15,16 +15,6 @@ spec:
           cpu: "12"
           memory: 24Gi
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pipeline.groovy
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pipeline.groovy
@@ -12,6 +12,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 2
         }

--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pod.yaml
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pod.yaml
@@ -15,16 +15,6 @@ spec:
           cpu: "16"
           memory: 64Gi
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_build.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_build.yaml
@@ -25,16 +25,6 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -141,16 +141,6 @@ spec:
           cpu: 200m
           memory: 4Gi
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
     - emptyDir: {}
       name: volume-0
   affinity:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_mysql_test.yaml
@@ -15,16 +15,6 @@ spec:
           memory: 16Gi
           cpu: "6"
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_pulsar_test.yaml
@@ -15,16 +15,6 @@ spec:
           memory: 32Gi
           cpu: "12"
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_storage_test.yaml
@@ -15,16 +15,6 @@ spec:
           memory: 16Gi
           cpu: "6"
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -35,6 +35,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
             }
@@ -93,6 +94,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -35,6 +35,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
             }
@@ -93,6 +94,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -35,6 +35,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
             }
@@ -92,6 +93,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -35,6 +35,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
             }
@@ -93,6 +94,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -29,6 +29,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yamlFile POD_TEMPLATE_FILE
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
@@ -28,6 +28,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yamlFile POD_TEMPLATE_FILE
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
@@ -22,16 +22,6 @@ spec:
           memory: 4Gi
           cpu: 2000m
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml
@@ -22,16 +22,6 @@ spec:
           memory: 4Gi
           cpu: 2000m
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_build.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_build.yaml
@@ -25,16 +25,6 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
@@ -141,16 +141,6 @@ spec:
           cpu: 200m
           memory: 4Gi
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
     - emptyDir: {}
       name: volume-0
   affinity:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml
@@ -15,16 +15,6 @@ spec:
           memory: 32Gi
           cpu: "12"
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml
@@ -15,16 +15,6 @@ spec:
           memory: 16Gi
           cpu: "6"
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
@@ -15,16 +15,6 @@ spec:
           memory: 32Gi
           cpu: "6"
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml
@@ -80,16 +80,6 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
     - name: mysql-config-volume
       emptyDir: {}
   affinity:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
@@ -80,16 +80,6 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
     - name: mysql-config-volume
       emptyDir: {}
   affinity:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
@@ -44,16 +44,6 @@ spec:
           memory: 2Gi
           cpu: "1"
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -34,6 +34,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
             }
@@ -89,6 +90,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -34,6 +34,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
             }
@@ -88,6 +89,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -34,6 +34,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
             }
@@ -89,6 +90,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -34,6 +34,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
             }
@@ -89,6 +90,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -19,6 +19,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -21,6 +21,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -153,6 +154,7 @@ pipeline {
                         label "dm-it-${UUID.randomUUID().toString()}"
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -18,6 +18,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -132,6 +133,7 @@ pipeline {
                         label "dm-it-${UUID.randomUUID().toString()}"
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_syncdiff_integration_test.groovy
@@ -16,6 +16,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
         }
     }

--- a/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
@@ -14,6 +14,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -48,6 +49,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-ghpr_verify.yaml
@@ -15,16 +15,6 @@ spec:
           memory: 16Gi
           cpu: "6"
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/main-pod.yaml
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/main-pod.yaml
@@ -22,16 +22,6 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -21,6 +21,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(MAIN_POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
         }
     }
     options {
@@ -180,6 +181,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
                         yaml pod_label.withCiLabels(TEST_POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml
@@ -36,16 +36,6 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: workspace-volume
-      ephemeral:
-        volumeClaimTemplate:
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 150Gi
-            storageClassName: hyperdisk-rwo
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc


### PR DESCRIPTION
## Summary
- part of the workspace PVC rollout correction split from `ci#4512`
- switch this job subset to Jenkins kubernetes plugin `workspaceVolume genericEphemeralVolume(...)`
- remove the ineffective pod-yaml `workspace-volume` blocks for the same subset

## Why This PR Exists
The original follow-up PR `ci#4512` proved the right fix, but `pull-replay-jenkins-pipelines` failed because that PR changed `111` pipeline files and exceeded the replay gate limit:
- `ERROR: replay file count 111 exceeds --max-replays 20`

This split PR keeps the same validated fix while staying within the replay gate bound.

## Scope
- changed pipeline files: `18`
- cleaned pod yaml files: `20`
- replay-safe split: yes (`<= 20` pipeline files)

## Validation
- each changed Jenkinsfile in this PR was validated via:
  - `https://prow.tidb.net/jenkins/pipeline-model-converter/validate`
- each changed pod yaml in this PR passed local YAML parsing
- root-cause evidence remains:
  - replay pod manifest for `ci#4509` still showed `workspace-volume: emptyDir`
  - https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/release-8.5/job/pull_build/30
