### PR TITLE
feat(tekton/v1): propagate git-url into package publish tasks to label OCI/image artifacts

### DIFF
--- a/tekton/v1/pipelines/pingcap-build-package-darwin.yaml
+++ b/tekton/v1/pipelines/pingcap-build-package-darwin.yaml
@@ -145,6 +145,8 @@ spec:
           value: "$(params.component)"
         - name: version
           value: "$(tasks.get-release-ver.results.version)"
+        - name: git-url
+          value: "$(params.git-url)"
         - name: git-ref
           value: "$(tasks.get-release-ver.results.build-ref)"
         - name: git-sha

--- a/tekton/v1/pipelines/pingcap-build-package-linux.yaml
+++ b/tekton/v1/pipelines/pingcap-build-package-linux.yaml
@@ -148,6 +148,8 @@ spec:
           value: "$(params.component)"
         - name: version
           value: "$(tasks.get-release-ver.results.version)"
+        - name: git-url
+          value: "$(params.git-url)"
         - name: git-ref
           value: "$(tasks.get-release-ver.results.build-ref)"
         - name: git-sha
@@ -188,6 +190,8 @@ spec:
           value: "$(params.component)"
         - name: version
           value: "$(tasks.get-release-ver.results.version)"
+        - name: git-url
+          value: "$(params.git-url)"
         - name: git-ref
           value: "$(tasks.get-release-ver.results.build-ref)"
         - name: git-sha

--- a/tekton/v1/tasks/pingcap-build-binaries-darwin.yaml
+++ b/tekton/v1/tasks/pingcap-build-binaries-darwin.yaml
@@ -75,8 +75,7 @@ spec:
           "$git_sha" \
           /workspace/artifacts/packages/packages.yaml.tmpl \
           "$out_script" \
-          $(params.registry) \
-          "$(params.git-url)"
+          $(params.registry)
 
         if [ -f "$out_script" ]; then
           echo -n "true" > $(step.results.generated.path)

--- a/tekton/v1/tasks/pingcap-build-binaries-darwin.yaml
+++ b/tekton/v1/tasks/pingcap-build-binaries-darwin.yaml
@@ -34,6 +34,7 @@ spec:
         supports: 'release' or 'failpoint'.
     - name: git-ref
     - name: git-sha
+    - name: git-url
     - name: builder-image
       default: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
     - name: release-dir
@@ -74,7 +75,8 @@ spec:
           "$git_sha" \
           /workspace/artifacts/packages/packages.yaml.tmpl \
           "$out_script" \
-          $(params.registry)
+          $(params.registry) \
+          "$(params.git-url)"
 
         if [ -f "$out_script" ]; then
           echo -n "true" > $(step.results.generated.path)
@@ -152,6 +154,9 @@ spec:
           operator: in
           values: ["true"]
       workingDir: $(workspaces.source.path)/$(params.component)
+      env:
+        - name: GIT_URL
+          value: $(params.git-url)
       script: |
         script="/workspace/build-package-artifacts.sh"
 

--- a/tekton/v1/tasks/pingcap-build-binaries-linux.yaml
+++ b/tekton/v1/tasks/pingcap-build-binaries-linux.yaml
@@ -77,8 +77,7 @@ spec:
           "$git_sha" \
           /workspace/artifacts/packages/packages.yaml.tmpl \
           "$out_script" \
-          $(params.registry) \
-          "$(params.git-url)"
+          $(params.registry)
 
         if [ -f "$out_script" ]; then
           echo -n "true" > $(step.results.generated.path)

--- a/tekton/v1/tasks/pingcap-build-binaries-linux.yaml
+++ b/tekton/v1/tasks/pingcap-build-binaries-linux.yaml
@@ -39,6 +39,7 @@ spec:
         supports: 'release' or 'failpoint'.
     - name: git-ref
     - name: git-sha
+    - name: git-url
     - name: builder-image
       default: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
     - name: release-dir
@@ -76,7 +77,8 @@ spec:
           "$git_sha" \
           /workspace/artifacts/packages/packages.yaml.tmpl \
           "$out_script" \
-          $(params.registry)
+          $(params.registry) \
+          "$(params.git-url)"
 
         if [ -f "$out_script" ]; then
           echo -n "true" > $(step.results.generated.path)
@@ -118,6 +120,9 @@ spec:
           operator: in
           values: ["true"]
       workingDir: $(workspaces.source.path)/$(params.component)
+      env:
+        - name: GIT_URL
+          value: $(params.git-url)
       script: |
         script="/workspace/build-package-artifacts.sh"
 

--- a/tekton/v1/tasks/pingcap-build-images.yaml
+++ b/tekton/v1/tasks/pingcap-build-images.yaml
@@ -39,6 +39,7 @@ spec:
         supports: 'release' or 'failpoint'.
     - name: git-ref
     - name: git-sha
+    - name: git-url
     - name: release-dir
       default: build
     - name: build
@@ -75,7 +76,8 @@ spec:
           "$git_sha" \
           /workspace/artifacts/packages/packages.yaml.tmpl \
           "$out_script" \
-          $(params.registry) || true
+          $(params.registry) \
+          "$(params.git-url)" || true
 
         if [ -f "$out_script" ]; then
           echo -n "true" > $(step.results.generated.path)
@@ -97,6 +99,8 @@ spec:
           value: /kaniko/executor
         - name: CREDS_DIR
           value: /tekton/creds-secrets
+        - name: GIT_URL
+          value: $(params.git-url)
       computeResources:
         requests:
           cpu: "4"

--- a/tekton/v1/tasks/pingcap-build-images.yaml
+++ b/tekton/v1/tasks/pingcap-build-images.yaml
@@ -76,8 +76,7 @@ spec:
           "$git_sha" \
           /workspace/artifacts/packages/packages.yaml.tmpl \
           "$out_script" \
-          $(params.registry) \
-          "$(params.git-url)" || true
+          $(params.registry) || true
 
         if [ -f "$out_script" ]; then
           echo -n "true" > $(step.results.generated.path)


### PR DESCRIPTION
## Summary
- pass `git-url` from the build-package linux/darwin pipelines into the binaries/images tasks
- feed `git-url` into the generated packaging scripts as the 11th argument
- export `GIT_URL=$(params.git-url)` in publish/build-and-publish so OCI source labels resolve to the pipeline input

## Validation
- `yq eval .` on the 5 modified Tekton YAMLs
- `git diff --check`
