### PR TITLE
fix(pipelines): skip tidb-test checkout cache

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pipeline.groovy
@@ -36,11 +36,9 @@ pipeline {
                     }
                 }
                 dir("tidb-test") {
-                    cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkoutSupportBatch('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
-                            }
+                    retry(2) {
+                        script {
+                            component.checkoutSupportBatch('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
                         }
                     }
                 }


### PR DESCRIPTION
### What

Temporarily skip the Jenkins pipeline cache wrapper around the `tidb-test` checkout in `pull_mysql_client_test_next_gen`.

### Why

Recent builds were failing in `Checkout` while restoring `git/PingCAP-QE/tidb-test/rev-` cache with:

```
java.io.IOException: unexpected EOF with 3072 bytes unread
Caused: java.io.IOException: Failed to extract input stream
```

Direct checkout avoids the corrupted prefix cache while keeping the job runnable.

### Validation

- Replay with temporary generated script: https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test_next_gen/3143/ - SUCCESS
- Replay with this committed pipeline file: https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test_next_gen/3144/ - SUCCESS
