### PR TITLE
ci(jobs): add tipipeline library for ti-community-infra

### DIFF
--- a/jobs/ti-community-infra/aa_folder.groovy
+++ b/jobs/ti-community-infra/aa_folder.groovy
@@ -1,2 +1,47 @@
 folder('ti-community-infra') {
+    properties {
+        folderLibraries {
+            libraries {
+                libraryConfiguration {
+                    // An identifier you pick for this library, to be used in the @Library annotation.
+                    name('tipipeline')
+                    retriever {
+                        modernSCM {
+                            scm {
+                                git {
+                                    remote('https://github.com/PingCAP-QE/ci')
+                                    extensions {
+                                        cloneOption {
+                                            depth(1)
+                                            shallow(true)
+                                            noTags(true)
+                                            reference('/var/lib/scm-git/ci')
+                                            timeout(5)
+                                        }
+                                    }
+                                }
+                            }
+                            // A relative path from the root of the SCM to the root of the library.
+                            libraryPath('libraries/tipipeline')
+                        }
+                    }
+                    // If checked, scripts may select a custom version of the library by appending @someversion in the @Library annotation.
+                    allowVersionOverride(true)
+                    // If checked, versions fetched using this library will be cached on the controller.
+                    cachingConfiguration {
+                        // Determines the amount of time until the cache is refreshed.
+                        refreshTimeMinutes(60)
+                        // Space separated list of versions to exclude from caching via substring search using .contains() method.
+                        excludedVersionsStr('feature/ fix/ bugfix/')
+                    }
+                    // A default version of the library to load if a script does not select another.
+                    defaultVersion('main')
+                    // If checked, scripts will automatically have access to this library without needing to request it via @Library.
+                    implicit(false)
+                    // If checked, any changes in the library will be included in the changesets of a build, and changing the library would cause new builds to run for Pipelines that include this library.
+                    includeInChangesets(true)
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add the `tipipeline` shared library configuration to `jobs/ti-community-infra/aa_folder.groovy`
- copy the existing folder-level library setup used by other org folders
- enable `@Library('tipipeline')` usage under the `ti-community-infra` Jenkins folder

## Testing
- not run locally; `groovy` is not installed in this environment for a parse check
