### PR TITLE
ci(tidb): switch ddlv1 unit test to bazel test

### DIFF
--- a/pipelines/pingcap/tidb/latest/merged_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_unit_test_ddlv1.groovy
@@ -79,7 +79,7 @@ pipeline {
                     """
                     sh '''#! /usr/bin/env bash
                         set -o pipefail
-                        make bazel_coverage_test_ddlargsv1 2>&1 | tee bazel-test.log
+                        ./build/jenkins_unit_test_ddlargsv1.sh 2>&1 | tee bazel-test.log
                     '''
                 }
             }

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
@@ -65,7 +65,7 @@ pipeline {
                     sh '''#! /usr/bin/env bash
                         set -o pipefail
 
-                        make bazel_coverage_test_ddlargsv1 2>&1 | tee bazel-test.log
+                        ./build/jenkins_unit_test_ddlargsv1.sh 2>&1 | tee bazel-test.log
                     '''
                 }
             }


### PR DESCRIPTION
### What changed

- Switch latest ddlv1 unit test jobs from `make bazel_coverage_test_ddlargsv1` to `./build/jenkins_unit_test_ddlargsv1.sh`.

### Why

`build/jenkins_unit_test_ddlargsv1.sh` in TiDB now runs `make bazel_ci_test_ddlargsv1`, which uses `bazel test` instead of `bazel coverage`.

The ddlv1 unit test jobs have been flaky with Bazel test timeouts under coverage mode. Switching to the TiDB-provided ddlargsv1 unit test script aligns the job with the new TiDB-side execution path and avoids coverage instrumentation overhead.

### Repaly Test Passed
- https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/merged_unit_test_ddlv1/191/
- https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_unit_test_ddlv1/1153/
