### PR TITLE
ci(prow): prefer c4 nodes for tiflash sanitizer jobs

### DIFF
--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -116,6 +116,10 @@ global_definitions:
                 operator: In
                 values:
                   - amd64
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                  - c4-standard-32
   pull_sanitizer_container: &pull_sanitizer_container
     name: run-sanitizer
     image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.8.10-2-gc9e3144-centos7


### PR DESCRIPTION
## Summary

This PR updates the TiFlash sanitizer presubmit jobs to prefer `c4-standard-32` nodes.

## Why

Recent sanitizer job history shows frequent `Pod pending timeout` failures.

From recent Prow runs, the pattern is:

- successful sanitizer jobs were scheduled on `c4` nodes
- many pending-timeout jobs were scheduled through `e2` nodes
- failed runs commonly showed:
  - `FailedScheduling`
  - `Insufficient cpu`
  - `Insufficient memory`
  - `TriggeredScaleUp`
 
These sanitizer jobs request large resources (`24 CPU / 64Gi`), and the `e2` appears much less reliable for getting the pod fully scheduled and initialized within the default timeout window.

Pinning them to `c4-standard-32` is intended to improve scheduling stability and reduce infrastructure-induced failures before build/test execution starts.
