### PR TITLE
fix(scripts/plugins): match SKIP test status to prevent false .fatal.log, add regression validation

### DIFF
--- a/scripts/plugins/analyze-go-test-from-bazel-output.sh
+++ b/scripts/plugins/analyze-go-test-from-bazel-output.sh
@@ -32,7 +32,7 @@ function parse_bazel_target_output_log() {
                 append="$append.race"
             fi
 
-        elif grep -E "(---|===) (PASS|FAIL|RUN)" "$saveFlag.log" | grep -oE "\bTest\w+\b" | sort | uniq -c | grep "^\s*1\b" >/dev/null; then
+        elif grep -E "(---|===) (PASS|FAIL|RUN|SKIP)" "$saveFlag.log" | grep -oE "\bTest\w+\b" | sort | uniq -c | grep "^\s*1\b" >/dev/null; then
             append="$append.fatal"
         fi
 

--- a/scripts/plugins/test_analyze-go-test-from-bazel-output.sh
+++ b/scripts/plugins/test_analyze-go-test-from-bazel-output.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cd "$tmpdir"
+
+bash "$repo_root/scripts/plugins/analyze-go-test-from-bazel-output.sh" \
+    "$repo_root/scripts/plugins/testdata/analyze-go-test-from-bazel-output/sample.log" >/dev/null
+
+test -f bazel-target-output-L1-4.log
+test -f bazel-target-output-L5-10.fail.race.log
+test -f bazel-target-output-L11-14.timeout.log
+test ! -e bazel-target-output-L1-4.fatal.log

--- a/scripts/plugins/testdata/analyze-go-test-from-bazel-output/sample.log
+++ b/scripts/plugins/testdata/analyze-go-test-from-bazel-output/sample.log
@@ -1,0 +1,14 @@
+==================== Test output for //pkg:skip_case (1 shards, 1 tests) ====================
+=== RUN   TestSkipOnly
+--- SKIP: TestSkipOnly (0.00s)
+==================== ========================================================= ====================
+==================== Test output for //pkg:fail_case (1 shards, 1 tests) ====================
+=== RUN   TestFailRace
+--- FAIL: TestFailRace (0.01s)
+WARNING: DATA RACE
+testing.go:123: race detected during execution of test
+==================== ========================================================= ====================
+==================== Test output for //pkg:timeout_case (1 shards, 1 tests) ====================
+=== RUN   TestTimeout
+-- Test timed out at 2026-05-20 00:00:00 UTC
+==================== ========================================================= ====================


### PR DESCRIPTION
Expand Bazel fatal detection to include SKIP so skip-only test blocks are no longer archived as .fatal.log. Add a regression sample and a shell check covering skip-vs-fail precedence.