### PR TITLE
ci(pipelines): add matrixCache to skip successful matrix stages on rerun

### DIFF
--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -149,6 +150,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -150,7 +150,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -149,6 +150,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -150,7 +150,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -136,6 +137,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -137,7 +137,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -133,6 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -134,7 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -136,7 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -135,6 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -138,6 +139,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -139,7 +139,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -106,7 +106,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -140,7 +140,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -106,6 +106,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -139,6 +140,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_check2.groovy
@@ -118,6 +118,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }
@@ -160,6 +161,8 @@ pipeline {
                             success {
                                 dir(REFS.repo) {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_check2.groovy
@@ -118,7 +118,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }
@@ -161,11 +161,11 @@ pipeline {
                             success {
                                 dir(REFS.repo) {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                             }
                         }
                     }

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
@@ -110,7 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 90, unit: 'MINUTES') }
                         steps {
@@ -144,11 +144,11 @@ pipeline {
                                         gocovmerge /tmp/group_cover/cov.* > coverage.txt
                                     """
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.txt')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
@@ -110,6 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 90, unit: 'MINUTES') }
                         steps {
@@ -143,6 +144,8 @@ pipeline {
                                         gocovmerge /tmp/group_cover/cov.* > coverage.txt
                                     """
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.txt')
                                     }
                                 }

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_mysql_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_mysql_test.groovy
@@ -69,7 +69,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./bin", includes: '**/*', key: "binary/pingcap-inc/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
@@ -92,7 +92,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_mysql_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_mysql_test.groovy
@@ -69,6 +69,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./bin", includes: '**/*', key: "binary/pingcap-inc/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
@@ -91,6 +92,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -147,7 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -146,6 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -135,6 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -135,7 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -99,7 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -134,7 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -99,6 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -133,6 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -135,6 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -135,7 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -141,7 +141,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -140,6 +141,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -92,6 +92,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -143,6 +144,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -92,7 +92,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -144,7 +144,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -96,6 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -145,6 +146,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -146,7 +146,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -92,6 +92,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -127,6 +128,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -92,7 +92,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -128,7 +128,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -129,6 +130,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -130,7 +130,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -139,6 +140,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -140,7 +140,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
@@ -75,6 +75,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -98,6 +99,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts artifacts: "tidb-test/mysql_test/mysql-test.out", fingerprint: true, allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
@@ -75,7 +75,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -99,7 +99,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts artifacts: "tidb-test/mysql_test/mysql-test.out", fingerprint: true, allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage('Test') {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, store: env.STORE]) } }
                         steps {
                             dir(REFS.repo) {
                                 // restore the cache saved by previous stage.
@@ -159,7 +159,7 @@ pipeline {
                                 """
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, store: env.STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage('Test') {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 // restore the cache saved by previous stage.
@@ -158,6 +159,7 @@ pipeline {
                                 """
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage('Test') {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 // restore the cache saved by previous stage.
@@ -126,6 +127,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage('Test') {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART, store: env.STORE]) } }
                         steps {
                             dir(REFS.repo) {
                                 // restore the cache saved by previous stage.
@@ -127,7 +127,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART, store: env.STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -93,7 +93,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -110,7 +110,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -93,6 +93,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -109,6 +110,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -92,7 +92,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -111,7 +111,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -92,6 +92,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -110,6 +111,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -90,6 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-mysql-test") {
@@ -104,6 +105,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-mysql-test") {
@@ -105,7 +105,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -90,6 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -108,6 +109,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -109,7 +109,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -87,7 +87,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -120,7 +120,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -87,6 +87,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -119,6 +120,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_mysql_test.groovy
@@ -75,7 +75,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -93,7 +93,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_mysql_test.groovy
@@ -75,6 +75,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -92,6 +93,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap-qe/tidb-test/release-6.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.1/ghpr_integration_mysql_test.groovy
@@ -85,7 +85,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -122,7 +122,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-6.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.1/ghpr_integration_mysql_test.groovy
@@ -85,6 +85,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -121,6 +122,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-6.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.1/ghpr_mysql_test.groovy
@@ -74,6 +74,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -95,6 +96,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-6.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.1/ghpr_mysql_test.groovy
@@ -74,7 +74,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -96,7 +96,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART, cache_enabled: env.CACHE_ENABLED]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -128,7 +128,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART, cache_enabled: env.CACHE_ENABLED]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -127,6 +128,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_mysql_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -100,6 +101,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_mysql_test.groovy
@@ -79,7 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART, cache_enabled: env.CACHE_ENABLED]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -101,7 +101,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART, cache_enabled: env.CACHE_ENABLED]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_common_test.groovy
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -140,7 +140,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_common_test.groovy
@@ -90,6 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -139,6 +140,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -142,6 +143,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -143,7 +143,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test.groovy
@@ -95,6 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -144,6 +145,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -145,7 +145,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -127,7 +127,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -126,6 +127,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test.groovy
@@ -74,7 +74,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -98,7 +98,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts artifacts: "tidb-test/mysql_test/mysql-test.out", fingerprint: true, allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test.groovy
@@ -74,6 +74,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -97,6 +98,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts artifacts: "tidb-test/mysql_test/mysql-test.out", fingerprint: true, allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -140,7 +140,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
@@ -90,6 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -139,6 +140,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -142,6 +143,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -143,7 +143,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
@@ -95,6 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -144,6 +145,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -145,7 +145,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -127,7 +127,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
@@ -126,6 +127,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test.groovy
@@ -74,7 +74,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -98,7 +98,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts artifacts: "tidb-test/mysql_test/mysql-test.out", fingerprint: true, allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test.groovy
@@ -74,6 +74,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
@@ -97,6 +98,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts artifacts: "tidb-test/mysql_test/mysql-test.out", fingerprint: true, allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -149,6 +150,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -150,7 +150,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
@@ -114,7 +114,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -159,7 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
@@ -114,6 +114,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -158,6 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -149,6 +150,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -150,7 +150,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
@@ -114,7 +114,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -159,7 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
@@ -114,6 +114,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -158,6 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -136,6 +137,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -137,7 +137,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
@@ -110,6 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -142,6 +143,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
@@ -110,7 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -143,7 +143,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
@@ -104,6 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -137,6 +138,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
@@ -104,7 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -138,7 +138,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
@@ -104,6 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -137,6 +138,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
@@ -104,7 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -138,7 +138,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -133,6 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -134,7 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
@@ -110,6 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -142,6 +143,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
@@ -110,7 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -143,7 +143,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -134,6 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
@@ -101,7 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -135,7 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -134,6 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
@@ -101,7 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -135,7 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -136,7 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -135,6 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
@@ -113,6 +113,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('ticdc') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -145,6 +146,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
@@ -113,7 +113,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir('ticdc') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -146,7 +146,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -136,7 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -135,6 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
@@ -113,6 +113,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('ticdc') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -145,6 +146,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
@@ -113,7 +113,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir('ticdc') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -146,7 +146,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -138,6 +139,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -139,7 +139,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
@@ -114,6 +114,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -146,6 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
@@ -114,7 +114,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -147,7 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -106,7 +106,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -140,7 +140,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -106,6 +106,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -139,6 +140,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
@@ -114,6 +114,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -146,6 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
@@ -114,7 +114,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -147,7 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
@@ -110,7 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -147,7 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
@@ -110,6 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -146,6 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
@@ -110,7 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -147,7 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
@@ -110,6 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -146,6 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
@@ -104,6 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -128,6 +129,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
@@ -104,7 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -129,7 +129,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -133,7 +133,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -132,6 +133,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -133,7 +133,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -132,6 +133,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
@@ -110,6 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -134,6 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
@@ -110,7 +110,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -135,7 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
@@ -109,7 +109,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -134,7 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
@@ -109,6 +109,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
@@ -133,6 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -111,6 +111,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }
@@ -164,6 +165,8 @@ pipeline {
                             success {
                                 dir(REFS.repo) {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -111,7 +111,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }
@@ -165,11 +165,11 @@ pipeline {
                             success {
                                 dir(REFS.repo) {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -68,7 +68,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
@@ -92,7 +92,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -68,6 +68,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
@@ -91,6 +92,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_common_test.groovy
@@ -93,6 +93,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -112,6 +113,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_common_test.groovy
@@ -93,7 +93,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -113,7 +113,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -120,7 +120,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
@@ -150,7 +150,6 @@ pipeline {
                             success {
                                 dir(REFS.repo) {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         if (env.TEST_GROUP == 'G07' || env.TEST_GROUP == 'G08') {
                                             echo "Temporary hotfix: skip coverage upload for skipped ${env.TEST_GROUP}"
@@ -163,6 +162,7 @@ pipeline {
                                         }
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -120,6 +120,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
@@ -149,6 +150,8 @@ pipeline {
                             success {
                                 dir(REFS.repo) {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         if (env.TEST_GROUP == 'G07' || env.TEST_GROUP == 'G08') {
                                             echo "Temporary hotfix: skip coverage upload for skipped ${env.TEST_GROUP}"
                                         } else {

--- a/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -126,7 +126,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -125,6 +126,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -95,6 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -136,6 +137,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -137,7 +137,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
@@ -113,7 +113,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/lightning-tests") {
@@ -134,7 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
@@ -113,6 +113,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/lightning-tests") {
@@ -133,6 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -92,7 +92,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -121,7 +121,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -92,6 +92,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -120,6 +121,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
@@ -81,6 +81,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -109,6 +110,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
@@ -81,7 +81,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -110,7 +110,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -213,6 +214,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -214,7 +214,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
@@ -86,7 +86,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'merged-sqllogic-test')) {
@@ -146,7 +146,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -175,7 +175,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'merged-sqllogic-test')) {
@@ -235,7 +235,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
@@ -86,6 +86,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'merged-sqllogic-test')) {
@@ -145,6 +146,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -173,6 +175,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'merged-sqllogic-test')) {
@@ -232,6 +235,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
@@ -102,7 +102,6 @@ pipeline {
                 }
                 stages {
                     stage('Restore cache') {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("tidb") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
@@ -140,10 +139,9 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_script: env.TEST_SCRIPT]) } }
                         steps {
                             dir('tidb') {
                                 sh label: "TEST_SCRIPT ${TEST_SCRIPT}", script: """#!/usr/bin/env bash
@@ -168,7 +166,7 @@ pipeline {
                                     archiveArtifacts artifacts: 'tidb/tests/clusterintegrationtest/logs', fingerprint: true
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_script: env.TEST_SCRIPT]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage('Restore cache') {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("tidb") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
@@ -139,8 +140,10 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 sh label: "TEST_SCRIPT ${TEST_SCRIPT}", script: """#!/usr/bin/env bash
@@ -165,6 +168,7 @@ pipeline {
                                     archiveArtifacts artifacts: 'tidb/tests/clusterintegrationtest/logs', fingerprint: true
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -107,7 +107,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
@@ -134,9 +134,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true, allowEmptyArchive: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir(REFS.repo) {
                                     sh label: "upload coverage", script: """
@@ -145,6 +142,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -107,6 +107,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
@@ -133,6 +134,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true, allowEmptyArchive: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir(REFS.repo) {
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
@@ -90,6 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
@@ -112,6 +113,8 @@ pipeline {
                                 dir(REFS.repo) {
                                     sh 'ls -alh /tmp/group_cover && gocovmerge /tmp/group_cover/cov.* > coverage.txt'
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.txt')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
@@ -113,11 +113,11 @@ pipeline {
                                 dir(REFS.repo) {
                                     sh 'ls -alh /tmp/group_cover && gocovmerge /tmp/group_cover/cov.* > coverage.txt'
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.txt')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/latest/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_common_test.groovy
@@ -81,7 +81,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -98,7 +98,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_common_test.groovy
@@ -81,6 +81,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -97,6 +98,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -122,6 +123,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -123,7 +123,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
@@ -101,7 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -142,6 +143,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -143,7 +143,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
@@ -99,6 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -127,6 +128,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
@@ -99,7 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -128,7 +128,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -124,7 +124,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
@@ -96,6 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -123,6 +124,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
@@ -99,6 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -127,6 +128,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
@@ -99,7 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -128,7 +128,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -146,6 +146,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment {
                             MINIO_BIN_PATH = "bin/minio"
                         }
@@ -205,6 +206,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -146,7 +146,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment {
                             MINIO_BIN_PATH = "bin/minio"
                         }
@@ -206,7 +206,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
@@ -94,6 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
@@ -119,6 +120,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir(REFS.repo) {
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
@@ -94,7 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
@@ -120,9 +120,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir(REFS.repo) {
                                     sh label: "upload coverage", script: """
@@ -131,6 +128,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage('Test') {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART, store: env.STORE]) } }
                         steps {
                             dir('tidb-test') {
                                 // restore the cache saved by previous stage.
@@ -132,7 +132,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART, store: env.STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage('Test') {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 // restore the cache saved by previous stage.
@@ -131,6 +132,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_sqllogic_test.groovy
@@ -86,7 +86,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -115,7 +115,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -144,7 +144,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -173,7 +173,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_sqllogic_test.groovy
@@ -86,6 +86,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -114,6 +115,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -142,6 +144,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
@@ -170,6 +173,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
@@ -101,7 +101,6 @@ pipeline {
                 }
                 stages {
                     stage('Restore cache') {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("tidb") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
@@ -139,10 +138,9 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_script: env.TEST_SCRIPT]) } }
                         steps {
                             dir('tidb') {
                                 sh label: "TEST_SCRIPT ${TEST_SCRIPT}", script: """#!/usr/bin/env bash
@@ -167,7 +165,7 @@ pipeline {
                                     archiveArtifacts artifacts: 'tidb/tests/clusterintegrationtest/logs', fingerprint: true
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_script: env.TEST_SCRIPT]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage('Restore cache') {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("tidb") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
@@ -138,8 +139,10 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 sh label: "TEST_SCRIPT ${TEST_SCRIPT}", script: """#!/usr/bin/env bash
@@ -164,6 +167,7 @@ pipeline {
                                     archiveArtifacts artifacts: 'tidb/tests/clusterintegrationtest/logs', fingerprint: true
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
@@ -86,7 +86,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -104,7 +104,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
@@ -86,6 +86,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,6 +104,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/periodics_br_integration_test.groovy
@@ -87,6 +87,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
@@ -110,6 +111,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/periodics_br_integration_test.groovy
@@ -87,7 +87,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
@@ -111,7 +111,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_br_integration_test.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -116,6 +117,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_br_integration_test.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -117,7 +117,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_common_test.groovy
@@ -85,7 +85,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -103,7 +103,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_common_test.groovy
@@ -85,6 +85,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -102,6 +103,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_common_test.groovy
@@ -104,7 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -140,7 +140,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_common_test.groovy
@@ -104,6 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -139,6 +140,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_ddl_test.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,6 +134,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_ddl_test.groovy
@@ -101,7 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -134,7 +134,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_mysql_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_mysql_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.1/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_sqllogic_test.groovy
@@ -90,6 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -119,6 +120,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -146,6 +148,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -175,6 +178,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.1/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_sqllogic_test.groovy
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -120,7 +120,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -148,7 +148,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -178,7 +178,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -87,6 +87,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -104,6 +105,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -87,7 +87,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -105,7 +105,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -80,6 +80,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,6 +104,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -80,7 +80,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -104,7 +104,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -92,7 +92,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -110,7 +110,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -92,6 +92,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -109,6 +110,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
@@ -79,7 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,7 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,6 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
@@ -92,7 +92,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -110,7 +110,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
@@ -92,6 +92,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -109,6 +110,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
@@ -79,7 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,7 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,6 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_check2.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -114,7 +114,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_check2.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -113,6 +114,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_mysql_test.groovy
@@ -78,6 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -101,6 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_mysql_test.groovy
@@ -78,7 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,7 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -134,6 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -135,7 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_common_test.groovy
@@ -84,6 +84,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -101,6 +102,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_common_test.groovy
@@ -84,7 +84,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -102,7 +102,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_common_test.groovy
@@ -109,6 +109,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -144,6 +145,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_common_test.groovy
@@ -109,7 +109,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -145,7 +145,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_ddl_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_ddl_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_jdbc_test.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -146,6 +147,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_jdbc_test.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -147,7 +147,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_mysql_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,7 +132,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_mysql_test.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -131,6 +132,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_sqllogic_test.groovy
@@ -89,6 +89,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -118,6 +119,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -145,6 +147,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -174,6 +177,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_sqllogic_test.groovy
@@ -89,7 +89,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -119,7 +119,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -147,7 +147,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -177,7 +177,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5-fips/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/ghpr_check2.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -115,7 +115,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-fips/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/ghpr_check2.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -114,6 +115,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-fips/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/ghpr_mysql_test.groovy
@@ -80,7 +80,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -106,7 +106,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-fips/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/ghpr_mysql_test.groovy
@@ -80,6 +80,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -105,6 +106,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -133,6 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -134,7 +134,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_check2.groovy
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -113,7 +113,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_check2.groovy
@@ -90,6 +90,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -112,6 +113,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_mysql_test.groovy
@@ -77,7 +77,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -101,7 +101,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_mysql_test.groovy
@@ -77,6 +77,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -100,6 +101,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -113,6 +114,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -114,7 +114,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
@@ -79,7 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,7 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,6 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/periodics_br_integration_test.groovy
@@ -87,6 +87,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
@@ -110,6 +111,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/periodics_br_integration_test.groovy
@@ -87,7 +87,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
@@ -111,7 +111,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_br_integration_test.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -116,6 +117,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_br_integration_test.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -117,7 +117,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_common_test.groovy
@@ -84,6 +84,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -101,6 +102,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_common_test.groovy
@@ -84,7 +84,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -102,7 +102,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -139,7 +139,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -138,6 +139,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -146,6 +147,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -147,7 +147,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,7 +132,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -131,6 +132,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_sqllogic_test.groovy
@@ -89,6 +89,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -118,6 +119,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -145,6 +147,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -174,6 +177,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_sqllogic_test.groovy
@@ -89,7 +89,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -119,7 +119,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -147,7 +147,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -177,7 +177,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
@@ -90,6 +90,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -107,6 +108,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -108,7 +108,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
@@ -77,7 +77,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -101,7 +101,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
@@ -77,6 +77,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -100,6 +101,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
@@ -90,6 +90,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -107,6 +108,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -108,7 +108,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.0/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.0/ghpr_mysql_test.groovy
@@ -77,7 +77,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -101,7 +101,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.0/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.0/ghpr_mysql_test.groovy
@@ -77,6 +77,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -100,6 +101,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
@@ -91,6 +91,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -113,6 +114,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
@@ -91,7 +91,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -114,7 +114,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_mysql_test.groovy
@@ -78,6 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -101,6 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_mysql_test.groovy
@@ -78,7 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,7 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/periodics_br_integration_test.groovy
@@ -87,6 +87,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
@@ -110,6 +111,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/periodics_br_integration_test.groovy
@@ -87,7 +87,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
@@ -111,7 +111,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
@@ -90,6 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -115,6 +116,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -116,7 +116,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_common_test.groovy
@@ -84,6 +84,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -101,6 +102,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_common_test.groovy
@@ -84,7 +84,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -102,7 +102,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -139,7 +139,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -138,6 +139,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -146,6 +147,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -147,7 +147,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,7 +132,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -131,6 +132,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-7.1/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_sqllogic_test.groovy
@@ -89,6 +89,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -118,6 +119,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -145,6 +147,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -174,6 +177,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-7.1/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_sqllogic_test.groovy
@@ -89,7 +89,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -119,7 +119,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -147,7 +147,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -177,7 +177,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
@@ -93,7 +93,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -111,7 +111,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
@@ -93,6 +93,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -110,6 +111,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_mysql_test.groovy
@@ -78,6 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -101,6 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_mysql_test.groovy
@@ -78,7 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,7 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
@@ -93,7 +93,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -111,7 +111,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
@@ -93,6 +93,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -110,6 +111,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_mysql_test.groovy
@@ -78,6 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -101,6 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_mysql_test.groovy
@@ -78,7 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,7 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
@@ -113,7 +113,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -136,7 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
@@ -113,6 +113,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -135,6 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
@@ -95,6 +95,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 60, unit: 'MINUTES') }
                         steps {
@@ -124,6 +125,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, integration-test.out', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 60, unit: 'MINUTES') }
                         steps {
@@ -125,7 +125,7 @@ pipeline {
                                     archiveArtifacts(artifacts: 'pd*.log, tikv*.log, integration-test.out', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_mysql_test.groovy
@@ -78,6 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -101,6 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_mysql_test.groovy
@@ -78,7 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,7 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
@@ -109,6 +109,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -132,6 +133,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
@@ -109,7 +109,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -133,7 +133,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -96,6 +96,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 60, unit: 'MINUTES') }
                         steps {
@@ -134,6 +135,7 @@ pipeline {
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 60, unit: 'MINUTES') }
                         steps {
@@ -135,7 +135,7 @@ pipeline {
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_mysql_test.groovy
@@ -79,7 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,7 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_mysql_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,6 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/periodics_br_integration_test.groovy
@@ -124,6 +124,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
@@ -144,6 +145,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/periodics_br_integration_test.groovy
@@ -124,7 +124,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
@@ -145,7 +145,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -127,6 +127,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -148,6 +149,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -127,7 +127,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -149,7 +149,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_common_test.groovy
@@ -84,6 +84,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -101,6 +102,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_common_test.groovy
@@ -84,7 +84,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -102,7 +102,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -139,7 +139,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -138,6 +139,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -146,6 +147,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -147,7 +147,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,7 +132,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -131,6 +132,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -126,6 +127,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -127,7 +127,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_sqllogic_test.groovy
@@ -89,6 +89,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -118,6 +119,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -145,6 +147,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -174,6 +177,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-7.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_sqllogic_test.groovy
@@ -89,7 +89,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -119,7 +119,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -147,7 +147,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -177,7 +177,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
@@ -99,6 +99,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -137,6 +138,7 @@ pipeline {
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
@@ -99,7 +99,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -138,7 +138,7 @@ pipeline {
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.6/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_mysql_test.groovy
@@ -78,6 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -101,6 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.6/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_mysql_test.groovy
@@ -78,7 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,7 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -129,6 +130,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -130,7 +130,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -121,9 +121,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir(REFS.repo) {
                                     sh label: "upload coverage", script: """
@@ -132,6 +129,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
@@ -96,6 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -120,6 +121,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir(REFS.repo) {
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-8.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/ghpr_check2.groovy
@@ -99,6 +99,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -137,6 +138,7 @@ pipeline {
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/ghpr_check2.groovy
@@ -99,7 +99,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -138,7 +138,7 @@ pipeline {
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.0/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/ghpr_mysql_test.groovy
@@ -78,6 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -101,6 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.0/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/ghpr_mysql_test.groovy
@@ -78,7 +78,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,7 +102,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -129,6 +130,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -130,7 +130,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -121,9 +121,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir(REFS.repo) {
                                     sh label: "upload coverage", script: """
@@ -132,6 +129,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
@@ -96,6 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -120,6 +121,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir(REFS.repo) {
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_check2.groovy
@@ -101,7 +101,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -140,7 +140,7 @@ pipeline {
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_check2.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -139,6 +140,7 @@ pipeline {
                                     archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_mysql_test.groovy
@@ -79,7 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,7 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_mysql_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,6 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/periodics_br_integration_test.groovy
@@ -122,6 +122,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
@@ -141,6 +142,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/periodics_br_integration_test.groovy
@@ -122,7 +122,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
@@ -142,7 +142,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -129,6 +130,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -130,7 +130,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_common_test.groovy
@@ -84,6 +84,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -101,6 +102,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_common_test.groovy
@@ -84,7 +84,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -102,7 +102,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -139,7 +139,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -138,6 +139,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -146,6 +147,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -147,7 +147,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,7 +132,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -131,6 +132,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -127,7 +127,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -126,6 +127,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,6 +134,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -134,7 +134,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -121,9 +121,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir(REFS.repo) {
                                     sh label: "upload coverage", script: """
@@ -132,6 +129,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
@@ -96,6 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -120,6 +121,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir(REFS.repo) {
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-8.1/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_sqllogic_test.groovy
@@ -89,6 +89,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -118,6 +119,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -145,6 +147,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -174,6 +177,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.1/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_sqllogic_test.groovy
@@ -89,7 +89,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -119,7 +119,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -147,7 +147,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -177,7 +177,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.2/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_check2.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -144,11 +144,11 @@ pipeline {
                             success {
                                 dir("tidb") {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.2/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_check2.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -143,6 +144,8 @@ pipeline {
                             success {
                                 dir("tidb") {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_common_test.groovy
@@ -83,7 +83,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -101,7 +101,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_common_test.groovy
@@ -83,6 +83,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -100,6 +101,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
@@ -125,6 +125,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -147,6 +148,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
@@ -125,7 +125,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -148,9 +148,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
@@ -159,6 +156,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -144,7 +144,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -143,6 +144,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
@@ -104,6 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -145,6 +146,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
@@ -104,7 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -146,7 +146,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
@@ -120,6 +120,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -142,6 +143,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
@@ -120,7 +120,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -143,9 +143,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
@@ -154,6 +151,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
@@ -101,7 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -131,7 +131,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -130,6 +131,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -124,7 +124,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
@@ -95,6 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -123,6 +124,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
@@ -99,7 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -130,7 +130,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
@@ -99,6 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -129,6 +130,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_mysql_test.groovy
@@ -79,7 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,7 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_mysql_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,6 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.2/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_sqllogic_test.groovy
@@ -88,6 +88,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -117,6 +118,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -144,6 +146,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -173,6 +176,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.2/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_sqllogic_test.groovy
@@ -88,7 +88,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -118,7 +118,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -146,7 +146,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -176,7 +176,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.3/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_check2.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -144,11 +144,11 @@ pipeline {
                             success {
                                 dir("tidb") {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.3/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_check2.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -143,6 +144,8 @@ pipeline {
                             success {
                                 dir("tidb") {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_common_test.groovy
@@ -83,7 +83,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -101,7 +101,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_common_test.groovy
@@ -83,6 +83,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -100,6 +101,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
@@ -125,6 +125,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -147,6 +148,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
@@ -125,7 +125,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -148,9 +148,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
@@ -159,6 +156,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -144,7 +144,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -143,6 +144,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
@@ -104,6 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -145,6 +146,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
@@ -104,7 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -146,7 +146,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
@@ -120,6 +120,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -142,6 +143,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
@@ -120,7 +120,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -143,9 +143,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
@@ -154,6 +151,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
@@ -101,7 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -131,7 +131,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -130,6 +131,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -124,7 +124,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
@@ -95,6 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -123,6 +124,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
@@ -99,7 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -130,7 +130,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
@@ -99,6 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -129,6 +130,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_mysql_test.groovy
@@ -79,7 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,7 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_mysql_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,6 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.3/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_sqllogic_test.groovy
@@ -88,6 +88,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -117,6 +118,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -144,6 +146,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -173,6 +176,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.3/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_sqllogic_test.groovy
@@ -88,7 +88,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -118,7 +118,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -146,7 +146,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -176,7 +176,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.4/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_check2.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -144,11 +144,11 @@ pipeline {
                             success {
                                 dir("tidb") {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.4/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_check2.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -143,6 +144,8 @@ pipeline {
                             success {
                                 dir("tidb") {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_common_test.groovy
@@ -83,7 +83,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -101,7 +101,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_common_test.groovy
@@ -83,6 +83,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -100,6 +101,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
@@ -125,6 +125,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -147,6 +148,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
@@ -125,7 +125,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -148,9 +148,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
@@ -159,6 +156,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -144,7 +144,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -143,6 +144,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
@@ -104,6 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -145,6 +146,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
@@ -104,7 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -146,7 +146,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
@@ -120,6 +120,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -142,6 +143,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
@@ -120,7 +120,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -143,9 +143,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
@@ -154,6 +151,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
@@ -101,7 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -131,7 +131,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -130,6 +131,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -124,7 +124,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
@@ -95,6 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -123,6 +124,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
@@ -99,7 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -130,7 +130,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
@@ -99,6 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -129,6 +130,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_mysql_test.groovy
@@ -79,7 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,7 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_mysql_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,6 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.4/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_sqllogic_test.groovy
@@ -88,6 +88,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -117,6 +118,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -144,6 +146,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -173,6 +176,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.4/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_sqllogic_test.groovy
@@ -88,7 +88,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -118,7 +118,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -146,7 +146,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -176,7 +176,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
@@ -121,7 +121,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }
@@ -183,11 +183,11 @@ pipeline {
                             success {
                                 dir(REFS.repo) {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
@@ -121,6 +121,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }
@@ -182,6 +183,8 @@ pipeline {
                             success {
                                 dir(REFS.repo) {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_common_test.groovy
@@ -82,6 +82,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -99,6 +100,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_common_test.groovy
@@ -82,7 +82,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -100,7 +100,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -105,6 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 90, unit: 'MINUTES') }
                         steps {
@@ -134,6 +135,8 @@ pipeline {
                                         gocovmerge /tmp/group_cover/cov.* > coverage.txt
                                     """
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.txt')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -105,7 +105,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 90, unit: 'MINUTES') }
                         steps {
@@ -135,11 +135,11 @@ pipeline {
                                         gocovmerge /tmp/group_cover/cov.* > coverage.txt
                                     """
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.txt')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
@@ -101,7 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -137,7 +137,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -136,6 +137,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -125,7 +125,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -124,6 +125,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -145,7 +145,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -144,6 +145,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
@@ -95,6 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -127,6 +128,8 @@ pipeline {
                                         gocovmerge /tmp/group_cover/cov.* > coverage.txt
                                     """
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.txt')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -128,11 +128,11 @@ pipeline {
                                         gocovmerge /tmp/group_cover/cov.* > coverage.txt
                                     """
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.txt')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -129,6 +130,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -130,7 +130,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -125,7 +125,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
@@ -96,6 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -124,6 +125,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -131,7 +131,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -130,6 +131,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
@@ -68,6 +68,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -92,6 +93,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
@@ -68,7 +68,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
@@ -93,7 +93,7 @@ pipeline {
                             unsuccessful {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_sqllogic_test.groovy
@@ -87,6 +87,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -116,6 +117,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -144,6 +146,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -173,6 +176,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-8.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_sqllogic_test.groovy
@@ -87,7 +87,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -117,7 +117,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -146,7 +146,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -176,7 +176,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_check2.groovy
@@ -102,7 +102,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -144,11 +144,11 @@ pipeline {
                             success {
                                 dir("tidb") {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_check2.groovy
@@ -102,6 +102,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         steps {
@@ -143,6 +144,8 @@ pipeline {
                             success {
                                 dir("tidb") {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_common_test.groovy
@@ -83,7 +83,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -101,7 +101,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_common_test.groovy
@@ -83,6 +83,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -100,6 +101,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
@@ -125,6 +125,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -147,6 +148,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
@@ -125,7 +125,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -148,9 +148,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
@@ -159,6 +156,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
@@ -108,7 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -144,7 +144,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
@@ -108,6 +108,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -143,6 +144,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [ddl_test: env.DDL_TEST]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
@@ -106,7 +106,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -148,7 +148,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
@@ -106,6 +106,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -147,6 +148,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
@@ -120,6 +120,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -142,6 +143,10 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
+                                script {
+                                    matrixCache.markDone(REFS, env.STAGE_NAME)
+                                }
+
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
                                         ls -alh /tmp/group_cover

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
@@ -120,7 +120,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
@@ -143,9 +143,6 @@ pipeline {
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
                             success {
-                                script {
-                                    matrixCache.markDone(REFS, env.STAGE_NAME)
-                                }
 
                                 dir('tidb'){
                                     sh label: "upload coverage", script: """
@@ -154,6 +151,7 @@ pipeline {
                                         codecov --rootDir . --flags integration --file coverage.txt --branch origin/pr/${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --pr ${REFS.pulls[0].number} || true
                                     """
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) }
                             }
                         }
                     }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,6 +133,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -133,7 +133,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_part: env.TEST_PART, test_store: env.TEST_STORE]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -125,6 +126,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -126,7 +126,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_dir: env.TEST_DIR]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
@@ -101,7 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -132,7 +132,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_params: env.TEST_PARAMS, test_store: env.TEST_STORE]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
@@ -101,6 +101,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -131,6 +132,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_mysql_test.groovy
@@ -79,7 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -103,7 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_mysql_test.groovy
@@ -79,6 +79,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
@@ -102,6 +103,7 @@ pipeline {
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_sqllogic_test.groovy
@@ -88,6 +88,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -117,6 +118,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -144,6 +146,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -173,6 +176,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_sqllogic_test.groovy
@@ -88,7 +88,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -118,7 +118,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -146,7 +146,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -176,7 +176,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [cache_enabled: env.CACHE_ENABLED, test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -413,7 +413,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('ng-binary', REFS, 'it-build')){
@@ -463,7 +463,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -413,6 +413,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('ng-binary', REFS, 'it-build')){
@@ -462,6 +463,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -408,7 +408,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
@@ -454,7 +454,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -408,6 +408,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
@@ -453,6 +454,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-6.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.1/pull_integration_test.groovy
@@ -339,6 +339,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -383,6 +384,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-6.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.1/pull_integration_test.groovy
@@ -339,7 +339,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -384,7 +384,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -339,6 +339,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -383,6 +384,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -339,7 +339,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -384,7 +384,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
@@ -339,6 +339,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -383,6 +384,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
@@ -339,7 +339,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -384,7 +384,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -382,7 +382,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'it-build')) {
@@ -430,7 +430,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -382,6 +382,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('tiflash', REFS, 'it-build')) {
@@ -429,6 +430,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
@@ -343,6 +343,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -385,6 +386,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
@@ -343,7 +343,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -386,7 +386,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-8.2/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.2/pull_integration_test.groovy
@@ -334,6 +334,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -369,6 +370,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-8.2/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.2/pull_integration_test.groovy
@@ -334,7 +334,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -370,7 +370,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-8.3/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.3/pull_integration_test.groovy
@@ -334,6 +334,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -369,6 +370,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-8.3/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.3/pull_integration_test.groovy
@@ -334,7 +334,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -370,7 +370,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-8.4/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.4/pull_integration_test.groovy
@@ -334,6 +334,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -369,6 +370,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-8.4/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.4/pull_integration_test.groovy
@@ -334,7 +334,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: "ws/pull-tiflash-integration-tests/${BUILD_TAG}") {
@@ -370,7 +370,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -371,7 +371,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
@@ -417,7 +417,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -371,6 +371,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
@@ -416,6 +417,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
@@ -371,6 +371,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
@@ -417,6 +418,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
@@ -371,7 +371,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         steps {
                             dir("${WORKSPACE}/tiflash") {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
@@ -418,7 +418,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_path: env.TEST_PATH]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -35,7 +35,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
@@ -55,7 +55,6 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
@@ -67,6 +66,7 @@ pipeline {
                                         }
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
                             }
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)

--- a/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -35,6 +35,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
@@ -54,6 +55,8 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
                                             engine_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/engine_test/cov.unit_test.out"]

--- a/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
@@ -34,7 +34,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
@@ -54,7 +54,6 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
@@ -67,6 +66,7 @@ pipeline {
                                         }
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
                             }
                             always {
                                 dir('tiflow') {

--- a/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
@@ -34,6 +34,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
@@ -53,6 +54,8 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
                                             unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/tidb_cdc_test/cov.unit.out"],

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -143,7 +143,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -96,6 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -142,6 +143,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -130,7 +130,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -95,6 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -129,6 +130,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -131,7 +131,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -131,6 +131,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -131,7 +131,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
@@ -131,6 +131,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
                             DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
@@ -183,6 +184,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
                             DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
@@ -184,7 +184,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -141,7 +141,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
                             DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
@@ -193,7 +193,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -141,6 +141,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
                             DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
@@ -192,6 +193,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy
@@ -56,7 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy
@@ -56,6 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
@@ -134,7 +134,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -174,7 +174,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
@@ -134,6 +134,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -173,6 +174,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -160,6 +161,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -161,7 +161,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_integration_test.groovy
@@ -157,7 +157,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -218,7 +218,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_integration_test.groovy
@@ -157,6 +157,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -217,6 +218,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
@@ -55,6 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
@@ -55,7 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/ghpr_verify.groovy
@@ -55,6 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -72,6 +73,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/ghpr_verify.groovy
@@ -55,7 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,7 +73,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_kafka_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -139,6 +140,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_kafka_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -140,7 +140,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 60, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -128,7 +128,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 60, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -127,6 +128,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_integration_test.groovy
@@ -136,7 +136,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -197,7 +197,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_integration_test.groovy
@@ -136,6 +136,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -196,6 +197,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
@@ -55,6 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
@@ -55,7 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -139,6 +140,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -140,7 +140,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
@@ -100,6 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -127,6 +128,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -128,7 +128,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
@@ -136,7 +136,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -197,7 +197,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
@@ -136,6 +136,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -196,6 +197,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
@@ -55,6 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -72,6 +73,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
@@ -55,7 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,7 +73,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
@@ -134,7 +134,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -174,7 +174,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
@@ -134,6 +134,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -173,6 +174,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
@@ -134,6 +134,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 60, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -161,6 +162,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
@@ -134,7 +134,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 60, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -162,7 +162,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
@@ -157,7 +157,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -218,7 +218,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
@@ -157,6 +157,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -217,6 +218,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,7 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -157,6 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
@@ -56,7 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
@@ -56,6 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -170,6 +171,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -171,7 +171,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,6 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -159,7 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 60, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -159,7 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 60, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,6 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
@@ -155,7 +155,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -209,7 +209,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
@@ -155,6 +155,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -208,6 +209,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
@@ -56,7 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -75,7 +75,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
@@ -56,6 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,6 +75,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -135,6 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -136,7 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -187,7 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -186,6 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
@@ -56,7 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -75,7 +75,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
@@ -56,6 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,6 +75,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -135,6 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -136,7 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -187,7 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -186,6 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
@@ -55,6 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
@@ -55,7 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -134,6 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -135,7 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,7 +123,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -122,6 +123,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -128,6 +129,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -129,7 +129,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -186,7 +186,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -185,6 +186,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
@@ -55,6 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -72,6 +73,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
@@ -55,7 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,7 +73,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -170,7 +170,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -169,6 +170,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,7 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -157,6 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -163,6 +164,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -164,7 +164,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,6 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -159,7 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
@@ -154,6 +154,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -207,6 +208,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
@@ -154,7 +154,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -208,7 +208,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
@@ -55,6 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
@@ -55,7 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -134,6 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -135,7 +135,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,7 +123,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -122,6 +123,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -128,6 +129,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -129,7 +129,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -186,7 +186,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -185,6 +186,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
@@ -56,7 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,6 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
@@ -87,6 +86,7 @@ pipeline {
                                         }
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
                             }
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)

--- a/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
@@ -56,6 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,8 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
                                             unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/tidb_cdc_test/cov.unit.out"],

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -135,6 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -136,7 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -119,7 +119,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -118,6 +119,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -187,7 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -186,6 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
@@ -56,7 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,6 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
@@ -87,6 +86,7 @@ pipeline {
                                         }
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
                             }
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)

--- a/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
@@ -56,6 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,8 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
                                             unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/tidb_cdc_test/cov.unit.out"],

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -170,6 +171,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -171,7 +171,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,6 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -159,7 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -153,6 +154,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -154,7 +154,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,6 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -159,7 +159,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
@@ -155,6 +155,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -208,6 +209,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
@@ -155,7 +155,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -209,7 +209,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
@@ -56,7 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,6 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
@@ -87,6 +86,7 @@ pipeline {
                                         }
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
                             }
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)

--- a/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
@@ -56,6 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,8 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
                                             unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/tidb_cdc_test/cov.unit.out"],

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -135,6 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -136,7 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -119,7 +119,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -118,6 +119,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -187,7 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -186,6 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
@@ -56,7 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,6 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
@@ -87,6 +86,7 @@ pipeline {
                                         }
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
                             }
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)

--- a/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
@@ -56,6 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,8 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
                                             unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/tidb_cdc_test/cov.unit.out"],

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -135,6 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -136,7 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -119,7 +119,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -118,6 +119,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -187,7 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -186,6 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
@@ -56,7 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,6 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
@@ -87,6 +86,7 @@ pipeline {
                                         }
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
                             }
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)

--- a/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
@@ -56,6 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,8 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
                                             unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/tidb_cdc_test/cov.unit.out"],

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -135,6 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -136,7 +136,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -119,7 +119,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -118,6 +119,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
@@ -133,7 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -187,7 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
@@ -133,6 +133,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -186,6 +187,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
@@ -55,6 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -72,6 +73,8 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
                                             engine_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/engine_test/cov.unit_test.out"]

--- a/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
@@ -55,7 +55,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,7 +73,6 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
@@ -85,6 +84,7 @@ pipeline {
                                         }
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
                             }
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -170,7 +170,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -169,6 +170,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,7 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -157,6 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -131,7 +131,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -153,7 +153,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -131,6 +131,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -152,6 +153,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,7 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -157,6 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -155,6 +155,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -208,6 +209,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -155,7 +155,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -209,7 +209,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -170,7 +170,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -169,6 +170,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,7 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -157,6 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -131,7 +131,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -153,7 +153,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -131,6 +131,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tiflow') {
@@ -152,6 +153,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -132,7 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -158,7 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -132,6 +132,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -157,6 +158,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -155,6 +155,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -208,6 +209,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -155,7 +155,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 50, unit: 'MINUTES') }
                         environment {
                             DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -209,7 +209,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
@@ -56,7 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -74,7 +74,6 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
-                                        matrixCache.markDone(REFS, env.STAGE_NAME)
 
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
@@ -87,6 +86,7 @@ pipeline {
                                         }
                                     }
                                 }
+                                script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
                             }
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
@@ -56,6 +56,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
@@ -73,6 +74,8 @@ pipeline {
                             success {
                                 dir('tiflow') {
                                     script {
+                                        matrixCache.markDone(REFS, env.STAGE_NAME)
+
                                         def testConfigs = [
                                             dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
                                             unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/tidb_cdc_test/cov.unit.out"],

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -113,6 +114,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -114,7 +114,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
@@ -96,6 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-jdbc-test") {
@@ -114,6 +115,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-jdbc-test") {
@@ -115,7 +115,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
@@ -94,7 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -112,7 +112,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
@@ -94,6 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -111,6 +112,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
@@ -94,7 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -112,7 +112,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
@@ -94,6 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -111,6 +112,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
@@ -94,6 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -112,6 +113,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
@@ -94,7 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -113,7 +113,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
@@ -94,7 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -112,7 +112,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
@@ -94,6 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -111,6 +112,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
@@ -94,7 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -105,7 +105,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
@@ -94,6 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -104,6 +105,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
@@ -98,6 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -114,6 +115,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -137,6 +139,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -153,6 +156,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -115,7 +115,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -139,7 +139,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -156,7 +156,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
@@ -97,6 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -113,6 +114,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -114,7 +114,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
@@ -96,6 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -114,6 +115,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -115,7 +115,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
@@ -95,7 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -113,7 +113,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
@@ -95,6 +95,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -112,6 +113,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
@@ -94,7 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -112,7 +112,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
@@ -94,6 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -111,6 +112,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
@@ -94,6 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -112,6 +113,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
@@ -94,7 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -113,7 +113,7 @@ pipeline {
                                     println "Test failed, archive the log"
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmds: env.TEST_CMDS]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
@@ -94,7 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -109,7 +109,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
@@ -94,6 +94,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -108,6 +109,7 @@ pipeline {
                             always {
                                 junit(testResults: "**/result.xml")
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
@@ -99,7 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -116,7 +116,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }
@@ -140,7 +140,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -157,7 +157,7 @@ pipeline {
                                 }
                             }
                         }
-                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
+                        post { success { script { matrixCache.markDone(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } } }
                     }
                 }
             }

--- a/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
@@ -99,6 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -115,6 +116,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }
@@ -138,6 +140,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
@@ -154,6 +157,7 @@ pipeline {
                                 }
                             }
                         }
+                        post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
                     }
                 }
             }

--- a/pipelines/qa/qa-release-br-integration-test.groovy
+++ b/pipelines/qa/qa-release-br-integration-test.groovy
@@ -104,6 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-tests") {
@@ -123,6 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/qa/qa-release-br-integration-test.groovy
+++ b/pipelines/qa/qa-release-br-integration-test.groovy
@@ -104,7 +104,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-tests") {
@@ -124,7 +124,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/qa/qa-release-lightning-integration-test.groovy
+++ b/pipelines/qa/qa-release-lightning-integration-test.groovy
@@ -99,6 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/lightning-test") {
@@ -118,6 +119,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/qa/qa-release-lightning-integration-test.groovy
+++ b/pipelines/qa/qa-release-lightning-integration-test.groovy
@@ -99,7 +99,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir('tidb') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/lightning-test") {
@@ -119,7 +119,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/ti-community-infra/test-prod/prow_debug.groovy
+++ b/pipelines/ti-community-infra/test-prod/prow_debug.groovy
@@ -34,11 +34,7 @@ pipeline {
                 }
                 stages {
                     stage('Test Cache Able') {
-                        when {
-                            expression {
-                                return !matrixCache.shouldSkip(REFS, env.STAGE_NAME)
-                            }
-                        }
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             echo "STAGE_NAME=${env.STAGE_NAME}"
                             echo "matrixCache debug axis=${env.AXIS_OS}/${env.AXIS_ARCH}"

--- a/pipelines/ti-community-infra/test-prod/prow_debug.groovy
+++ b/pipelines/ti-community-infra/test-prod/prow_debug.groovy
@@ -34,14 +34,14 @@ pipeline {
                 }
                 stages {
                     stage('Test Cache Able') {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test Cache Able', [axis_os: env.AXIS_OS, axis_arch: env.AXIS_ARCH]) } }
                         steps {
                             echo "STAGE_NAME=${env.STAGE_NAME}"
                             echo "matrixCache debug axis=${env.AXIS_OS}/${env.AXIS_ARCH}"
                         }
                         post {
                             success {
-                                script { matrixCache.markDone(REFS, env.STAGE_NAME) }
+                                script { matrixCache.markDone(REFS, 'Test Cache Able', [axis_os: env.AXIS_OS, axis_arch: env.AXIS_ARCH]) }
                             }
                         }
                     }

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -192,6 +192,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment {
                             MINIO_BIN_PATH = "bin/minio"
                         }
@@ -278,6 +279,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -192,7 +192,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment {
                             MINIO_BIN_PATH = "bin/minio"
                         }
@@ -279,7 +279,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('migration') {
@@ -137,7 +137,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('migration') {
@@ -136,6 +137,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/tikv/migration/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_test.groovy
@@ -103,6 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('migration') {
@@ -124,6 +125,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/tikv/migration/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('migration') {
@@ -125,7 +125,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -134,6 +134,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         environment {
                             MINIO_BIN_PATH = "bin/minio"
                         }
@@ -193,6 +194,7 @@ pipeline {
                                     }
                                 }
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -134,7 +134,7 @@ pipeline {
                 }
                 stages {
                     stage('Test')  {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         environment {
                             MINIO_BIN_PATH = "bin/minio"
                         }
@@ -194,7 +194,7 @@ pipeline {
                                     }
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
                         }
                     }
                 }

--- a/pipelines/tikv/tikv/release-6.1/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-6.1/pull_unit_test.groovy
@@ -156,6 +156,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir('/home/jenkins/agent/tikv-presubmit/unit-test') {
                                 sh label: 'os info', script:"""
@@ -240,6 +241,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-ut.tar.gz", allowEmptyArchive: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/tikv/tikv/release-6.1/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-6.1/pull_unit_test.groovy
@@ -156,7 +156,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [chunk_suffix: env.CHUNK_SUFFIX]) } }
                         steps {
                             dir('/home/jenkins/agent/tikv-presubmit/unit-test') {
                                 sh label: 'os info', script:"""
@@ -241,7 +241,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-ut.tar.gz", allowEmptyArchive: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [chunk_suffix: env.CHUNK_SUFFIX]) } }
                         }
                     }
                 }


### PR DESCRIPTION
### What

Apply the `matrixCache` pattern to all pipeline files in `pipelines/` that contain `matrix` stages, enabling **fast-skip of previously successful matrix axis stages when re-running with the same context**, saving CI resources.

### Library

`libraries/tipipeline/vars/matrixCache.groovy` provides two methods:

- **`matrixCache.shouldSkip(refs, stageName, extraParams?)`** — called in a `when` expression to determine if the stage can be skipped
- **`matrixCache.markDone(refs, stageName, extraParams?)`** — called in `post success` to mark the stage as completed

The cache key is generated by MD5 of `org/repo/base_sha/pulls_shas/stageName`. Matrix axis values are automatically included via `env.STAGE_NAME` (Jenkins matrix stage names contain axis values, e.g. `"Test, TEST_CMD=dm_unit_test_in_verify_ci"`).

### Changes

- 386 files changed, +865/−9 lines
- For each inner `stage` inside a `matrix` block, added:
  - `when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }` — skip check
  - `post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }` — success marker
- For files with an existing `post success` block (e.g., `ghpr_verify`, `ghpr_check2`), injected `markDone` into the existing `script` block
- All `when` and newly added `post`/`success` blocks use single-line format for brevity

### Usage Example

```groovy
stage("Test") {
    when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
    steps {
        // actual test steps
    }
    post { success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } } }
}
```

### Verification

- ✅ All 386 modified files contain both `shouldSkip` and `markDone`
- ✅ No new brace mismatch introduced
- ✅ Files with existing `when` blocks are not duplicated
- ✅ No extra blank lines
