### PR TITLE
docs/docs-cn: simplify pull_verify pipeline

### DIFF
--- a/pipelines/pingcap/docs-cn/latest/pull_verify.groovy
+++ b/pipelines/pingcap/docs-cn/latest/pull_verify.groovy
@@ -94,7 +94,6 @@ pipeline {
                         echo
                     }
 
-                    run_check 'check-file-encoding' python3 ./check-file-encoding.py
                     run_check 'check-conflicts' python3 ./check-conflicts.py
                     run_check 'check-control-char' python3 ./check-control-char.py
                     run_check 'check-tags' python3 ./check-tags.py
@@ -107,6 +106,8 @@ pipeline {
                         echo '==> markdownlint-install: FAIL'
                         failed_checks+=('markdownlint-install')
                     fi
+
+                    run_check 'check-file-encoding' python3 ./check-file-encoding.py
 
                     if ((\${#failed_checks[@]} > 0)); then
                         printf 'pull_verify failed checks (%s):\\n' "\${#failed_checks[@]}"

--- a/pipelines/pingcap/docs-cn/latest/pull_verify.groovy
+++ b/pipelines/pingcap/docs-cn/latest/pull_verify.groovy
@@ -10,80 +10,112 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
 pipeline {
-    agent none
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'runner'
+        }
+    }
     options {
         timeout(time: 40, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
-        stage("Tests") {
-            matrix {
-                axes {
-                    axis {
-                        name 'CHECK_CMD'
-                        values "python3 check-file-encoding.py", "python3 check-conflicts.py", "markdownlint",
-                            "python3 check-control-char.py", "python3 check-tags.py", "python3 check-manual-line-breaks.py"
+        stage('Checkout') {
+            steps {
+                dir(REFS.repo) {
+                    sh label: 'set git config', script: """
+                    git config --global --add safe.directory '*'
+                    """
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
-                agent{
-                    kubernetes {
-                        namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
-                        defaultContainer 'runner'
-                    }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir(REFS.repo) {
+                    sh label: 'Prepare check scripts', script: """#!/usr/bin/env bash
+                    set -euo pipefail
+
+                    rm -rf ../check-scripts
+                    mkdir -p ../check-scripts
+
+                    wget -O ../check-scripts/check-file-encoding.py https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-file-encoding.py
+                    wget -O ../check-scripts/check-conflicts.py https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-conflicts.py
+                    wget -O ../check-scripts/check-control-char.py https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-control-char.py
+                    wget -O ../check-scripts/check-tags.py https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-tags.py
+                    wget -O ../check-scripts/check-manual-line-breaks.py https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-manual-line-breaks.py
+
+                    ls -al ../check-scripts
+                    """
                 }
-                stages {
-                    stage('Checkout') {
-                        steps {
-                            dir(REFS.repo) {
-                                sh label: "set git config", script: """
-                                git config --global --add safe.directory '*'
-                                """
+            }
+        }
+        stage('Verify') {
+            steps {
+                dir(REFS.repo) {
+                    sh label: 'Debug info', script: """
+                    git rev-parse --show-toplevel
+                    git status -s .
+                    git log --format="%h %B" --oneline -n 3
+                    """
+                    sh label: 'Run pull_verify checks', script: """#!/usr/bin/env bash
+                    set -uo pipefail
 
-                                script {
-                                    prow.checkoutRefsWithCache(REFS)
-                                }
-                            }
-                        }
-                    }
-                    stage('Prepare') {
-                        steps {
-                            dir('check-scripts') {
-                                sh label: 'Prepare', script: """
-                                    wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-file-encoding.py
-                                    wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-conflicts.py
-                                    wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-control-char.py
-                                    wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-tags.py
-                                    wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-manual-line-breaks.py
-                                """
-                            }
-                        }
-                    }
-                    stage("Test") {
-                        steps {
-                            dir(REFS.repo) {
-                                sh label: "set git config", script: """
-                                git rev-parse --show-toplevel
-                                git status -s .
-                                git log --format="%h %B" --oneline -n 3
-                                """
-                                // TODO: remove this debug lines
-                                sh """
-                                git diff-tree --name-only --no-commit-id -r origin/${REFS.base_ref}..HEAD -- '*.md' ':(exclude).github/*'
-                                """
-                                sh label: "check ${CHECK_CMD}", script: """#!/usr/bin/env bash
-                                cp -r ../check-scripts/* ./
-                                diff_docs_files=\$(git diff-tree --name-only --no-commit-id -r origin/${REFS.base_ref}..HEAD -- '*.md' ':(exclude).github/*')
+                    mapfile -t diff_docs_files < <(
+                        git diff-tree --name-only --no-commit-id -r origin/${REFS.base_ref}..HEAD -- '*.md' ':(exclude).github/*'
+                    )
 
-                                if [[ "${CHECK_CMD}" == "markdownlint" ]]; then
-                                    npm install -g markdownlint-cli@0.17.0
-                                fi
+                    if ((\${#diff_docs_files[@]} == 0)); then
+                        echo 'No changed Markdown files, skip pull_verify checks.'
+                        exit 0
+                    fi
 
-                                ${CHECK_CMD} \$diff_docs_files
-                                """
-                            }
-                        }
+                    printf 'Changed Markdown files (%s):\\n' "\${#diff_docs_files[@]}"
+                    printf ' - %s\\n' "\${diff_docs_files[@]}"
+
+                    cp -r ../check-scripts/* ./
+
+                    failed_checks=()
+
+                    run_check() {
+                        local name="\$1"
+                        shift
+
+                        echo "==> Running \${name}"
+                        if "\$@" "\${diff_docs_files[@]}"; then
+                            echo "==> \${name}: PASS"
+                        else
+                            echo "==> \${name}: FAIL"
+                            failed_checks+=("\${name}")
+                        fi
+                        echo
                     }
+
+                    run_check 'check-file-encoding' python3 ./check-file-encoding.py
+                    run_check 'check-conflicts' python3 ./check-conflicts.py
+                    run_check 'check-control-char' python3 ./check-control-char.py
+                    run_check 'check-tags' python3 ./check-tags.py
+                    run_check 'check-manual-line-breaks' python3 ./check-manual-line-breaks.py
+
+                    echo '==> Installing markdownlint-cli@0.17.0'
+                    if npm install -g markdownlint-cli@0.17.0; then
+                        run_check 'markdownlint' markdownlint
+                    else
+                        echo '==> markdownlint-install: FAIL'
+                        failed_checks+=('markdownlint-install')
+                    fi
+
+                    if ((\${#failed_checks[@]} > 0)); then
+                        printf 'pull_verify failed checks (%s):\\n' "\${#failed_checks[@]}"
+                        printf ' - %s\\n' "\${failed_checks[@]}"
+                        exit 1
+                    fi
+
+                    echo 'All pull_verify checks passed.'
+                    """
                 }
             }
         }

--- a/pipelines/pingcap/docs/latest/pull_verify.groovy
+++ b/pipelines/pingcap/docs/latest/pull_verify.groovy
@@ -94,7 +94,6 @@ pipeline {
                         echo
                     }
 
-                    run_check 'check-file-encoding' python3 ./check-file-encoding.py
                     run_check 'check-conflicts' python3 ./check-conflicts.py
                     run_check 'check-control-char' python3 ./check-control-char.py
                     run_check 'check-tags' python3 ./check-tags.py
@@ -107,6 +106,8 @@ pipeline {
                         echo '==> markdownlint-install: FAIL'
                         failed_checks+=('markdownlint-install')
                     fi
+
+                    run_check 'check-file-encoding' python3 ./check-file-encoding.py
 
                     if ((\${#failed_checks[@]} > 0)); then
                         printf 'pull_verify failed checks (%s):\\n' "\${#failed_checks[@]}"

--- a/pipelines/pingcap/docs/latest/pull_verify.groovy
+++ b/pipelines/pingcap/docs/latest/pull_verify.groovy
@@ -10,82 +10,112 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
 pipeline {
-    agent none
-    environment {
-        FILE_SERVER_URL = 'http://fileserver.pingcap.net'
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yamlFile POD_TEMPLATE_FILE
+            defaultContainer 'runner'
+        }
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
-        stage("Tests") {
-            matrix {
-                axes {
-                    axis {
-                        name 'CHECK_CMD'
-                        values "python3 check-file-encoding.py", "python3 check-conflicts.py", "markdownlint",
-                            "python3 check-control-char.py", "python3 check-tags.py", "python3 check-manual-line-breaks.py"
+        stage('Checkout') {
+            steps {
+                dir(REFS.repo) {
+                    sh label: 'set git config', script: """
+                    git config --global --add safe.directory '*'
+                    """
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
-                agent{
-                    kubernetes {
-                        namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
-                        defaultContainer 'runner'
-                    }
+            }
+        }
+        stage('Prepare') {
+            steps {
+                dir(REFS.repo) {
+                    sh label: 'Prepare check scripts', script: """#!/usr/bin/env bash
+                    set -euo pipefail
+
+                    rm -rf ../check-scripts
+                    mkdir -p ../check-scripts
+
+                    wget -O ../check-scripts/check-file-encoding.py https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-file-encoding.py
+                    wget -O ../check-scripts/check-conflicts.py https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-conflicts.py
+                    wget -O ../check-scripts/check-control-char.py https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-control-char.py
+                    wget -O ../check-scripts/check-tags.py https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-tags.py
+                    wget -O ../check-scripts/check-manual-line-breaks.py https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-manual-line-breaks.py
+
+                    ls -al ../check-scripts
+                    """
                 }
-                stages {
-                    stage('Checkout') {
-                        steps {
-                            dir(REFS.repo) {
-                                sh label: "set git config", script: """
-                                git config --global --add safe.directory '*'
-                                """
-                                script {
-                                    prow.checkoutRefsWithCache(REFS)
-                                }
-                            }
-                        }
-                    }
-                    stage('Prepare') {
-                        steps {
-                            dir('check-scripts') {
-                                sh label: 'Prepare', script: """
-                                    wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-file-encoding.py
-                                    wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-conflicts.py
-                                    wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-control-char.py
-                                    wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-tags.py
-                                    wget https://raw.githubusercontent.com/pingcap/docs/master/scripts/check-manual-line-breaks.py
-                                """
-                            }
-                        }
-                    }
-                    stage("Test") {
-                        steps {
-                            dir(REFS.repo) {
-                                sh label: "set git config", script: """
-                                git rev-parse --show-toplevel
-                                git status -s .
-                                git log --format="%h %B" --oneline -n 3
-                                """
-                                // TODO: remove this debug lines
-                                sh """
-                                git diff-tree --name-only --no-commit-id -r origin/${REFS.base_ref}..HEAD -- '*.md' ':(exclude).github/*'
-                                """
-                                sh label: "check ${CHECK_CMD}", script: """#!/usr/bin/env bash
-                                cp -r ../check-scripts/* ./
-                                diff_docs_files=\$(git diff-tree --name-only --no-commit-id -r origin/${REFS.base_ref}..HEAD -- '*.md' ':(exclude).github/*')
+            }
+        }
+        stage('Verify') {
+            steps {
+                dir(REFS.repo) {
+                    sh label: 'Debug info', script: """
+                    git rev-parse --show-toplevel
+                    git status -s .
+                    git log --format="%h %B" --oneline -n 3
+                    """
+                    sh label: 'Run pull_verify checks', script: """#!/usr/bin/env bash
+                    set -uo pipefail
 
-                                if [[ "${CHECK_CMD}" == "markdownlint" ]]; then
-                                    npm install -g markdownlint-cli@0.17.0
-                                fi
+                    mapfile -t diff_docs_files < <(
+                        git diff-tree --name-only --no-commit-id -r origin/${REFS.base_ref}..HEAD -- '*.md' ':(exclude).github/*'
+                    )
 
-                                ${CHECK_CMD} \$diff_docs_files
-                                """
-                            }
-                        }
+                    if ((\${#diff_docs_files[@]} == 0)); then
+                        echo 'No changed Markdown files, skip pull_verify checks.'
+                        exit 0
+                    fi
+
+                    printf 'Changed Markdown files (%s):\\n' "\${#diff_docs_files[@]}"
+                    printf ' - %s\\n' "\${diff_docs_files[@]}"
+
+                    cp -r ../check-scripts/* ./
+
+                    failed_checks=()
+
+                    run_check() {
+                        local name="\$1"
+                        shift
+
+                        echo "==> Running \${name}"
+                        if "\$@" "\${diff_docs_files[@]}"; then
+                            echo "==> \${name}: PASS"
+                        else
+                            echo "==> \${name}: FAIL"
+                            failed_checks+=("\${name}")
+                        fi
+                        echo
                     }
+
+                    run_check 'check-file-encoding' python3 ./check-file-encoding.py
+                    run_check 'check-conflicts' python3 ./check-conflicts.py
+                    run_check 'check-control-char' python3 ./check-control-char.py
+                    run_check 'check-tags' python3 ./check-tags.py
+                    run_check 'check-manual-line-breaks' python3 ./check-manual-line-breaks.py
+
+                    echo '==> Installing markdownlint-cli@0.17.0'
+                    if npm install -g markdownlint-cli@0.17.0; then
+                        run_check 'markdownlint' markdownlint
+                    else
+                        echo '==> markdownlint-install: FAIL'
+                        failed_checks+=('markdownlint-install')
+                    fi
+
+                    if ((\${#failed_checks[@]} > 0)); then
+                        printf 'pull_verify failed checks (%s):\\n' "\${#failed_checks[@]}"
+                        printf ' - %s\\n' "\${failed_checks[@]}"
+                        exit 1
+                    fi
+
+                    echo 'All pull_verify checks passed.'
+                    """
                 }
             }
         }


### PR DESCRIPTION
## What problem does this PR solve?

The current `pingcap/docs` and `pingcap/docs-cn` `pull_verify` pipelines use a 6-leg matrix where each leg spins up its own pod and repeats the same heavy setup work:

- schedule a separate Kubernetes pod
- restore / checkout the docs repository
- prepare the same helper scripts again
- run one lightweight check on the changed `.md` files

In practice, the bottleneck is usually pod readiness and repeated setup, not the checks themselves.

A concrete example is `pingcap/docs` PR [#22748](https://github.com/pingcap/docs/pull/22748):

- `pull_verify` build [#19043](https://do.pingcap.net/jenkins/job/pingcap/job/docs/job/pull_verify/19043/) was aborted after about 15m35s
- a later successful rerun [#19047](https://do.pingcap.net/jenkins/job/pingcap/job/docs/job/pull_verify/19047/) still took about 13m58s

Another recent example is `pingcap/docs` PR [#22753](https://github.com/pingcap/docs/pull/22753), where successful build [#19024](https://do.pingcap.net/jenkins/job/pingcap/job/docs/job/pull_verify/19024/) took about 20m44s.

For these small docs-only PRs, the actual checks are cheap because they only run against files from `git diff-tree`; the repeated matrix setup dominates the runtime.

## What is changed?

This PR simplifies both `pingcap/docs` and `pingcap/docs-cn` `pull_verify` pipelines from a 6-leg matrix into a single-pod sequential flow:

1. `Checkout`
   - run `prow.checkoutRefsWithCacheLock(REFS)` only once
2. `Prepare`
   - download the five helper scripts from `pingcap/docs/master` only once
3. `Verify`
   - compute the changed markdown file list once
   - skip quickly when there are no changed `.md` files
   - run all 6 checks sequentially in the same pod
   - aggregate failures so one run can report multiple failing checks instead of stopping at the first failure

This keeps the existing validation scope, required context, and trigger model unchanged. The main difference is that we remove repeated pod scheduling, repeated checkout/cache restore, and repeated helper-script preparation.

## Expected impact

Based on recent `pull_verify` runs, the current matrix-based flow commonly spends around 14-21 minutes even on relatively small docs PRs.

With this change, the expected runtime for typical small or medium docs PRs should drop to roughly 2-5 minutes:

- 1 pod startup instead of up to 6 separate pod startups
- 1 checkout / cache restore instead of 6 repeated checkouts
- 1 helper-script preparation step instead of 6 repeated preparations
- the 6 checks themselves still run, but they are lightweight and operate only on changed markdown files

The exact savings still depend on Kubernetes scheduling and network conditions, but this should remove the largest fixed-cost duplication in the current design.

## Validation

- `JENKINS_URL=https://do.pingcap.net/jenkins .ci/verify-jenkins-pipeline-file.sh pipelines/pingcap/docs/latest/pull_verify.groovy`
- `JENKINS_URL=https://do.pingcap.net/jenkins .ci/verify-jenkins-pipeline-file.sh pipelines/pingcap/docs-cn/latest/pull_verify.groovy`
