### PR TITLE
fix(prow-jobs/pingcap/tidb-operator): update nodeAffinity to presubmits

### DIFF
--- a/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-operator/latest-presubmits.yaml
@@ -2,11 +2,18 @@ global_definitions:
   branches: &branches
     - ^release-2[.][0-9]+$
     - ^main$
-  skip_if_only_changed: &skip_if_only_changed
-    "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|OWNERS|OWNERS_ALIASES)$"
+  affinity: &affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
   decoration_config: &decoration_config
     timeout: 3h
-
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
@@ -36,12 +43,12 @@ presubmits:
                     key: token
                     name: github-token
             command:
-            - gh
-            - pr
-            - ready
-            - $(PULL_NUMBER)
-            - --repo
-            - pingcap/tidb-operator
+              - gh
+              - pr
+              - ready
+              - $(PULL_NUMBER)
+              - --repo
+              - pingcap/tidb-operator
 
     - name: pull-e2e
       decorate: true # need add this.
@@ -49,8 +56,7 @@ presubmits:
       skip_if_only_changed: *skip_if_only_changed
       branches: *branches
       spec:
-        nodeSelector:
-          node.kubernetes.io/instance-type: e2-highmem-8
+        affinity: *affinity
         volumes:
           - name: docker-sock-dir
             emptyDir: {}
@@ -71,16 +77,16 @@ presubmits:
             image: docker:28.1-dind
             restartPolicy: Always
             command:
-            - /bin/sh
-            - -c
-            - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
+              - /bin/sh
+              - -c
+              - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
             env:
-            - name: DOCKER_TLS_CERTDIR
-              value: ""
-            - name: POD_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+              - name: POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
             securityContext:
               privileged: true
             volumeMounts:

--- a/prow-jobs/pingcap/tidb-operator/release-1.x-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-operator/release-1.x-presubmits.yaml
@@ -2,11 +2,18 @@ global_definitions:
   branches: &branches
     - ^release-1[.][0-9]+$
     - ^release-1[.]x$
-  skip_if_only_changed: &skip_if_only_changed
-    "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|OWNERS|OWNERS_ALIASES)$"
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|OWNERS|OWNERS_ALIASES)$"
+  affinity: &affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
   decoration_config: &decoration_config
     timeout: 3h
-
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
@@ -19,18 +26,7 @@ presubmits:
       always_run: false
       optional: true
       spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: node.kubernetes.io/instance-type
-                      operator: In
-                      values:
-                        - e2-highmem-8
-                        - e2-highmem-16
-                        - e2-standard-16
-                        - e2-standard-32
+        affinity: *affinity
         volumes:
           - name: docker-sock-dir
             emptyDir: {}
@@ -63,16 +59,16 @@ presubmits:
             image: docker:28.1-dind
             restartPolicy: Always
             command:
-            - /bin/sh
-            - -c
-            - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
+              - /bin/sh
+              - -c
+              - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
             env:
-            - name: DOCKER_TLS_CERTDIR
-              value: ""
-            - name: POD_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+              - name: POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
             securityContext:
               privileged: true
             volumeMounts:
@@ -144,18 +140,7 @@ presubmits:
       always_run: false
       optional: true
       spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: node.kubernetes.io/instance-type
-                      operator: In
-                      values:
-                        - e2-highmem-8
-                        - e2-highmem-16
-                        - e2-standard-16
-                        - e2-standard-32
+        affinity: *affinity
         volumes:
           - name: docker-sock-dir
             emptyDir: {}
@@ -188,16 +173,16 @@ presubmits:
             image: docker:28.1-dind
             restartPolicy: Always
             command:
-            - /bin/sh
-            - -c
-            - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
+              - /bin/sh
+              - -c
+              - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
             env:
-            - name: DOCKER_TLS_CERTDIR
-              value: ""
-            - name: POD_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+              - name: POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
             securityContext:
               privileged: true
             volumeMounts:
@@ -269,18 +254,7 @@ presubmits:
       always_run: false
       optional: true
       spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: node.kubernetes.io/instance-type
-                      operator: In
-                      values:
-                        - e2-highmem-8
-                        - e2-highmem-16
-                        - e2-standard-16
-                        - e2-standard-32
+        affinity: *affinity
         volumes:
           - name: docker-sock-dir
             emptyDir: {}
@@ -313,16 +287,16 @@ presubmits:
             image: docker:28.1-dind
             restartPolicy: Always
             command:
-            - /bin/sh
-            - -c
-            - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
+              - /bin/sh
+              - -c
+              - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
             env:
-            - name: DOCKER_TLS_CERTDIR
-              value: ""
-            - name: POD_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+              - name: POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
             securityContext:
               privileged: true
             volumeMounts:
@@ -395,18 +369,7 @@ presubmits:
       always_run: false
       optional: true
       spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: node.kubernetes.io/instance-type
-                      operator: In
-                      values:
-                        - e2-highmem-8
-                        - e2-highmem-16
-                        - e2-standard-16
-                        - e2-standard-32
+        affinity: *affinity
         volumes:
           - name: docker-sock-dir
             emptyDir: {}
@@ -439,16 +402,16 @@ presubmits:
             image: docker:28.1-dind
             restartPolicy: Always
             command:
-            - /bin/sh
-            - -c
-            - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
+              - /bin/sh
+              - -c
+              - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
             env:
-            - name: DOCKER_TLS_CERTDIR
-              value: ""
-            - name: POD_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+              - name: POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
             securityContext:
               privileged: true
             volumeMounts:
@@ -520,18 +483,7 @@ presubmits:
       always_run: false
       optional: true
       spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: node.kubernetes.io/instance-type
-                      operator: In
-                      values:
-                        - e2-highmem-8
-                        - e2-highmem-16
-                        - e2-standard-16
-                        - e2-standard-32
+        affinity: *affinity
         volumes:
           - name: docker-sock-dir
             emptyDir: {}
@@ -564,16 +516,16 @@ presubmits:
             image: docker:28.1-dind
             restartPolicy: Always
             command:
-            - /bin/sh
-            - -c
-            - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
+              - /bin/sh
+              - -c
+              - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
             env:
-            - name: DOCKER_TLS_CERTDIR
-              value: ""
-            - name: POD_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+              - name: POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
             securityContext:
               privileged: true
             volumeMounts:
@@ -646,18 +598,7 @@ presubmits:
       always_run: false
       optional: true
       spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: node.kubernetes.io/instance-type
-                      operator: In
-                      values:
-                        - e2-highmem-8
-                        - e2-highmem-16
-                        - e2-standard-16
-                        - e2-standard-32
+        affinity: *affinity
         volumes:
           - name: docker-sock-dir
             emptyDir: {}
@@ -690,16 +631,16 @@ presubmits:
             image: docker:28.1-dind
             restartPolicy: Always
             command:
-            - /bin/sh
-            - -c
-            - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
+              - /bin/sh
+              - -c
+              - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
             env:
-            - name: DOCKER_TLS_CERTDIR
-              value: ""
-            - name: POD_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+              - name: POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
             securityContext:
               privileged: true
             volumeMounts:
@@ -771,18 +712,7 @@ presubmits:
       always_run: false
       optional: true
       spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: node.kubernetes.io/instance-type
-                      operator: In
-                      values:
-                        - e2-highmem-8
-                        - e2-highmem-16
-                        - e2-standard-16
-                        - e2-standard-32
+        affinity: *affinity
         volumes:
           - name: docker-sock-dir
             emptyDir: {}
@@ -815,16 +745,16 @@ presubmits:
             image: docker:28.1-dind
             restartPolicy: Always
             command:
-            - /bin/sh
-            - -c
-            - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
+              - /bin/sh
+              - -c
+              - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
             env:
-            - name: DOCKER_TLS_CERTDIR
-              value: ""
-            - name: POD_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+              - name: POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
             securityContext:
               privileged: true
             volumeMounts:
@@ -897,18 +827,7 @@ presubmits:
       always_run: false
       optional: true
       spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: node.kubernetes.io/instance-type
-                      operator: In
-                      values:
-                        - e2-highmem-8
-                        - e2-highmem-16
-                        - e2-standard-16
-                        - e2-standard-32
+        affinity: *affinity
         volumes:
           - name: docker-sock-dir
             emptyDir: {}
@@ -941,16 +860,16 @@ presubmits:
             image: docker:28.1-dind
             restartPolicy: Always
             command:
-            - /bin/sh
-            - -c
-            - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
+              - /bin/sh
+              - -c
+              - "dockerd-entrypoint.sh --cgroup-parent /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod$(echo ${POD_UID} | tr - _).slice"
             env:
-            - name: DOCKER_TLS_CERTDIR
-              value: ""
-            - name: POD_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+              - name: DOCKER_TLS_CERTDIR
+                value: ""
+              - name: POD_UID
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.uid
             securityContext:
               privileged: true
             volumeMounts:


### PR DESCRIPTION
- Add nodeAffinity for tidb-operator presubmits to require amd64 arch. 
- Replace previous nodeSelector constraints in latest presets. 
- Applies to latest and release-1.x presubmits.