### PR TITLE
ci(ticdc): enable matrix cache for storage light next gen

### DIFF
--- a/jobs/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen.groovy
@@ -10,6 +10,9 @@ pipelineJob('pingcap/ticdc/pull_cdc_storage_integration_light_next_gen') {
         stringParam("PROW_JOB_ID")
         stringParam("JOB_SPEC")
     }
+    properties {
+        githubProjectUrl("https://github.com/pingcap/ticdc")
+    }
 
     definition {
         cpsScm {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
@@ -114,6 +114,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
+                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -146,6 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
+                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
@@ -114,7 +114,7 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        when { expression { return !matrixCache.shouldSkip(REFS, env.STAGE_NAME) } }
+                        when { expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         steps {
                             dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
@@ -147,7 +147,7 @@ pipeline {
                                 """
                                 archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
                             }
-                            success { script { matrixCache.markDone(REFS, env.STAGE_NAME) } }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- extract the `pull_cdc_storage_integration_light_next_gen` matrix cache trial from #4594
- add the ticdc job property used in the upstream PR
- skip already successful matrix stages on rerun and mark successful stages in post actions

## Testing
- `git diff --check`
- not run: `.ci/verify-jenkins-pipelines.sh` requires a live Jenkins endpoint via `JENKINS_URL`
