### PR TITLE
ci(tikv/pd): migrate latest presubmit jenkins jobs to GCP

### DIFF
--- a/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
@@ -5,8 +5,11 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi
@@ -15,7 +18,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml
@@ -5,11 +5,8 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi
@@ -18,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml
@@ -5,8 +5,11 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 16Gi
@@ -15,7 +18,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml
+++ b/pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml
@@ -5,11 +5,8 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 16Gi
@@ -18,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
@@ -2,8 +2,8 @@
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-tidb"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final K8S_NAMESPACE = "jenkins-pd"
+final GIT_CREDENTIALS_ID = ''
 final GIT_FULL_REPO_NAME = 'tikv/pd'
 final POD_TEMPLATE_FILE = 'pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
@@ -2,18 +2,20 @@
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-pd"
+final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'tikv/pd'
 final POD_TEMPLATE_FILE = 'pipelines/tikv/pd/latest/pod-pull_integration_copr_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -29,12 +31,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("pd") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb") {

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
@@ -2,8 +2,8 @@
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-tidb"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final K8S_NAMESPACE = "jenkins-pd"
+final GIT_CREDENTIALS_ID = ''
 final POD_TEMPLATE_FILE = 'pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_TIDB = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
@@ -2,18 +2,21 @@
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-pd"
+final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/tikv/pd/latest/pod-pull_integration_realcluster_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_TIDB = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIFLASH = component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -29,12 +32,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("pd") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
             }

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/main-pod.yaml
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/main-pod.yaml
@@ -5,11 +5,8 @@ spec:
     fsGroup: 1000
   containers:
     - name: builder
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
@@ -18,7 +15,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/main-pod.yaml
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/main-pod.yaml
@@ -5,8 +5,11 @@ spec:
     fsGroup: 1000
   containers:
     - name: builder
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
@@ -15,7 +18,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -43,11 +43,9 @@ pipeline {
                     }
                 }
                 dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkout('https://github.com/pingcap/tidb.git', 'tidb', TARGET_BRANCH_TIDB, REFS.pulls[0].title, '')
-                            }
+                    retry(2) {
+                        script {
+                            component.checkout('https://github.com/pingcap/tidb.git', 'tidb', TARGET_BRANCH_TIDB, REFS.pulls[0].title, '')
                         }
                     }
                 }

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -4,7 +4,7 @@
 
 final BRANCH_ALIAS = 'latest'
 final K8S_NAMESPACE = "jenkins-tidb"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_CREDENTIALS_ID = ''
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final GIT_FULL_REPO_NAME = "${REFS.org}/${REFS.repo}"
 final MAIN_POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/main-pod.yaml"

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -4,6 +4,7 @@
 
 final BRANCH_ALIAS = 'latest'
 final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final GIT_FULL_REPO_NAME = "${REFS.org}/${REFS.repo}"
 final MAIN_POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/main-pod.yaml"
@@ -20,7 +21,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile MAIN_POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(MAIN_POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+            defaultContainer 'builder'
         }
     }
     options {
@@ -29,18 +32,14 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = 'hub-zot.pingcap.net/mirrors/tidbx'  // cache mirror for us-docker.pkg.dev/pingcap-testing-account/tidbx
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
     }
     stages {
         stage('Checkout') {
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir('tidb') {
@@ -51,6 +50,35 @@ pipeline {
                             }
                         }
                     }
+                }
+            }
+        }
+        stage('Hotfix bazel deps/cache (temporary)') {
+            steps {
+                dir('tidb') {
+                    sh '''#!/usr/bin/env bash
+                        set -euxo pipefail
+
+                        # Clean legacy cache/mirror URLs that are unstable on GCP workers.
+                        for f in WORKSPACE DEPS.bzl; do
+                          [ -f "$f" ] || continue
+                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                        done
+
+                        # Avoid "check" targets re-writing legacy cache settings during migration replay.
+                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+
+                        # Disable remote cache usage for this migration replay path.
+                        if [ -f .bazelrc ]; then
+                          sed -i '/^try-import \\/data\\/bazel$/d' .bazelrc
+                          grep -q '^build --noremote_accept_cached$' .bazelrc || echo 'build --noremote_accept_cached' >> .bazelrc
+                          grep -q '^build --noremote_upload_local_results$' .bazelrc || echo 'build --noremote_upload_local_results' >> .bazelrc
+                          grep -q '^test --noremote_accept_cached$' .bazelrc || echo 'test --noremote_accept_cached' >> .bazelrc
+                          grep -q '^test --noremote_upload_local_results$' .bazelrc || echo 'test --noremote_upload_local_results' >> .bazelrc
+                          grep -q '^run --noremote_accept_cached$' .bazelrc || echo 'run --noremote_accept_cached' >> .bazelrc
+                          grep -q '^run --noremote_upload_local_results$' .bazelrc || echo 'run --noremote_upload_local_results' >> .bazelrc
+                        fi
+                    '''
                 }
             }
         }
@@ -66,6 +94,12 @@ pipeline {
                 }
                 dir('tidb') {
                     container("utils") {
+                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                            sh label: "prepare docker auth", script: '''
+                                mkdir -p ~/.docker
+                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
+                            '''
+                        }
                         dir('bin') {
                             sh label: 'download peer component binaries', script: """#!/usr/bin/env bash
                                 set -eo pipefail
@@ -123,7 +157,8 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile TEST_POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(TEST_POD_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '200Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -148,9 +183,9 @@ pipeline {
                                 }
 
                                 sh """
-                                sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
-                                git diff .
-                                git status
+                                mkdir -p /home/jenkins/.tidb/tmp
+                                git diff . || true
+                                git status || true
                                 """
                                 sh """#! /usr/bin/env bash
                                     set -o pipefail

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -3,7 +3,7 @@
 @Library('tipipeline') _
 
 final BRANCH_ALIAS = 'latest'
-final K8S_NAMESPACE = "jenkins-pd"
+final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_CREDENTIALS_ID = ''
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final GIT_FULL_REPO_NAME = "${REFS.org}/${REFS.repo}"

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -3,7 +3,7 @@
 @Library('tipipeline') _
 
 final BRANCH_ALIAS = 'latest'
-final K8S_NAMESPACE = "jenkins-tidb"
+final K8S_NAMESPACE = "jenkins-pd"
 final GIT_CREDENTIALS_ID = ''
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final GIT_FULL_REPO_NAME = "${REFS.org}/${REFS.repo}"

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/test-pod.yaml
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/test-pod.yaml
@@ -5,28 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12320241009"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
+        requests:
+          memory: 48Gi
+          cpu: "12"
+          ephemeral-storage: 20Gi
         limits:
-          memory: 32Gi
-          cpu: "8"
+          memory: 48Gi
+          cpu: "12"
+          ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-        - mountPath: /share/.cache/bazel-repository-cache
-          name: bazel-repository-cache
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -39,25 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
-    - name: bazel-repository-cache
-      persistentVolumeClaim:
-        claimName: bazel-repository-cache
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:
@@ -86,7 +77,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/test-pod.yaml
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/test-pod.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/prow-jobs/tikv/pd/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/tikv/pd/latest-presubmits-next-gen.yaml
@@ -17,7 +17,7 @@ global_definitions:
   jenkins_job: &jenkins_job
     agent: jenkins
     labels:
-      master: "0"
+      master: "1"
     decorate: false
   kubernetes_job: &kubernetes_job
     agent: kubernetes

--- a/prow-jobs/tikv/pd/latest-presubmits.yaml
+++ b/prow-jobs/tikv/pd/latest-presubmits.yaml
@@ -82,7 +82,7 @@ presubmits:
       name: tikv/pd/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -94,7 +94,7 @@ presubmits:
       name: tikv/pd/pull_integration_realcluster_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: true
       optional: false


### PR DESCRIPTION
## Summary

Migrate `tikv/pd` latest Jenkins presubmit jobs from KS cloud to GCP.
This follows the existing GCP migration patterns used by `pingcap/tidb` .

## Validation

Replay tested:

- `pull_integration_realcluster_test_next_gen`: https://prow.tidb.net/jenkins/job/tikv/job/pd/job/pull_integration_realcluster_test_next_gen/18/stages/
- `pull_integration_realcluster_test`: https://prow.tidb.net/jenkins/job/tikv/job/pd/job/pull_integration_realcluster_test/7/stages/
