### PR TITLE
ci(tidb): align pull_unit_test_next_gen pod resources

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
@@ -16,13 +16,13 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 24Gi
-          cpu: "6"
+          memory: 48Gi
+          cpu: "24"
           ephemeral-storage: 20Gi
         limits:
-          memory: 48Gi
-          cpu: "12"
-          ephemeral-storage: 80Gi
+          memory: 64Gi
+          cpu: "24"
+          ephemeral-storage: 300Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged


### PR DESCRIPTION
## Summary
- align `pull_unit_test_next_gen` pod resource requests/limits with the master presubmit unit test baseline
- keep the next-gen-specific `bazel-repository-cache` mount and `300Gi` workspace PVC unchanged

## Testing
- not run (pod yaml change only)
