### PR TITLE
feat(ci): add query image tag workflow

### DIFF
--- a/.ci/test-query-image-tag.sh
+++ b/.ci/test-query-image-tag.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+mock_bin="${tmp_dir}/bin"
+mkdir -p "${mock_bin}"
+
+cat > "${mock_bin}/oras" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+fixture_for_ref() {
+    case "$1" in
+        example.com/team/app:v1.2.3)
+            printf '%s\n' single
+            ;;
+        registry.example.com/org/app:multi)
+            printf '%s\n' multi
+            ;;
+        *)
+            echo "not found: $1" >&2
+            return 1
+            ;;
+    esac
+}
+
+copy_fixture() {
+    local source_file="$1"
+    local output_file="$2"
+
+    cp "${MOCK_FIXTURE_DIR}/${source_file}" "${output_file}"
+}
+
+main() {
+    local subcommand="$1"
+    shift
+
+    if [[ "${subcommand}" != "manifest" ]]; then
+        echo "unsupported mock subcommand: ${subcommand}" >&2
+        exit 1
+    fi
+
+    local action="$1"
+    shift
+    local descriptor=false
+    local output_file=""
+    local platform=""
+
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            --plain-http)
+                shift
+                ;;
+            --descriptor)
+                descriptor=true
+                shift
+                ;;
+            --output)
+                output_file="$2"
+                shift 2
+                ;;
+            --platform)
+                platform="$2"
+                shift 2
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    local image_ref="$1"
+    local fixture
+
+    fixture="$(fixture_for_ref "${image_ref}")"
+
+    case "${action}" in
+        fetch)
+            if [[ "${descriptor}" == "true" ]]; then
+                copy_fixture "${fixture}/descriptor.json" "${output_file}"
+            else
+                copy_fixture "${fixture}/manifest.json" "${output_file}"
+            fi
+            ;;
+        fetch-config)
+            if [[ -z "${platform}" ]]; then
+                copy_fixture "${fixture}/config.json" "${output_file}"
+                exit 0
+            fi
+
+            case "${platform}" in
+                linux/amd64)
+                    copy_fixture "${fixture}/config-linux-amd64.json" "${output_file}"
+                    ;;
+                linux/arm64)
+                    copy_fixture "${fixture}/config-linux-arm64.json" "${output_file}"
+                    ;;
+                *)
+                    echo "unsupported mock platform: ${platform}" >&2
+                    exit 1
+                    ;;
+            esac
+            ;;
+        *)
+            echo "unsupported mock manifest action: ${action}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"
+EOF
+
+chmod +x "${mock_bin}/oras"
+
+fixture_dir="${tmp_dir}/fixtures"
+mkdir -p "${fixture_dir}/single" "${fixture_dir}/multi"
+
+cat > "${fixture_dir}/single/manifest.json" <<'EOF'
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "digest": "sha256:singleconfig",
+    "size": 7023
+  }
+}
+EOF
+
+cat > "${fixture_dir}/single/descriptor.json" <<'EOF'
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "digest": "sha256:singlemanifest",
+  "size": 1024
+}
+EOF
+
+cat > "${fixture_dir}/single/config.json" <<'EOF'
+{
+  "created": "2026-05-20T12:34:56Z",
+  "architecture": "amd64",
+  "os": "linux",
+  "config": {
+    "Labels": {
+      "org.opencontainers.image.revision": "abc123",
+      "app.kubernetes.io/name": "single-app"
+    }
+  }
+}
+EOF
+
+cat > "${fixture_dir}/multi/manifest.json" <<'EOF'
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:linuxamd64",
+      "size": 768,
+      "platform": {
+        "os": "linux",
+        "architecture": "amd64"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:linuxarm64",
+      "size": 768,
+      "platform": {
+        "os": "linux",
+        "architecture": "arm64"
+      }
+    }
+  ]
+}
+EOF
+
+cat > "${fixture_dir}/multi/descriptor.json" <<'EOF'
+{
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "digest": "sha256:multimanifest",
+  "size": 2048
+}
+EOF
+
+cat > "${fixture_dir}/multi/config-linux-amd64.json" <<'EOF'
+{
+  "created": "2026-05-20T11:00:00Z",
+  "architecture": "amd64",
+  "os": "linux",
+  "config": {
+    "Labels": {
+      "org.opencontainers.image.source": "https://github.com/example/app",
+      "org.opencontainers.image.revision": "deadbeef"
+    }
+  }
+}
+EOF
+
+cat > "${fixture_dir}/multi/config-linux-arm64.json" <<'EOF'
+{
+  "created": "2026-05-20T11:05:00Z",
+  "architecture": "arm64",
+  "os": "linux",
+  "config": {
+    "Labels": {
+      "org.opencontainers.image.source": "https://github.com/example/app",
+      "org.opencontainers.image.version": "multi"
+    }
+  }
+}
+EOF
+
+output_dir="${tmp_dir}/output"
+mkdir -p "${output_dir}"
+
+PATH="${mock_bin}:${PATH}" MOCK_FIXTURE_DIR="${fixture_dir}" \
+    "${repo_root}/scripts/artifacts/query-image-tag.sh" \
+    "example.com/team/app" \
+    "v1.2.3" \
+    "${output_dir}/single.json"
+
+jq -e '
+    .image_ref == "example.com/team/app:v1.2.3" and
+    .pushed_at == "2026-05-20T12:34:56Z" and
+    .digest == "sha256:singlemanifest" and
+    .multi_arch == false and
+    .platforms == ["linux/amd64"] and
+    .labels["org.opencontainers.image.revision"] == "abc123" and
+    .labels["app.kubernetes.io/name"] == "single-app"
+' "${output_dir}/single.json" >/dev/null
+
+PATH="${mock_bin}:${PATH}" MOCK_FIXTURE_DIR="${fixture_dir}" \
+    "${repo_root}/scripts/artifacts/query-image-tag.sh" \
+    "registry.example.com/org/app" \
+    "multi" \
+    "${output_dir}/multi.json"
+
+jq -e '
+    .image_ref == "registry.example.com/org/app:multi" and
+    .pushed_at == "2026-05-20T11:05:00Z" and
+    .digest == "sha256:multimanifest" and
+    .multi_arch == true and
+    .platforms == ["linux/amd64", "linux/arm64"] and
+    .labels["org.opencontainers.image.source"] == "https://github.com/example/app" and
+    .labels["org.opencontainers.image.revision"] == "deadbeef" and
+    .labels["org.opencontainers.image.version"] == "multi"
+' "${output_dir}/multi.json" >/dev/null
+
+if PATH="${mock_bin}:${PATH}" MOCK_FIXTURE_DIR="${fixture_dir}" \
+    "${repo_root}/scripts/artifacts/query-image-tag.sh" \
+    "registry.example.com/org/app" \
+    "missing" \
+    "${output_dir}/missing.json"; then
+    echo "expected missing image lookup to fail" >&2
+    exit 1
+fi
+
+if [[ -e "${output_dir}/missing.json" ]]; then
+    echo "missing image lookup should not create an artifact" >&2
+    exit 1
+fi

--- a/.ci/test-query-image-tag.sh
+++ b/.ci/test-query-image-tag.sh
@@ -227,7 +227,7 @@ PATH="${mock_bin}:${PATH}" MOCK_FIXTURE_DIR="${fixture_dir}" \
 
 jq -e '
     .image_ref == "example.com/team/app:v1.2.3" and
-    .pushed_at == "2026-05-20T12:34:56Z" and
+    .created_at == "2026-05-20T12:34:56Z" and
     .digest == "sha256:singlemanifest" and
     .multi_arch == false and
     .platforms == ["linux/amd64"] and
@@ -243,7 +243,7 @@ PATH="${mock_bin}:${PATH}" MOCK_FIXTURE_DIR="${fixture_dir}" \
 
 jq -e '
     .image_ref == "registry.example.com/org/app:multi" and
-    .pushed_at == "2026-05-20T11:05:00Z" and
+    .created_at == "2026-05-20T11:05:00Z" and
     .digest == "sha256:multimanifest" and
     .multi_arch == true and
     .platforms == ["linux/amd64", "linux/arm64"] and

--- a/.github/workflows/query-image-tag.yml
+++ b/.github/workflows/query-image-tag.yml
@@ -27,6 +27,7 @@ jobs:
   inspect-image:
     name: Inspect image metadata
     runs-on: ubuntu-latest
+    timeout-minutes: 300
     environment:
       name: ${{ inputs.credential_ref != '' && inputs.credential_ref || 'query-image-public' }}
     env:

--- a/.github/workflows/query-image-tag.yml
+++ b/.github/workflows/query-image-tag.yml
@@ -1,0 +1,111 @@
+name: Query Image Tag
+
+run-name: query-image-tag ${{ inputs.registry_url }}:${{ inputs.image_tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      registry_url:
+        description: Image repository reference without the tag (for example, ghcr.io/org/image)
+        required: true
+        type: string
+      image_tag:
+        description: Tag to inspect
+        required: true
+        type: string
+      credential_ref:
+        description: Optional GitHub Environment name that provides registry auth
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  inspect-image:
+    name: Inspect image metadata
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.credential_ref != '' && inputs.credential_ref || 'query-image-public' }}
+    env:
+      REGISTRY_LOGIN_COMMAND: ${{ vars.REGISTRY_LOGIN_COMMAND }}
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+      REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
+      HAS_LOGIN_COMMAND: ${{ vars.REGISTRY_LOGIN_COMMAND != '' }}
+      HAS_PULL_CREDS: ${{ secrets.REGISTRY_USERNAME != '' && (secrets.REGISTRY_PASSWORD != '' || secrets.REGISTRY_TOKEN != '') }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up ORAS CLI
+        uses: oras-project/setup-oras@v1
+        with:
+          version: 1.3.0
+
+      - name: Resolve registry coordinates
+        id: registry
+        env:
+          REGISTRY_URL_INPUT: ${{ inputs.registry_url }}
+        run: |
+          set -euo pipefail
+
+          registry_ref="${REGISTRY_URL_INPUT#https://}"
+          registry_ref="${registry_ref#http://}"
+          registry_host="${registry_ref%%/*}"
+          plain_http=false
+
+          if [[ "${REGISTRY_URL_INPUT}" == http://* ]]; then
+            plain_http=true
+          fi
+
+          {
+            echo "registry_ref=${registry_ref}"
+            echo "registry_host=${registry_host}"
+            echo "plain_http=${plain_http}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Authenticate with environment-provided login command
+        if: ${{ env.HAS_LOGIN_COMMAND == 'true' }}
+        env:
+          REGISTRY_URL: ${{ inputs.registry_url }}
+          REGISTRY_REF: ${{ steps.registry.outputs.registry_ref }}
+          REGISTRY_HOST: ${{ steps.registry.outputs.registry_host }}
+          REGISTRY_PLAIN_HTTP: ${{ steps.registry.outputs.plain_http }}
+        run: |
+          set -euo pipefail
+          bash -euo pipefail -c "${REGISTRY_LOGIN_COMMAND}"
+
+      - name: Authenticate with environment-scoped pull credentials
+        if: ${{ env.HAS_LOGIN_COMMAND != 'true' && env.HAS_PULL_CREDS == 'true' }}
+        env:
+          REGISTRY_HOST: ${{ steps.registry.outputs.registry_host }}
+          REGISTRY_PLAIN_HTTP: ${{ steps.registry.outputs.plain_http }}
+        run: |
+          set -euo pipefail
+
+          login_args=()
+          if [[ "${REGISTRY_PLAIN_HTTP}" == "true" ]]; then
+            login_args+=(--plain-http)
+          fi
+
+          password="${REGISTRY_PASSWORD:-${REGISTRY_TOKEN:-}}"
+          printf '%s' "${password}" | oras login "${login_args[@]}" "${REGISTRY_HOST}" --username "${REGISTRY_USERNAME}" --password-stdin
+
+      - name: Inspect image and write result artifact
+        run: |
+          set -euo pipefail
+          scripts/artifacts/query-image-tag.sh "${{ inputs.registry_url }}" "${{ inputs.image_tag }}" result.json
+
+      - name: Upload result artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: result.json
+          path: result.json
+          if-no-files-found: error

--- a/scripts/artifacts/query-image-tag.sh
+++ b/scripts/artifacts/query-image-tag.sh
@@ -57,7 +57,7 @@ main() {
     local manifest_file
     local descriptor_file
     local manifest_created
-    local pushed_at=""
+    local created_at=""
     local digest
     local media_type
     local multi_arch=false
@@ -123,10 +123,11 @@ main() {
 
             labels_json="$(jq -cs 'reduce .[] as $config ({}; . * ($config.config.Labels // {}))' "${config_files[@]}")"
 
+            # This workflow exposes image creation time, not registry-side push time.
             if [[ -n "${manifest_created}" ]]; then
-                pushed_at="${manifest_created}"
+                created_at="${manifest_created}"
             elif [[ "${#created_values[@]}" -gt 0 ]]; then
-                pushed_at="$(printf '%s\n' "${created_values[@]}" | sort | tail -n 1)"
+                created_at="$(printf '%s\n' "${created_values[@]}" | sort | tail -n 1)"
             fi
             ;;
         *)
@@ -137,20 +138,20 @@ main() {
             labels_json="$(jq -c '.config.Labels // {}' "${config_file}")"
 
             if [[ -n "${manifest_created}" ]]; then
-                pushed_at="${manifest_created}"
+                created_at="${manifest_created}"
             else
-                pushed_at="$(jq -r '.created // empty' "${config_file}")"
+                created_at="$(jq -r '.created // empty' "${config_file}")"
             fi
             ;;
     esac
 
-    if [[ -z "${pushed_at}" ]]; then
+    if [[ -z "${created_at}" ]]; then
         echo "image ${image_ref} does not expose a created timestamp" >&2
         exit 1
     fi
 
-    if ! jq -en --arg timestamp "${pushed_at}" '$timestamp | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T")' >/dev/null; then
-        echo "image ${image_ref} returned a non-ISO8601 timestamp: ${pushed_at}" >&2
+    if ! jq -en --arg timestamp "${created_at}" '$timestamp | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T")' >/dev/null; then
+        echo "image ${image_ref} returned a non-ISO8601 timestamp: ${created_at}" >&2
         exit 1
     fi
 
@@ -158,14 +159,14 @@ main() {
 
     jq -n \
         --arg image_ref "${image_ref}" \
-        --arg pushed_at "${pushed_at}" \
+        --arg created_at "${created_at}" \
         --arg digest "${digest}" \
         --argjson multi_arch "${multi_arch}" \
         --argjson platforms "${platforms_json}" \
         --argjson labels "${labels_json}" \
         '{
             image_ref: $image_ref,
-            pushed_at: $pushed_at,
+            created_at: $created_at,
             digest: $digest,
             multi_arch: $multi_arch,
             platforms: $platforms,
@@ -174,7 +175,7 @@ main() {
 
     jq -e '
         (.image_ref | type == "string") and
-        (.pushed_at | type == "string") and
+        (.created_at | type == "string") and
         (.digest | type == "string") and
         (.multi_arch | type == "boolean") and
         (.platforms | type == "array") and

--- a/scripts/artifacts/query-image-tag.sh
+++ b/scripts/artifacts/query-image-tag.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 <registry-url> <image-tag> <output-path>" >&2
+}
+
+normalize_registry_ref() {
+    local registry_url="$1"
+
+    registry_url="${registry_url#https://}"
+    registry_url="${registry_url#http://}"
+    printf '%s\n' "${registry_url}"
+}
+
+build_platform_list_from_index() {
+    local manifest_file="$1"
+
+    jq -c '
+        [
+            .manifests[]
+            | select(.platform.os != null and .platform.architecture != null)
+            | .platform
+            | .os + "/" + .architecture + (if .variant then "/" + .variant else "" end)
+        ]
+    ' "${manifest_file}"
+}
+
+build_platform_list_from_config() {
+    local config_file="$1"
+
+    jq -ce '
+        [
+            (
+                if (.os // "") == "" or (.architecture // "") == "" then
+                    error("image config is missing os/architecture")
+                else
+                    .os + "/" + .architecture + (if .variant then "/" + .variant else "" end)
+                end
+            )
+        ]
+    ' "${config_file}"
+}
+
+main() {
+    if [[ "$#" -ne 3 ]]; then
+        usage
+        exit 1
+    fi
+
+    local registry_url="$1"
+    local image_tag="$2"
+    local output_path="$3"
+    local registry_ref
+    local image_ref
+    local tmp_dir
+    local manifest_file
+    local descriptor_file
+    local manifest_created
+    local pushed_at=""
+    local digest
+    local media_type
+    local multi_arch=false
+    local platforms_json
+    local labels_json="{}"
+    local config_file
+    local plain_http_arg=""
+
+    registry_ref="$(normalize_registry_ref "${registry_url}")"
+    image_ref="${registry_ref}:${image_tag}"
+
+    if [[ "${registry_url}" == http://* ]]; then
+        plain_http_arg="--plain-http"
+    fi
+
+    tmp_dir="$(mktemp -d)"
+    trap "rm -rf '${tmp_dir}'" EXIT
+
+    manifest_file="${tmp_dir}/manifest.json"
+    descriptor_file="${tmp_dir}/descriptor.json"
+
+    oras manifest fetch ${plain_http_arg:+"${plain_http_arg}"} --output "${manifest_file}" "${image_ref}" >/dev/null
+    oras manifest fetch ${plain_http_arg:+"${plain_http_arg}"} --descriptor --output "${descriptor_file}" "${image_ref}" >/dev/null
+
+    digest="$(jq -r '.digest // empty' "${descriptor_file}")"
+    if [[ -z "${digest}" ]]; then
+        echo "missing digest in descriptor for ${image_ref}" >&2
+        exit 1
+    fi
+
+    media_type="$(jq -r '.mediaType // empty' "${manifest_file}")"
+    manifest_created="$(jq -r '.annotations["org.opencontainers.image.created"] // empty' "${manifest_file}")"
+
+    case "${media_type}" in
+        application/vnd.oci.image.index.v1+json|application/vnd.docker.distribution.manifest.list.v2+json)
+            local -a platforms=()
+            local -a created_values=()
+            local -a config_files=()
+            local created
+
+            multi_arch=true
+            platforms_json="$(build_platform_list_from_index "${manifest_file}")"
+
+            if [[ "${platforms_json}" == "[]" ]]; then
+                echo "multi-arch image ${image_ref} does not expose any platforms" >&2
+                exit 1
+            fi
+
+            while IFS= read -r platform; do
+                platforms+=("${platform}")
+            done < <(jq -r '.[]' <<<"${platforms_json}")
+
+            for i in "${!platforms[@]}"; do
+                config_file="${tmp_dir}/config-${i}.json"
+                oras manifest fetch-config ${plain_http_arg:+"${plain_http_arg}"} --platform "${platforms[$i]}" --output "${config_file}" "${image_ref}" >/dev/null
+                config_files+=("${config_file}")
+
+                created="$(jq -r '.created // empty' "${config_file}")"
+                if [[ -n "${created}" ]]; then
+                    created_values+=("${created}")
+                fi
+            done
+
+            labels_json="$(jq -cs 'reduce .[] as $config ({}; . * ($config.config.Labels // {}))' "${config_files[@]}")"
+
+            if [[ -n "${manifest_created}" ]]; then
+                pushed_at="${manifest_created}"
+            elif [[ "${#created_values[@]}" -gt 0 ]]; then
+                pushed_at="$(printf '%s\n' "${created_values[@]}" | sort | tail -n 1)"
+            fi
+            ;;
+        *)
+            config_file="${tmp_dir}/config.json"
+            oras manifest fetch-config ${plain_http_arg:+"${plain_http_arg}"} --output "${config_file}" "${image_ref}" >/dev/null
+
+            platforms_json="$(build_platform_list_from_config "${config_file}")"
+            labels_json="$(jq -c '.config.Labels // {}' "${config_file}")"
+
+            if [[ -n "${manifest_created}" ]]; then
+                pushed_at="${manifest_created}"
+            else
+                pushed_at="$(jq -r '.created // empty' "${config_file}")"
+            fi
+            ;;
+    esac
+
+    if [[ -z "${pushed_at}" ]]; then
+        echo "image ${image_ref} does not expose a created timestamp" >&2
+        exit 1
+    fi
+
+    if ! jq -en --arg timestamp "${pushed_at}" '$timestamp | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T")' >/dev/null; then
+        echo "image ${image_ref} returned a non-ISO8601 timestamp: ${pushed_at}" >&2
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "${output_path}")"
+
+    jq -n \
+        --arg image_ref "${image_ref}" \
+        --arg pushed_at "${pushed_at}" \
+        --arg digest "${digest}" \
+        --argjson multi_arch "${multi_arch}" \
+        --argjson platforms "${platforms_json}" \
+        --argjson labels "${labels_json}" \
+        '{
+            image_ref: $image_ref,
+            pushed_at: $pushed_at,
+            digest: $digest,
+            multi_arch: $multi_arch,
+            platforms: $platforms,
+            labels: $labels
+        }' > "${output_path}"
+
+    jq -e '
+        (.image_ref | type == "string") and
+        (.pushed_at | type == "string") and
+        (.digest | type == "string") and
+        (.multi_arch | type == "boolean") and
+        (.platforms | type == "array") and
+        (.labels | type == "object")
+    ' "${output_path}" >/dev/null
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow that inspects an OCI image tag and uploads `result.json`
- support auth via a GitHub Environment login command or environment-scoped pull credentials
- add a local mocked verification script for single-arch, multi-arch, and missing-tag cases

## Testing
- `bash -n scripts/artifacts/query-image-tag.sh .ci/test-query-image-tag.sh`
- `yq eval . .github/workflows/query-image-tag.yml >/dev/null`
- `./.ci/test-query-image-tag.sh`
