### PR TITLE
ci(prow): expand flaky reporter issue mutation limit

### DIFF
--- a/prow-jobs/pingcap-qe/ci/periodics.yaml
+++ b/prow-jobs/pingcap-qe/ci/periodics.yaml
@@ -69,6 +69,8 @@ periodics:
               value: --issue-create --issue-reopen --issue-comment
             - name: PARAM_ISSUE_LABELS
               value: "component/test,flaky-test,severity/critical"
+            - name: ISSUE_MUTATION_LIMIT
+              value: "10000"
             - name: PARAM_DSN
               valueFrom:
                 secretKeyRef:
@@ -134,6 +136,8 @@ periodics:
               value: --issue-comment
             - name: PARAM_ISSUE_LABELS
               value: "component/test,flaky-test,severity/critical,affects-8.5"
+            - name: ISSUE_MUTATION_LIMIT
+              value: "10000"
             - name: PARAM_DSN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Set ISSUE_MUTATION_LIMIT=10000 for flaky reporter periodics (master + release-8.5) so GitHub issue mutation covers all flaky cases (instead of default top10).\n\nRef: FLA-115