### PR TITLE
ci(tiflash): fix sanitizer submodule auth

### DIFF
--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -43,13 +43,6 @@ global_definitions:
     fi
 
     repo_root="$(pwd)"
-    git config "submodule.contrib/tiflash-proxy-next-gen.update" none
-    git submodule sync --recursive
-    if [[ -n "${GITHUB_API_TOKEN:-}" ]]; then
-      git config --local url."https://x-access-token:${GITHUB_API_TOKEN}@github.com/".insteadOf "git@github.com:"
-      git config --local --add url."https://x-access-token:${GITHUB_API_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
-    fi
-    git submodule update --init --recursive
 
     rm -rf "${repo_root}/.ccache" "${repo_root}/build-${sanitizer}"
     mkdir -p "${repo_root}/build-${sanitizer}"
@@ -115,12 +108,20 @@ global_definitions:
       limits:
         cpu: "12"
         memory: 48Gi
+  pull_sanitizer_decoration_config: &pull_sanitizer_decoration_config
+    timeout: 3h
+    ssh_key_secrets:
+      - github-ssh-secret
+    ssh_host_fingerprints:
+      - github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+      - github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+      - github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
   pull_sanitizer_job: &pull_sanitizer_job
     <<: *brancher
     decorate: true
-    decoration_config:
-      timeout: 3h
-    skip_submodules: true
+    clone_uri: git@github.com:pingcap/tiflash.git
+    decoration_config: *pull_sanitizer_decoration_config
+    skip_submodules: false
     always_run: false
     optional: true
     skip_if_only_changed: *skip_if_only_changed
@@ -167,11 +168,6 @@ presubmits:
         containers:
           - <<: *pull_sanitizer_container
             env:
-              - name: GITHUB_API_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    key: token
-                    name: github-token
               - name: SANITIZER
                 value: ASan
 
@@ -184,11 +180,6 @@ presubmits:
         containers:
           - <<: *pull_sanitizer_container
             env:
-              - name: GITHUB_API_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    key: token
-                    name: github-token
               - name: SANITIZER
                 value: TSan
             securityContext:

--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -45,6 +45,10 @@ global_definitions:
     repo_root="$(pwd)"
     git config "submodule.contrib/tiflash-proxy-next-gen.update" none
     git submodule sync --recursive
+    if [[ -n "${GITHUB_API_TOKEN:-}" ]]; then
+      git config --local url."https://x-access-token:${GITHUB_API_TOKEN}@github.com/".insteadOf "git@github.com:"
+      git config --local --add url."https://x-access-token:${GITHUB_API_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+    fi
     git submodule update --init --recursive
 
     rm -rf "${repo_root}/.ccache" "${repo_root}/build-${sanitizer}"
@@ -163,6 +167,11 @@ presubmits:
         containers:
           - <<: *pull_sanitizer_container
             env:
+              - name: GITHUB_API_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    key: token
+                    name: github-token
               - name: SANITIZER
                 value: ASan
 
@@ -175,6 +184,11 @@ presubmits:
         containers:
           - <<: *pull_sanitizer_container
             env:
+              - name: GITHUB_API_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    key: token
+                    name: github-token
               - name: SANITIZER
                 value: TSan
             securityContext:


### PR DESCRIPTION
## Background
The TiFlash repository recently introduced a new submodule, `contrib/tici`. The sanitizer jobs fail during `git submodule update --init --recursive` because the submodule is hosted in a private repository and the current CI configuration does not provide authentication for it.

## Summary
- allow private submodules such as contrib/tici to be fetched during sanitizer job setup