### PR TITLE
dm: download tikv-worker for next-gen integration tests

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -63,6 +63,7 @@ pipeline {
                                         \$script \
                                             --tidb=${OCI_TAG_TIDB} \
                                             --tikv=${OCI_TAG_TIKV} \
+                                            --tikv-worker=${OCI_TAG_TIKV} \
                                             --pd=${OCI_TAG_PD} \
                                             --minio=${OCI_TAG_MINIO} \
                                             --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR}
@@ -81,6 +82,7 @@ pipeline {
                                 ./tidb-server -V
                                 ./pd-server -V
                                 ./tikv-server -V
+                                ./tikv-worker -V
                             """
                         }
                     }


### PR DESCRIPTION
## Summary
- Download \`tikv-worker\` binary alongside TiKV via \`--tikv-worker=\${OCI_TAG_TIKV}\`.

## Why

DM integration tests on next-gen TiDB require a full cluster including a tikv-worker process and a MinIO server that serves DFS storage for TiKV and IA (ingest) for tikv-worker.

Without tikv-worker, next-gen TiDB's lightning backend cannot complete ingest backfill (ADD INDEX, IMPORT INTO, etc.), because \`kerneltype.IsNextGen()\` unconditionally routes region jobs through \`objStoreRegionJobWorker\` / \`TiKVWorkerURL\` (see \`pkg/lightning/backend/local/local.go\` in pingcap/tidb).

Current build #31 on the next-gen DM pipeline fails G00 (ha_cases) because \`ALTER TABLE ... ADD INDEX\` gets stuck at \"write reorganization\" with \`Put \"http:///write_sst?...\": http: no Host in request URL\` — the TiDB never had a tikv-worker URL to talk to.

## Follow-up

A follow-up PR to \`pingcap/tiflow\` will update \`dm/tests/_utils/run_downstream_cluster\` to spin up MinIO + PD (keyspace pre-alloc) + TiKV (API V2 + TTL + DFS) + tikv-worker + SYSTEM TiDB + user keyspace TiDB, mirroring the CDC \`start_tidb_cluster_nextgen\` helper.

## Test plan

- [ ] Trigger the next-gen DM integration pipeline from a tiflow PR once both this and the tiflow-side changes land.

Ref: \`tests/integration_tests/_utils/start_tidb_cluster_nextgen\` in pingcap/ticdc.