### PR TITLE
ci(pipelines): update tidb ghpr_unit_test image

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -7,7 +7,7 @@ spec:
     - name: golang
       # TODO(wuhuizuo): using standard bazel build image to shrink the image size
       # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
       securityContext:
         privileged: true
       tty: true


### PR DESCRIPTION
## Summary
- update `pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml`
- switch the TiDB CI image from `go12320241009` to `go12520260122`
- keep this PR scoped to `ghpr_unit_test` only

## Validation
- replayed `ghpr_unit_test` with inline pod yaml and the new image
- success: https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/2792/
- success: https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_unit_test/2798/

## Notes
- no additional repo-wide verification was run for this one-line pod image update
