### PR TITLE
ci(pipelines): back BR integration temp dir with PVC

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
@@ -10,11 +10,14 @@ spec:
         - sh
         - -c
         - |
+          chmod 1777 /tmp/tidb
           echo "[client]" > /mysql-config/.my.cnf
           echo "ssl-mode=DISABLED" >> /mysql-config/.my.cnf
       volumeMounts:
         - mountPath: "/mysql-config"
           name: "mysql-config-volume"
+        - mountPath: "/tmp/tidb"
+          name: "tidb-temp-dir-volume"
   containers:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
@@ -33,6 +36,8 @@ spec:
         - mountPath: "/home/jenkins/.my.cnf"
           name: "mysql-config-volume"
           subPath: ".my.cnf"
+        - mountPath: "/tmp/tidb"
+          name: "tidb-temp-dir-volume"
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
@@ -59,3 +64,13 @@ spec:
   volumes:
     - name: mysql-config-volume
       emptyDir: {}
+    - name: tidb-temp-dir-volume
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo


### PR DESCRIPTION
## Summary
- mount `/tmp/tidb` in `pull_br_integration_test` onto a PVC-backed ephemeral volume
- keep the existing workspace volume unchanged
- initialize the dedicated temp dir permissions in the init container so TiDB can write DDL ingest data there

## Validation
- `./.ci/verify-k8s-pod-yaml.sh pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml`
- replay success (full `/tmp` PVC experiment): https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_br_integration_test/1015/
- replay success (`/tmp/tidb` PVC, 300Gi): https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_br_integration_test/1016/
- replay in progress for final `/tmp/tidb` PVC shape (200Gi): https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_br_integration_test/1017/

## Context
`pull_br_integration_test` hit DDL ingest temp-dir pressure under `/tmp/tidb/tmp_ddl-4000`. This change gives TiDB temp storage its own PVC-backed space without changing the rest of the pod layout.