### PR TITLE
ci(dm): set dm_integration_test_next_gen as required

### DIFF
--- a/prow-jobs/pingcap/tiflow/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits-next-gen.yaml
@@ -14,7 +14,7 @@ presubmits:
       decorate: false # need add this.
       always_run: false
       run_if_changed: "^(dm/.*|pkg/.*|sync_diff_inspector/.*|go\\.mod)$"
-      optional: true
+      optional: false
       context: pull-dm-integration-test-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test-next-gen|next-gen-dm|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-dm-integration-test-next-gen"

--- a/prow-jobs/pingcap/tiflow/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits-next-gen.yaml
@@ -12,9 +12,7 @@ presubmits:
       labels:
         master: "1"
       decorate: false # need add this.
-      always_run: false
       run_if_changed: "^(dm/.*|pkg/.*|sync_diff_inspector/.*|go\\.mod)$"
-      optional: false
       context: pull-dm-integration-test-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-dm-integration-test-next-gen|next-gen-dm|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-dm-integration-test-next-gen"


### PR DESCRIPTION
After https://github.com/pingcap/tiflow/pull/12599 is merged, now we can enable dm_integration_test_next_gen.
It can pass on other PRs, like https://prow.tidb.net/jenkins/job/pingcap/job/tiflow/job/pull_dm_integration_test_next_gen/377/