### PR TITLE
fix(pipelines): skip tidb-test checkout cache

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -37,11 +37,9 @@ pipeline {
                     }
                 }
                 dir("tidb-test") {
-                    cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkoutSupportBatch('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
-                            }
+                    retry(2) {
+                        script {
+                            component.checkoutSupportBatch('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
                         }
                     }
                     sh "git branch && git status"

--- a/pipelines/pingcap/tidb/latest/pull_mysql_client_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_client_test.groovy
@@ -31,11 +31,9 @@ pipeline {
                     }
                 }
                 dir("tidb-test") {
-                    cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkout('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
-                            }
+                    retry(2) {
+                        script {
+                            component.checkout('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
                         }
                     }
                 }


### PR DESCRIPTION
### Changed
skip the Jenkins pipeline cache wrapper around the `tidb-test` checkout in `ghpr_mysql_test` and `pull_mysql_client_test`.

### Why

Recent builds were failing in `Checkout` while restoring `git/PingCAP-QE/tidb-test/rev-` cache with:

```
java.io.IOException: unexpected EOF with 3072 bytes unread
Caused: java.io.IOException: Failed to extract input stream
```

Direct checkout avoids the corrupted prefix cache while keeping the job runnable.

### Validation
- https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_mysql_test/4003/
- https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_mysql_client_test/3386/