### PR TITLE
chore(pipelines): update pull_unit_test_next_gen image

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
@@ -7,7 +7,7 @@ spec:
     - name: golang
       # TODO(wuhuizuo): using standard bazel build image to shrink the image size
       # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
       securityContext:
         privileged: true
       tty: true


### PR DESCRIPTION
## Summary
- update the pull_unit_test_next_gen pod image to us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122

## Validation
- Jenkins pipeline file validation passed for pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pipeline.groovy
- Pod YAML validation passed for pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
- replay from pull_unit_test_next_gen/3817 -> pull_unit_test_next_gen/3825: SUCCESS
  https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_unit_test_next_gen/3825/
- replay from pull_unit_test_next_gen/3819 -> pull_unit_test_next_gen/3826: SUCCESS
  https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_unit_test_next_gen/3826/