### PR TITLE
ci(prow): add presubmit secret scan gate with gitleaks

### DIFF
--- a/.ci/verify-secret-scan.sh
+++ b/.ci/verify-secret-scan.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "gitleaks is required but not found" >&2
+  exit 1
+fi
+
+# Run in source mode to scan workspace contents in PR, fail-fast on findings.
+gitleaks detect \
+  --source . \
+  --no-git \
+  --redact \
+  --verbose

--- a/docs/guides/CI.md
+++ b/docs/guides/CI.md
@@ -127,6 +127,9 @@ This repository has two related presubmit jobs for pipeline changes:
   - Verifies pipeline Pod YAML files stay structurally valid Kubernetes Pod manifests.
   - When in-cluster Kubernetes API access is available, injects a test `metadata.name` and also runs both `kubectl --dry-run=client --validate=strict` and `kubectl --dry-run=server --validate=strict`.
   - Triggered by `pipelines/**/*.yaml` changes.
+- `pull-verify-secret-scan`
+  - Runs gitleaks in presubmit and blocks the PR when new credential leakage is detected.
+  - Always runs for `PingCAP-QE/ci` pull requests to keep a uniform security gate.
 - `pull-replay-jenkins-pipelines`
   - Optional replay validation using `--auto-changed`.
   - Trigger manually in PR comments:

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -73,6 +73,25 @@ presubmits:
               limits:
                 memory: 256Mi
                 cpu: 200m
+    - name: pull-verify-secret-scan
+      labels: *labels
+      decorate: true
+      always_run: true
+      max_concurrency: 1
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - name: main
+            image: zricethezav/gitleaks:v8.30.1
+            command: [sh, -ce]
+            args:
+              - |
+                sh .ci/verify-secret-scan.sh
+            resources:
+              limits:
+                memory: 256Mi
+                cpu: 200m
     - name: pull-verify-jenkins-pipelines
       labels: *labels
       decorate: true


### PR DESCRIPTION
## Summary
- add a dedicated presubmit job  for 
- run gitleaks in fail-fast mode via 
- document the new security gate in 

## Why
Implements TDS v1 PR1 by adding a unified presubmit blocking path for secret leakage detection.

## Test
- 