### PR TITLE
ci(prow): focus secret gate on Jenkins credential misuse risks

### DIFF
--- a/.ci/verify-jenkins-credential-policy.sh
+++ b/.ci/verify-jenkins-credential-policy.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_SHA="${PULL_BASE_SHA:-}"
+HEAD_SHA="${PULL_PULL_SHA:-${PULL_HEAD_SHA:-HEAD}}"
+
+if [[ -z "$BASE_SHA" ]]; then
+  BASE_SHA="HEAD~1"
+fi
+
+# Focus on credentials-risk surface only.
+changed_files=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && changed_files+=("$line")
+done < <(
+  git diff --name-only "${BASE_SHA}..${HEAD_SHA}" -- \
+    'pipelines/**' 'jobs/**' 'libraries/**' 'prow-jobs/**' \
+    | rg -N '\.(groovy|ya?ml)$' || true
+)
+
+if [[ ${#changed_files[@]} -eq 0 ]]; then
+  echo "No changed Groovy/YAML files in credentials-risk scope."
+  exit 0
+fi
+
+echo "Checking credential policy on ${#changed_files[@]} changed files"
+
+failed=0
+
+for f in "${changed_files[@]}"; do
+  [[ -f "$f" ]] || continue
+
+  # Rule 1: reject explicit secret-like literals in changed CI scripts.
+  if rg -n -i "(token|password|secret|access[_-]?key|secret[_-]?key)\s*[:=]\s*['\"][^$][^'\"]{4,}['\"]" "$f" >/tmp/cred_literal.$$; then
+    echo "[BLOCK] potential hard-coded secret literal in $f"
+    cat /tmp/cred_literal.$$
+    failed=1
+  fi
+
+  # Rule 2: reject obvious secret echo/printf in Groovy/bash snippets.
+  if rg -n -i "\b(echo|printf)\b.*\$\{?[A-Za-z_][A-Za-z0-9_]*(TOKEN|PASSWORD|SECRET|KEY)[A-Za-z0-9_]*\}?" "$f" >/tmp/cred_echo.$$; then
+    echo "[BLOCK] potential secret value echo in $f"
+    cat /tmp/cred_echo.$$
+    failed=1
+  fi
+
+  # Rule 3: for Prow job YAML, forbid direct `value:` for secret-like env names.
+  if [[ "$f" == prow-jobs/* && "$f" =~ \.(yaml|yml)$ ]]; then
+    if awk '
+      BEGIN{bad=0; name=""}
+      /^[[:space:]]*- name:[[:space:]]*/ {
+        name=$0
+        sub(/.*- name:[[:space:]]*/, "", name)
+      }
+      /^[[:space:]]*name:[[:space:]]*/ {
+        name=$0
+        sub(/.*name:[[:space:]]*/, "", name)
+      }
+      /^[[:space:]]*value:[[:space:]]*/ {
+        if (name ~ /(TOKEN|PASSWORD|SECRET|KEY)/) {
+          print NR ":" $0
+          bad=1
+        }
+      }
+      END{exit bad}
+    ' "$f" >/tmp/cred_yaml.$$; then
+      :
+    else
+      echo "[BLOCK] secret-like env var should use valueFrom/secretKeyRef in $f"
+      cat /tmp/cred_yaml.$$
+      failed=1
+    fi
+  fi
+
+done
+
+rm -f /tmp/cred_literal.$$ /tmp/cred_echo.$$ /tmp/cred_yaml.$$
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "Credential policy violations found."
+  exit 1
+fi
+
+echo "Credential policy check passed."

--- a/.ci/verify-secret-scan.sh
+++ b/.ci/verify-secret-scan.sh
@@ -6,9 +6,17 @@ if ! command -v gitleaks >/dev/null 2>&1; then
   exit 1
 fi
 
-# Run in source mode to scan workspace contents in PR, fail-fast on findings.
-gitleaks detect \
-  --source . \
-  --no-git \
+BASE_SHA="${PULL_BASE_SHA:-}"
+HEAD_SHA="${PULL_PULL_SHA:-${PULL_HEAD_SHA:-HEAD}}"
+
+if [[ -z "$BASE_SHA" ]]; then
+  echo "PULL_BASE_SHA is empty, fallback to HEAD~1..HEAD" >&2
+  BASE_SHA="HEAD~1"
+fi
+
+echo "Running incremental gitleaks scan on range: ${BASE_SHA}..${HEAD_SHA}"
+
+gitleaks git \
+  --log-opts "${BASE_SHA}..${HEAD_SHA}" \
   --redact \
   --verbose

--- a/docs/guides/CI.md
+++ b/docs/guides/CI.md
@@ -131,7 +131,7 @@ This repository has two related presubmit jobs for pipeline changes:
   - Triggered only when changed files are in the Jenkins credentials-risk surface:
     `pipelines/**`, `jobs/**`, `libraries/**`, `prow-jobs/**` (`*.groovy|*.yml|*.yaml`).
   - Runs two fail-fast checks:
-    - Jenkins credential policy check (`.ci/verify-jenkins-credential-policy.sh`) to block obvious insecure patterns such as secret-like literal assignments, secret value echo, and secret-like env vars with direct `value:` in Prow YAML.
+    - Jenkins credential policy check (`bash .ci/verify-jenkins-credential-policy.sh`) to block obvious insecure patterns such as secret-like literal assignments, secret value echo, and secret-like env vars with direct `value:` in Prow YAML.
     - Incremental gitleaks check (`.ci/verify-secret-scan.sh`) on `${PULL_BASE_SHA}..${PULL_PULL_SHA}` instead of whole-repo scan.
 - `pull-replay-jenkins-pipelines`
   - Optional replay validation using `--auto-changed`.

--- a/docs/guides/CI.md
+++ b/docs/guides/CI.md
@@ -128,8 +128,11 @@ This repository has two related presubmit jobs for pipeline changes:
   - When in-cluster Kubernetes API access is available, injects a test `metadata.name` and also runs both `kubectl --dry-run=client --validate=strict` and `kubectl --dry-run=server --validate=strict`.
   - Triggered by `pipelines/**/*.yaml` changes.
 - `pull-verify-secret-scan`
-  - Runs gitleaks in presubmit and blocks the PR when new credential leakage is detected.
-  - Always runs for `PingCAP-QE/ci` pull requests to keep a uniform security gate.
+  - Triggered only when changed files are in the Jenkins credentials-risk surface:
+    `pipelines/**`, `jobs/**`, `libraries/**`, `prow-jobs/**` (`*.groovy|*.yml|*.yaml`).
+  - Runs two fail-fast checks:
+    - Jenkins credential policy check (`.ci/verify-jenkins-credential-policy.sh`) to block obvious insecure patterns such as secret-like literal assignments, secret value echo, and secret-like env vars with direct `value:` in Prow YAML.
+    - Incremental gitleaks check (`.ci/verify-secret-scan.sh`) on `${PULL_BASE_SHA}..${PULL_PULL_SHA}` instead of whole-repo scan.
 - `pull-replay-jenkins-pipelines`
   - Optional replay validation using `--auto-changed`.
   - Trigger manually in PR comments:

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -76,7 +76,7 @@ presubmits:
     - name: pull-verify-secret-scan
       labels: *labels
       decorate: true
-      always_run: true
+      run_if_changed: "^(pipelines|jobs|libraries|prow-jobs)/.*\\.(groovy|yaml|yml)$|^\\.ci/verify-(secret-scan|jenkins-credential-policy)\\.sh$"
       max_concurrency: 1
       branches:
         - ^main$
@@ -87,6 +87,8 @@ presubmits:
             command: [sh, -ce]
             args:
               - |
+                apk add --no-cache bash git ripgrep
+                sh .ci/verify-jenkins-credential-policy.sh
                 sh .ci/verify-secret-scan.sh
             resources:
               limits:

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -88,7 +88,7 @@ presubmits:
             args:
               - |
                 apk add --no-cache bash git ripgrep
-                sh .ci/verify-jenkins-credential-policy.sh
+                bash .ci/verify-jenkins-credential-policy.sh
                 sh .ci/verify-secret-scan.sh
             resources:
               limits:


### PR DESCRIPTION
## Summary
- narrow `pull-verify-secret-scan` trigger scope to Jenkins credential-risk files only (`pipelines/jobs/libraries/prow-jobs`)
- switch gitleaks from whole-repo scan to incremental commit-range scan (`PULL_BASE_SHA..PULL_PULL_SHA`)
- add `.ci/verify-jenkins-credential-policy.sh` to block high-risk credential misuse patterns in changed Groovy/YAML files

## Why
Continue FLA-109 remaining scope based on Architect TDS v1.1: focus on credential misuse/abuse risk in Jenkins task surface and reduce duplicated broad scanning.

## Test
- `bash -n .ci/verify-secret-scan.sh`
- `bash -n .ci/verify-jenkins-credential-policy.sh`
- `PULL_BASE_SHA=$(git merge-base HEAD origin/main) PULL_PULL_SHA=HEAD .ci/verify-jenkins-credential-policy.sh`
