### PR TITLE
ci(tidb): align ddlv1 unit test reporting with unit test job

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
@@ -14,7 +14,7 @@ pipeline {
         kubernetes {
             namespace K8S_NAMESPACE
             yamlFile POD_TEMPLATE_FILE
-            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '200Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -62,10 +62,24 @@ pipeline {
                         git diff .
                         git status
                     '''
-                    sh """#! /usr/bin/env bash
+                    sh '''#! /usr/bin/env bash
                         set -o pipefail
-                        make bazel_coverage_test_ddlargsv1
-                    """
+
+                        make bazel_coverage_test_ddlargsv1 2>&1 | tee bazel-test.log
+                    '''
+                }
+            }
+            post {
+                always {
+                    dir(REFS.repo) {
+                        junit(testResults: "**/bazel.xml", allowEmptyResults: true)
+                        archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
+                    }
+                    sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
+                    script {
+                        prow.sendTestCaseRunReport("${REFS.org}/${REFS.repo}", "${REFS.base_ref}")
+                    }
+                    archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
                 }
             }
         }


### PR DESCRIPTION
### What changed

- Increase `pull_unit_test_ddlv1` workspace from `150Gi` to `200Gi`, aligning it with `ghpr_unit_test`.
- Capture `bazel_coverage_test_ddlargsv1` output into `bazel-test.log`.
- Add the same test result archive/report flow used by the regular unit test job:
  - archive Bazel JUnit XML
  - archive `bazel-test.log`
  - run `analyze-go-test-from-bazel-output.sh`
  - send test case run report
  - archive `bazel-*.log` and `bazel-*.json`

### Why

`pull_unit_test_ddlv1` has been hard to diagnose when Bazel reports timeout/failure summaries, because the job did not archive and parse test output like the regular unit test job. This change aligns the diagnostics path and removes the workspace size difference.
