### PR TITLE
fix(flaky-tests): apply issue mutation limit consistently

### DIFF
--- a/tools/reporters/ci/flaky-tests/core/GithubIssueManager.test.ts
+++ b/tools/reporters/ci/flaky-tests/core/GithubIssueManager.test.ts
@@ -43,14 +43,22 @@ function buildCase(): CaseAgg {
 
 function createManager(
   client: Record<string, unknown>,
+  opts?: {
+    allowCreate?: boolean;
+    allowReopen?: boolean;
+    allowComment?: boolean;
+    mutationLimit?: number;
+    dryRun?: boolean;
+  },
   fetchFn?: typeof fetch,
 ): GithubIssueManager {
   const manager = new GithubIssueManager({
     token: "test-token",
-    allowCreate: false,
-    allowReopen: true,
-    allowComment: false,
-    dryRun: false,
+    allowCreate: opts?.allowCreate ?? false,
+    allowReopen: opts?.allowReopen ?? true,
+    allowComment: opts?.allowComment ?? false,
+    mutationLimit: opts?.mutationLimit ?? 10,
+    dryRun: opts?.dryRun ?? false,
     labels: [],
     now: () => new Date("2026-03-13T12:00:00Z"),
     fetchFn,
@@ -99,7 +107,7 @@ Deno.test("GithubIssueManager.sync reopens issues when latest flaky build starte
   const report = buildReport();
   const flakyCase = buildCase();
 
-  await manager.sync(report, [flakyCase], [flakyCase]);
+  await manager.sync(report, [flakyCase]);
 
   assertEquals(reopenCalls, 1);
   assertEquals(comments.length, 1);
@@ -131,7 +139,7 @@ Deno.test("GithubIssueManager.sync keeps issue closed when latest flaky build is
     latestFlakyFoundAt: new Date("2026-03-10T12:00:00Z"),
   };
 
-  await manager.sync(report, [flakyCase], [flakyCase]);
+  await manager.sync(report, [flakyCase]);
 
   assertEquals(reopenCalls, 0);
   assertEquals(flakyCase.issue?.status, "closed");
@@ -169,7 +177,7 @@ Deno.test("GithubIssueManager.sync reopens issue even if it was closed in curren
     latestFlakyFoundAt: new Date("2026-03-12T01:00:00Z"),
   };
 
-  await manager.sync(report, [flakyCase], [flakyCase]);
+  await manager.sync(report, [flakyCase]);
 
   assertEquals(reopenCalls, 1);
   assertEquals(flakyCase.issue?.status, "reopened");
@@ -203,25 +211,29 @@ Deno.test("GithubIssueManager.sync uses Jenkins timestamp when available for reo
     return new Response("not found", { status: 404 });
   };
 
-  const manager = createManager({
-    searchIssues: async () => [issue],
-    reopenIssue: async () => {
-      reopenCalls += 1;
-      return {
-        ...issue,
-        state: "open",
-        closed_at: null,
-      };
+  const manager = createManager(
+    {
+      searchIssues: async () => [issue],
+      reopenIssue: async () => {
+        reopenCalls += 1;
+        return {
+          ...issue,
+          state: "open",
+          closed_at: null,
+        };
+      },
+      addComment: async (
+        _owner: string,
+        _repo: string,
+        _issueNumber: number,
+        body: string,
+      ) => {
+        comments.push(body);
+      },
     },
-    addComment: async (
-      _owner: string,
-      _repo: string,
-      _issueNumber: number,
-      body: string,
-    ) => {
-      comments.push(body);
-    },
-  }, fetchFn);
+    undefined,
+    fetchFn,
+  );
 
   const report = buildReport();
   const flakyCase = {
@@ -231,7 +243,7 @@ Deno.test("GithubIssueManager.sync uses Jenkins timestamp when available for reo
     latestFlakyFoundAt: new Date("2026-03-09T00:00:00Z"),
   };
 
-  await manager.sync(report, [flakyCase], [flakyCase]);
+  await manager.sync(report, [flakyCase]);
 
   assertEquals(reopenCalls, 1);
   assertEquals(comments.length, 1);
@@ -263,32 +275,38 @@ Deno.test("GithubIssueManager.sync uses Prow started.json when available for reo
     if (url === startedJsonUrl) {
       // started.json timestamp is seconds.
       return new Response(
-        JSON.stringify({ timestamp: Math.floor(prowStartedAt.getTime() / 1000) }),
+        JSON.stringify({
+          timestamp: Math.floor(prowStartedAt.getTime() / 1000),
+        }),
         { status: 200, headers: { "content-type": "application/json" } },
       );
     }
     return new Response("not found", { status: 404 });
   };
 
-  const manager = createManager({
-    searchIssues: async () => [issue],
-    reopenIssue: async () => {
-      reopenCalls += 1;
-      return {
-        ...issue,
-        state: "open",
-        closed_at: null,
-      };
+  const manager = createManager(
+    {
+      searchIssues: async () => [issue],
+      reopenIssue: async () => {
+        reopenCalls += 1;
+        return {
+          ...issue,
+          state: "open",
+          closed_at: null,
+        };
+      },
+      addComment: async (
+        _owner: string,
+        _repo: string,
+        _issueNumber: number,
+        body: string,
+      ) => {
+        comments.push(body);
+      },
     },
-    addComment: async (
-      _owner: string,
-      _repo: string,
-      _issueNumber: number,
-      body: string,
-    ) => {
-      comments.push(body);
-    },
-  }, fetchFn);
+    undefined,
+    fetchFn,
+  );
 
   const report = buildReport();
   const flakyCase = {
@@ -298,7 +316,7 @@ Deno.test("GithubIssueManager.sync uses Prow started.json when available for reo
     latestFlakyFoundAt: new Date("2026-03-09T00:00:00Z"),
   };
 
-  await manager.sync(report, [flakyCase], [flakyCase]);
+  await manager.sync(report, [flakyCase]);
 
   assertEquals(reopenCalls, 1);
   assertEquals(comments.length, 1);
@@ -331,7 +349,7 @@ Deno.test("GithubIssueManager.sync skips reopen when started_at cannot be resolv
     latestFlakyFoundAt: undefined,
   };
 
-  await manager.sync(report, [flakyCase], [flakyCase]);
+  await manager.sync(report, [flakyCase]);
 
   assertEquals(reopenCalls, 0);
   assertEquals(flakyCase.issue?.status, "closed");
@@ -374,7 +392,7 @@ Deno.test("GithubIssueManager.sync prefers open issue over closed exact title ma
   const report = buildReport();
   const flakyCase = buildCase();
 
-  await manager.sync(report, [flakyCase], [flakyCase]);
+  await manager.sync(report, [flakyCase]);
 
   assertEquals(searchModes, ["exact", "loose"]);
   assertEquals(flakyCase.issue?.number, 100);
@@ -410,7 +428,7 @@ Deno.test("GithubIssueManager.sync prefers exact title when issue state is same"
   const report = buildReport();
   const flakyCase = buildCase();
 
-  await manager.sync(report, [flakyCase], [flakyCase]);
+  await manager.sync(report, [flakyCase]);
 
   assertEquals(flakyCase.issue?.number, 300);
   assertEquals(flakyCase.issue?.state, "open");
@@ -445,11 +463,95 @@ Deno.test("GithubIssueManager.sync can match issue from loose title query", asyn
   const report = buildReport();
   const flakyCase = buildCase();
 
-  await manager.sync(report, [flakyCase], [flakyCase]);
+  await manager.sync(report, [flakyCase]);
 
   assertEquals(exactCalls, 1);
   assertEquals(looseCalls, 1);
   assertEquals(flakyCase.issue?.number, 140);
   assertEquals(flakyCase.issue?.state, "open");
   assertEquals(flakyCase.issue?.status, "open");
+});
+
+Deno.test("GithubIssueManager.sync comments only top-N cases within the same issue key", async () => {
+  const issue: TestIssue = {
+    number: 555,
+    title: "Flaky test: TestFlakyCase in pkg/executor",
+    state: "open",
+    html_url: "https://github.com/pingcap/tidb/issues/555",
+  };
+  const comments: string[] = [];
+  const manager = createManager({
+    searchIssues: async () => [issue],
+    addComment: async (
+      _owner: string,
+      _repo: string,
+      _issueNumber: number,
+      body: string,
+    ) => {
+      comments.push(body);
+    },
+  }, {
+    allowComment: true,
+    mutationLimit: 1,
+  });
+  const report = buildReport();
+  const mainCase = {
+    ...buildCase(),
+    branch: "main",
+    flakyCount: 5,
+  };
+  const releaseCase = {
+    ...buildCase(),
+    branch: "release-8.5",
+    flakyCount: 1,
+  };
+
+  await manager.sync(report, [releaseCase, mainCase]);
+
+  assertEquals(comments.length, 1);
+  assertEquals(comments[0].includes("- Branch: main"), true);
+  assertEquals(mainCase.issue?.status, "open");
+  assertEquals(releaseCase.issue?.status, "open");
+});
+
+Deno.test("GithubIssueManager.sync creates shared issue from the top-ranked case in a mutable group", async () => {
+  const createBodies: string[] = [];
+  const manager = createManager({
+    searchIssues: async () => [],
+    createIssue: async (
+      _owner: string,
+      _repo: string,
+      _title: string,
+      body: string,
+    ) => {
+      createBodies.push(body);
+      return {
+        number: 556,
+        title: "Flaky test: TestFlakyCase in pkg/executor",
+        state: "open",
+        html_url: "https://github.com/pingcap/tidb/issues/556",
+      };
+    },
+  }, {
+    allowCreate: true,
+    mutationLimit: 1,
+  });
+  const report = buildReport();
+  const mainCase = {
+    ...buildCase(),
+    branch: "main",
+    flakyCount: 5,
+  };
+  const releaseCase = {
+    ...buildCase(),
+    branch: "release-8.5",
+    flakyCount: 1,
+  };
+
+  await manager.sync(report, [releaseCase, mainCase]);
+
+  assertEquals(createBodies.length, 1);
+  assertEquals(createBodies[0].includes("- Branch: main"), true);
+  assertEquals(mainCase.issue?.status, "new");
+  assertEquals(releaseCase.issue?.status, "new");
 });

--- a/tools/reporters/ci/flaky-tests/core/GithubIssueManager.ts
+++ b/tools/reporters/ci/flaky-tests/core/GithubIssueManager.ts
@@ -19,6 +19,7 @@ interface IssueManagerOptions {
   allowCreate: boolean;
   allowReopen: boolean;
   allowComment: boolean;
+  mutationLimit: number;
   dryRun: boolean;
   labels: string[];
   repoOverride?: string;
@@ -197,6 +198,7 @@ export class GithubIssueManager {
   private readonly allowCreate: boolean;
   private readonly allowReopen: boolean;
   private readonly allowComment: boolean;
+  private readonly mutationLimit: number;
   private readonly dryRun: boolean;
   private readonly labels: string[];
   private readonly repoOverride?: string;
@@ -217,6 +219,7 @@ export class GithubIssueManager {
     this.allowCreate = !!opts.allowCreate;
     this.allowReopen = !!opts.allowReopen;
     this.allowComment = !!opts.allowComment;
+    this.mutationLimit = Math.max(1, opts.mutationLimit || 10);
     this.dryRun = !!opts.dryRun;
     this.labels = opts.labels ?? [];
     this.repoOverride = opts.repoOverride;
@@ -245,7 +248,6 @@ export class GithubIssueManager {
   async sync(
     report: ReportData,
     cases: CaseAgg[],
-    mutateCases?: CaseAgg[],
   ): Promise<void> {
     if (!cases || cases.length === 0) return;
 
@@ -260,14 +262,31 @@ export class GithubIssueManager {
     }
 
     const groups = this.groupCasesByIssueKey(cases);
-    const mutateKeys = mutateCases
-      ? new Set(this.groupCasesByIssueKey(mutateCases).keys())
-      : null;
+    const mutableCases = this.selectMutableCases(cases);
 
-    for (const [key, group] of groups.entries()) {
-      const canMutate = mutateKeys ? mutateKeys.has(key) : true;
-      await this.processGroup(report, group, canMutate);
+    for (const group of groups.values()) {
+      const rankedGroup = this.sortCasesByPriority(group);
+      const mutableGroup = rankedGroup.filter((c) => mutableCases.has(c));
+      await this.processGroup(report, rankedGroup, mutableGroup);
     }
+  }
+
+  private selectMutableCases(cases: CaseAgg[]): Set<CaseAgg> {
+    return new Set(
+      this.sortCasesByPriority(cases).slice(0, this.mutationLimit),
+    );
+  }
+
+  private sortCasesByPriority(cases: CaseAgg[]): CaseAgg[] {
+    return [...cases].sort((a, b) => {
+      if (b.flakyCount !== a.flakyCount) return b.flakyCount - a.flakyCount;
+      if (b.thresholdedCount !== a.thresholdedCount) {
+        return b.thresholdedCount - a.thresholdedCount;
+      }
+      const ak = `${a.repo}/${a.branch}/${a.suite_name}/${a.case_name}`;
+      const bk = `${b.repo}/${b.branch}/${b.suite_name}/${b.case_name}`;
+      return ak.localeCompare(bk);
+    });
   }
 
   private groupCasesByIssueKey(cases: CaseAgg[]): Map<string, CaseAgg[]> {
@@ -290,9 +309,10 @@ export class GithubIssueManager {
   private async processGroup(
     report: ReportData,
     group: CaseAgg[],
-    canMutate: boolean,
+    mutableGroup: CaseAgg[],
   ): Promise<void> {
-    const sample = group[0];
+    const canMutate = mutableGroup.length > 0;
+    const sample = mutableGroup[0] ?? group[0];
     const issueRepo = this.resolveIssueRepo(sample);
     const parsed = parseRepo(issueRepo);
     if (!parsed) {
@@ -334,11 +354,18 @@ export class GithubIssueManager {
                 reopenCheck.evidence,
               );
               try {
-                await this.client!.addComment(owner, repo, issue.number, comment);
+                await this.client!.addComment(
+                  owner,
+                  repo,
+                  issue.number,
+                  comment,
+                );
               } catch (e: unknown) {
                 const msg = e instanceof Error ? e.message : String(e);
                 if (this.verbose) {
-                  console.error(`[github] add reopen evidence comment failed: ${msg}`);
+                  console.error(
+                    `[github] add reopen evidence comment failed: ${msg}`,
+                  );
                 }
               }
             }
@@ -411,13 +438,13 @@ export class GithubIssueManager {
     if (this.dryRun) {
       if (this.verbose) {
         console.debug(
-          `[github] dryrun comment: ${issueRepo}#${issue.number} cases=${group.length}`,
+          `[github] dryrun comment: ${issueRepo}#${issue.number} cases=${mutableGroup.length}`,
         );
       }
       return;
     }
 
-    for (const c of group) {
+    for (const c of mutableGroup) {
       const comment = buildIssueComment(report, c);
       try {
         await this.client!.addComment(owner, repo, issue.number, comment);

--- a/tools/reporters/ci/flaky-tests/main.ts
+++ b/tools/reporters/ci/flaky-tests/main.ts
@@ -261,6 +261,7 @@ export async function main(args: string[]): Promise<number> {
     allowCreate: cli.issueCreate,
     allowReopen: cli.issueReopen,
     allowComment: cli.issueComment,
+    mutationLimit: cli.issueMutationLimit,
     dryRun: cli.issueDryRun,
     labels: cli.issueLabels,
     repoOverride: cli.issueRepoOverride,
@@ -274,11 +275,8 @@ export async function main(args: string[]): Promise<number> {
   const casesForIssue = report.byCase.filter((c: CaseAgg) =>
     (c.flakyCount || 0) > 0 || (c.thresholdedCount || 0) > 0
   );
-  const topCasesForIssue = report.byCase.filter((c: CaseAgg) =>
-    (c.flakyCount || 0) > 0 || (c.thresholdedCount || 0) > 0
-  ).slice(0, Math.max(1, cli.issueMutationLimit || 10));
   if (casesForIssue.length > 0) {
-    await issueManager.sync(report, casesForIssue, topCasesForIssue);
+    await issueManager.sync(report, casesForIssue);
   }
 
   const reportFileHtml = new HtmlRenderer().render(report);


### PR DESCRIPTION
## Summary
- move `issueMutationLimit` ownership into `GithubIssueManager` so create/reopen/comment share one ranking path
- rank candidate cases inside the manager, use the highest-ranked mutable case as the issue sample, and only comment mutable cases within a shared issue key
- add regression tests for shared issue-key comment/create behavior plus keep the existing reopen coverage green

## Testing
- `deno test` (from `tools/reporters/ci/flaky-tests`)
