### PR TITLE
chore: ignore deprecated tekton v0 renovate paths

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,5 +14,5 @@
     }
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
-  "ignorePaths": ["tools/deprecated/**", "**/requirements.txt"]
+  "ignorePaths": ["tools/deprecated/**", "**/requirements.txt", "tekton/v0/**"]
 }


### PR DESCRIPTION
## Summary
- add `tekton/v0/**` to Renovate `ignorePaths`
- keep the rest of `.github/renovate.json` unchanged

## Testing
- `jq empty .github/renovate.json`
