### PR TITLE
prow(docs): migrate pull_verify presubmits from jenkins to kubernetes

### DIFF
--- a/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   pingcap/docs-cn:
-    - name: pingcap-docs-cn-pull-verify
+    - name: pull-verify
       agent: kubernetes
       decorate: true
       always_run: true
@@ -24,7 +24,6 @@ presubmits:
               - |
                 #!/usr/bin/env bash
                 set -euo pipefail
-                git config --global --add safe.directory '*'
 
                 base_ref="${PULL_BASE_REF:?missing PULL_BASE_REF}"
                 base_target="origin/${base_ref}"

--- a/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   pingcap/docs-cn:
-    - name: pingcap/docs-cn/pull_verify
+    - name: pingcap-docs-cn-pull-verify
       agent: kubernetes
       decorate: true
       always_run: true

--- a/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
@@ -1,17 +1,70 @@
 presubmits:
   pingcap/docs-cn:
     - name: pingcap/docs-cn/pull_verify
-      agent: jenkins
-      labels:
-        master: "0"
-      decorate: false # need add this.
+      agent: kubernetes
+      decorate: true
       always_run: true
       skip_report: false
       optional: false
       context: pull-verify
       trigger: "(?m)^/test (?:.*? )?(pull-verify|all)(?: .*?)?$"
       rerun_command: "/test pull-verify"
+      decoration_config:
+        timeout: 40m
       branches:
         - ^master$
         - ^release-\d+\.\d+$
         - ^feature/.+
+      spec:
+        containers:
+          - name: pull-verify
+            image: node:lts
+            command: [bash, -ce]
+            args:
+              - |
+                set -euo pipefail
+                git config --global --add safe.directory '*'
+
+                base_ref="${PULL_BASE_REF:?missing PULL_BASE_REF}"
+                base_target="origin/${base_ref}"
+                if ! git rev-parse --verify --quiet "${base_target}" >/dev/null; then
+                  base_target="${PULL_BASE_SHA:?missing PULL_BASE_SHA}"
+                fi
+
+                mapfile -t diff_docs_files < <(git diff-tree --name-only --no-commit-id -r "${base_target}..HEAD" -- '*.md' ':(exclude).github/*')
+
+                mkdir -p /tmp/check-scripts
+                for check_script in \
+                  check-file-encoding.py \
+                  check-conflicts.py \
+                  check-control-char.py \
+                  check-tags.py \
+                  check-manual-line-breaks.py; do
+                  curl -fsSL --retry 3 "https://raw.githubusercontent.com/pingcap/docs/master/scripts/${check_script}" \
+                    -o "/tmp/check-scripts/${check_script}"
+                done
+                cp -r /tmp/check-scripts/* ./
+
+                python3 check-file-encoding.py "${diff_docs_files[@]}"
+                python3 check-conflicts.py "${diff_docs_files[@]}"
+                python3 check-control-char.py "${diff_docs_files[@]}"
+                python3 check-tags.py "${diff_docs_files[@]}"
+                python3 check-manual-line-breaks.py "${diff_docs_files[@]}"
+                npm install -g markdownlint-cli@0.17.0
+                markdownlint "${diff_docs_files[@]}"
+            resources:
+              requests:
+                memory: 4Gi
+                cpu: "2"
+              limits:
+                memory: 4Gi
+                cpu: "2"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64

--- a/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml
@@ -22,6 +22,7 @@ presubmits:
             command: [bash, -ce]
             args:
               - |
+                #!/usr/bin/env bash
                 set -euo pipefail
                 git config --global --add safe.directory '*'
 
@@ -35,23 +36,23 @@ presubmits:
 
                 mkdir -p /tmp/check-scripts
                 for check_script in \
-                  check-file-encoding.py \
                   check-conflicts.py \
                   check-control-char.py \
                   check-tags.py \
-                  check-manual-line-breaks.py; do
+                  check-manual-line-breaks.py \
+                  check-file-encoding.py; do
                   curl -fsSL --retry 3 "https://raw.githubusercontent.com/pingcap/docs/master/scripts/${check_script}" \
                     -o "/tmp/check-scripts/${check_script}"
                 done
                 cp -r /tmp/check-scripts/* ./
 
-                python3 check-file-encoding.py "${diff_docs_files[@]}"
                 python3 check-conflicts.py "${diff_docs_files[@]}"
                 python3 check-control-char.py "${diff_docs_files[@]}"
                 python3 check-tags.py "${diff_docs_files[@]}"
                 python3 check-manual-line-breaks.py "${diff_docs_files[@]}"
                 npm install -g markdownlint-cli@0.17.0
                 markdownlint "${diff_docs_files[@]}"
+                python3 check-file-encoding.py "${diff_docs_files[@]}"
             resources:
               requests:
                 memory: 4Gi

--- a/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   pingcap/docs:
-    - name: pingcap/docs/pull_verify
+    - name: pingcap-docs-pull-verify
       agent: kubernetes
       decorate: true
       always_run: true

--- a/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   pingcap/docs:
-    - name: pingcap-docs-pull-verify
+    - name: pull-verify
       agent: kubernetes
       decorate: true
       always_run: true
@@ -26,7 +26,6 @@ presubmits:
               - |
                 #!/usr/bin/env bash
                 set -euo pipefail
-                git config --global --add safe.directory '*'
 
                 base_ref="${PULL_BASE_REF:?missing PULL_BASE_REF}"
                 base_target="origin/${base_ref}"

--- a/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
             command: [bash, -ce]
             args:
               - |
+                #!/usr/bin/env bash
                 set -euo pipefail
                 git config --global --add safe.directory '*'
 
@@ -37,23 +38,23 @@ presubmits:
 
                 mkdir -p /tmp/check-scripts
                 for check_script in \
-                  check-file-encoding.py \
                   check-conflicts.py \
                   check-control-char.py \
                   check-tags.py \
-                  check-manual-line-breaks.py; do
+                  check-manual-line-breaks.py \
+                  check-file-encoding.py; do
                   curl -fsSL --retry 3 "https://raw.githubusercontent.com/pingcap/docs/master/scripts/${check_script}" \
                     -o "/tmp/check-scripts/${check_script}"
                 done
                 cp -r /tmp/check-scripts/* ./
 
-                python3 check-file-encoding.py "${diff_docs_files[@]}"
                 python3 check-conflicts.py "${diff_docs_files[@]}"
                 python3 check-control-char.py "${diff_docs_files[@]}"
                 python3 check-tags.py "${diff_docs_files[@]}"
                 python3 check-manual-line-breaks.py "${diff_docs_files[@]}"
                 npm install -g markdownlint-cli@0.17.0
                 markdownlint "${diff_docs_files[@]}"
+                python3 check-file-encoding.py "${diff_docs_files[@]}"
             resources:
               requests:
                 memory: 4Gi

--- a/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-latest-presubmits.yaml
@@ -1,19 +1,72 @@
 presubmits:
   pingcap/docs:
     - name: pingcap/docs/pull_verify
-      agent: jenkins
-      labels:
-        master: "0"
-      decorate: false # need add this.
+      agent: kubernetes
+      decorate: true
       always_run: true
       skip_report: false
       optional: false
       context: pull-verify
       trigger: "(?m)^/test (?:.*? )?(pull-verify|all)(?: .*?)?$"
       rerun_command: "/test pull-verify"
+      decoration_config:
+        timeout: 40m
       branches:
         - ^master$
         - ^release-\d+\.\d+$
         - ^release-cloud$
         - ^feature/.+
         - ^support-azure$
+      spec:
+        containers:
+          - name: pull-verify
+            image: node:lts
+            command: [bash, -ce]
+            args:
+              - |
+                set -euo pipefail
+                git config --global --add safe.directory '*'
+
+                base_ref="${PULL_BASE_REF:?missing PULL_BASE_REF}"
+                base_target="origin/${base_ref}"
+                if ! git rev-parse --verify --quiet "${base_target}" >/dev/null; then
+                  base_target="${PULL_BASE_SHA:?missing PULL_BASE_SHA}"
+                fi
+
+                mapfile -t diff_docs_files < <(git diff-tree --name-only --no-commit-id -r "${base_target}..HEAD" -- '*.md' ':(exclude).github/*')
+
+                mkdir -p /tmp/check-scripts
+                for check_script in \
+                  check-file-encoding.py \
+                  check-conflicts.py \
+                  check-control-char.py \
+                  check-tags.py \
+                  check-manual-line-breaks.py; do
+                  curl -fsSL --retry 3 "https://raw.githubusercontent.com/pingcap/docs/master/scripts/${check_script}" \
+                    -o "/tmp/check-scripts/${check_script}"
+                done
+                cp -r /tmp/check-scripts/* ./
+
+                python3 check-file-encoding.py "${diff_docs_files[@]}"
+                python3 check-conflicts.py "${diff_docs_files[@]}"
+                python3 check-control-char.py "${diff_docs_files[@]}"
+                python3 check-tags.py "${diff_docs_files[@]}"
+                python3 check-manual-line-breaks.py "${diff_docs_files[@]}"
+                npm install -g markdownlint-cli@0.17.0
+                markdownlint "${diff_docs_files[@]}"
+            resources:
+              requests:
+                memory: 4Gi
+                cpu: "2"
+              limits:
+                memory: 4Gi
+                cpu: "2"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - amd64


### PR DESCRIPTION
## Summary
- migrate `pingcap/docs` and `pingcap/docs-cn` `pull_verify` presubmits to `agent: kubernetes`
- keep trigger/context/branches compatibility (`/test pull-verify`, `context: pull-verify`)
- add explicit timeout, resources, amd64 affinity, and strict failure handling

## Changed files
- `prow-jobs/pingcap/docs/docs-latest-presubmits.yaml`
- `prow-jobs/pingcap/docs/docs-cn-latest-presubmits.yaml`

## Notes
- commit: `b0d3b513`
- related Multica issue: FLA-107
