### PR TITLE
chore(script/tikv/titan): clear conclusion will be printed first when the format check fails

### DIFF
--- a/scripts/tikv/titan/format.sh
+++ b/scripts/tikv/titan/format.sh
@@ -14,14 +14,14 @@ fi
 find . \( -iname "*.h" -o -iname "*.cc" \) -print0 | \
   xargs -0 -L1 clang-format -style=google -i
 
-if [[ -n "$(git diff --stat)" ]]; then
-  echo "ERROR: titan format check failed."
-  echo "clang-format produced changes for the following files:"
-  git diff --name-only
+if [[ -n "$(git diff --stat .)" ]]; then
+  echo "❌ [ERROR] these files are not formatted: 👇👇👇"
+  git diff --name-only .
+  echo "👆👆👆 Please format these files and run it again!"
   echo
   echo "Diff summary:"
-  git diff --stat
+  git diff --stat .
   echo
-  echo "To fix locally, run scripts/format-diff.sh in the titan repository and commit the formatting changes."
+  echo "To fix locally, run clang-format -style=google -i on the listed files, then commit the formatting changes."
   exit 1
 fi

--- a/scripts/tikv/titan/format.sh
+++ b/scripts/tikv/titan/format.sh
@@ -15,7 +15,13 @@ find . \( -iname "*.h" -o -iname "*.cc" \) -print0 | \
   xargs -0 -L1 clang-format -style=google -i
 
 if [[ -n "$(git diff --stat)" ]]; then
-  echo "Run scripts/format-diff.sh to format your code."
+  echo "ERROR: titan format check failed."
+  echo "clang-format produced changes for the following files:"
+  git diff --name-only
+  echo
+  echo "Diff summary:"
   git diff --stat
+  echo
+  echo "To fix locally, run scripts/format-diff.sh in the titan repository and commit the formatting changes."
   exit 1
 fi


### PR DESCRIPTION
Add explicit conclusion output in the CI wrapper script format.sh. 
This allows anyone checking Prow logs to immediately identify the root cause: the failure is not caused by broken tests or errors in format-diff.sh, but by code style violations detected during the CI format check.