### PR TITLE
fix(prow): update kubekins image for prow jobs

### DIFF
--- a/prow-jobs/ti-community-infra/prow/presubmits.yaml
+++ b/prow-jobs/ti-community-infra/prow/presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       clone_depth: 1
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-test-infra
+          - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:latest-master
             command:
               - runner.sh
             args:
@@ -24,7 +24,7 @@ presubmits:
       spec:
         serviceAccountName: prow-pusher
         containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-test-infra
+          - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:latest-master
             command:
               - runner.sh
             args:
@@ -48,7 +48,7 @@ presubmits:
       clone_depth: 1
       spec:
         containers:
-          - image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240515-17c6d50e24-test-infra
+          - image: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:latest-master
             command:
               - runner.sh
             args:


### PR DESCRIPTION
## What

Update the ti-community-infra/prow presubmit jobs to use the current Artifact Registry kubekins image:

- `us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:latest-master`

This replaces the old GCR tag that now returns `MANIFEST_UNKNOWN` and causes `pull-test` / `pull-verify` to fail with `ImagePullBackOff`.

## Jobs updated

- `pull-test`
- `pull-build-images`
- `pull-verify`

## Verification

- Parsed `prow-jobs/ti-community-infra/prow/presubmits.yaml` with Python YAML
- Verified the new image manifest endpoint returns HTTP 200
- Ran `.ci/update-prow-job-kustomization.sh` and confirmed no generated changes
