### PR TITLE
fix(pipeline) fix job's CI duration: on GCP, the duration became longer because we reduced the pod requests.

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -16,8 +16,8 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 48Gi
-          cpu: "12"
+          memory: 32Gi
+          cpu: "16"
           ephemeral-storage: 20Gi
         limits:
           memory: 64Gi

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -16,12 +16,12 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 32Gi
-          cpu: "16"
+          memory: 48Gi
+          cpu: "24"
           ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
-          cpu: "16"
+          cpu: "24"
           ephemeral-storage: 300Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
@@ -16,12 +16,12 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 32Gi
-          cpu: "16"
+          memory: 48Gi
+          cpu: "24"
           ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
-          cpu: "16"
+          cpu: "24"
           ephemeral-storage: 300Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
@@ -16,8 +16,8 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 16Gi
-          cpu: "2"
+          memory: 32Gi
+          cpu: "16"
           ephemeral-storage: 20Gi
         limits:
           memory: 64Gi

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
@@ -14,8 +14,8 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 24Gi
-          cpu: "6"
+          memory: 48Gi
+          cpu: "12"
           ephemeral-storage: 20Gi
         limits:
           memory: 48Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
@@ -14,12 +14,12 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          cpu: "16"
+          cpu: "24"
           memory: 64Gi
           ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
-          cpu: "16"
+          cpu: "24"
           ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
@@ -14,8 +14,8 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          cpu: "12"
-          memory: 48Gi
+          cpu: "16"
+          memory: 64Gi
           ephemeral-storage: 20Gi
         limits:
           memory: 64Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
@@ -16,12 +16,12 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 32Gi
-          cpu: "16"
+          memory: 48Gi
+          cpu: "24"
           ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
-          cpu: "16"
+          cpu: "24"
           ephemeral-storage: 200Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
@@ -17,7 +17,7 @@ spec:
       resources:
         requests:
           memory: 32Gi
-          cpu: "12"
+          cpu: "16"
           ephemeral-storage: 20Gi
         limits:
           memory: 64Gi


### PR DESCRIPTION
enlarge job pod spec
and update pull_integration_br_test image