### PR TITLE
fix(prow-jobs/pingcap-qe/ci): use deno task for flaky-tests reporter

### DIFF
--- a/prow-jobs/pingcap-qe/ci/periodics.yaml
+++ b/prow-jobs/pingcap-qe/ci/periodics.yaml
@@ -41,12 +41,12 @@ periodics:
               #!/usr/bin/env bash
               set -euo pipefail
 
-              script_url="https://github.com/PingCAP-QE/ci/raw/main/tools/reporters/ci/flaky-tests/main.ts"
+              project_url="https://github.com/PingCAP-QE/ci/raw/main/tools/reporters/ci/flaky-tests/deno.json"
               start_date=$(date -d "1 days ago" +%Y-%m-%d)
               end_date=$(date +%Y-%m-%d)
               email_subject="Flaky Tests Report of $PARAM_REPO repository (branch: $PARAM_BRANCH) between ${start_date} and ${end_date}"
 
-              deno run --allow-env --allow-net --allow-write ${script_url} \
+              deno task run --allow-env --allow-net --allow-write ${project_url} \
                 --repo ${PARAM_REPO} \
                 --branch ${PARAM_BRANCH} \
                 --from ${start_date} \


### PR DESCRIPTION
Replace direct deno script execution with a deno task that references tools/reporters/ci/flaky-tests/deno.json. Rename script_url to project_url and call `deno task run` to execute the configured task, preserving the same repo/branch/date arguments.