### PR TITLE
ci(tidb): improve ddlv1 unit test diagnostics

### DIFF
--- a/pipelines/pingcap/tidb/latest/merged_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_unit_test_ddlv1.groovy
@@ -79,7 +79,8 @@ pipeline {
                     """
                     sh '''#! /usr/bin/env bash
                         set -o pipefail
-                        make bazel_coverage_test_ddlargsv1
+
+                        make bazel_coverage_test_ddlargsv1 2>&1 | tee bazel-test.log
                     '''
                 }
             }
@@ -88,7 +89,13 @@ pipeline {
                     dir(REFS.repo) {
                         // archive test report to Jenkins.
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
+                        archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
                     }
+                    sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
+                    script {
+                        prow.sendTestCaseRunReport("${REFS.org}/${REFS.repo}", "${REFS.base_ref}")
+                    }
+                    archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/merged_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_unit_test_ddlv1.groovy
@@ -79,7 +79,6 @@ pipeline {
                     """
                     sh '''#! /usr/bin/env bash
                         set -o pipefail
-
                         make bazel_coverage_test_ddlargsv1 2>&1 | tee bazel-test.log
                     '''
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
@@ -79,8 +79,22 @@ pipeline {
                     """
                     sh '''#! /usr/bin/env bash
                         set -o pipefail
-                        make bazel_coverage_test_ddlargsv1
+
+                        make bazel_coverage_test_ddlargsv1 2>&1 | tee bazel-test.log
                     '''
+                }
+            }
+            post {
+                always {
+                    dir(REFS.repo) {
+                        junit(testResults: "**/bazel.xml", allowEmptyResults: true)
+                        archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
+                    }
+                    sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
+                    script {
+                        prow.sendTestCaseRunReport("${REFS.org}/${REFS.repo}", "${REFS.base_ref}")
+                    }
+                    archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
@@ -79,7 +79,6 @@ pipeline {
                     """
                     sh '''#! /usr/bin/env bash
                         set -o pipefail
-
                         make bazel_coverage_test_ddlargsv1 2>&1 | tee bazel-test.log
                     '''
                 }


### PR DESCRIPTION
### What changed
- Capture `bazel_coverage_test_ddlargsv1` output into `bazel-test.log`.
- Add the same test result archive/report flow used by the regular unit test job:
  - archive Bazel JUnit XML
  - archive `bazel-test.log`
  - run `analyze-go-test-from-bazel-output.sh`
  - send test case run report
  - archive `bazel-*.log` and `bazel-*.json`

### Why
To improve diagnostics when Bazel reports timeout/failure summaries, because the job did not archive and parse test output like the regular unit test job. This change aligns the diagnostics path and removes the workspace size difference.

### Replay Test Passed
- https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/release-8.5/job/pull_unit_test_ddlv1/270/