### PR TITLE
chore(pingcap/tiflow): update latest Go 1.25 CI images for tiflow jobs

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.15-1-g5625431-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_build.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
@@ -19,7 +19,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - command: [tini, --, bash]
-      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       command:
         - sh
         - -c
@@ -17,7 +17,7 @@ spec:
           name: "mysql-config-volume"
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       command: [tini, --, bash]
       tty: true
       resources:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       command:
         - sh
         - -c
@@ -17,7 +17,7 @@ spec:
           name: "mysql-config-volume"
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       command: [tini, --, bash]
       tty: true
       resources:

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
       spec:
         containers:
           - name: check
-            image: ghcr.io/pingcap-qe/ci/base:v2026.3.8-1-g9d412f4-go1.25
+            image: ghcr.io/pingcap-qe/ci/base:v2026.4.12-10-gc29110c-go1.25
             command: [bash, -ce]
             args:
               - |
@@ -37,7 +37,7 @@ presubmits:
       spec:
         containers:
           - name: build
-            image: ghcr.io/pingcap-qe/ci/base:v2026.3.8-1-g9d412f4-go1.25
+            image: ghcr.io/pingcap-qe/ci/base:v2026.4.12-10-gc29110c-go1.25
             command: [bash, -ce]
             args:
               - |

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
       spec:
         containers:
           - name: cdc-unit-test
-            image: ghcr.io/pingcap-qe/ci/base:v2026.3.15-1-g5625431-go1.25
+            image: ghcr.io/pingcap-qe/ci/base:v2026.4.12-10-gc29110c-go1.25
             command: [bash, -ce]
             args:
               - |


### PR DESCRIPTION
### What

Update TiFlow latest CI images to the newer Go 1.25 image tag:

- `ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25` for jenkins job
- `ghcr.io/pingcap-qe/ci/base:v2026.4.12-10-gc29110c-go1.25` for the Prow unit test job

### Why

TiFlow PR pingcap/tiflow#12628 updates `go.mod` to `go 1.25.9`.
Some CI jobs were still running with older Go 1.25 images, causing errors like:
```text
compile: version "go1.25.9" does not match go tool version "go1.25.8" 
``` 
### Test result
I have run replay tests for all failed tasks. The Go version mismatch issue is now fully resolved. The remaining failures are either integration test failures inherent to the TiFlow PR itself, or runtime issues on individual Jenkins/K8s agents. These are not directly related to the current upgrade of the Go image.