### PR TITLE
fix(flaky-tests): resolve build started time for reopen

### DIFF
--- a/tools/reporters/ci/flaky-tests/core/FlakyReporter.ts
+++ b/tools/reporters/ci/flaky-tests/core/FlakyReporter.ts
@@ -87,7 +87,7 @@ export class FlakyReporter {
           latestBuildUrl: undefined,
           latestReportTime: undefined,
           latestFlakyBuildUrl: undefined,
-          latestFlakyReportTime: undefined,
+          latestFlakyFoundAt: undefined,
         };
         caseMap.set(key, agg);
 
@@ -115,10 +115,10 @@ export class FlakyReporter {
 
       if (r.flaky && Number(r.flaky) > 0) {
         if (
-          !agg.latestFlakyReportTime ||
-          rt.getTime() > agg.latestFlakyReportTime.getTime()
+          !agg.latestFlakyFoundAt ||
+          rt.getTime() > agg.latestFlakyFoundAt.getTime()
         ) {
-          agg.latestFlakyReportTime = rt;
+          agg.latestFlakyFoundAt = rt;
           agg.latestFlakyBuildUrl = r.build_url;
         }
       }

--- a/tools/reporters/ci/flaky-tests/core/GithubIssueManager.test.ts
+++ b/tools/reporters/ci/flaky-tests/core/GithubIssueManager.test.ts
@@ -37,11 +37,14 @@ function buildCase(): CaseAgg {
     thresholdedCount: 1,
     owner: "@test-owner",
     latestFlakyBuildUrl: "https://ci.example.com/build/1",
-    latestFlakyReportTime: new Date("2026-03-12T12:00:00Z"),
+    latestFlakyFoundAt: new Date("2026-03-12T12:00:00Z"),
   };
 }
 
-function createManager(client: Record<string, unknown>): GithubIssueManager {
+function createManager(
+  client: Record<string, unknown>,
+  fetchFn?: typeof fetch,
+): GithubIssueManager {
   const manager = new GithubIssueManager({
     token: "test-token",
     allowCreate: false,
@@ -50,6 +53,7 @@ function createManager(client: Record<string, unknown>): GithubIssueManager {
     dryRun: false,
     labels: [],
     now: () => new Date("2026-03-13T12:00:00Z"),
+    fetchFn,
     verbose: false,
   });
   Object.defineProperty(manager, "client", {
@@ -124,7 +128,7 @@ Deno.test("GithubIssueManager.sync keeps issue closed when latest flaky build is
   const report = buildReport();
   const flakyCase = {
     ...buildCase(),
-    latestFlakyReportTime: new Date("2026-03-10T12:00:00Z"),
+    latestFlakyFoundAt: new Date("2026-03-10T12:00:00Z"),
   };
 
   await manager.sync(report, [flakyCase], [flakyCase]);
@@ -135,7 +139,7 @@ Deno.test("GithubIssueManager.sync keeps issue closed when latest flaky build is
   assertEquals(flakyCase.issue?.number, 456);
   assertEquals(
     flakyCase.issue?.note,
-    "skip reopen: latest flaky build start 2026-03-10T12:00:00.000Z <= closed_at 2026-03-10T12:00:01.000Z",
+    "skip reopen: latest flaky build started_at 2026-03-10T12:00:00.000Z <= closed_at 2026-03-10T12:00:01.000Z (branch=main)",
   );
 });
 
@@ -162,7 +166,7 @@ Deno.test("GithubIssueManager.sync reopens issue even if it was closed in curren
   const report = buildReport();
   const flakyCase = {
     ...buildCase(),
-    latestFlakyReportTime: new Date("2026-03-12T01:00:00Z"),
+    latestFlakyFoundAt: new Date("2026-03-12T01:00:00Z"),
   };
 
   await manager.sync(report, [flakyCase], [flakyCase]);
@@ -171,6 +175,170 @@ Deno.test("GithubIssueManager.sync reopens issue even if it was closed in curren
   assertEquals(flakyCase.issue?.status, "reopened");
   assertEquals(flakyCase.issue?.state, "open");
   assertEquals(flakyCase.issue?.number, 789);
+});
+
+Deno.test("GithubIssueManager.sync uses Jenkins timestamp when available for reopen check", async () => {
+  const issue: TestIssue = {
+    number: 321,
+    title: "Flaky test: TestFlakyCase in pkg/executor",
+    state: "closed",
+    html_url: "https://github.com/pingcap/tidb/issues/321",
+    closed_at: "2026-03-10T12:00:00Z",
+  };
+
+  const jenkinsBuildUrl = "https://prow.tidb.net/jenkins/job/test/123/";
+  const jenkinsStartedAt = new Date("2026-03-12T00:00:00Z");
+
+  let reopenCalls = 0;
+  const comments: string[] = [];
+
+  const fetchFn: typeof fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url === `${jenkinsBuildUrl}api/json?tree=timestamp`) {
+      return new Response(
+        JSON.stringify({ timestamp: jenkinsStartedAt.getTime() }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response("not found", { status: 404 });
+  };
+
+  const manager = createManager({
+    searchIssues: async () => [issue],
+    reopenIssue: async () => {
+      reopenCalls += 1;
+      return {
+        ...issue,
+        state: "open",
+        closed_at: null,
+      };
+    },
+    addComment: async (
+      _owner: string,
+      _repo: string,
+      _issueNumber: number,
+      body: string,
+    ) => {
+      comments.push(body);
+    },
+  }, fetchFn);
+
+  const report = buildReport();
+  const flakyCase = {
+    ...buildCase(),
+    latestFlakyBuildUrl: jenkinsBuildUrl,
+    // Make fallback older than closed_at to ensure Jenkins timestamp is used.
+    latestFlakyFoundAt: new Date("2026-03-09T00:00:00Z"),
+  };
+
+  await manager.sync(report, [flakyCase], [flakyCase]);
+
+  assertEquals(reopenCalls, 1);
+  assertEquals(comments.length, 1);
+  assertEquals(comments[0].includes("jenkins.timestamp"), true);
+  assertEquals(comments[0].includes(jenkinsBuildUrl), true);
+  assertEquals(flakyCase.issue?.status, "reopened");
+});
+
+Deno.test("GithubIssueManager.sync uses Prow started.json when available for reopen check", async () => {
+  const issue: TestIssue = {
+    number: 654,
+    title: "Flaky test: TestFlakyCase in pkg/executor",
+    state: "closed",
+    html_url: "https://github.com/pingcap/tidb/issues/654",
+    closed_at: "2026-03-10T12:00:00Z",
+  };
+
+  const prowViewUrl =
+    "https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/foo/bar/123";
+  const startedJsonUrl =
+    "https://storage.googleapis.com/prow-tidb-logs/pr-logs/pull/foo/bar/123/started.json";
+  const prowStartedAt = new Date("2026-03-12T00:00:00Z");
+
+  let reopenCalls = 0;
+  const comments: string[] = [];
+
+  const fetchFn: typeof fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url === startedJsonUrl) {
+      // started.json timestamp is seconds.
+      return new Response(
+        JSON.stringify({ timestamp: Math.floor(prowStartedAt.getTime() / 1000) }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response("not found", { status: 404 });
+  };
+
+  const manager = createManager({
+    searchIssues: async () => [issue],
+    reopenIssue: async () => {
+      reopenCalls += 1;
+      return {
+        ...issue,
+        state: "open",
+        closed_at: null,
+      };
+    },
+    addComment: async (
+      _owner: string,
+      _repo: string,
+      _issueNumber: number,
+      body: string,
+    ) => {
+      comments.push(body);
+    },
+  }, fetchFn);
+
+  const report = buildReport();
+  const flakyCase = {
+    ...buildCase(),
+    latestFlakyBuildUrl: prowViewUrl,
+    // Make fallback older than closed_at to ensure started.json is used.
+    latestFlakyFoundAt: new Date("2026-03-09T00:00:00Z"),
+  };
+
+  await manager.sync(report, [flakyCase], [flakyCase]);
+
+  assertEquals(reopenCalls, 1);
+  assertEquals(comments.length, 1);
+  assertEquals(comments[0].includes("prow.started.json"), true);
+  assertEquals(comments[0].includes(prowViewUrl), true);
+  assertEquals(flakyCase.issue?.status, "reopened");
+});
+
+Deno.test("GithubIssueManager.sync skips reopen when started_at cannot be resolved and no fallback exists", async () => {
+  const issue: TestIssue = {
+    number: 999,
+    title: "Flaky test: TestFlakyCase in pkg/executor",
+    state: "closed",
+    html_url: "https://github.com/pingcap/tidb/issues/999",
+    closed_at: "2026-03-10T12:00:00Z",
+  };
+  let reopenCalls = 0;
+  const manager = createManager({
+    searchIssues: async () => [issue],
+    reopenIssue: async () => {
+      reopenCalls += 1;
+      return issue;
+    },
+  });
+  const report = buildReport();
+  const flakyCase = {
+    ...buildCase(),
+    latestFlakyBuildUrl: "https://ci.example.com/unknown/1",
+    // No fallback time available.
+    latestFlakyFoundAt: undefined,
+  };
+
+  await manager.sync(report, [flakyCase], [flakyCase]);
+
+  assertEquals(reopenCalls, 0);
+  assertEquals(flakyCase.issue?.status, "closed");
+  assertEquals(
+    flakyCase.issue?.note,
+    "skip reopen: missing latest flaky evidence (build_url/started_at/fallback time)",
+  );
 });
 
 Deno.test("GithubIssueManager.sync prefers open issue over closed exact title match", async () => {

--- a/tools/reporters/ci/flaky-tests/core/GithubIssueManager.ts
+++ b/tools/reporters/ci/flaky-tests/core/GithubIssueManager.ts
@@ -24,6 +24,7 @@ interface IssueManagerOptions {
   repoOverride?: string;
   titleIncludesRepo?: boolean;
   now?: () => Date;
+  fetchFn?: typeof fetch;
   verbose?: boolean;
 }
 
@@ -201,7 +202,12 @@ export class GithubIssueManager {
   private readonly repoOverride?: string;
   private readonly titleIncludesRepo: boolean;
   private readonly now: () => Date;
+  private readonly fetchFn: typeof fetch;
   private readonly verbose: boolean;
+  private readonly buildStartedAtCache = new Map<
+    string,
+    { startedAt: Date; source: string } | null
+  >();
 
   constructor(opts: IssueManagerOptions) {
     this.enabled = !!opts.token;
@@ -216,6 +222,7 @@ export class GithubIssueManager {
     this.repoOverride = opts.repoOverride;
     this.titleIncludesRepo = !!opts.titleIncludesRepo;
     this.now = opts.now ?? (() => new Date());
+    this.fetchFn = opts.fetchFn ?? fetch;
     this.verbose = !!opts.verbose;
   }
 
@@ -315,7 +322,7 @@ export class GithubIssueManager {
         status = "open";
       } else if (issue?.state === "closed") {
         const reopenCheck = this.allowReopen && canMutate
-          ? this.checkReopenEligibility(issue, group)
+          ? await this.checkReopenEligibility(issue, group)
           : { eligible: false, note: undefined };
         if (reopenCheck.eligible) {
           status = "reopened";
@@ -507,20 +514,20 @@ export class GithubIssueManager {
     return 0;
   }
 
-  private checkReopenEligibility(
+  private async checkReopenEligibility(
     issue: GitHubIssueApi,
     group: CaseAgg[],
-  ): {
+  ): Promise<{
     eligible: boolean;
     note?: string;
     evidence?: {
       closedAt: Date;
-      buildStart: Date;
-      buildUrl?: string;
-      usedFallbackTime: boolean;
+      buildStartedAt: Date;
+      buildUrl: string;
+      startedAtSource: string;
       sample: CaseAgg;
     };
-  } {
+  }> {
     const closedAt = this.parseClosedAt(issue.closed_at);
     if (!closedAt) {
       return {
@@ -529,69 +536,252 @@ export class GithubIssueManager {
       };
     }
 
-    const evidence = this.pickLatestFlakyBuildEvidence(group);
-    if (!evidence) {
+    const candidates = await this.collectLatestFlakyBuildCandidates(group);
+    if (candidates.length === 0) {
       return {
         eligible: false,
-        note: "skip reopen: missing latest flaky build timestamp",
+        note:
+          "skip reopen: missing latest flaky evidence (build_url/started_at/fallback time)",
       };
     }
 
-    if (evidence.buildStart.getTime() <= closedAt.getTime()) {
+    const latest = candidates.reduce((best, cur) => {
+      if (cur.buildStartedAt.getTime() > best.buildStartedAt.getTime()) {
+        return cur;
+      }
+      return best;
+    }, candidates[0]);
+
+    const reopenCandidates = candidates.filter((c) =>
+      c.buildStartedAt.getTime() > closedAt.getTime()
+    );
+
+    if (reopenCandidates.length === 0) {
       return {
         eligible: false,
-        note: `skip reopen: latest flaky build start ${evidence.buildStart.toISOString()} <= closed_at ${closedAt.toISOString()}`,
+        note:
+          `skip reopen: latest flaky build started_at ${latest.buildStartedAt.toISOString()} <= closed_at ${closedAt.toISOString()} (branch=${latest.sample.branch})`,
       };
     }
+
+    const best = reopenCandidates.reduce((b, c) => {
+      if (c.buildStartedAt.getTime() > b.buildStartedAt.getTime()) return c;
+      return b;
+    }, reopenCandidates[0]);
 
     return {
       eligible: true,
       evidence: {
         closedAt,
-        buildStart: evidence.buildStart,
-        buildUrl: evidence.buildUrl,
-        usedFallbackTime: evidence.usedFallbackTime,
-        sample: evidence.sample,
+        buildStartedAt: best.buildStartedAt,
+        buildUrl: best.buildUrl,
+        startedAtSource: best.startedAtSource,
+        sample: best.sample,
       },
     };
   }
 
-  private pickLatestFlakyBuildEvidence(
+  private async collectLatestFlakyBuildCandidates(
     group: CaseAgg[],
-  ): {
-    buildStart: Date;
-    buildUrl?: string;
-    usedFallbackTime: boolean;
-    sample: CaseAgg;
-  } | null {
-    let best: {
-      buildStart: Date;
-      buildUrl?: string;
-      usedFallbackTime: boolean;
+  ): Promise<
+    Array<{
+      buildStartedAt: Date;
+      buildUrl: string;
+      startedAtSource: string;
       sample: CaseAgg;
-    } | null = null;
+    }>
+  > {
+    const out: Array<{
+      buildStartedAt: Date;
+      buildUrl: string;
+      startedAtSource: string;
+      sample: CaseAgg;
+    }> = [];
 
     for (const c of group) {
-      const buildStart = c.latestFlakyReportTime ?? c.latestReportTime;
-      if (!buildStart) continue;
+      if (!c || (c.flakyCount ?? 0) <= 0) continue;
 
-      const usedFallbackTime = !c.latestFlakyReportTime;
-      const buildUrl = c.latestFlakyBuildUrl ?? c.latestBuildUrl;
-      if (!best || buildStart.getTime() > best.buildStart.getTime()) {
-        best = { buildStart, buildUrl, usedFallbackTime, sample: c };
+      const buildUrl = String(c.latestFlakyBuildUrl ?? "").trim();
+      if (!buildUrl) continue;
+
+      const resolved = await this.resolveBuildStartedAt(buildUrl);
+      const fallback = c.latestFlakyFoundAt;
+      if (!resolved && !fallback) continue;
+
+      out.push({
+        buildStartedAt: resolved?.startedAt ?? fallback!,
+        buildUrl,
+        startedAtSource: resolved?.source ?? "fallback latestFlakyFoundAt",
+        sample: c,
+      });
+    }
+
+    return out;
+  }
+
+  private async resolveBuildStartedAt(
+    buildUrl: string,
+  ): Promise<{ startedAt: Date; source: string } | null> {
+    const normalized = this.normalizeBuildUrl(buildUrl);
+    if (!normalized) return null;
+
+    if (this.buildStartedAtCache.has(normalized)) {
+      return this.buildStartedAtCache.get(normalized) ?? null;
+    }
+
+    let out: { startedAt: Date; source: string } | null = null;
+    try {
+      const j = await this.tryResolveJenkinsBuildStartedAt(normalized);
+      if (j) out = { startedAt: j, source: "jenkins.timestamp" };
+    } catch (_e: unknown) {
+      // best-effort only
+    }
+
+    if (!out) {
+      try {
+        const p = await this.tryResolveProwBuildStartedAt(normalized);
+        if (p) out = { startedAt: p, source: "prow.started.json" };
+      } catch (_e: unknown) {
+        // best-effort only
       }
     }
 
-    return best;
+    this.buildStartedAtCache.set(normalized, out);
+    return out;
+  }
+
+  private normalizeBuildUrl(value: string): string | null {
+    const v = String(value ?? "").trim();
+    if (!v) return null;
+    return v;
+  }
+
+  private async tryResolveJenkinsBuildStartedAt(
+    buildUrl: string,
+  ): Promise<Date | null> {
+    if (!this.looksLikeJenkinsBuildUrl(buildUrl)) return null;
+
+    const apiUrl = this.joinUrl(buildUrl, "api/json?tree=timestamp");
+    const res = await this.fetchJson(apiUrl);
+    const ts = this.parseEpochMs((res as { timestamp?: unknown })?.timestamp);
+    if (ts === null) return null;
+    const startedAt = new Date(ts);
+    if (Number.isNaN(startedAt.getTime())) return null;
+    return startedAt;
+  }
+
+  private async tryResolveProwBuildStartedAt(
+    buildUrl: string,
+  ): Promise<Date | null> {
+    const startedJsonUrl = this.buildProwStartedJsonUrl(buildUrl);
+    if (!startedJsonUrl) return null;
+
+    const res = await this.fetchJson(startedJsonUrl);
+    const ts = this.parseEpochMs((res as { timestamp?: unknown })?.timestamp);
+    if (ts === null) return null;
+    const startedAt = new Date(ts);
+    if (Number.isNaN(startedAt.getTime())) return null;
+    return startedAt;
+  }
+
+  private buildProwStartedJsonUrl(buildUrl: string): string | null {
+    const v = this.normalizeBuildUrl(buildUrl);
+    if (!v) return null;
+
+    if (v.startsWith("gs://")) {
+      const rest = v.slice("gs://".length).replace(/^\/+/, "");
+      return this.ensureEndsWithStartedJson(
+        `https://storage.googleapis.com/${rest}`,
+      );
+    }
+
+    let u: URL;
+    try {
+      u = new URL(v);
+    } catch (_e: unknown) {
+      return null;
+    }
+
+    if (u.hostname === "storage.googleapis.com") {
+      return this.ensureEndsWithStartedJson(
+        `https://storage.googleapis.com${u.pathname}`,
+      );
+    }
+
+    if (u.hostname !== "prow.tidb.net") return null;
+
+    const path = u.pathname;
+    const prefixes = ["/view/gs/", "/view/gcs/"];
+    for (const prefix of prefixes) {
+      if (!path.startsWith(prefix)) continue;
+      const rest = path.slice(prefix.length).replace(/^\/+/, "");
+      return this.ensureEndsWithStartedJson(
+        `https://storage.googleapis.com/${rest}`,
+      );
+    }
+
+    return null;
+  }
+
+  private ensureEndsWithStartedJson(url: string): string {
+    const cleaned = url.replace(/\/+$/, "");
+    if (cleaned.endsWith("started.json")) return cleaned;
+    return `${cleaned}/started.json`;
+  }
+
+  private looksLikeJenkinsBuildUrl(buildUrl: string): boolean {
+    try {
+      const u = new URL(buildUrl);
+      if (u.hostname.includes("jenkins")) return true;
+      if (u.pathname.includes("/jenkins/")) return true;
+      if (u.pathname.includes("/job/")) return true;
+      return false;
+    } catch (_e: unknown) {
+      return false;
+    }
+  }
+
+  private joinUrl(baseUrl: string, suffix: string): string {
+    const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+    const s = suffix.startsWith("/") ? suffix.slice(1) : suffix;
+    return `${base}${s}`;
+  }
+
+  private async fetchJson(url: string): Promise<unknown | null> {
+    try {
+      const res = await this.fetchFn(url, {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "flaky-reporter",
+        },
+      });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch (e: unknown) {
+      if (this.verbose) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(`[build] fetch json failed: ${url}: ${msg}`);
+      }
+      return null;
+    }
+  }
+
+  private parseEpochMs(value: unknown): number | null {
+    if (value === null || value === undefined) return null;
+    const n = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    // Jenkins "timestamp" is ms; Prow started.json "timestamp" is seconds.
+    return n < 1e12 ? n * 1000 : n;
   }
 
   private buildReopenEvidenceComment(
     report: ReportData,
     evidence: {
       closedAt: Date;
-      buildStart: Date;
-      buildUrl?: string;
-      usedFallbackTime: boolean;
+      buildStartedAt: Date;
+      buildUrl: string;
+      startedAtSource: string;
       sample: CaseAgg;
     },
   ): string {
@@ -605,11 +795,9 @@ export class GithubIssueManager {
       `- Case: ${c.case_name}`,
       "",
       `- Issue closed_at: ${evidence.closedAt.toISOString()}`,
-      `- Latest flaky build start: ${evidence.buildStart.toISOString()}`,
-      evidence.buildUrl ? `- Build: ${evidence.buildUrl}` : `- Build: N/A`,
-      evidence.usedFallbackTime
-        ? "- Note: latestFlakyReportTime missing; fallback to latestReportTime"
-        : undefined,
+      `- Build started_at: ${evidence.buildStartedAt.toISOString()}`,
+      `- Build started_at source: ${evidence.startedAtSource}`,
+      `- Build: ${evidence.buildUrl}`,
       "",
       `Window: ${report.window.from} → ${report.window.to}`,
       `Threshold: ${report.window.thresholdMs} ms`,

--- a/tools/reporters/ci/flaky-tests/core/types.ts
+++ b/tools/reporters/ci/flaky-tests/core/types.ts
@@ -162,7 +162,7 @@ export interface CaseAgg {
    * Used for GitHub issue reopen evidence.
    */
   latestFlakyBuildUrl?: string;
-  latestFlakyReportTime?: Date;
+  latestFlakyFoundAt?: Date;
   previousWeekFlakyCount?: number;
   issue?: GithubIssueInfo;
 }

--- a/tools/reporters/ci/flaky-tests/docs/README.md
+++ b/tools/reporters/ci/flaky-tests/docs/README.md
@@ -208,10 +208,15 @@ Defaults:
 - When a GitHub token is provided, the reporter searches issues by title using
   exact + loose matching (branch is not part of the title).
 - New issues are created only with `--issue-create`; closed issues are reopened
-  only with `--issue-reopen`, and only when the latest build (on the same
+  only with `--issue-reopen`, and only when the latest build (for a specific
   branch) that observed the flaky case started after the issue's `closed_at`
-  timestamp. When reopening, a comment is added with the reopen evidence
-  (including the build link).
+  timestamp.
+  - Build `started_at` is resolved best-effort from `build_url`:
+    - Jenkins build: `GET <build_url>/api/json?tree=timestamp`
+    - Prow (view/gs or view/gcs URL): `GET <build_url>/started.json`
+    - Fallback: latest flaky `report_time` (max report_time where flaky > 0)
+  - When reopening, an evidence comment is always added (includes branch, build
+    link, and the started_at vs closed_at comparison).
 - The configured labels are applied to any matched/created issue.
 - For open or reopened issues, a comment is appended with the current window’s
   stats only when `--issue-comment` is enabled.


### PR DESCRIPTION
### Background

Follow-up to #4551: align reopen eligibility with the latest design by resolving real CI build started time from `build_url` when possible.

### What

- Reopen check compares latest flaky build `started_at` (best-effort from build URL) vs Issue `closed_at`.
- When reopened, always adds an evidence comment (branch/build URL/timestamps + source).

### How

- Jenkins: `GET <build_url>/api/json?tree=timestamp`
- Prow view (gs/gcs): `GET <build_url>/started.json` (via GCS)
- Fallback: latest flaky `report_time` (max report_time where flaky > 0).

### Tests

- Updated `GithubIssueManager.test.ts` to cover Jenkins/Prow/fallback/no-fallback cases.
