### PR TITLE
fix(flaky-tests): reopen issues using build start time

### DIFF
--- a/tools/reporters/ci/flaky-tests/core/FlakyReporter.ts
+++ b/tools/reporters/ci/flaky-tests/core/FlakyReporter.ts
@@ -86,6 +86,8 @@ export class FlakyReporter {
           owner: ownerRes.owner,
           latestBuildUrl: undefined,
           latestReportTime: undefined,
+          latestFlakyBuildUrl: undefined,
+          latestFlakyReportTime: undefined,
         };
         caseMap.set(key, agg);
 
@@ -109,6 +111,16 @@ export class FlakyReporter {
       ) {
         agg.latestReportTime = rt;
         agg.latestBuildUrl = r.build_url;
+      }
+
+      if (r.flaky && Number(r.flaky) > 0) {
+        if (
+          !agg.latestFlakyReportTime ||
+          rt.getTime() > agg.latestFlakyReportTime.getTime()
+        ) {
+          agg.latestFlakyReportTime = rt;
+          agg.latestFlakyBuildUrl = r.build_url;
+        }
       }
     }
 

--- a/tools/reporters/ci/flaky-tests/core/GithubIssueManager.test.ts
+++ b/tools/reporters/ci/flaky-tests/core/GithubIssueManager.test.ts
@@ -36,10 +36,12 @@ function buildCase(): CaseAgg {
     flakyCount: 3,
     thresholdedCount: 1,
     owner: "@test-owner",
+    latestFlakyBuildUrl: "https://ci.example.com/build/1",
+    latestFlakyReportTime: new Date("2026-03-12T12:00:00Z"),
   };
 }
 
-function createManager(client: object): GithubIssueManager {
+function createManager(client: Record<string, unknown>): GithubIssueManager {
   const manager = new GithubIssueManager({
     token: "test-token",
     allowCreate: false,
@@ -51,14 +53,17 @@ function createManager(client: object): GithubIssueManager {
     verbose: false,
   });
   Object.defineProperty(manager, "client", {
-    value: client,
+    value: {
+      addComment: async () => {},
+      ...client,
+    },
     configurable: true,
     writable: true,
   });
   return manager;
 }
 
-Deno.test("GithubIssueManager.sync reopens issues closed before report window", async () => {
+Deno.test("GithubIssueManager.sync reopens issues when latest flaky build started after issue closed", async () => {
   const issue: TestIssue = {
     number: 123,
     title: "Flaky test: TestFlakyCase in pkg/executor",
@@ -67,6 +72,7 @@ Deno.test("GithubIssueManager.sync reopens issues closed before report window", 
     closed_at: "2026-03-03T12:00:00Z",
   };
   let reopenCalls = 0;
+  const comments: string[] = [];
   const manager = createManager({
     searchIssues: async () => [issue],
     reopenIssue: async () => {
@@ -77,6 +83,14 @@ Deno.test("GithubIssueManager.sync reopens issues closed before report window", 
         closed_at: null,
       };
     },
+    addComment: async (
+      _owner: string,
+      _repo: string,
+      _issueNumber: number,
+      body: string,
+    ) => {
+      comments.push(body);
+    },
   });
   const report = buildReport();
   const flakyCase = buildCase();
@@ -84,12 +98,14 @@ Deno.test("GithubIssueManager.sync reopens issues closed before report window", 
   await manager.sync(report, [flakyCase], [flakyCase]);
 
   assertEquals(reopenCalls, 1);
+  assertEquals(comments.length, 1);
+  assertEquals(comments[0].includes("https://ci.example.com/build/1"), true);
   assertEquals(flakyCase.issue?.status, "reopened");
   assertEquals(flakyCase.issue?.state, "open");
   assertEquals(flakyCase.issue?.number, 123);
 });
 
-Deno.test("GithubIssueManager.sync keeps issues closed in report window closed", async () => {
+Deno.test("GithubIssueManager.sync keeps issue closed when latest flaky build is not newer than closed_at", async () => {
   const issue: TestIssue = {
     number: 456,
     title: "Flaky test: TestFlakyCase in pkg/executor",
@@ -106,7 +122,10 @@ Deno.test("GithubIssueManager.sync keeps issues closed in report window closed",
     },
   });
   const report = buildReport();
-  const flakyCase = buildCase();
+  const flakyCase = {
+    ...buildCase(),
+    latestFlakyReportTime: new Date("2026-03-10T12:00:00Z"),
+  };
 
   await manager.sync(report, [flakyCase], [flakyCase]);
 
@@ -116,8 +135,42 @@ Deno.test("GithubIssueManager.sync keeps issues closed in report window closed",
   assertEquals(flakyCase.issue?.number, 456);
   assertEquals(
     flakyCase.issue?.note,
-    "skip reopen: issue closed in current statistics window",
+    "skip reopen: latest flaky build start 2026-03-10T12:00:00.000Z <= closed_at 2026-03-10T12:00:01.000Z",
   );
+});
+
+Deno.test("GithubIssueManager.sync reopens issue even if it was closed in current window (build after closed_at)", async () => {
+  const issue: TestIssue = {
+    number: 789,
+    title: "Flaky test: TestFlakyCase in pkg/executor",
+    state: "closed",
+    html_url: "https://github.com/pingcap/tidb/issues/789",
+    closed_at: "2026-03-10T12:00:01Z",
+  };
+  let reopenCalls = 0;
+  const manager = createManager({
+    searchIssues: async () => [issue],
+    reopenIssue: async () => {
+      reopenCalls += 1;
+      return {
+        ...issue,
+        state: "open",
+        closed_at: null,
+      };
+    },
+  });
+  const report = buildReport();
+  const flakyCase = {
+    ...buildCase(),
+    latestFlakyReportTime: new Date("2026-03-12T01:00:00Z"),
+  };
+
+  await manager.sync(report, [flakyCase], [flakyCase]);
+
+  assertEquals(reopenCalls, 1);
+  assertEquals(flakyCase.issue?.status, "reopened");
+  assertEquals(flakyCase.issue?.state, "open");
+  assertEquals(flakyCase.issue?.number, 789);
 });
 
 Deno.test("GithubIssueManager.sync prefers open issue over closed exact title match", async () => {

--- a/tools/reporters/ci/flaky-tests/core/GithubIssueManager.ts
+++ b/tools/reporters/ci/flaky-tests/core/GithubIssueManager.ts
@@ -315,12 +315,26 @@ export class GithubIssueManager {
         status = "open";
       } else if (issue?.state === "closed") {
         const reopenCheck = this.allowReopen && canMutate
-          ? this.checkReopenEligibility(issue, report)
+          ? this.checkReopenEligibility(issue, group)
           : { eligible: false, note: undefined };
         if (reopenCheck.eligible) {
           status = "reopened";
           if (!this.dryRun) {
             issue = await this.client!.reopenIssue(owner, repo, issue.number);
+            if (reopenCheck.evidence) {
+              const comment = this.buildReopenEvidenceComment(
+                report,
+                reopenCheck.evidence,
+              );
+              try {
+                await this.client!.addComment(owner, repo, issue.number, comment);
+              } catch (e: unknown) {
+                const msg = e instanceof Error ? e.message : String(e);
+                if (this.verbose) {
+                  console.error(`[github] add reopen evidence comment failed: ${msg}`);
+                }
+              }
+            }
           }
         } else {
           status = "closed";
@@ -495,8 +509,18 @@ export class GithubIssueManager {
 
   private checkReopenEligibility(
     issue: GitHubIssueApi,
-    report: ReportData,
-  ): { eligible: boolean; note?: string } {
+    group: CaseAgg[],
+  ): {
+    eligible: boolean;
+    note?: string;
+    evidence?: {
+      closedAt: Date;
+      buildStart: Date;
+      buildUrl?: string;
+      usedFallbackTime: boolean;
+      sample: CaseAgg;
+    };
+  } {
     const closedAt = this.parseClosedAt(issue.closed_at);
     if (!closedAt) {
       return {
@@ -505,22 +529,92 @@ export class GithubIssueManager {
       };
     }
 
-    const windowStart = new Date(report.window.from);
-    if (Number.isNaN(windowStart.getTime())) {
+    const evidence = this.pickLatestFlakyBuildEvidence(group);
+    if (!evidence) {
       return {
         eligible: false,
-        note: `skip reopen: invalid report window start ${report.window.from}`,
+        note: "skip reopen: missing latest flaky build timestamp",
       };
     }
 
-    if (closedAt.getTime() >= windowStart.getTime()) {
+    if (evidence.buildStart.getTime() <= closedAt.getTime()) {
       return {
         eligible: false,
-        note: "skip reopen: issue closed in current statistics window",
+        note: `skip reopen: latest flaky build start ${evidence.buildStart.toISOString()} <= closed_at ${closedAt.toISOString()}`,
       };
     }
 
-    return { eligible: true };
+    return {
+      eligible: true,
+      evidence: {
+        closedAt,
+        buildStart: evidence.buildStart,
+        buildUrl: evidence.buildUrl,
+        usedFallbackTime: evidence.usedFallbackTime,
+        sample: evidence.sample,
+      },
+    };
+  }
+
+  private pickLatestFlakyBuildEvidence(
+    group: CaseAgg[],
+  ): {
+    buildStart: Date;
+    buildUrl?: string;
+    usedFallbackTime: boolean;
+    sample: CaseAgg;
+  } | null {
+    let best: {
+      buildStart: Date;
+      buildUrl?: string;
+      usedFallbackTime: boolean;
+      sample: CaseAgg;
+    } | null = null;
+
+    for (const c of group) {
+      const buildStart = c.latestFlakyReportTime ?? c.latestReportTime;
+      if (!buildStart) continue;
+
+      const usedFallbackTime = !c.latestFlakyReportTime;
+      const buildUrl = c.latestFlakyBuildUrl ?? c.latestBuildUrl;
+      if (!best || buildStart.getTime() > best.buildStart.getTime()) {
+        best = { buildStart, buildUrl, usedFallbackTime, sample: c };
+      }
+    }
+
+    return best;
+  }
+
+  private buildReopenEvidenceComment(
+    report: ReportData,
+    evidence: {
+      closedAt: Date;
+      buildStart: Date;
+      buildUrl?: string;
+      usedFallbackTime: boolean;
+      sample: CaseAgg;
+    },
+  ): string {
+    const c = evidence.sample;
+    const lines = [
+      "Automated reopen: flaky detected after this issue was closed.",
+      "",
+      `- Repo: ${c.repo}`,
+      `- Branch: ${c.branch}`,
+      `- Package: ${formatSuiteName(c.suite_name)}`,
+      `- Case: ${c.case_name}`,
+      "",
+      `- Issue closed_at: ${evidence.closedAt.toISOString()}`,
+      `- Latest flaky build start: ${evidence.buildStart.toISOString()}`,
+      evidence.buildUrl ? `- Build: ${evidence.buildUrl}` : `- Build: N/A`,
+      evidence.usedFallbackTime
+        ? "- Note: latestFlakyReportTime missing; fallback to latestReportTime"
+        : undefined,
+      "",
+      `Window: ${report.window.from} → ${report.window.to}`,
+      `Threshold: ${report.window.thresholdMs} ms`,
+    ].filter((x) => x !== undefined) as string[];
+    return lines.join("\n");
   }
 
   private parseClosedAt(value?: string | null): Date | null {

--- a/tools/reporters/ci/flaky-tests/core/types.ts
+++ b/tools/reporters/ci/flaky-tests/core/types.ts
@@ -157,6 +157,12 @@ export interface CaseAgg {
   owner: string;
   latestBuildUrl?: string;
   latestReportTime?: Date;
+  /**
+   * Latest build (report_time/build_url) where flaky > 0 for this case.
+   * Used for GitHub issue reopen evidence.
+   */
+  latestFlakyBuildUrl?: string;
+  latestFlakyReportTime?: Date;
   previousWeekFlakyCount?: number;
   issue?: GithubIssueInfo;
 }

--- a/tools/reporters/ci/flaky-tests/docs/README.md
+++ b/tools/reporters/ci/flaky-tests/docs/README.md
@@ -208,8 +208,10 @@ Defaults:
 - When a GitHub token is provided, the reporter searches issues by title using
   exact + loose matching (branch is not part of the title).
 - New issues are created only with `--issue-create`; closed issues are reopened
-  only with `--issue-reopen`, and only when the issue was closed before the
-  current report window starts.
+  only with `--issue-reopen`, and only when the latest build (on the same
+  branch) that observed the flaky case started after the issue's `closed_at`
+  timestamp. When reopening, a comment is added with the reopen evidence
+  (including the build link).
 - The configured labels are applied to any matched/created issue.
 - For open or reopened issues, a comment is appended with the current window’s
   stats only when `--issue-comment` is enabled.


### PR DESCRIPTION
### What

- Adjust flaky issue reopen logic for top N cases.

### How

- Reopen check now compares (same branch) the latest build start time that observed the flaky case vs GitHub Issue `closed_at`.
- If build start > `closed_at`, reopen the issue and append a reopen-evidence comment (includes the build link + timestamps).

### Notes

- Updated docs + unit tests in `tools/reporters/ci/flaky-tests`.
