### PR TITLE
fix(tidb): lock checkout cache for TiDB GCP Jenkins jobs

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
@@ -36,12 +36,8 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                    prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true, gitBaseUrl = 'https://github.com')
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
@@ -37,7 +37,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_build.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_build.groovy
@@ -26,12 +26,8 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        script {
-                            retry(2) {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true, gitBaseUrl = 'https://github.com')
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_build.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_build.groovy
@@ -27,7 +27,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_check.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_check.groovy
@@ -28,7 +28,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_check.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_check.groovy
@@ -27,12 +27,8 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        script {
-                            retry(2) {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true, gitBaseUrl = 'https://github.com')
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
@@ -34,7 +34,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                     cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS)) {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'

--- a/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
@@ -33,12 +33,8 @@ pipeline {
             }
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                     cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS)) {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'

--- a/pipelines/pingcap/tidb/release-8.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_common_test.groovy
@@ -27,12 +27,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_common_test.groovy
@@ -28,7 +28,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_e2e_test.groovy
@@ -31,7 +31,7 @@ pipeline {
             steps {
                 dir('tidb') {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_e2e_test.groovy
@@ -30,12 +30,8 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -39,7 +39,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
 
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'br-integration-test')) {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -38,12 +38,8 @@ pipeline {
             }
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
 
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'br-integration-test')) {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
@@ -32,12 +32,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
@@ -33,7 +33,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_copr_test.groovy
@@ -32,7 +32,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tikv-copr-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_copr_test.groovy
@@ -31,12 +31,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tikv-copr-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
@@ -32,12 +32,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
@@ -33,7 +33,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
@@ -34,7 +34,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
@@ -33,12 +33,8 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
@@ -32,12 +32,8 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
@@ -33,7 +33,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
@@ -38,7 +38,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                     cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS, 'tidb-server')) {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
@@ -37,12 +37,8 @@ pipeline {
             }
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                     cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS, 'tidb-server')) {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
@@ -32,12 +32,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
@@ -33,7 +33,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
@@ -31,7 +31,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
@@ -31,7 +31,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_tidb_tools_test.groovy
@@ -33,7 +33,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-tools") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_tidb_tools_test.groovy
@@ -32,12 +32,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-tools") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_mysql_client_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_mysql_client_test.groovy
@@ -27,12 +27,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_mysql_client_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_mysql_client_test.groovy
@@ -28,7 +28,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
@@ -29,7 +29,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'

--- a/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
@@ -28,12 +28,8 @@ pipeline {
             }
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'

--- a/pipelines/pingcap/tidb/release-8.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_sqllogic_test.groovy
@@ -28,7 +28,7 @@ pipeline {
             steps {
                 dir("tidb") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_sqllogic_test.groovy
@@ -27,12 +27,8 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
@@ -25,12 +25,8 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        script {
-                            retry(2) {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true, gitBaseUrl = 'https://github.com')
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
@@ -26,7 +26,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
@@ -25,12 +25,8 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        script {
-                            retry(2) {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true, gitBaseUrl = 'https://github.com')
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
@@ -26,7 +26,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
                     }
                 }
             }


### PR DESCRIPTION
### What changed

Use `prow.checkoutRefsWithCacheLock` for TiDB GCP Jenkins pipeline checkout caches in:

- `pingcap/tidb/latest/pull_integration_e2e_test_next_gen`
- `pingcap/tidb/release-8.5/*` GCP Jenkins jobs

The change keeps the existing checkout parameters, including `withSubmodule = true` where it was already used.

### Why

Some GCP Jenkins jobs can fail while restoring/updating the Jenkins pipeline S3 cache with:

`AmazonS3Exception: A conflicting conditional operation is currently in progress against this resource`

This happens on shared git checkout cache keys when multiple builds access the same cache concurrently. `prow.checkoutRefsWithCacheLock` already wraps the git cache with a Jenkins lock, matching the pattern used by most latest TiDB jobs.
