### PR TITLE
ci(security): add regression presubmit for credential policy checks

### DIFF
--- a/.ci/security-policy-allowlist.txt
+++ b/.ci/security-policy-allowlist.txt
@@ -1,0 +1,8 @@
+# Format: <rule>\t<path-regex>
+# Rules:
+# - hardcoded_literal
+# - secret_echo
+# - secret_env_plain_value
+#
+# Example:
+# secret_echo	^pipelines/pingcap/example/legacy-debug\.groovy$

--- a/.ci/test-verify-jenkins-credential-policy.sh
+++ b/.ci/test-verify-jenkins-credential-policy.sh
@@ -73,6 +73,20 @@ presubmits:
                 value: plain-token
 PAYLOAD
       ;;
+    allowlisted_secret_echo)
+      cat >"${head_file}" <<'PAYLOAD'
+def call() {
+  sh 'echo ${DEBUG_TOKEN}'
+}
+PAYLOAD
+      ;;
+    non_allowlisted_secret_echo)
+      cat >"${head_file}" <<'PAYLOAD'
+def call() {
+  sh 'echo ${ANY_SECRET}'
+}
+PAYLOAD
+      ;;
     *)
       echo "unknown case: ${name}" >&2
       exit 1
@@ -83,6 +97,13 @@ PAYLOAD
   git commit -q -m "head"
   local head_sha
   head_sha="$(git rev-parse HEAD)"
+
+  if [[ "${name}" == "allowlisted_secret_echo" ]]; then
+    mkdir -p .ci
+    cat > .ci/security-policy-allowlist.txt <<'ALLOW'
+secret_echo	^pipelines/pingcap/tidb/latest/pull_allowlisted\.groovy$
+ALLOW
+  fi
 
   set +e
   PULL_BASE_SHA="${base_sha}" PULL_PULL_SHA="${head_sha}" bash "${SCRIPT_PATH}"
@@ -116,5 +137,13 @@ run_case "hardcoded_secret_literal" "fail" \
 run_case "secret_like_env_value_in_prow_yaml" "fail" \
   "prow-jobs/pingcap-qe/ci/presubmits.yaml" \
   "prow-jobs/pingcap-qe/ci/presubmits.yaml"
+
+run_case "allowlisted_secret_echo" "pass" \
+  "pipelines/pingcap/tidb/latest/pull_allowlisted.groovy" \
+  "pipelines/pingcap/tidb/latest/pull_allowlisted.groovy"
+
+run_case "non_allowlisted_secret_echo" "fail" \
+  "pipelines/pingcap/tidb/latest/pull_not_allowlisted.groovy" \
+  "pipelines/pingcap/tidb/latest/pull_not_allowlisted.groovy"
 
 echo "All credential-policy regression tests passed."

--- a/.ci/test-verify-jenkins-credential-policy.sh
+++ b/.ci/test-verify-jenkins-credential-policy.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/.ci/verify-jenkins-credential-policy.sh"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) is required" >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required" >&2
+  exit 1
+fi
+
+run_case() {
+  local name="$1"
+  local expect="$2"
+  local seed_file="$3"
+  local head_file="$4"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp}"' RETURN
+
+  pushd "${tmp}" >/dev/null
+
+  git init -q
+  git config user.email "ci-bot@example.com"
+  git config user.name "CI Bot"
+
+  mkdir -p "$(dirname "${seed_file}")"
+  cat >"${seed_file}" <<'SEED'
+// baseline safe content
+SEED
+
+  git add .
+  git commit -q -m "seed"
+  local base_sha
+  base_sha="$(git rev-parse HEAD)"
+
+  mkdir -p "$(dirname "${head_file}")"
+  cat >"${head_file}" <<'HEAD'
+PLACEHOLDER
+HEAD
+
+  # Replace placeholder with actual case-specific payload.
+  case "${name}" in
+    safe_groovy)
+      cat >"${head_file}" <<'PAYLOAD'
+def call() {
+  withCredentials([string(credentialsId: 'safe-token-id', variable: 'SAFE_TOKEN')]) {
+    sh 'echo "run checks"'
+  }
+}
+PAYLOAD
+      ;;
+    hardcoded_secret_literal)
+      cat >"${head_file}" <<'PAYLOAD'
+def token = "hardcoded_secret_token"
+PAYLOAD
+      ;;
+    secret_like_env_value_in_prow_yaml)
+      cat >"${head_file}" <<'PAYLOAD'
+presubmits:
+  PingCAP-QE/ci:
+    - name: test
+      spec:
+        containers:
+          - env:
+              - name: JENKINS_TOKEN
+                value: plain-token
+PAYLOAD
+      ;;
+    *)
+      echo "unknown case: ${name}" >&2
+      exit 1
+      ;;
+  esac
+
+  git add .
+  git commit -q -m "head"
+  local head_sha
+  head_sha="$(git rev-parse HEAD)"
+
+  set +e
+  PULL_BASE_SHA="${base_sha}" PULL_PULL_SHA="${head_sha}" bash "${SCRIPT_PATH}"
+  local rc=$?
+  set -e
+
+  popd >/dev/null
+
+  if [[ "${expect}" == "pass" && "${rc}" -eq 0 ]]; then
+    echo "[PASS] ${name}"
+    return 0
+  fi
+
+  if [[ "${expect}" == "fail" && "${rc}" -ne 0 ]]; then
+    echo "[PASS] ${name}"
+    return 0
+  fi
+
+  echo "[FAIL] ${name} (expect=${expect}, rc=${rc})" >&2
+  return 1
+}
+
+run_case "safe_groovy" "pass" \
+  "pipelines/pingcap/tidb/latest/pull_safe.groovy" \
+  "pipelines/pingcap/tidb/latest/pull_safe.groovy"
+
+run_case "hardcoded_secret_literal" "fail" \
+  "jobs/pingcap/tidb/latest/pull_check.groovy" \
+  "jobs/pingcap/tidb/latest/pull_check.groovy"
+
+run_case "secret_like_env_value_in_prow_yaml" "fail" \
+  "prow-jobs/pingcap-qe/ci/presubmits.yaml" \
+  "prow-jobs/pingcap-qe/ci/presubmits.yaml"
+
+echo "All credential-policy regression tests passed."

--- a/.ci/verify-jenkins-credential-policy.sh
+++ b/.ci/verify-jenkins-credential-policy.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 BASE_SHA="${PULL_BASE_SHA:-}"
 HEAD_SHA="${PULL_PULL_SHA:-${PULL_HEAD_SHA:-HEAD}}"
+ALLOWLIST_FILE="${CREDENTIAL_POLICY_ALLOWLIST_FILE:-.ci/security-policy-allowlist.txt}"
 
 if [[ -z "$BASE_SHA" ]]; then
   BASE_SHA="HEAD~1"
@@ -27,21 +28,54 @@ echo "Checking credential policy on ${#changed_files[@]} changed files"
 
 failed=0
 
+is_allowlisted() {
+  local rule="$1"
+  local file_path="$2"
+
+  [[ -f "${ALLOWLIST_FILE}" ]] || return 1
+
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] || continue
+    [[ "${line}" =~ ^# ]] && continue
+
+    local allow_rule path_regex
+    allow_rule="$(echo "${line}" | cut -f1)"
+    path_regex="$(echo "${line}" | cut -f2-)"
+
+    [[ "${allow_rule}" == "${rule}" ]] || continue
+    [[ -n "${path_regex}" ]] || continue
+
+    if [[ "${file_path}" =~ ${path_regex} ]]; then
+      return 0
+    fi
+  done < "${ALLOWLIST_FILE}"
+
+  return 1
+}
+
 for f in "${changed_files[@]}"; do
   [[ -f "$f" ]] || continue
 
   # Rule 1: reject explicit secret-like literals in changed CI scripts.
   if rg -n -i "(token|password|secret|access[_-]?key|secret[_-]?key)\s*[:=]\s*['\"][^$][^'\"]{4,}['\"]" "$f" >/tmp/cred_literal.$$; then
-    echo "[BLOCK] potential hard-coded secret literal in $f"
-    cat /tmp/cred_literal.$$
-    failed=1
+    if is_allowlisted "hardcoded_literal" "$f"; then
+      echo "[ALLOWLIST] hardcoded_literal matched for $f"
+    else
+      echo "[BLOCK] potential hard-coded secret literal in $f"
+      cat /tmp/cred_literal.$$
+      failed=1
+    fi
   fi
 
   # Rule 2: reject obvious secret echo/printf in Groovy/bash snippets.
-  if rg -n -i "\b(echo|printf)\b.*\$\{?[A-Za-z_][A-Za-z0-9_]*(TOKEN|PASSWORD|SECRET|KEY)[A-Za-z0-9_]*\}?" "$f" >/tmp/cred_echo.$$; then
-    echo "[BLOCK] potential secret value echo in $f"
-    cat /tmp/cred_echo.$$
-    failed=1
+  if rg -n -i '(^|[^[:alnum:]_])(echo|printf)([^[:alnum:]_]|$).*\$\{?[A-Za-z_][A-Za-z0-9_]*(TOKEN|PASSWORD|SECRET|KEY)[A-Za-z0-9_]*\}?' "$f" >/tmp/cred_echo.$$; then
+    if is_allowlisted "secret_echo" "$f"; then
+      echo "[ALLOWLIST] secret_echo matched for $f"
+    else
+      echo "[BLOCK] potential secret value echo in $f"
+      cat /tmp/cred_echo.$$
+      failed=1
+    fi
   fi
 
   # Rule 3: for Prow job YAML, forbid direct `value:` for secret-like env names.
@@ -66,9 +100,13 @@ for f in "${changed_files[@]}"; do
     ' "$f" >/tmp/cred_yaml.$$; then
       :
     else
-      echo "[BLOCK] secret-like env var should use valueFrom/secretKeyRef in $f"
-      cat /tmp/cred_yaml.$$
-      failed=1
+      if is_allowlisted "secret_env_plain_value" "$f"; then
+        echo "[ALLOWLIST] secret_env_plain_value matched for $f"
+      else
+        echo "[BLOCK] secret-like env var should use valueFrom/secretKeyRef in $f"
+        cat /tmp/cred_yaml.$$
+        failed=1
+      fi
     fi
   fi
 

--- a/docs/guides/CI.md
+++ b/docs/guides/CI.md
@@ -130,12 +130,18 @@ This repository has two related presubmit jobs for pipeline changes:
 - `pull-verify-secret-scan`
   - Triggered only when changed files are in the Jenkins credentials-risk surface:
     `pipelines/**`, `jobs/**`, `libraries/**`, `prow-jobs/**` (`*.groovy|*.yml|*.yaml`).
+  - Uses pinned scanner image digest and explicit timeout for predictable operations.
   - Runs two fail-fast checks:
     - Jenkins credential policy check (`bash .ci/verify-jenkins-credential-policy.sh`) to block obvious insecure patterns such as secret-like literal assignments, secret value echo, and secret-like env vars with direct `value:` in Prow YAML.
     - Incremental gitleaks check (`.ci/verify-secret-scan.sh`) on `${PULL_BASE_SHA}..${PULL_PULL_SHA}` instead of whole-repo scan.
+  - Supports explicit exemptions via `.ci/security-policy-allowlist.txt`:
+    - format: `<rule><TAB><path-regex>`
+    - supported rules: `hardcoded_literal`, `secret_echo`, `secret_env_plain_value`
+    - exemptions should be narrow and path-scoped to avoid broad bypasses.
 - `pull-test-security-policy-scripts`
   - Runs regression tests for `.ci/verify-jenkins-credential-policy.sh` with both positive and negative fixtures.
-  - Triggered when `.ci/verify-jenkins-credential-policy.sh` or `.ci/test-verify-jenkins-credential-policy.sh` changes.
+  - Includes allowlist regression fixtures (allowlisted vs non-allowlisted secret echo).
+  - Triggered when `.ci/verify-jenkins-credential-policy.sh`, `.ci/test-verify-jenkins-credential-policy.sh`, or `.ci/security-policy-allowlist.txt` changes.
 - `pull-replay-jenkins-pipelines`
   - Optional replay validation using `--auto-changed`.
   - Trigger manually in PR comments:

--- a/docs/guides/CI.md
+++ b/docs/guides/CI.md
@@ -133,6 +133,9 @@ This repository has two related presubmit jobs for pipeline changes:
   - Runs two fail-fast checks:
     - Jenkins credential policy check (`bash .ci/verify-jenkins-credential-policy.sh`) to block obvious insecure patterns such as secret-like literal assignments, secret value echo, and secret-like env vars with direct `value:` in Prow YAML.
     - Incremental gitleaks check (`.ci/verify-secret-scan.sh`) on `${PULL_BASE_SHA}..${PULL_PULL_SHA}` instead of whole-repo scan.
+- `pull-test-security-policy-scripts`
+  - Runs regression tests for `.ci/verify-jenkins-credential-policy.sh` with both positive and negative fixtures.
+  - Triggered when `.ci/verify-jenkins-credential-policy.sh` or `.ci/test-verify-jenkins-credential-policy.sh` changes.
 - `pull-replay-jenkins-pipelines`
   - Optional replay validation using `--auto-changed`.
   - Trigger manually in PR comments:

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -76,14 +76,15 @@ presubmits:
     - name: pull-verify-secret-scan
       labels: *labels
       decorate: true
-      run_if_changed: "^(pipelines|jobs|libraries|prow-jobs)/.*\\.(groovy|yaml|yml)$|^\\.ci/verify-(secret-scan|jenkins-credential-policy)\\.sh$"
+      run_if_changed: "^(pipelines|jobs|libraries|prow-jobs)/.*\\.(groovy|yaml|yml)$|^\\.ci/(verify-secret-scan|verify-jenkins-credential-policy|security-policy-allowlist)\\.(sh|txt)$"
       max_concurrency: 1
+      timeout: 15m
       branches:
         - ^main$
       spec:
         containers:
           - name: main
-            image: zricethezav/gitleaks:v8.30.1
+            image: zricethezav/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f
             command: [sh, -ce]
             args:
               - |
@@ -98,7 +99,8 @@ presubmits:
       labels: *labels
       decorate: true
       max_concurrency: 1
-      run_if_changed: '^\.ci/(verify-jenkins-credential-policy|test-verify-jenkins-credential-policy)\.sh$'
+      run_if_changed: '^\.ci/(verify-jenkins-credential-policy|test-verify-jenkins-credential-policy)\.sh$|^\.ci/security-policy-allowlist\.txt$'
+      timeout: 10m
       branches:
         - ^main$
       spec:

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -98,7 +98,7 @@ presubmits:
       labels: *labels
       decorate: true
       max_concurrency: 1
-      run_if_changed: "^\.ci/(verify-jenkins-credential-policy|test-verify-jenkins-credential-policy)\.sh$"
+      run_if_changed: '^\.ci/(verify-jenkins-credential-policy|test-verify-jenkins-credential-policy)\.sh$'
       branches:
         - ^main$
       spec:

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -94,6 +94,27 @@ presubmits:
               limits:
                 memory: 256Mi
                 cpu: 200m
+    - name: pull-test-security-policy-scripts
+      labels: *labels
+      decorate: true
+      max_concurrency: 1
+      run_if_changed: "^\.ci/(verify-jenkins-credential-policy|test-verify-jenkins-credential-policy)\.sh$"
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - name: main
+            image: alpine:3.22
+            command: [sh, -ce]
+            args:
+              - |
+                apk add --no-cache bash git ripgrep
+                bash .ci/test-verify-jenkins-credential-policy.sh
+            resources:
+              limits:
+                memory: 256Mi
+                cpu: 200m
+
     - name: pull-verify-jenkins-pipelines
       labels: *labels
       decorate: true


### PR DESCRIPTION
## Summary
Continue phased delivery after PR #4541 (remaining scope):
- add regression test script `.ci/test-verify-jenkins-credential-policy.sh`
- add new presubmit `pull-test-security-policy-scripts` to run these tests automatically
- document the new regression gate in `docs/guides/CI.md`

## Why
The earlier phase introduced credential policy checks. This PR adds positive/negative regression coverage so policy rules are stable and safe to evolve.

## Test
- `bash -n .ci/test-verify-jenkins-credential-policy.sh`
- `bash .ci/test-verify-jenkins-credential-policy.sh`
