### PR TITLE
feat(ci): add stage agent retries for tidb release-8.5

### DIFF
--- a/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
@@ -27,6 +27,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
                     workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
@@ -116,6 +117,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        retries 2
                         workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -32,6 +32,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
                     workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
@@ -100,6 +101,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        retries 2
                         workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
@@ -31,6 +31,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
                     workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
@@ -90,6 +91,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        retries 2
                         workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }

--- a/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
@@ -22,6 +22,7 @@ pipeline {
                 kubernetes {
                     namespace K8S_NAMESPACE
                     yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
                     workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     defaultContainer 'golang'
                 }
@@ -63,6 +64,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        retries 2
                         workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }


### PR DESCRIPTION
## Summary
- add `retries 2` to the stage and matrix Kubernetes agent blocks in the matching `pipelines/pingcap/tidb/release-8.5` agent-none files
- keep the change inline beside each `yaml pod_label.withCiLabels(...)` stanza with no shared-library edits
- split the original larger patch into replay-sized batches because `pull-replay-jenkins-pipelines` caps a PR at 20 changed pipeline files

## Verification
- `git diff --check`
- targeted grep verification confirmed every target `yaml` line in this batch is immediately followed by `retries 2`
