### PR TITLE
fix(tikv/rust-rocksdb): migrate CI from CentOS 7 to Rocky Linux 8

### DIFF
--- a/prow-jobs/tikv/rust-rocksdb/latest-presubmits.yaml
+++ b/prow-jobs/tikv/rust-rocksdb/latest-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
                         - amd64
         containers:
           - name: rust
-            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
             command: [bash, -ce]
             args:
               - |
@@ -38,11 +38,7 @@ presubmits:
 
                 # Check C++ formatting
                 if ! command -v clang-format &> /dev/null; then
-                  # CentOS 7 uses yum and llvm-toolset-7.0
-                  yum install -y llvm-toolset-7.0
-                  if [ -f /opt/rh/llvm-toolset-7.0/enable ]; then
-                    source /opt/rh/llvm-toolset-7.0/enable
-                  fi
+                  dnf install -y clang-tools-extra
                 fi
                 find librocksdb_sys/crocksdb/ \( -iname "*.h" -o -iname "*.cc" \) | while read f; do
                   diff -q <(clang-format "$f") "$f" || (echo "❌ $f" && exit 1)
@@ -72,7 +68,7 @@ presubmits:
                         - amd64
         containers:
           - name: rust
-            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
             command: [bash, -ce]
             env:
               - name: RUST_BACKTRACE
@@ -82,12 +78,6 @@ presubmits:
                 #!/usr/bin/env bash
                 set -exo pipefail
 
-                yum install -y openssl-devel
-
-                # Setup GCC 8
-                if [ -f /opt/rh/devtoolset-8/enable ]; then
-                  source /opt/rh/devtoolset-8/enable
-                fi
                 g++ --version
                 cmake --version
 
@@ -149,7 +139,7 @@ presubmits:
                         - arm64
         containers:
           - name: rust
-            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2025.12.14-1-g33e22ac-centos7-devtoolset8
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
             command: [bash, -ce]
             env:
               - name: RUST_BACKTRACE
@@ -159,12 +149,6 @@ presubmits:
                 #!/usr/bin/env bash
                 set -exo pipefail
 
-                yum install -y openssl-devel
-
-                # Setup GCC 8
-                if [ -f /opt/rh/devtoolset-8/enable ]; then
-                  source /opt/rh/devtoolset-8/enable
-                fi
                 g++ --version
                 cmake --version
 


### PR DESCRIPTION
## Problem

`openssl-sys` v0.9.114 (released ~April 2026) dropped support for OpenSSL < 1.1.0. The current CentOS 7 builder image installs `openssl-devel` from the CentOS 7 repos, which provides OpenSSL **1.0.2k** — now rejected at compile time with:

> "This crate is only compatible with OpenSSL (version 1.1.0, 1.1.1, 3.x, or 4.x), but a different version of OpenSSL was found."

This breaks the `encryption` feature build for **all PRs** targeting `tikv/rust-rocksdb` (confirmed also broken on PR #849, an unrelated change).

Upstream issue: tikv/rust-rocksdb#850

## Fix

Switch all three jobs (`pull-rust-rocksdb-lint`, `pull-rust-rocksdb-test-x86`, `pull-rust-rocksdb-test-arm`) to the same Rocky Linux 8 builder image that `tikv/tikv` latest presubmits already use (`v2026.3.22-3-g892e449`).

Rocky Linux 8 ships OpenSSL 1.1.1 and a modern GCC system-wide, so:
- `yum install -y openssl-devel` is removed (pre-installed in the image)
- The `devtoolset-8` source block is removed (system GCC is sufficient)
- The CentOS-specific `llvm-toolset-7.0` SCL install is replaced with `dnf install -y clang-tools-extra`

## Precedent

`tikv/tikv` latest presubmits already run on this image (see PR #4383).