### PR TITLE
ci(pipelines): add retries to matrix kubernetes agents

### DIFF
--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
@@ -106,6 +106,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         defaultContainer 'golang'
+                        retries 2
                     }
                 }
                 when {

--- a/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
@@ -93,6 +93,7 @@ pipeline {
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
+                        retries 2
                     }
                 }
                 when {

--- a/pipelines/pingcap/tidb/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_sqllogic_test.groovy
@@ -80,6 +80,7 @@ pipeline {
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
+                        retries 2
                     }
                 }
                 when {

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -128,6 +128,7 @@ pipeline {
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
+                        retries 2
                     }
                 }
                 when {

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
@@ -90,6 +90,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
                         yamlFile POD_TEMPLATE_FILE
+                        retries 2
                     }
                 }
                 when {

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -157,6 +157,7 @@ pipeline {
                         defaultContainer 'golang'
                         yaml pod_label.withCiLabels(TEST_POD_TEMPLATE_FILE, REFS)
                         workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '200Gi', storageClassName: 'hyperdisk-rwo')
+                        retries 2
                     }
                 }
                 when {


### PR DESCRIPTION
## Summary
- add `retries 2` to matrix-stage Kubernetes agents in the updated pipelines
- cover the tidb, tiflow, tiproxy, ticdc, and pd pipelines changed in this branch

## Testing
- not run (pipeline config change only)