### PR TITLE
ci(jenkins): disabled deprecated jenkins job on ci.pingcap.net and ci2.pingcap.net

### DIFF
--- a/jenkins/jobs/ci/tiflash/ghpr_build_sanitier.groovy
+++ b/jenkins/jobs/ci/tiflash/ghpr_build_sanitier.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('tiflash-ghpr-sanitizer') {
+    disabled(true)
     logRotator {
         numToKeep(1500)
     }

--- a/jenkins/jobs/ci2/pingcap/tidb-binlog/ghpr_integration.groovy
+++ b/jenkins/jobs/ci2/pingcap/tidb-binlog/ghpr_integration.groovy
@@ -1,5 +1,6 @@
 // REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
 pipelineJob('binlog_ghpr_integration') {
+    disabled(true)
     logRotator {
         daysToKeep(30)
     }


### PR DESCRIPTION
Issue Number: ref https://github.com/PingCAP-QE/ci/issues/3342  https://github.com/PingCAP-QE/ci/issues/3338?issue=PingCAP-QE%7Cci%7C4348

ref PR : https://github.com/PingCAP-QE/ci/pull/4535 https://github.com/ti-community-infra/configs/pull/1269