### PR TITLE
ci(tiflash-scripts): tune schrodinger test resources

### DIFF
--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pod.yaml
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pod.yaml
@@ -9,11 +9,11 @@ spec:
       tty: true
       resources:
         requests:
-          cpu: "16"
-          memory: 64Gi
+          cpu: "12"
+          memory: 96Gi
         limits:
-          cpu: "16"
-          memory: 64Gi
+          cpu: "12"
+          memory: 96Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Increase memory to prevent OOM.


Previously failed tests:
- https://prow.tidb.net/jenkins/job/pingcap-inc/job/tiflash-scripts/job/pull_schrodinger_test/21/

Replay test successful:
- https://prow.tidb.net/jenkins/job/pingcap-inc/job/tiflash-scripts/job/pull_schrodinger_test/23/