### PR TITLE
refactor(pipelines): replace hub-zot.pingcap.net/mirrors/hub with GAR mirror

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 70, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
@@ -107,12 +107,7 @@ pipeline {
                                             fi
                                             cd /git
                                             rm -rf sqllogictest sqllogictest_v20241212.tar.gz
-                                            # Prefer GAR mirror on GCP; keep hub-zot as fallback for compatibility.
-                                            for source in \
-                                                "${OCI_ARTIFACT_HOST}/pingcap/case-data/sqllogic:v20241212" \
-                                                "hub-zot.pingcap.net/mirrors/hub/pingcap/case-data/sqllogic:v20241212"; do
-                                                timeout 60 oras pull "${source}" && break || true
-                                            done
+                                            timeout 60 oras pull "${OCI_ARTIFACT_HOST}/pingcap/case-data/sqllogic:v20241212" || true
                                             if [ -f sqllogictest_v20241212.tar.gz ]; then
                                                 tar xzf sqllogictest_v20241212.tar.gz
                                                 rm -f sqllogictest_v20241212.tar.gz
@@ -194,12 +189,7 @@ pipeline {
                                             fi
                                             cd /git
                                             rm -rf sqllogictest sqllogictest_v20241212.tar.gz
-                                            # Prefer GAR mirror on GCP; keep hub-zot as fallback for compatibility.
-                                            for source in \
-                                                "${OCI_ARTIFACT_HOST}/pingcap/case-data/sqllogic:v20241212" \
-                                                "hub-zot.pingcap.net/mirrors/hub/pingcap/case-data/sqllogic:v20241212"; do
-                                                timeout 60 oras pull "${source}" && break || true
-                                            done
+                                            timeout 60 oras pull "${OCI_ARTIFACT_HOST}/pingcap/case-data/sqllogic:v20241212" || true
                                             if [ -f sqllogictest_v20241212.tar.gz ]; then
                                                 tar xzf sqllogictest_v20241212.tar.gz
                                                 rm -f sqllogictest_v20241212.tar.gz

--- a/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
@@ -25,7 +25,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-6.1/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_e2e_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_binlog_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_copr_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_ddl_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_mysql_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.1/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/pull_integration_tidb_tools_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -25,7 +25,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -25,7 +25,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
@@ -25,7 +25,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/ghpr_check2.groovy
@@ -24,7 +24,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_e2e_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_common_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_copr_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_ddl_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_jdbc_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-20241101-v6.5.7/pull_integration_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
         ENABLE_FIPS = 1
     }
     options {

--- a/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-with-kv-timeout-feature/ghpr_check2.groovy
@@ -23,7 +23,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -24,7 +24,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-6.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_e2e_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_binlog_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_copr_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_tidb_tools_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
@@ -23,7 +23,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
@@ -23,7 +23,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
@@ -24,7 +24,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-7.1/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_e2e_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_binlog_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_copr_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_tidb_tools_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
@@ -24,7 +24,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
         CI = "1"
     }
     stages {

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
@@ -24,7 +24,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
         CI = "1"
     }
     stages {

--- a/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
@@ -24,7 +24,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -25,7 +25,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-7.5/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/periodics_br_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_e2e_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_binlog_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_copr_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_tidb_tools_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
@@ -24,7 +24,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/ghpr_check2.groovy
@@ -24,7 +24,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_check2.groovy
@@ -25,7 +25,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-8.1/periodics_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/periodics_br_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_e2e_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_binlog_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_copr_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_tidb_tools_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_check2.groovy
@@ -25,7 +25,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-8.2/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_e2e_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_check2.groovy
@@ -25,7 +25,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-8.3/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_e2e_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_check2.groovy
@@ -25,7 +25,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-8.4/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_e2e_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_check2.groovy
@@ -25,7 +25,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_e2e_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'  // cache mirror for us-docker.pkg.dev/pingcap-testing-account/hub
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'  // cache mirror for us-docker.pkg.dev/pingcap-testing-account/hub
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_tidb_tools_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_compatibility_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.1/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 80, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_compatibility_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-20241101-v6.5.7/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 80, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 80, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.5/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_syncdiff_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_syncdiff_integration_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_connector_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_connector_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
@@ -18,7 +18,7 @@ pipeline {
     }
     environment {
         CI = "1"
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/qa/qa-release-br-integration-test.groovy
+++ b/pipelines/qa/qa-release-br-integration-test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/qa/qa-release-lightning-integration-test.groovy
+++ b/pipelines/qa/qa-release-lightning-integration-test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         // tidb-server: hub-zot.pingcap.net/mirrors/hub/pingcap/tidb/package:<tag>_linux_amd64
         // tikv-server: hub-zot.pingcap.net/mirrors/hub/tikv/tikv/package:<tag>_linux_amd64
         // pd-server:   hub-zot.pingcap.net/mirrors/hub/tikv/pd/package:<tag>_linux_amd64
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/tikv/migration/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         // tidb-server: hub-zot.pingcap.net/mirrors/hub/pingcap/tidb/package:<tag>_linux_amd64
         // tikv-server: hub-zot.pingcap.net/mirrors/hub/tikv/tikv/package:<tag>_linux_amd64
         // pd-server:   hub-zot.pingcap.net/mirrors/hub/tikv/pd/package:<tag>_linux_amd64
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-7.1/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-7.1/pull_integration_copr_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-7.5/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-7.5/pull_integration_copr_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-8.1/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-8.1/pull_integration_copr_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-8.5/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-8.5/pull_integration_copr_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-9.0-beta/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-9.0-beta/pull_integration_copr_test.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/latest/pull_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-6.1/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-6.1/pull_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-6.5/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-6.5/pull_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-7.1/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-7.1/pull_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-7.5/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-7.5/pull_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-8.1/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-8.1/pull_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/hub'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 50, unit: 'MINUTES')


### PR DESCRIPTION
Replace all code-level references of `hub-zot.pingcap.net/mirrors/hub` with `us-docker.pkg.dev/pingcap-testing-account/hub`. Comment-only occurrences (ticdc pipeline comments and tikv/migration doc comments) are left unchanged.

Also simplify the sqllogic test data download loop in `merged_sqllogic_test.groovy` since both sources point to the same location after the replacement.