### PR TITLE
feat(prow-jobs/tikv/tikv): add release arm64 clippy presubmits

### DIFF
--- a/prow-jobs/tikv/tikv/release-6.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-6.1-presubmits.yaml
@@ -33,3 +33,38 @@ presubmits:
       trigger: "(?m)^/debug (?:.*? )?pull-integration-test(?: .*?)?$"
       rerun_command: "/debug pull-integration-test"
       branches: *branches
+
+    - name: tikv/tikv/release-6.1/pull-clippy-linux-arm64
+      agent: kubernetes
+      decorate: true
+      skip_if_only_changed: *skip_if_only_changed
+      context: release-6.1/pull-clippy-linux-arm64
+      branches: *branches
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
+            command: [bash, -ce]
+            args:
+              - |
+                if [ -f /opt/rh/devtoolset-8/enable ]; then
+                  source /opt/rh/devtoolset-8/enable
+                fi
+                make clippy
+                ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
+            resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
+              limits:
+                memory: 16Gi
+                cpu: "8"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64

--- a/prow-jobs/tikv/tikv/release-6.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-6.1-presubmits.yaml
@@ -34,11 +34,11 @@ presubmits:
       rerun_command: "/debug pull-integration-test"
       branches: *branches
 
-    - name: tikv/tikv/release-6.1/pull-clippy-linux-arm64
+    - name: pull-clippy-linux-arm64-release-6.1
       agent: kubernetes
       decorate: true
       skip_if_only_changed: *skip_if_only_changed
-      context: release-6.1/pull-clippy-linux-arm64
+      context: pull-clippy-linux-arm64-release-6.1
       branches: *branches
       spec:
         containers:

--- a/prow-jobs/tikv/tikv/release-6.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-6.5-presubmits.yaml
@@ -31,3 +31,38 @@ presubmits:
       trigger: "(?m)^/debug (?:.*? )?pull-integration-test(?: .*?)?$"
       rerun_command: "/debug pull-integration-test"
       branches: *branches
+
+    - name: tikv/tikv/release-6.5/pull-clippy-linux-arm64
+      agent: kubernetes
+      decorate: true
+      skip_if_only_changed: *skip_if_only_changed
+      context: release-6.5/pull-clippy-linux-arm64
+      branches: *branches
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
+            command: [bash, -ce]
+            args:
+              - |
+                if [ -f /opt/rh/devtoolset-8/enable ]; then
+                  source /opt/rh/devtoolset-8/enable
+                fi
+                make clippy
+                ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
+            resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
+              limits:
+                memory: 16Gi
+                cpu: "8"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64

--- a/prow-jobs/tikv/tikv/release-6.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-6.5-presubmits.yaml
@@ -32,11 +32,11 @@ presubmits:
       rerun_command: "/debug pull-integration-test"
       branches: *branches
 
-    - name: tikv/tikv/release-6.5/pull-clippy-linux-arm64
+    - name: pull-clippy-linux-arm64-release-6.5
       agent: kubernetes
       decorate: true
       skip_if_only_changed: *skip_if_only_changed
-      context: release-6.5/pull-clippy-linux-arm64
+      context: pull-clippy-linux-arm64-release-6.5
       branches: *branches
       spec:
         containers:

--- a/prow-jobs/tikv/tikv/release-7.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-7.1-presubmits.yaml
@@ -30,3 +30,38 @@ presubmits:
       trigger: "(?m)^/debug (?:.*? )?pull-integration-test(?: .*?)?$"
       rerun_command: "/debug pull-integration-test"
       branches: *branches
+
+    - name: tikv/tikv/release-7.1/pull-clippy-linux-arm64
+      agent: kubernetes
+      decorate: true
+      skip_if_only_changed: *skip_if_only_changed
+      context: release-7.1/pull-clippy-linux-arm64
+      branches: *branches
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
+            command: [bash, -ce]
+            args:
+              - |
+                if [ -f /opt/rh/devtoolset-8/enable ]; then
+                  source /opt/rh/devtoolset-8/enable
+                fi
+                make clippy
+                ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
+            resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
+              limits:
+                memory: 16Gi
+                cpu: "8"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64

--- a/prow-jobs/tikv/tikv/release-7.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-7.1-presubmits.yaml
@@ -31,11 +31,11 @@ presubmits:
       rerun_command: "/debug pull-integration-test"
       branches: *branches
 
-    - name: tikv/tikv/release-7.1/pull-clippy-linux-arm64
+    - name: pull-clippy-linux-arm64-release-7.1
       agent: kubernetes
       decorate: true
       skip_if_only_changed: *skip_if_only_changed
-      context: release-7.1/pull-clippy-linux-arm64
+      context: pull-clippy-linux-arm64-release-7.1
       branches: *branches
       spec:
         containers:

--- a/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
@@ -33,3 +33,38 @@ presubmits:
       rerun_command: "/debug pull-integration-test"
       branches:
         - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
+
+    - name: tikv/tikv/release-7.5/pull-clippy-linux-arm64
+      agent: kubernetes
+      decorate: true
+      skip_if_only_changed: *skip_if_only_changed
+      context: release-7.5/pull-clippy-linux-arm64
+      branches: *branches
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
+            command: [bash, -ce]
+            args:
+              - |
+                if [ -f /opt/rh/devtoolset-8/enable ]; then
+                  source /opt/rh/devtoolset-8/enable
+                fi
+                make clippy
+                ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
+            resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
+              limits:
+                memory: 16Gi
+                cpu: "8"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64

--- a/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
@@ -34,11 +34,11 @@ presubmits:
       branches:
         - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?$
 
-    - name: tikv/tikv/release-7.5/pull-clippy-linux-arm64
+    - name: pull-clippy-linux-arm64-release-7.5
       agent: kubernetes
       decorate: true
       skip_if_only_changed: *skip_if_only_changed
-      context: release-7.5/pull-clippy-linux-arm64
+      context: pull-clippy-linux-arm64-release-7.5
       branches: *branches
       spec:
         containers:

--- a/prow-jobs/tikv/tikv/release-8.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.1-presubmits.yaml
@@ -30,3 +30,38 @@ presubmits:
       trigger: "(?m)^/debug (?:.*? )?pull-integration-test(?: .*?)?$"
       rerun_command: "/debug pull-integration-test"
       branches: *branches
+
+    - name: tikv/tikv/release-8.1/pull-clippy-linux-arm64
+      agent: kubernetes
+      decorate: true
+      skip_if_only_changed: *skip_if_only_changed
+      context: release-8.1/pull-clippy-linux-arm64
+      branches: *branches
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
+            command: [bash, -ce]
+            args:
+              - |
+                if [ -f /opt/rh/devtoolset-8/enable ]; then
+                  source /opt/rh/devtoolset-8/enable
+                fi
+                make clippy
+                ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
+            resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
+              limits:
+                memory: 16Gi
+                cpu: "8"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64

--- a/prow-jobs/tikv/tikv/release-8.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.1-presubmits.yaml
@@ -31,11 +31,11 @@ presubmits:
       rerun_command: "/debug pull-integration-test"
       branches: *branches
 
-    - name: tikv/tikv/release-8.1/pull-clippy-linux-arm64
+    - name: pull-clippy-linux-arm64-release-8.1
       agent: kubernetes
       decorate: true
       skip_if_only_changed: *skip_if_only_changed
-      context: release-8.1/pull-clippy-linux-arm64
+      context: pull-clippy-linux-arm64-release-8.1
       branches: *branches
       spec:
         containers:

--- a/prow-jobs/tikv/tikv/release-8.2-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.2-presubmits.yaml
@@ -17,3 +17,38 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?pull-unit-test(?: .*?)?$"
       rerun_command: "/test pull-unit-test"
       branches: *branches
+
+    - name: tikv/tikv/release-8.2/pull-clippy-linux-arm64
+      agent: kubernetes
+      decorate: true
+      skip_if_only_changed: *skip_if_only_changed
+      context: release-8.2/pull-clippy-linux-arm64
+      branches: *branches
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
+            command: [bash, -ce]
+            args:
+              - |
+                if [ -f /opt/rh/devtoolset-8/enable ]; then
+                  source /opt/rh/devtoolset-8/enable
+                fi
+                make clippy
+                ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
+            resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
+              limits:
+                memory: 16Gi
+                cpu: "8"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64

--- a/prow-jobs/tikv/tikv/release-8.2-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.2-presubmits.yaml
@@ -18,11 +18,11 @@ presubmits:
       rerun_command: "/test pull-unit-test"
       branches: *branches
 
-    - name: tikv/tikv/release-8.2/pull-clippy-linux-arm64
+    - name: pull-clippy-linux-arm64-release-8.2
       agent: kubernetes
       decorate: true
       skip_if_only_changed: *skip_if_only_changed
-      context: release-8.2/pull-clippy-linux-arm64
+      context: pull-clippy-linux-arm64-release-8.2
       branches: *branches
       spec:
         containers:

--- a/prow-jobs/tikv/tikv/release-8.3-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.3-presubmits.yaml
@@ -18,11 +18,11 @@ presubmits:
       rerun_command: "/test pull-unit-test"
       branches: *branches
 
-    - name: tikv/tikv/release-8.3/pull-clippy-linux-arm64
+    - name: pull-clippy-linux-arm64-release-8.3
       agent: kubernetes
       decorate: true
       skip_if_only_changed: *skip_if_only_changed
-      context: release-8.3/pull-clippy-linux-arm64
+      context: pull-clippy-linux-arm64-release-8.3
       branches: *branches
       spec:
         containers:

--- a/prow-jobs/tikv/tikv/release-8.3-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.3-presubmits.yaml
@@ -17,3 +17,38 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?pull-unit-test(?: .*?)?$"
       rerun_command: "/test pull-unit-test"
       branches: *branches
+
+    - name: tikv/tikv/release-8.3/pull-clippy-linux-arm64
+      agent: kubernetes
+      decorate: true
+      skip_if_only_changed: *skip_if_only_changed
+      context: release-8.3/pull-clippy-linux-arm64
+      branches: *branches
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
+            command: [bash, -ce]
+            args:
+              - |
+                if [ -f /opt/rh/devtoolset-8/enable ]; then
+                  source /opt/rh/devtoolset-8/enable
+                fi
+                make clippy
+                ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
+            resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
+              limits:
+                memory: 16Gi
+                cpu: "8"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64

--- a/prow-jobs/tikv/tikv/release-8.4-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.4-presubmits.yaml
@@ -17,11 +17,11 @@ presubmits:
       rerun_command: "/test pull-unit-test"
       branches: *branches
 
-    - name: tikv/tikv/release-8.4/pull-clippy-linux-arm64
+    - name: pull-clippy-linux-arm64-release-8.4
       agent: kubernetes
       decorate: true
       skip_if_only_changed: *skip_if_only_changed
-      context: release-8.4/pull-clippy-linux-arm64
+      context: pull-clippy-linux-arm64-release-8.4
       branches: *branches
       spec:
         containers:

--- a/prow-jobs/tikv/tikv/release-8.4-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.4-presubmits.yaml
@@ -16,3 +16,38 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?pull-unit-test(?: .*?)?$"
       rerun_command: "/test pull-unit-test"
       branches: *branches
+
+    - name: tikv/tikv/release-8.4/pull-clippy-linux-arm64
+      agent: kubernetes
+      decorate: true
+      skip_if_only_changed: *skip_if_only_changed
+      context: release-8.4/pull-clippy-linux-arm64
+      branches: *branches
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
+            command: [bash, -ce]
+            args:
+              - |
+                if [ -f /opt/rh/devtoolset-8/enable ]; then
+                  source /opt/rh/devtoolset-8/enable
+                fi
+                make clippy
+                ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
+            resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
+              limits:
+                memory: 16Gi
+                cpu: "8"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64

--- a/prow-jobs/tikv/tikv/release-8.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.5-presubmits.yaml
@@ -18,11 +18,11 @@ presubmits:
       rerun_command: "/test pull-unit-test"
       branches: *branches
 
-    - name: tikv/tikv/release-8.5/pull-clippy-linux-arm64
+    - name: pull-clippy-linux-arm64-release-8.5
       agent: kubernetes
       decorate: true
       skip_if_only_changed: *skip_if_only_changed
-      context: release-8.5/pull-clippy-linux-arm64
+      context: pull-clippy-linux-arm64-release-8.5
       branches: *branches
       spec:
         containers:

--- a/prow-jobs/tikv/tikv/release-8.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.5-presubmits.yaml
@@ -17,3 +17,38 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?pull-unit-test(?: .*?)?$"
       rerun_command: "/test pull-unit-test"
       branches: *branches
+
+    - name: tikv/tikv/release-8.5/pull-clippy-linux-arm64
+      agent: kubernetes
+      decorate: true
+      skip_if_only_changed: *skip_if_only_changed
+      context: release-8.5/pull-clippy-linux-arm64
+      branches: *branches
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
+            command: [bash, -ce]
+            args:
+              - |
+                if [ -f /opt/rh/devtoolset-8/enable ]; then
+                  source /opt/rh/devtoolset-8/enable
+                fi
+                make clippy
+                ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
+            resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
+              limits:
+                memory: 16Gi
+                cpu: "8"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64

--- a/prow-jobs/tikv/tikv/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-9.0-beta-presubmits.yaml
@@ -17,3 +17,38 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?pull-unit-test(?: .*?)?$"
       rerun_command: "/test pull-unit-test"
       branches: *branches
+
+    - name: tikv/tikv/release-9.0-beta/pull-clippy-linux-arm64
+      agent: kubernetes
+      decorate: true
+      skip_if_only_changed: *skip_if_only_changed
+      context: release-9.0-beta/pull-clippy-linux-arm64
+      branches: *branches
+      spec:
+        containers:
+          - name: build
+            image: ghcr.io/pingcap-qe/cd/builders/tikv:v2026.3.22-3-g892e449
+            command: [bash, -ce]
+            args:
+              - |
+                if [ -f /opt/rh/devtoolset-8/enable ]; then
+                  source /opt/rh/devtoolset-8/enable
+                fi
+                make clippy
+                ENABLE_FEATURES="test-engines-panic nortcheck" NO_DEFAULT_TEST_ENGINES=1 make clippy
+            resources:
+              requests:
+                memory: 8Gi
+                cpu: "4"
+              limits:
+                memory: 16Gi
+                cpu: "8"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: kubernetes.io/arch
+                      operator: In
+                      values:
+                        - arm64

--- a/prow-jobs/tikv/tikv/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-9.0-beta-presubmits.yaml
@@ -18,11 +18,11 @@ presubmits:
       rerun_command: "/test pull-unit-test"
       branches: *branches
 
-    - name: tikv/tikv/release-9.0-beta/pull-clippy-linux-arm64
+    - name: pull-clippy-linux-arm64-release-9.0-beta
       agent: kubernetes
       decorate: true
       skip_if_only_changed: *skip_if_only_changed
-      context: release-9.0-beta/pull-clippy-linux-arm64
+      context: pull-clippy-linux-arm64-release-9.0-beta
       branches: *branches
       spec:
         containers:


### PR DESCRIPTION
## Summary
- add arm64 clippy presubmit jobs to all maintained `tikv/tikv` `release-*-presubmits.yaml` files
- keep each new job branch-scoped to the file's existing branch matcher so release and hotfix branches stay covered without changing existing Jenkins triggers
- give each job a release-specific name and context to avoid collisions with `latest` and other release jobs

## Validation
- `yq e . prow-jobs/tikv/tikv/release-*-presubmits.yaml`
- `./.ci/update-prow-job-kustomization.sh`
- Dockerized `checkconfig` using `ghcr.io/ti-community-infra/prow/checkconfig:v20250905-a0cfed255`
- Dockerized `flux build kustomization prow-jobs --path=prow-jobs --kustomization-file=../ee-ops/apps/gcp/prow/pre/prow-jobs.yaml --dry-run`