### PR TITLE
ci(prow): migrate tidb-binlog integration test to GCP

### DIFF
--- a/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
@@ -106,10 +106,8 @@ presubmits:
       decorate: true
       decoration_config:
         timeout: 120m
-      optional: false
+      optional: true
       skip_if_only_changed: *skip_if_only_changed
-      # TiDB Binlog is removed from TiDB >= 8.3. Keep this integration job focused on
-      # the maintained legacy-compatible lines only.
       spec:
         affinity:
           nodeAffinity:

--- a/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
@@ -4,6 +4,11 @@ global_definitions:
       - ^master$
       - ^release-6[.][1-9].*$
       - ^release-[78][.].*$
+  integration_brancher: &integration_brancher
+    branches:
+      - ^release-8[.]1.*$
+      - ^release-7[.]5.*$
+      - ^release-7[.]1.*$
 
   skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
@@ -95,40 +100,65 @@ presubmits:
                       operator: In
                       values:
                         - amd64
-    - <<: *brancher
-      name: wip-pull-integration-test # WIP
+    - <<: *integration_brancher
+      name: pull-integration-test
       agent: kubernetes
-      # TODO(@wuhuizuo): migrate images hub.pingcap.net/jenkins/zookeeper and hub.pingcap.net/jenkins/kafka to a public registry.
-      decorate: true # need add this.
-      always_run: false
-      optional: true
-      # skip_if_only_changed: *skip_if_only_changed
-      # context: idc-jenkins-ci-tidb-binlog/integration-test
+      decorate: true
+      decoration_config:
+        timeout: 120m
+      always_run: true
+      optional: false
+      skip_if_only_changed: *skip_if_only_changed
+      # TiDB Binlog is removed from TiDB >= 8.3. Keep this integration job focused on
+      # the maintained legacy-compatible lines only.
       spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+        volumes:
+          - name: tools
+            emptyDir: {}
         containers:
           - name: build
             image: ghcr.io/pingcap-qe/ci/base:v2024.10.8-81-gec616ff-go1.21
+            imagePullPolicy: Always
             command: [bash, -ce]
+            env:
+              - name: OCI_ARTIFACT_HOST
+                value: us-docker.pkg.dev/pingcap-testing-account/hub
+              - name: TIDB_BINLOG_SUPPORTED_REFS
+                value: release-8.1,release-7.5,release-7.1
             args:
               - |
-                trap 'touch /tools/run.done' EXIT # notify other containers to exit, `/tools` is shared volume.
-
-                make build
-                ls -l ./bin
-                # KAFKA_ADDRS=127.0.0.1:9092 make integration-test
+                curl -fsSL --retry 3 \
+                  https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/pingcap/tidb-binlog/pull_integration_test.sh \
+                  -o /tmp/pull_integration_test.sh
+                bash /tmp/pull_integration_test.sh
+            volumeMounts:
+              - name: tools
+                mountPath: /tools
             resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
               limits:
                 memory: 8Gi
                 cpu: "4"
           - name: zookeeper
-            image: hub.pingcap.net/jenkins/zookeeper
+            image: wurstmeister/zookeeper
             command: [bash, -ce]
             args:
               - |
                 echo "🚩 This is the Zookeeper server."
 
                 # Start Zookeeper in the background
-                /usr/bin/start-zk.sh > /logs/artifacts/container-output-zookeeper.log 2>&1 &
+                bash /usr/bin/start-zk.sh > /logs/artifacts/container-output-zookeeper.log 2>&1 &
                 ZK_PID=$!
 
                 # Function to handle termination signal
@@ -151,12 +181,15 @@ presubmits:
                 # Call the terminate function to stop Zookeeper
                 echo "👀 Saw termination flag, exiting."
                 terminate
+            volumeMounts:
+              - name: tools
+                mountPath: /tools
             resources:
               requests:
                 memory: 4Gi
                 cpu: "2"
           - name: kafka
-            image: hub.pingcap.net/jenkins/kafka
+            image: wurstmeister/kafka:2.12-2.4.1
             command: [bash, -ce]
             args:
               - |
@@ -191,26 +224,20 @@ presubmits:
                 value: "1073741824"
               - name: KAFKA_REPLICA_FETCH_MAX_BYTES
                 value: "1073741824"
-              - name: KAFKA_ADVERTISED_PORT
-                value: "9092"
-              - name: KAFKA_ADVERTISED_HOST_NAME
-                value: "127.0.0.1"
               - name: KAFKA_BROKER_ID
                 value: "1"
+              - name: KAFKA_ADVERTISED_LISTENERS
+                value: "PLAINTEXT://127.0.0.1:9092"
+              - name: KAFKA_LISTENERS
+                value: "PLAINTEXT://127.0.0.1:9092"
               - name: ZK
                 value: "zk"
               - name: KAFKA_ZOOKEEPER_CONNECT
                 value: "localhost:2181"
+            volumeMounts:
+              - name: tools
+                mountPath: /tools
             resources:
               requests:
                 memory: 4Gi
                 cpu: "2"
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/arch
-                      operator: In
-                      values:
-                        - amd64

--- a/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
@@ -6,9 +6,9 @@ global_definitions:
       - ^release-[78][.].*$
   integration_brancher: &integration_brancher
     branches:
-      - ^release-8[.]1.*$
-      - ^release-7[.]5.*$
-      - ^release-7[.]1.*$
+      - ^release-8[.]1([.-].*)?$
+      - ^release-7[.]5([.-].*)?$
+      - ^release-7[.]1([.-].*)?$
 
   skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
 
@@ -106,7 +106,6 @@ presubmits:
       decorate: true
       decoration_config:
         timeout: 120m
-      always_run: true
       optional: false
       skip_if_only_changed: *skip_if_only_changed
       # TiDB Binlog is removed from TiDB >= 8.3. Keep this integration job focused on
@@ -121,13 +120,9 @@ presubmits:
                       operator: In
                       values:
                         - amd64
-        volumes:
-          - name: tools
-            emptyDir: {}
         containers:
           - name: build
             image: ghcr.io/pingcap-qe/ci/base:v2024.10.8-81-gec616ff-go1.21
-            imagePullPolicy: Always
             command: [bash, -ce]
             env:
               - name: OCI_ARTIFACT_HOST
@@ -136,13 +131,11 @@ presubmits:
                 value: release-8.1,release-7.5,release-7.1
             args:
               - |
+                trap 'touch /tools/run.done' EXIT
                 curl -fsSL --retry 3 \
                   https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/pingcap/tidb-binlog/pull_integration_test.sh \
                   -o /tmp/pull_integration_test.sh
                 bash /tmp/pull_integration_test.sh
-            volumeMounts:
-              - name: tools
-                mountPath: /tools
             resources:
               requests:
                 memory: 8Gi
@@ -181,9 +174,6 @@ presubmits:
                 # Call the terminate function to stop Zookeeper
                 echo "👀 Saw termination flag, exiting."
                 terminate
-            volumeMounts:
-              - name: tools
-                mountPath: /tools
             resources:
               requests:
                 memory: 4Gi
@@ -234,9 +224,6 @@ presubmits:
                 value: "zk"
               - name: KAFKA_ZOOKEEPER_CONNECT
                 value: "localhost:2181"
-            volumeMounts:
-              - name: tools
-                mountPath: /tools
             resources:
               requests:
                 memory: 4Gi

--- a/scripts/artifacts/download_pingcap_oci_artifact.sh
+++ b/scripts/artifacts/download_pingcap_oci_artifact.sh
@@ -145,11 +145,6 @@ function main() {
         chmod +x pd-ctl
         echo "🎉 download pd-ctl success"
     fi
-    if [[ -n "$TIDB_TOOLS" ]]; then
-        echo "🚀 start download tidb-tools"
-        download "$tidb_tools_oci_url" '^tidb-tools-v.+.tar.gz$' tidb-tools.tar.gz
-        echo "🎉 download tidb-tools success"
-    fi
     if [[ -n "$TIFLASH" ]]; then
         echo "🚀 start download TiFlash"
         download_and_extract_with_path "$tiflash_oci_url" '^tiflash-v.+.tar.gz$' tiflash.tar.gz tiflash
@@ -277,10 +272,6 @@ function parse_cli_args() {
         PD_CTL="${i#*=}"
         shift # past argument=value
         ;;
-        -tidb-tools=*|--tidb-tools=*)
-        TIDB_TOOLS="${i#*=}"
-        shift # past argument=value
-        ;;
         -tikv=*|--tikv=*)
         TIKV="${i#*=}"
         shift # past argument=value
@@ -365,7 +356,6 @@ function parse_cli_args() {
     [[ -n "${TIKV_CTL}" ]]      && echo "TIKV_CTL    = ${TIKV_CTL}"
     [[ -n "${PD}" ]]            && echo "PD          = ${PD}"
     [[ -n "${PD_CTL}" ]]        && echo "PD_CTL      = ${PD_CTL}"
-    [[ -n "${TIDB_TOOLS}" ]]    && echo "TIDB_TOOLS  = ${TIDB_TOOLS}"
     [[ -n "${TIFLASH}" ]]       && echo "TIFLASH     = ${TIFLASH}"
     [[ -n "${TICDC}" ]]         && echo "TICDC       = ${TICDC}"
     [[ -n "${TICDC_NEW}" ]]     && echo "TICDC_NEW   = ${TICDC_NEW}"
@@ -400,7 +390,6 @@ function parse_cli_args() {
     ticdc_oci_url="${registry_host}/pingcap/tiflow/package:${TICDC}_${tag_suffix}"
     ticdc_new_oci_url="${registry_host}/pingcap/ticdc/package:${TICDC_NEW}_${tag_suffix}"
     tici_oci_url="${registry_host}/pingcap/tici/package:${TICI}_${tag_suffix}"
-    tidb_tools_oci_url="${registry_host_community}/pingcap/tidb-tools/package:${TIDB_TOOLS}_${tag_suffix}"
     sync_diff_inspector_oci_url="${registry_host_community}/pingcap/tiflow/package:${SYNC_DIFF_INSPECTOR}_${tag_suffix}"
 
     # third party or public test tools.

--- a/scripts/artifacts/download_pingcap_oci_artifact.sh
+++ b/scripts/artifacts/download_pingcap_oci_artifact.sh
@@ -145,6 +145,11 @@ function main() {
         chmod +x pd-ctl
         echo "🎉 download pd-ctl success"
     fi
+    if [[ -n "$TIDB_TOOLS" ]]; then
+        echo "🚀 start download tidb-tools"
+        download "$tidb_tools_oci_url" '^tidb-tools-v.+.tar.gz$' tidb-tools.tar.gz
+        echo "🎉 download tidb-tools success"
+    fi
     if [[ -n "$TIFLASH" ]]; then
         echo "🚀 start download TiFlash"
         download_and_extract_with_path "$tiflash_oci_url" '^tiflash-v.+.tar.gz$' tiflash.tar.gz tiflash
@@ -272,6 +277,10 @@ function parse_cli_args() {
         PD_CTL="${i#*=}"
         shift # past argument=value
         ;;
+        -tidb-tools=*|--tidb-tools=*)
+        TIDB_TOOLS="${i#*=}"
+        shift # past argument=value
+        ;;
         -tikv=*|--tikv=*)
         TIKV="${i#*=}"
         shift # past argument=value
@@ -356,6 +365,7 @@ function parse_cli_args() {
     [[ -n "${TIKV_CTL}" ]]      && echo "TIKV_CTL    = ${TIKV_CTL}"
     [[ -n "${PD}" ]]            && echo "PD          = ${PD}"
     [[ -n "${PD_CTL}" ]]        && echo "PD_CTL      = ${PD_CTL}"
+    [[ -n "${TIDB_TOOLS}" ]]    && echo "TIDB_TOOLS  = ${TIDB_TOOLS}"
     [[ -n "${TIFLASH}" ]]       && echo "TIFLASH     = ${TIFLASH}"
     [[ -n "${TICDC}" ]]         && echo "TICDC       = ${TICDC}"
     [[ -n "${TICDC_NEW}" ]]     && echo "TICDC_NEW   = ${TICDC_NEW}"
@@ -390,6 +400,7 @@ function parse_cli_args() {
     ticdc_oci_url="${registry_host}/pingcap/tiflow/package:${TICDC}_${tag_suffix}"
     ticdc_new_oci_url="${registry_host}/pingcap/ticdc/package:${TICDC_NEW}_${tag_suffix}"
     tici_oci_url="${registry_host}/pingcap/tici/package:${TICI}_${tag_suffix}"
+    tidb_tools_oci_url="${registry_host_community}/pingcap/tidb-tools/package:${TIDB_TOOLS}_${tag_suffix}"
     sync_diff_inspector_oci_url="${registry_host_community}/pingcap/tiflow/package:${SYNC_DIFF_INSPECTOR}_${tag_suffix}"
 
     # third party or public test tools.

--- a/scripts/pingcap/tidb-binlog/pull_integration_test.sh
+++ b/scripts/pingcap/tidb-binlog/pull_integration_test.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ARTIFACTS_DIR="${ARTIFACTS:-/logs/artifacts}"
+TOOLS_DIR="/tmp/bin-tools"
+OCI_SCRIPT="/tmp/download_pingcap_oci_artifact.sh"
+OCI_ARTIFACT_HOST="${OCI_ARTIFACT_HOST:-us-docker.pkg.dev/pingcap-testing-account/hub}"
+OCI_ARTIFACT_HOST_COMMUNITY="${OCI_ARTIFACT_HOST_COMMUNITY:-us-docker.pkg.dev/pingcap-testing-account/hub}"
+TIDB_BINLOG_SUPPORTED_REFS="${TIDB_BINLOG_SUPPORTED_REFS:-release-8.1,release-7.5,release-7.1}"
+REPO_ROOT="$(pwd)"
+
+mkdir -p "${ARTIFACTS_DIR}" "${TOOLS_DIR}" /tools
+export PATH="${TOOLS_DIR}:${PATH}"
+
+log() {
+  printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" | tee -a "${ARTIFACTS_DIR}/steps.log"
+}
+
+fail() {
+  log "ERROR: $*"
+  exit 1
+}
+
+normalize_component_ref() {
+  local ref="$1"
+
+  if [[ "${ref}" =~ ^release-([0-9]+\.[0-9]+)(-beta\.[0-9]+)?([.-].*)?$ ]]; then
+    echo "release-${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+    return 0
+  fi
+
+  echo "${ref}"
+}
+
+normalize_oci_tag() {
+  local ref="$1"
+  echo "${ref//\//-}"
+}
+
+is_supported_binlog_ref() {
+  local ref="$1"
+  case ",${TIDB_BINLOG_SUPPORTED_REFS}," in
+    *,"${ref}",*) return 0 ;;
+  esac
+  return 1
+}
+
+determine_dependency_ref() {
+  local base_ref="$1"
+  local normalized_ref
+
+  normalized_ref="$(normalize_component_ref "${base_ref}")"
+
+  if is_supported_binlog_ref "${normalized_ref}"; then
+    echo "${normalized_ref}"
+    return 0
+  fi
+
+  fail "Base ref ${base_ref} is outside the maintained binlog-compatible TiDB matrix (${TIDB_BINLOG_SUPPORTED_REFS}). This job only serves release-8.1, release-7.5, and release-7.1."
+}
+
+install_oras() {
+  local version="1.2.3"
+
+  if command -v oras >/dev/null 2>&1; then
+    return 0
+  fi
+
+  log "Installing oras ${version}"
+  curl -fsSL --retry 3 \
+    "https://github.com/oras-project/oras/releases/download/v${version}/oras_${version}_linux_amd64.tar.gz" \
+    | tar -xz -C "${TOOLS_DIR}" oras
+  chmod +x "${TOOLS_DIR}/oras"
+}
+
+install_yq() {
+  local version="v4.47.2"
+
+  if command -v yq >/dev/null 2>&1; then
+    return 0
+  fi
+
+  log "Installing yq ${version}"
+  curl -fsSL --retry 3 \
+    "https://github.com/mikefarah/yq/releases/download/${version}/yq_linux_amd64" \
+    -o "${TOOLS_DIR}/yq"
+  chmod +x "${TOOLS_DIR}/yq"
+}
+
+prepare_download_tools() {
+  command -v curl >/dev/null 2>&1 || fail "curl is required"
+  command -v tar >/dev/null 2>&1 || fail "tar is required"
+
+  install_oras
+  install_yq
+
+  if [[ -f /ci/download_pingcap_oci_artifact.sh ]]; then
+    log "Using mounted OCI download helper"
+    cp /ci/download_pingcap_oci_artifact.sh "${OCI_SCRIPT}"
+  else
+    log "Fetching OCI download helper"
+    curl -fsSL --retry 3 \
+      "https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/artifacts/download_pingcap_oci_artifact.sh" \
+      -o "${OCI_SCRIPT}"
+  fi
+  chmod +x "${OCI_SCRIPT}"
+}
+
+wait_for_port() {
+  local name="$1"
+  local port="$2"
+
+  for _ in $(seq 1 60); do
+    if bash -c "exec 3<>/dev/tcp/127.0.0.1/${port}" >/dev/null 2>&1; then
+      log "${name} is ready on 127.0.0.1:${port}"
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+collect_logs() {
+  local src="/tmp/tidb_binlog_test"
+  local dest="${ARTIFACTS_DIR}/tidb_binlog_test"
+
+  if [[ ! -d "${src}" ]]; then
+    return 0
+  fi
+
+  mkdir -p "${dest}"
+  find "${src}" -maxdepth 1 -type f \( -name "*.log" -o -name "*.out" \) -print0 \
+    | while IFS= read -r -d '' file; do
+        cp -f "${file}" "${dest}/$(basename "${file}")" || true
+      done
+}
+
+print_failure_logs() {
+  local src="/tmp/tidb_binlog_test"
+  local files=(
+    "pd.log"
+    "tikv.log"
+    "tidb.log"
+    "drainer.log"
+    "pump_8250.log"
+    "pump_8251.log"
+    "reparo.log"
+    "binlog.out"
+    "kafka.out"
+  )
+
+  for name in "${files[@]}"; do
+    local file="${src}/${name}"
+    if [[ -f "${file}" ]]; then
+      log "===== ${name} ====="
+      tail -n 200 "${file}" || true
+    fi
+  done
+}
+
+cleanup() {
+  local exit_code="$1"
+
+  if [[ "${exit_code}" -ne 0 ]]; then
+    print_failure_logs
+  fi
+
+  collect_logs
+  touch /tools/run.done || true
+}
+
+main() {
+  trap 'exit_code=$?; cleanup "${exit_code}"; exit "${exit_code}"' EXIT
+
+  local base_ref="${PULL_BASE_REF:-release-8.1}"
+  local dependency_ref
+  local tikv_ref
+  local pd_ref
+  local tidb_ref
+  local tidb_tools_ref
+  local tikv_tag
+  local pd_tag
+  local tidb_tag
+  local tidb_tools_tag
+  local tidb_tools_tarball="${REPO_ROOT}/bin/tidb-tools.tar.gz"
+  local tidb_tools_extract_dir="/tmp/tidb-tools-bin"
+  local tidb_tools_bin_dir
+
+  if ! command -v git >/dev/null 2>&1; then
+    fail "git is required"
+  fi
+  if ! command -v make >/dev/null 2>&1; then
+    fail "make is required"
+  fi
+
+  log "Repo root: ${REPO_ROOT}"
+  log "Base ref: ${base_ref}"
+  log "Supported TiDB Binlog compatibility refs: ${TIDB_BINLOG_SUPPORTED_REFS}"
+
+  dependency_ref="$(determine_dependency_ref "${base_ref}")"
+  tikv_ref="${dependency_ref}"
+  pd_ref="${dependency_ref}"
+  tidb_ref="${dependency_ref}"
+  tidb_tools_ref="master"
+
+  log "Base ref ${base_ref} uses maintained binlog-compatible TiDB ref ${dependency_ref}"
+  log "tidb-tools uses the maintained public artifact line: ${tidb_tools_ref}"
+
+  tikv_tag="$(normalize_oci_tag "${tikv_ref}")"
+  pd_tag="$(normalize_oci_tag "${pd_ref}")"
+  tidb_tag="$(normalize_oci_tag "${tidb_ref}")"
+  tidb_tools_tag="$(normalize_oci_tag "${tidb_tools_ref}")"
+
+  log "Resolved TiKV ref: ${tikv_ref} -> OCI tag ${tikv_tag}"
+  log "Resolved PD ref: ${pd_ref} -> OCI tag ${pd_tag}"
+  log "Resolved TiDB ref: ${tidb_ref} -> OCI tag ${tidb_tag}"
+  log "Resolved tidb-tools ref: ${tidb_tools_ref} -> OCI tag ${tidb_tools_tag}"
+
+  prepare_download_tools
+
+  log "Building tidb-binlog"
+  make build
+  ls -alh "${REPO_ROOT}/bin"
+
+  log "Downloading TiDB/TiKV/PD artifacts from OCI"
+  (
+    cd "${REPO_ROOT}/bin"
+    OCI_ARTIFACT_HOST="${OCI_ARTIFACT_HOST}" bash "${OCI_SCRIPT}" \
+      --pd="${pd_tag}" \
+      --tikv="${tikv_tag}" \
+      --tidb="${tidb_tag}"
+  )
+
+  log "Downloading tidb-tools artifacts from OCI/public artifact"
+  rm -rf "${tidb_tools_extract_dir}"
+  mkdir -p "${tidb_tools_extract_dir}"
+  (
+    cd "${REPO_ROOT}/bin"
+    OCI_ARTIFACT_HOST="${OCI_ARTIFACT_HOST}" \
+    OCI_ARTIFACT_HOST_COMMUNITY="${OCI_ARTIFACT_HOST_COMMUNITY}" \
+      bash "${OCI_SCRIPT}" --tidb-tools="${tidb_tools_tag}"
+  )
+  tar -xzf "${tidb_tools_tarball}" -C "${tidb_tools_extract_dir}"
+  tidb_tools_bin_dir="$(find "${tidb_tools_extract_dir}" -type d -name bin | head -n1 || true)"
+  if [[ -n "${tidb_tools_bin_dir}" ]]; then
+    cp -f "${tidb_tools_bin_dir}"/* "${REPO_ROOT}/bin/"
+  else
+    log "tidb-tools archive uses flat binary layout"
+    find "${tidb_tools_extract_dir}" -maxdepth 1 -type f -exec cp -f {} "${REPO_ROOT}/bin/" \;
+  fi
+  rm -f "${tidb_tools_tarball}"
+  rm -f "${REPO_ROOT}/bin/ddl_checker" "${REPO_ROOT}/bin/importer"
+
+  log "Prepared binary layout"
+  ls -alh "${REPO_ROOT}/bin"
+
+  wait_for_port "Zookeeper" 2181 || fail "Zookeeper did not become ready in time"
+  wait_for_port "Kafka" 9092 || fail "Kafka did not become ready in time"
+
+  log "Running binlog integration test"
+  KAFKA_ADDRS=127.0.0.1:9092 make integration_test
+  log "Binlog integration test finished successfully"
+}
+
+main "$@"

--- a/scripts/pingcap/tidb-binlog/pull_integration_test.sh
+++ b/scripts/pingcap/tidb-binlog/pull_integration_test.sh
@@ -112,7 +112,7 @@ wait_for_port() {
   local port="$2"
 
   for _ in $(seq 1 60); do
-    if bash -c "exec 3<>/dev/tcp/127.0.0.1/${port}" >/dev/null 2>&1; then
+    if (echo > /dev/tcp/127.0.0.1/${port}) >/dev/null 2>&1; then
       log "${name} is ready on 127.0.0.1:${port}"
       return 0
     fi
@@ -245,7 +245,7 @@ main() {
   tar -xzf "${tidb_tools_tarball}" -C "${tidb_tools_extract_dir}"
   tidb_tools_bin_dir="$(find "${tidb_tools_extract_dir}" -type d -name bin | head -n1 || true)"
   if [[ -n "${tidb_tools_bin_dir}" ]]; then
-    cp -f "${tidb_tools_bin_dir}"/* "${REPO_ROOT}/bin/"
+    find "${tidb_tools_bin_dir}" -maxdepth 1 -type f -exec cp -f {} "${REPO_ROOT}/bin/" \;
   else
     log "tidb-tools archive uses flat binary layout"
     find "${tidb_tools_extract_dir}" -maxdepth 1 -type f -exec cp -f {} "${REPO_ROOT}/bin/" \;

--- a/scripts/pingcap/tidb-binlog/pull_integration_test.sh
+++ b/scripts/pingcap/tidb-binlog/pull_integration_test.sh
@@ -216,7 +216,7 @@ main() {
   tikv_ref="${dependency_ref}"
   pd_ref="${dependency_ref}"
   tidb_ref="${dependency_ref}"
-  sync_diff_inspector_ref="${dependency_ref}"
+  sync_diff_inspector_ref="${SYNC_DIFF_INSPECTOR_REF:-master}"
 
   log "Base ref ${base_ref} uses maintained binlog-compatible TiDB ref ${dependency_ref}"
   log "sync_diff_inspector uses the maintained public artifact line: ${sync_diff_inspector_ref}"

--- a/scripts/pingcap/tidb-binlog/pull_integration_test.sh
+++ b/scripts/pingcap/tidb-binlog/pull_integration_test.sh
@@ -195,14 +195,11 @@ main() {
   local tikv_ref
   local pd_ref
   local tidb_ref
-  local tidb_tools_ref
+  local sync_diff_inspector_ref
   local tikv_tag
   local pd_tag
   local tidb_tag
-  local tidb_tools_tag
-  local tidb_tools_tarball="${REPO_ROOT}/bin/tidb-tools.tar.gz"
-  local tidb_tools_extract_dir="/tmp/tidb-tools-bin"
-  local tidb_tools_bin_dir
+  local sync_diff_inspector_tag
 
   if ! command -v git >/dev/null 2>&1; then
     fail "git is required"
@@ -219,20 +216,20 @@ main() {
   tikv_ref="${dependency_ref}"
   pd_ref="${dependency_ref}"
   tidb_ref="${dependency_ref}"
-  tidb_tools_ref="master"
+  sync_diff_inspector_ref="${dependency_ref}"
 
   log "Base ref ${base_ref} uses maintained binlog-compatible TiDB ref ${dependency_ref}"
-  log "tidb-tools uses the maintained public artifact line: ${tidb_tools_ref}"
+  log "sync_diff_inspector uses the maintained public artifact line: ${sync_diff_inspector_ref}"
 
   tikv_tag="$(normalize_oci_tag "${tikv_ref}")"
   pd_tag="$(normalize_oci_tag "${pd_ref}")"
   tidb_tag="$(normalize_oci_tag "${tidb_ref}")"
-  tidb_tools_tag="$(normalize_oci_tag "${tidb_tools_ref}")"
+  sync_diff_inspector_tag="$(normalize_oci_tag "${sync_diff_inspector_ref}")"
 
   log "Resolved TiKV ref: ${tikv_ref} -> OCI tag ${tikv_tag}"
   log "Resolved PD ref: ${pd_ref} -> OCI tag ${pd_tag}"
   log "Resolved TiDB ref: ${tidb_ref} -> OCI tag ${tidb_tag}"
-  log "Resolved tidb-tools ref: ${tidb_tools_ref} -> OCI tag ${tidb_tools_tag}"
+  log "Resolved sync_diff_inspector ref: ${sync_diff_inspector_ref} -> OCI tag ${sync_diff_inspector_tag}"
 
   prepare_download_tools
 
@@ -242,25 +239,13 @@ main() {
 
   download_core_dependencies "${dependency_ref}" "${tikv_tag}" "${pd_tag}" "${tidb_tag}"
 
-  log "Downloading tidb-tools artifacts from OCI/public artifact"
-  rm -rf "${tidb_tools_extract_dir}"
-  mkdir -p "${tidb_tools_extract_dir}"
+  log "Downloading sync_diff_inspector from OCI/public artifact"
   (
     cd "${REPO_ROOT}/bin"
     OCI_ARTIFACT_HOST="${OCI_ARTIFACT_HOST}" \
     OCI_ARTIFACT_HOST_COMMUNITY="${OCI_ARTIFACT_HOST_COMMUNITY}" \
-      bash "${OCI_SCRIPT}" --tidb-tools="${tidb_tools_tag}"
+      bash "${OCI_SCRIPT}" --sync-diff-inspector="${sync_diff_inspector_tag}"
   )
-  tar -xzf "${tidb_tools_tarball}" -C "${tidb_tools_extract_dir}"
-  tidb_tools_bin_dir="$(find "${tidb_tools_extract_dir}" -type d -name bin | head -n1 || true)"
-  if [[ -n "${tidb_tools_bin_dir}" ]]; then
-    find "${tidb_tools_bin_dir}" -maxdepth 1 -type f -exec cp -f {} "${REPO_ROOT}/bin/" \;
-  else
-    log "tidb-tools archive uses flat binary layout"
-    find "${tidb_tools_extract_dir}" -maxdepth 1 -type f -exec cp -f {} "${REPO_ROOT}/bin/" \;
-  fi
-  rm -f "${tidb_tools_tarball}"
-  rm -f "${REPO_ROOT}/bin/ddl_checker" "${REPO_ROOT}/bin/importer"
 
   log "Prepared binary layout"
   ls -alh "${REPO_ROOT}/bin"

--- a/scripts/pingcap/tidb-binlog/pull_integration_test.sh
+++ b/scripts/pingcap/tidb-binlog/pull_integration_test.sh
@@ -107,6 +107,22 @@ prepare_download_tools() {
   chmod +x "${OCI_SCRIPT}"
 }
 
+download_core_dependencies() {
+  local dependency_ref="$1"
+  local tikv_tag="$2"
+  local pd_tag="$3"
+  local tidb_tag="$4"
+
+  log "Downloading TiDB/TiKV/PD artifacts from OCI for ${dependency_ref}"
+  (
+    cd "${REPO_ROOT}/bin"
+    OCI_ARTIFACT_HOST="${OCI_ARTIFACT_HOST}" bash "${OCI_SCRIPT}" \
+      --pd="${pd_tag}" \
+      --tikv="${tikv_tag}" \
+      --tidb="${tidb_tag}"
+  )
+}
+
 wait_for_port() {
   local name="$1"
   local port="$2"
@@ -224,14 +240,7 @@ main() {
   make build
   ls -alh "${REPO_ROOT}/bin"
 
-  log "Downloading TiDB/TiKV/PD artifacts from OCI"
-  (
-    cd "${REPO_ROOT}/bin"
-    OCI_ARTIFACT_HOST="${OCI_ARTIFACT_HOST}" bash "${OCI_SCRIPT}" \
-      --pd="${pd_tag}" \
-      --tikv="${tikv_tag}" \
-      --tidb="${tidb_tag}"
-  )
+  download_core_dependencies "${dependency_ref}" "${tikv_tag}" "${pd_tag}" "${tidb_tag}"
 
   log "Downloading tidb-tools artifacts from OCI/public artifact"
   rm -rf "${tidb_tools_extract_dir}"


### PR DESCRIPTION
## Background

This PR migrates the legacy [binlog_ghpr_integration](https://ci2.pingcap.net/view/ghpr_binlog/job/binlog_ghpr_integration/) Jenkins job into a GCP-compatible Prow Kubernetes presubmit for `pingcap/tidb-binlog`.

Issue Number: ref https://github.com/PingCAP-QE/ci/issues/3342

## What Changed
The new `pull-integration-test` job now can be running on GCP as a native prow job.
The new `pull-integration-test` job is intentionally scoped to the maintained TiDB Binlog compatible lines only:
- `release-8.1`
- `release-7.5`
- `release-7.1` 

This pr keep the job non-gating as a staged rollout, the follow-up step is to flip them to required after we gain enough confidence from the new GCP lane.

## Implementation details

- rename the old WIP job to the formal `pull-integration-test`
- use public Kafka / Zookeeper images instead of `hub.pingcap.net`
- add a dedicated `scripts/pingcap/tidb-binlog/pull_integration_test.sh` entry script
- download TiDB / TiKV / PD artifacts from OCI
- download `sync_diff_inspector` from OCI and remove the dependency on `fileserver.pingcap.net`
- fail fast for unsupported base refs so the job stays focused on the legacy-compatible release lines

## Test Passed
- 7.5 and 8.1 passed stably.
- Occasional failures on 7.1
   Conclusion from AI after analysis log：
   The root cause of the failures is the same issue. 
   The direct cause is now relatively clear: the pause-drainer step encountered a response/exit timing race in the drainer. The client binlogctl received an EOF, causing the test to fail.
   In terms of classification, this is more like a flaky test / timing race on the release-7.1 branch. More precisely, it is a real race in product code that manifests as a flaky test.