### PR TITLE
chore(prow-jobs/pingcap/docs): remove v5.4 as it is archived

### DIFF
--- a/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml
@@ -11,7 +11,6 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5\.4$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
         - ^release-8\.[15]$

--- a/prow-jobs/pingcap/docs/docs-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/docs-postsubmits.yaml
@@ -11,7 +11,6 @@ postsubmits:
       skip_report: false
       branches:
         - ^master$
-        - ^release-5\.4$
         - ^release-6\.[15]$
         - ^release-7\.[15]$
         - ^release-8\.[15]$


### PR DESCRIPTION
### What changed?
- remove the `release-5.4` postsubmit branch rule from `prow-jobs/pingcap/docs/docs-cn-postsubmits.yaml`
- remove the `release-5.4` postsubmit branch rule from `prow-jobs/pingcap/docs/docs-postsubmits.yaml`

### Why?
- `release-5.4` documentation has been archived and should no longer trigger these docs postsubmit jobs

### Validation
- verified the diff only removes the `- ^release-5\.4$` rule from the two target files
- loaded both YAML files successfully with Ruby `YAML.load_file`

### Reference
- https://github.com/PingCAP-QE/ci/pull/3638/files
- https://github.com/pingcap/docs-staging/pull/133
- https://github.com/pingcap/docs-staging/pull/134
