### PR TITLE
ci(tikv/titan): the new prowjob support other branches

### DIFF
--- a/prow-jobs/kustomization.yaml
+++ b/prow-jobs/kustomization.yaml
@@ -156,3 +156,4 @@ configMapGenerator:
       - tikv_tikv_release-8.5-presubmits.yaml=tikv/tikv/release-8.5-presubmits.yaml
       - tikv_tikv_release-9.0-beta-presubmits.yaml=tikv/tikv/release-9.0-beta-presubmits.yaml
       - tikv_titan_latest-presubmits.yaml=tikv/titan/latest-presubmits.yaml
+      - tikv_titan_release-presubmits.yaml=tikv/titan/release-presubmits.yaml

--- a/prow-jobs/tikv/titan/release-presubmits.yaml
+++ b/prow-jobs/tikv/titan/release-presubmits.yaml
@@ -1,0 +1,295 @@
+global_definitions:
+  brancher: &brancher
+    branches:
+      - ^tikv-7\.5$
+      - ^tikv-7\.1$
+      - ^tikv-6\.5$
+      - ^tikv-6\.1$
+      - ^tikv-5\.2$
+      - ^tikv-5\.0$
+      - ^tikv-4\.x$
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+
+presubmits:
+  tikv/titan:
+    - <<: *brancher
+      name: pull-titan-format
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      decoration_config:
+        timeout: 3h
+      always_run: false
+      optional: true
+      skip_if_only_changed: *skip_if_only_changed
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+        containers:
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/format.sh
+            resources:
+              requests:
+                cpu: "2"
+                memory: 2Gi
+              limits:
+                cpu: "2"
+                memory: 2Gi
+
+    - <<: *brancher
+      name: pull-titan-test
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      decoration_config:
+        timeout: 3h
+      always_run: false
+      optional: true
+      skip_if_only_changed: *skip_if_only_changed
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+        containers:
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test-release.sh
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
+
+    - <<: *brancher
+      name: pull-titan-sanitizer-asan
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      decoration_config:
+        timeout: 3h
+      always_run: false
+      optional: true
+      skip_if_only_changed: *skip_if_only_changed
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+        containers:
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test-release.sh
+            env:
+              - name: SANITIZER
+                value: ASAN
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
+
+    - <<: *brancher
+      name: pull-titan-sanitizer-tsan
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      decoration_config:
+        timeout: 3h
+      always_run: false
+      optional: true
+      skip_if_only_changed: *skip_if_only_changed
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+        containers:
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test-release.sh
+            env:
+              - name: SANITIZER
+                value: TSAN
+            securityContext:
+              # Required for TSAN on GCP. Without privileged mode, the TSAN job hit
+              # `ThreadSanitizer: unexpected memory mapping` during test execution.
+              privileged: true
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
+
+    - <<: *brancher
+      name: pull-titan-sanitizer-ubsan
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      decoration_config:
+        timeout: 3h
+      always_run: false
+      optional: true
+      skip_if_only_changed: *skip_if_only_changed
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+        containers:
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test-release.sh
+            env:
+              - name: SANITIZER
+                value: UBSAN
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
+
+    - <<: *brancher
+      name: pull-titan-release
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      decoration_config:
+        timeout: 3h
+      always_run: false
+      optional: true
+      skip_if_only_changed: *skip_if_only_changed
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64
+        containers:
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test-release.sh
+            env:
+              - name: BUILD_TYPE
+                value: Release
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi
+
+    - <<: *brancher
+      name: pull-titan-test-arm64
+      decorate: true
+      extra_refs:
+        - org: PingCAP-QE
+          repo: ci
+          base_ref: main
+          repo_link: https://github.com/PingCAP-QE/ci
+      decoration_config:
+        timeout: 3h
+      always_run: false
+      optional: true
+      skip_if_only_changed: *skip_if_only_changed
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64
+        containers:
+          - name: builder
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            imagePullPolicy: Always
+            command:
+              - bash
+              - ../../PingCAP-QE/ci/scripts/tikv/titan/test-release.sh
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "4"
+                memory: 8Gi

--- a/scripts/tikv/titan/resolve_rocksdb_ref.sh
+++ b/scripts/tikv/titan/resolve_rocksdb_ref.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+branch="${1:-${PULL_BASE_REF:-}}"
+
+case "${branch}" in
+  tikv-7.5)
+    rocksdb_repo="https://github.com/tikv/rocksdb.git"
+    rocksdb_ref="6.29.tikv"
+    rocksdb_sha="21be567683b709fc1e5dbe25394579ee45529212"
+    ;;
+  tikv-7.1)
+    rocksdb_repo="https://github.com/tikv/rocksdb.git"
+    rocksdb_ref="6.29.tikv"
+    rocksdb_sha="21be567683b709fc1e5dbe25394579ee45529212"
+    ;;
+  tikv-6.5)
+    rocksdb_repo="https://github.com/tikv/rocksdb.git"
+    rocksdb_ref="tikv-6.5"
+    rocksdb_sha="13e7fa00fde49656a4f96ee7b1f2342b0ff6fb70"
+    ;;
+  tikv-6.1)
+    rocksdb_repo="https://github.com/tikv/rocksdb.git"
+    rocksdb_ref="6.4.tikv"
+    rocksdb_sha="9ca5afb9be6d437be7e17457cef5de5ddcfdac04"
+    ;;
+  tikv-5.2 | tikv-5.0 | tikv-4.x)
+    rocksdb_repo="https://github.com/pingcap/rocksdb.git"
+    rocksdb_ref="6.4.tikv"
+    # 6.4.tikv kept moving after these Titan branches were cut. Pin to a
+    # pre-revert commit that still provides the historical MultiBatchWrite API.
+    rocksdb_sha="6b97c0567c4694ef1d06374d54bf582e541d215d"
+    ;;
+  *)
+    echo "unsupported titan base branch: ${branch}" >&2
+    exit 1
+    ;;
+esac
+
+printf '%s\t%s\t%s\t%s\n' \
+  "${branch}" \
+  "${rocksdb_repo}" \
+  "${rocksdb_ref}" \
+  "${rocksdb_sha}"

--- a/scripts/tikv/titan/test-release.sh
+++ b/scripts/tikv/titan/test-release.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+target_branch="${PULL_BASE_REF:-}"
+build_type="${BUILD_TYPE:-}"
+sanitizer="${SANITIZER:-}"
+cmake_build_type="Debug"
+run_tests="yes"
+build_jobs="${MAKE_JOBS:-2}"
+cmake_cxx_flags="${CXXFLAGS:-}"
+rocksdb_dir=""
+
+if [[ -z "${target_branch}" ]]; then
+  echo "PULL_BASE_REF is required for Titan release branch jobs" >&2
+  exit 1
+fi
+
+run_with_sanitizer_runtime() {
+  "$@"
+}
+
+run_git_in_dir() {
+  local repo_dir="$1"
+  shift
+  (
+    cd "${repo_dir}"
+    git "$@"
+  )
+}
+
+prepare_rocksdb_source() {
+  local resolved=""
+  local rocksdb_branch=""
+  local rocksdb_repo=""
+  local rocksdb_ref=""
+  local rocksdb_sha=""
+  local repo_path=""
+  local repo_key=""
+  local rocksdb_root=""
+
+  resolved="$(bash "${script_dir}/resolve_rocksdb_ref.sh" "${target_branch}")"
+  IFS=$'\t' read -r rocksdb_branch rocksdb_repo rocksdb_ref rocksdb_sha <<< "${resolved}"
+
+  repo_path="${rocksdb_repo#https://github.com/}"
+  repo_path="${repo_path%.git}"
+  repo_key="${repo_path//\//-}"
+  rocksdb_root="${PWD}/.rocksdb-src"
+  rocksdb_dir="${rocksdb_root}/${repo_key}-${rocksdb_sha}"
+
+  mkdir -p "${rocksdb_root}"
+
+  if [[ ! -d "${rocksdb_dir}/.git" ]]; then
+    git clone --branch "${rocksdb_ref}" --depth=1 "${rocksdb_repo}" "${rocksdb_dir}"
+  else
+    run_git_in_dir "${rocksdb_dir}" remote set-url origin "${rocksdb_repo}"
+  fi
+
+  if [[ "$(run_git_in_dir "${rocksdb_dir}" rev-parse HEAD 2>/dev/null || true)" != "${rocksdb_sha}" ]]; then
+    run_git_in_dir "${rocksdb_dir}" fetch --depth=1 origin "${rocksdb_sha}"
+    run_git_in_dir "${rocksdb_dir}" checkout -f "${rocksdb_sha}"
+  fi
+
+  echo "using rocksdb for ${rocksdb_branch}: repo=${rocksdb_repo} ref=${rocksdb_ref} sha=${rocksdb_sha}"
+}
+
+required_packages=(
+  git
+  libstdc++-devel
+  snappy-devel
+  lz4-devel
+  zlib-devel
+  libzstd-devel
+  gflags-devel
+)
+
+cmake_args=(
+  .
+  -L
+  -DWITH_SNAPPY=ON
+  -DWITH_LZ4=ON
+  -DWITH_ZLIB=ON
+  -DWITH_ZSTD=ON
+  -DROCKSDB_BUILD_SHARED=OFF
+)
+
+if [[ -n "${build_type}" ]]; then
+  cmake_build_type="${build_type}"
+  run_tests="no"
+fi
+
+if [[ -n "${sanitizer}" ]]; then
+  case "${sanitizer}" in
+    ASAN)
+      cmake_args+=("-DWITH_ASAN=ON" "-DWITH_TITAN_TOOLS=OFF")
+      required_packages+=(devtoolset-8-libasan-devel)
+      ;;
+    TSAN)
+      cmake_args+=("-DWITH_TSAN=ON" "-DWITH_TITAN_TOOLS=OFF")
+      required_packages+=(devtoolset-8-libtsan-devel)
+      ;;
+    UBSAN)
+      cmake_args+=("-DWITH_UBSAN=ON" "-DWITH_TITAN_TOOLS=OFF")
+      required_packages+=(devtoolset-8-libubsan-devel)
+      ;;
+    *)
+      echo "unsupported sanitizer: ${sanitizer}" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [[ "${sanitizer}" == "TSAN" ]]; then
+  if ! command -v setarch >/dev/null 2>&1; then
+    echo "setarch is required for TSan runtime on this job" >&2
+    exit 1
+  fi
+
+  arch_name="$(uname -m)"
+  run_with_sanitizer_runtime() {
+    setarch "${arch_name}" -R "$@"
+  }
+fi
+
+if ! rpm -q "${required_packages[@]}" >/dev/null 2>&1; then
+  yum install -y "${required_packages[@]}"
+fi
+
+if [[ -f /usr/include/gflags/gflags.h ]] \
+  && grep -q 'namespace gflags' /usr/include/gflags/gflags.h \
+  && ! grep -q 'namespace google' /usr/include/gflags/gflags.h; then
+  cmake_cxx_flags="${cmake_cxx_flags:+${cmake_cxx_flags} }-DGFLAGS_NAMESPACE=gflags"
+fi
+
+if [[ -n "${cmake_cxx_flags}" ]]; then
+  cmake_args+=("-DCMAKE_CXX_FLAGS=${cmake_cxx_flags}")
+fi
+
+cmake_args+=("-DCMAKE_BUILD_TYPE=${cmake_build_type}")
+
+if [[ -f /opt/rh/devtoolset-8/enable ]]; then
+  set +u
+  source /opt/rh/devtoolset-8/enable
+  set -u
+fi
+
+g++ --version
+cmake --version
+
+rm -rf ./tmp_dir
+mkdir -p ./tmp_dir
+
+prepare_rocksdb_source
+cmake_args+=("-DROCKSDB_DIR=${rocksdb_dir}")
+
+cmake "${cmake_args[@]}"
+
+VERBOSE=1 make -j"${build_jobs}"
+
+if [[ "${run_tests}" == "yes" ]]; then
+  ctest_bin=ctest
+  if ! command -v "${ctest_bin}" >/dev/null 2>&1; then
+    ctest_bin=ctest3
+  fi
+
+  TEST_TMPDIR=./tmp_dir ASAN_OPTIONS=detect_leaks=0 \
+    run_with_sanitizer_runtime "${ctest_bin}" --verbose -R titan
+fi


### PR DESCRIPTION
## Background
Issue Number: ref https://github.com/PingCAP-QE/ci/issues/4508

## What Changed
- Added a new release-presubmits.yaml to handle the remaining legacy branches.
- Added resolve_rocksdb_ref.sh and test-release.sh. 
   - Pin the corresponding historical commit of RocksDB against the Titan baseline branch. 
   - Without this pinning layer, CI on release branches may fail randomly as the RocksDB branch evolves.

## Why These Changes
### Why added resolve_rocksdb_ref.sh
Due to the dependency of these legacy branches on RocksDB, many references actually point to a branch name rather than an immutable commit. 

For example, when we locally examine the Titan code for tikv-5.2, it references the 6.4.tikv branch of pingcap/rocksdb in CMakeLists.txt. That is exactly the problem:
- The tip of the 6.4.tikv branch keeps moving forward.
- The Titan tikv-5.2 branch itself may not be updated accordingly.

tikv-5.2 serves as direct evidence:
- The tip of the Titan tikv-5.2 branch is 2d178df.
- It depends on the RocksDB 6.4.tikv branch.
- However, the tip of 6.4.tikv has since advanced to 9ca5afb.
- The commit message of 9ca5afb is Revert multi-batch write optimization (#313).
- Meanwhile, the Titan 5.2 code still relies on assumptions about the old MultiBatchWrite interface.

Actual test results in the pod:
- Building with the 6.4.tikv branch tip 9ca5afb… causes pull-titan-test compilation failure.
- The error is a mismatch in MultiBatchWrite-related overrides.
- When RocksDB is pinned back to the earlier compatible commit 6b97c0567c4694ef1d06374d54bf582e541d215d,
- The entire pull-titan-test pipeline passes.

So some release branches pin corresponding historical commits of RocksDB based on the Titan baseline branch.

## Local Test
- tikv-5.0-rc relies on sudo and mounting tmpfs for legacy testing, but the current builder image does not provide the real /usr/bin/sudo. For tikv-3.0 and tikv-3.x, there appears to be behavioral semantic drift in these old branches, specifically causing assertion failures in TitanDBTest.DeleteFilesInRange. In short, these branches are mostly no longer updated and will be temporarily unsupported.
- Other release branches passed the tests. 