### PR TITLE
ci: fix in-cluster kubectl validation for pull-verify-k8s-pod-yaml

### DIFF
--- a/.ci/verify-k8s-pod-yaml.sh
+++ b/.ci/verify-k8s-pod-yaml.sh
@@ -3,9 +3,16 @@
 set -eu
 
 KUBECTL_BIN=${KUBECTL_BIN:-kubectl}
+KUBE_APISERVER_HOST=${KUBE_APISERVER_HOST:-${KUBERNETES_SERVICE_HOST:-kubernetes.default.svc}}
+KUBE_APISERVER_PORT=${KUBE_APISERVER_PORT:-${KUBERNETES_SERVICE_PORT_HTTPS:-443}}
 KUBE_SERVICEACCOUNT_TOKEN_PATH=${KUBE_SERVICEACCOUNT_TOKEN_PATH:-/var/run/secrets/kubernetes.io/serviceaccount/token}
+KUBE_SERVICEACCOUNT_CA_PATH=${KUBE_SERVICEACCOUNT_CA_PATH:-/var/run/secrets/kubernetes.io/serviceaccount/ca.crt}
 KUBE_SERVICEACCOUNT_NAMESPACE_PATH=${KUBE_SERVICEACCOUNT_NAMESPACE_PATH:-/var/run/secrets/kubernetes.io/serviceaccount/namespace}
 POD_YAML_TEST_NAME=${POD_YAML_TEST_NAME:-ci-pod-yaml-validate}
+KUBE_CONTEXT_NAME=${KUBE_CONTEXT_NAME:-in-cluster-validation}
+KUBE_CLUSTER_NAME=${KUBE_CLUSTER_NAME:-in-cluster}
+KUBE_USER_NAME=${KUBE_USER_NAME:-service-account}
+KUBECTL_REQUEST_TIMEOUT=${KUBECTL_REQUEST_TIMEOUT:-20s}
 export POD_YAML_TEST_NAME
 
 if [ -z "${POD_YAML_TEST_NAMESPACE:-}" ] && [ -f "$KUBE_SERVICEACCOUNT_NAMESPACE_PATH" ]; then
@@ -13,6 +20,16 @@ if [ -z "${POD_YAML_TEST_NAMESPACE:-}" ] && [ -f "$KUBE_SERVICEACCOUNT_NAMESPACE
 fi
 POD_YAML_TEST_NAMESPACE=${POD_YAML_TEST_NAMESPACE:-}
 export POD_YAML_TEST_NAMESPACE
+
+temp_kubeconfig=""
+
+cleanup() {
+    if [ -n "$temp_kubeconfig" ] && [ -f "$temp_kubeconfig" ]; then
+        rm -f "$temp_kubeconfig"
+    fi
+}
+
+trap cleanup EXIT INT TERM
 
 if [ "$#" -gt 0 ]; then
     files="$*"
@@ -22,34 +39,127 @@ fi
 
 count=0
 failed=0
-kubectl_validation_enabled=1
+
+require_file() {
+    path=$1
+    description=$2
+    if [ ! -f "$path" ]; then
+        echo "missing $description at $path"
+        exit 1
+    fi
+}
+
+prepare_kubeconfig() {
+    if [ -n "${KUBECONFIG:-}" ]; then
+        return
+    fi
+
+    require_file "$KUBE_SERVICEACCOUNT_TOKEN_PATH" "service account token"
+    require_file "$KUBE_SERVICEACCOUNT_CA_PATH" "service account CA certificate"
+
+    token=$(tr -d '\n' < "$KUBE_SERVICEACCOUNT_TOKEN_PATH")
+    if [ -z "$token" ]; then
+        echo "service account token is empty: $KUBE_SERVICEACCOUNT_TOKEN_PATH"
+        exit 1
+    fi
+
+    temp_kubeconfig=$(mktemp)
+    cat >"$temp_kubeconfig" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: $KUBE_CLUSTER_NAME
+    cluster:
+      certificate-authority: $KUBE_SERVICEACCOUNT_CA_PATH
+      server: https://$KUBE_APISERVER_HOST:$KUBE_APISERVER_PORT
+users:
+  - name: $KUBE_USER_NAME
+    user:
+      token: $token
+contexts:
+  - name: $KUBE_CONTEXT_NAME
+    context:
+      cluster: $KUBE_CLUSTER_NAME
+      user: $KUBE_USER_NAME
+      namespace: ${POD_YAML_TEST_NAMESPACE:-default}
+current-context: $KUBE_CONTEXT_NAME
+EOF
+
+    export KUBECONFIG="$temp_kubeconfig"
+}
+
+render_manifest_with_defaults() {
+    input_file=$1
+    output_file=$2
+
+    if [ -n "$POD_YAML_TEST_NAMESPACE" ]; then
+        yq e '.metadata = (.metadata // {}) |
+            .metadata.name = (.metadata.name // strenv(POD_YAML_TEST_NAME)) |
+            .metadata.namespace = (.metadata.namespace // strenv(POD_YAML_TEST_NAMESPACE))' "$input_file" >"$output_file"
+    else
+        yq e '.metadata = (.metadata // {}) |
+            .metadata.name = (.metadata.name // strenv(POD_YAML_TEST_NAME))' "$input_file" >"$output_file"
+    fi
+}
+
+preflight_kubectl() {
+    manifest=$(mktemp)
+    rendered_manifest=$(mktemp)
+    stderr_file=$(mktemp)
+
+    cat >"$manifest" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${POD_YAML_TEST_NAME}-preflight
+spec:
+  containers:
+    - name: preflight
+      image: busybox:1.36
+      command: ["sh", "-c", "exit 0"]
+EOF
+
+    render_manifest_with_defaults "$manifest" "$rendered_manifest"
+
+    if ! "$KUBECTL_BIN" apply --request-timeout="$KUBECTL_REQUEST_TIMEOUT" --dry-run=client --validate=strict -f "$rendered_manifest" >/dev/null 2>"$stderr_file"; then
+        echo "kubectl client dry-run preflight failed:"
+        sed 's/^/  /' "$stderr_file"
+        rm -f "$manifest" "$rendered_manifest" "$stderr_file"
+        exit 1
+    fi
+
+    : >"$stderr_file"
+    if ! "$KUBECTL_BIN" apply --request-timeout="$KUBECTL_REQUEST_TIMEOUT" --dry-run=server --validate=strict -f "$rendered_manifest" >/dev/null 2>"$stderr_file"; then
+        echo "kubectl server dry-run preflight failed:"
+        sed 's/^/  /' "$stderr_file"
+        rm -f "$manifest" "$rendered_manifest" "$stderr_file"
+        exit 1
+    fi
+
+    rm -f "$manifest" "$rendered_manifest" "$stderr_file"
+}
 
 validate_with_kubectl() {
     file=$1
     manifest=$(mktemp)
-    manifest_with_ns=$(mktemp)
     stderr_file=$(mktemp)
 
-    yq e '.metadata = (.metadata // {}) | .metadata.name = (.metadata.name // strenv(POD_YAML_TEST_NAME))' "$file" >"$manifest"
-    if [ -n "$POD_YAML_TEST_NAMESPACE" ]; then
-        yq e '.metadata.namespace = (.metadata.namespace // strenv(POD_YAML_TEST_NAMESPACE))' "$manifest" >"$manifest_with_ns"
-        mv "$manifest_with_ns" "$manifest"
-    fi
+    render_manifest_with_defaults "$file" "$manifest"
 
-    if ! "$KUBECTL_BIN" apply --dry-run=client --validate=strict -f "$manifest" >/dev/null 2>"$stderr_file"; then
+    if ! "$KUBECTL_BIN" apply --request-timeout="$KUBECTL_REQUEST_TIMEOUT" --dry-run=client --validate=strict -f "$manifest" >/dev/null 2>"$stderr_file"; then
         echo "$file: kubectl client dry-run validation failed:"
         sed 's/^/  /' "$stderr_file"
         failed=1
     fi
 
     : >"$stderr_file"
-    if ! "$KUBECTL_BIN" apply --dry-run=server --validate=strict -f "$manifest" >/dev/null 2>"$stderr_file"; then
+    if ! "$KUBECTL_BIN" apply --request-timeout="$KUBECTL_REQUEST_TIMEOUT" --dry-run=server --validate=strict -f "$manifest" >/dev/null 2>"$stderr_file"; then
         echo "$file: kubectl server dry-run validation failed:"
         sed 's/^/  /' "$stderr_file"
         failed=1
     fi
 
-    rm -f "$manifest" "$manifest_with_ns" "$stderr_file"
+    rm -f "$manifest" "$stderr_file"
 }
 
 check_file() {
@@ -89,10 +199,11 @@ check_file() {
         failed=1
     fi
 
-    if [ "$kubectl_validation_enabled" -eq 1 ]; then
-        validate_with_kubectl "$file"
-    fi
+    validate_with_kubectl "$file"
 }
+
+prepare_kubeconfig
+preflight_kubectl
 
 for file in $files; do
     check_file "$file"

--- a/docs/guides/CI.md
+++ b/docs/guides/CI.md
@@ -125,7 +125,8 @@ This repository has two related presubmit jobs for pipeline changes:
   - Triggered by pipeline file changes.
 - `pull-verify-k8s-pod-yaml`
   - Verifies pipeline Pod YAML files stay structurally valid Kubernetes Pod manifests.
-  - When in-cluster Kubernetes API access is available, injects a test `metadata.name` and also runs both `kubectl --dry-run=client --validate=strict` and `kubectl --dry-run=server --validate=strict`.
+  - Always injects a test `metadata.name` (and namespace when available) and runs both `kubectl --dry-run=client --validate=strict` and `kubectl --dry-run=server --validate=strict`.
+  - In prow job pods, if `KUBECONFIG` is not set, the script automatically builds one from in-cluster service account token/CA and uses `https://kubernetes.default.svc:443` (or `KUBERNETES_SERVICE_HOST`/`KUBERNETES_SERVICE_PORT_HTTPS` when present).
   - Triggered by `pipelines/**/*.yaml` changes.
 - `pull-replay-jenkins-pipelines`
   - Optional replay validation using `--auto-changed`.


### PR DESCRIPTION
## Summary
- build an in-cluster kubeconfig from service account token/CA when KUBECONFIG is unset
- force both kubectl client/server dry-run validation (including preflight) instead of conditional skip
- keep yq structural checks and update docs to match the enforced behavior

## Why
`kubectl` in prow pods did not auto-use in-cluster credentials, so it fell back to `localhost:8080` and failed against OpenAPI endpoint.

## Validation
- `sh -n .ci/verify-k8s-pod-yaml.sh`
- mock run with fake service account + fake kubectl confirmed 4 apply calls (preflight client/server + file client/server)
