### PR TITLE
fix(pipelines): batch failpoint-ctl in ddlv1 unit test jobs

### DIFF
--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_unit_test_ddlv1.groovy
@@ -48,6 +48,10 @@ pipeline {
                     # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
                     sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
 
+                    # Batch failpoint enable/disable to avoid argv limits on large repos.
+                    sed -i 's|xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable|xargs -n 200 bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable|' Makefile || true
+                    sed -i 's|xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable|xargs -n 200 bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable|' Makefile || true
+
                     # Replay-only timeout hotfix: raise ci shard timeout to avoid 150s timeout flakes.
                     if [ -f .bazelrc ]; then
                       echo 'test:ci --test_timeout=600,900,1800,3600' >> .bazelrc
@@ -55,6 +59,7 @@ pipeline {
 
                     grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
                     grep -n '^check:' Makefile | head -n 3 || true
+                    grep -n 'xargs -n 200 bazel .*failpoint-ctl:failpoint-ctl --' Makefile | head -n 4 || true
                     grep -n 'test:ci --test_timeout=' .bazelrc | tail -n 3 || true
                     '''
                 }

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
@@ -48,6 +48,10 @@ pipeline {
                         # Avoid "check" targets re-writing legacy cache settings during migration replay.
                         sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
 
+                        # Batch failpoint enable/disable to avoid argv limits on large repos.
+                        sed -i 's|xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable|xargs -n 200 bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable|' Makefile || true
+                        sed -i 's|xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable|xargs -n 200 bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable|' Makefile || true
+
                         # Ensure expected bazel tmp dir exists after mount point change.
                         mkdir -p /home/jenkins/.tidb/tmp
 
@@ -59,6 +63,7 @@ pipeline {
                             echo "shared bazel repository cache unavailable or not writable, keep repository_cache=/home/jenkins/.tidb/tmp"
                         fi
 
+                        grep -n 'xargs -n 200 bazel .*failpoint-ctl:failpoint-ctl --' Makefile | head -n 4 || true
                         git diff .
                         git status
                     '''

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
@@ -48,6 +48,10 @@ pipeline {
                     # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
                     sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
 
+                    # Batch failpoint enable/disable to avoid argv limits on large repos.
+                    sed -i 's|xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable|xargs -n 200 bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable|' Makefile || true
+                    sed -i 's|xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable|xargs -n 200 bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable|' Makefile || true
+
                     # Replay-only timeout hotfix: raise ci shard timeout to avoid timeout flakes.
                     if [ -f .bazelrc ]; then
                       echo 'test:ci --test_timeout=600,900,1800,3600' >> .bazelrc
@@ -62,6 +66,7 @@ pipeline {
 
                     grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
                     grep -n '^check:' Makefile | head -n 3 || true
+                    grep -n 'xargs -n 200 bazel .*failpoint-ctl:failpoint-ctl --' Makefile | head -n 4 || true
                     grep -n 'test:ci --test_timeout=' .bazelrc | tail -n 3 || true
                     grep -n 'pkg/ddl/ingest:ingest_test' Makefile || true
                     grep -n 'timeout = "long"' pkg/executor/test/distsqltest/BUILD.bazel || true

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_unit_test_ddlv1.groovy
@@ -39,7 +39,10 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     sh """
+                        sed -i 's|xargs bazel \$(BAZEL_GLOBAL_CONFIG) run \$(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable|xargs -n 200 bazel \$(BAZEL_GLOBAL_CONFIG) run \$(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable|' Makefile || true
+                        sed -i 's|xargs bazel \$(BAZEL_GLOBAL_CONFIG) run \$(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable|xargs -n 200 bazel \$(BAZEL_GLOBAL_CONFIG) run \$(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable|' Makefile || true
                         sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
+                        grep -n 'xargs -n 200 bazel .*failpoint-ctl:failpoint-ctl --' Makefile | head -n 4 || true
                         git diff .
                         git status
                     """


### PR DESCRIPTION
## What
- batch `failpoint-ctl enable/disable` invocations in `pull_unit_test_ddlv1` pipelines by rewriting `xargs bazel ...` to `xargs -n 200 bazel ...`
- apply the same safeguard to these variants:
  - `pingcap/tidb/latest/pull_unit_test_ddlv1`
  - `pingcap/tidb/release-8.5/pull_unit_test_ddlv1`
  - `pingcap/tidb/release-9.0-beta/pull_unit_test_ddlv1`
  - `pingcap-inc/tidb/release-8.5/pull_unit_test_ddlv1`
- keep a small `grep` in the job log so replay/production runs show whether the patch was applied

## Why
`pull_unit_test_ddlv1` was failing before actual tests started in `make bazel-failpoint-enable` with:

```text
FATAL: execv of '/bin/bash' failed: (error: 7): Argument list too long
make: *** [Makefile:345: bazel-failpoint-enable] Error 123
```

The root cause is that the job passes too many directories to `failpoint-ctl enable` in a single argv. Batching the xargs input keeps the behavior the same while avoiding the shell argument length limit.

## Validation
- replayed `pingcap/tidb/pull_unit_test_ddlv1 #821`
- confirmed the patched job rewrote Makefile to use `xargs -n 200`
- confirmed the run moved past the original `Argument list too long` failure and entered the real Bazel test phase
- validated the updated Jenkinsfiles with `.ci/verify-jenkins-pipeline-file.sh`

Replay reference:
- https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_unit_test_ddlv1/821/console
