### PR TITLE
ci(tiflash): migrate latest and release-8.5 jobs to GCP

### DIFF
--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -26,7 +26,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -44,28 +45,16 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
+                    script {
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        """
+                        prow.checkoutRefsWithCacheLock(REFS, 10, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        retry(2) {
                             sh """
-                            git config --global --add safe.directory "*"
-                            git version
                             git status
                             """
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 10, withSubmodule = true, gitBaseUrl = 'https://github.com')
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"
@@ -290,6 +279,7 @@ pipeline {
                             rm -rf ccache.tar
                             tar -cf ccache.tar .ccache
                             ls -alh ccache.tar
+                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
                             cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
                             cd -
                             """

--- a/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
@@ -26,7 +26,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -44,28 +45,16 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
+                    script {
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        """
+                        prow.checkoutRefsWithCacheLock(REFS, 10, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        retry(2) {
                             sh """
-                            git config --global --add safe.directory "*"
-                            git version
                             git status
                             """
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 10, withSubmodule = true, gitBaseUrl = 'https://github.com')
                             // Get next-gen tiflash-proxy commit hash.
                             // For submodule, we need to enter the submodule directory and get the commit hash from there.
                             dir("contrib/tiflash-proxy-next-gen") {
@@ -293,6 +282,7 @@ pipeline {
                             rm -rf ccache.tar
                             tar -cf ccache.tar .ccache
                             ls -alh ccache.tar
+                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
                             cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
                             cd -
                             """

--- a/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
@@ -20,7 +20,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -38,28 +39,16 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
+                    script {
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        """
+                        prow.checkoutRefsWithCacheLock(REFS, 10, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        retry(2) {
                             sh """
-                            git config --global --add safe.directory "*"
-                            git version
                             git status
                             """
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 10, withSubmodule = true, gitBaseUrl = 'https://github.com')
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"
@@ -300,9 +289,10 @@ pipeline {
                             rm -rf ccache.tar
                             tar -cf ccache.tar .ccache
                             ls -alh ccache.tar
+                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
                             cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
                             cd -
-                        """
+                            """
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
       imagePullPolicy: Always
       command:
         - "/bin/bash"
@@ -16,9 +16,11 @@ spec:
         requests:
           memory: 32Gi
           cpu: "12"
+          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
+          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -44,16 +46,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]
@@ -66,35 +58,17 @@ spec:
           memory: "4Gi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-7"
       emptyDir: {}
     - name: "volume-8"
@@ -109,7 +83,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
@@ -1,9 +1,11 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
       imagePullPolicy: Always
       command:
         - "cat"
@@ -12,6 +14,7 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "12000m"
+          ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -37,47 +40,19 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-7"
       emptyDir: {}
     - name: "volume-8"
@@ -92,7 +67,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
       imagePullPolicy: Always
       command:
         - "/bin/bash"
@@ -16,9 +16,11 @@ spec:
         requests:
           memory: 32Gi
           cpu: "12"
+          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
+          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -44,16 +46,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]
@@ -66,35 +58,17 @@ spec:
           memory: "4Gi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-7"
       emptyDir: {}
     - name: "volume-8"
@@ -109,7 +83,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
@@ -1,17 +1,26 @@
 apiVersion: "v1"
 kind: "Pod"
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
-    - image: "docker:18.09.6-dind"
+    - image: "docker:24.0.9-dind"
       imagePullPolicy: "IfNotPresent"
       name: "dockerd"
+      env:
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+        - name: DOCKER_DRIVER
+          value: overlay2
       resources:
         limits:
           memory: "32Gi"
           cpu: "16000m"
+          ephemeral-storage: 150Gi
         requests:
           memory: "12Gi"
           cpu: "5000m"
+          ephemeral-storage: 20Gi
       securityContext:
         privileged: true
       tty: false
@@ -19,11 +28,15 @@ spec:
         - mountPath: "/tmp"
           name: "volume-tmp"
           readOnly: false
+        - mountPath: "/var/lib/docker"
+          name: "docker-graph"
     - command:
         - "cat"
       env:
         - name: "DOCKER_HOST"
           value: "tcp://localhost:2375"
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
       image: ghcr.io/pingcap-qe/ci/base:v2026.4.12-11-g402978f-go1.25
       imagePullPolicy: "Always"
       name: "docker"
@@ -31,6 +44,11 @@ spec:
         requests:
           memory: "8Gi"
           cpu: "5000m"
+          ephemeral-storage: 10Gi
+        limits:
+          memory: "16Gi"
+          cpu: "8000m"
+          ephemeral-storage: 50Gi
       tty: true
       volumeMounts:
         - mountPath: "/tmp"
@@ -39,6 +57,16 @@ spec:
   volumes:
     - name: "volume-tmp"
       emptyDir: {}
+    - name: "docker-graph"
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -48,7 +76,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
@@ -1,9 +1,11 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
       imagePullPolicy: Always
       command:
         - "cat"
@@ -13,6 +15,7 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "12000m"
+          ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -41,47 +44,19 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-9"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-7"
       emptyDir: {}
     - name: "volume-8"

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -13,6 +13,9 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
 final OCI_TAG_TIDB = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
 final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
+final MINIO_VERSION = 'RELEASE.2025-07-23T15-54-02Z'
+final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
+final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-next-gen-it-build'
 
 Boolean proxy_cache_ready = false
 Boolean build_cache_ready = false
@@ -25,7 +28,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -47,27 +51,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                             println "tiflash_commit_hash: ${tiflash_commit_hash}"
 
@@ -374,7 +364,7 @@ pipeline {
                     sh label: "change permission", script: """
                         chown -R 1000:1000 ./
                     """
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('ng-binary', REFS, 'it-build')){
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
                        dir('tests/.build') {
                             sh label: "archive tiflash binary", script: """
                             cp -r ${WORKSPACE}/install/* ./
@@ -386,6 +376,7 @@ pipeline {
                         git show --oneline -s
                         rm -rf .git
                         rm -rf contrib
+                        rm -rf tests/fullstack-test-next-gen-columnar
                         du -sh ./
                         ls -alh
                         """
@@ -405,7 +396,8 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_INTEGRATIONTEST_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_INTEGRATIONTEST_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'docker'
                         retries 5
                         customWorkspace "/home/jenkins/agent/workspace/tiflash-integration-test"
@@ -419,23 +411,46 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir("${WORKSPACE}/tiflash") {
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('ng-binary', REFS, 'it-build')){
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
                                     dir("tests/${TEST_PATH}") {
                                         withEnv([
                                             "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${OCI_TAG_PD}",
                                             "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${OCI_TAG_TIKV}",
                                             "TIDB_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${OCI_TAG_TIDB}",
+                                            "MINIO_IMAGE=quay.io/minio/minio:${MINIO_VERSION}",
+                                            "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
                                         ]) {
                                             withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
                                                 sh label: "prepare docker images", script: '''
+                                                    set -eux
                                                     mkdir -p ~/.docker
-                                                    cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                                                    docker ps -a && docker version
+                                                    cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
+                                                    for i in $(seq 1 30); do
+                                                        if docker version; then
+                                                            break
+                                                        fi
+                                                        sleep 2
+                                                    done
+                                                    docker ps -a
 
-                                                    docker pull $PD_IMAGE
-                                                    docker pull $TIKV_IMAGE
-                                                    docker pull $TIDB_IMAGE
+                                                    timeout 300 docker pull "${PD_IMAGE}"
+                                                    timeout 300 docker pull "${TIKV_IMAGE}"
+                                                    timeout 300 docker pull "${TIDB_IMAGE}"
+                                                    timeout 300 docker pull "${MINIO_IMAGE}"
+                                                    timeout 600 docker pull "${TIFLASH_IMAGE}"
 
+                                                    find ../docker . -name '*.yaml' -type f -exec sed -i \
+                                                        -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                                                        -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                                                        -e 's#hub.pingcap.net/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                                                        -e "s#hub.pingcap.net/test-infra/minio:latest#${MINIO_IMAGE}#g" \
+                                                        -e "s#hub.pingcap.net/tikv/pd/image:master#${PD_IMAGE}#g" \
+                                                        -e "s#hub.pingcap.net/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                                                        -e "s#hub.pingcap.net/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                                                        -e 's#hub.pingcap.net/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                        -e 's#hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                        -e 's#hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                        {} +
                                                     rm -rf ~/.docker
                                                 '''
                                             }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -440,16 +440,21 @@ pipeline {
                                                     timeout 600 docker pull "${TIFLASH_IMAGE}"
 
                                                     find ../docker . -name '*.yaml' -type f -exec sed -i \
-                                                        -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
-                                                        -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
-                                                        -e 's#hub.pingcap.net/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
-                                                        -e "s#hub.pingcap.net/test-infra/minio:latest#${MINIO_IMAGE}#g" \
-                                                        -e "s#hub.pingcap.net/tikv/pd/image:master#${PD_IMAGE}#g" \
-                                                        -e "s#hub.pingcap.net/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
-                                                        -e "s#hub.pingcap.net/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
-                                                        -e 's#hub.pingcap.net/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                        -e 's#hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                        -e 's#hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                        -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
+                                                        -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
+                                                        -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
+                                                        -e 's#${MINIO_IMAGE:[^}]*}#'"${MINIO_IMAGE}"'#g' \
+                                                        -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/test-infra/minio:latest#${MINIO_IMAGE}#g" \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
                                                         {} +
                                                     rm -rf ~/.docker
                                                 '''

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -450,25 +450,30 @@ pipeline {
                                                         timeout 600 docker pull "${TIFLASH_IMAGE}"
 
                                                         find ../docker . -name '*.yaml' -type f -exec sed -i \
-                                                            -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
-                                                            -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
-                                                            -e 's#hub.pingcap.net/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
-                                                            -e 's#hub.pingcap.net/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                            -e "s#hub.pingcap.net/tikv/pd/image:master#${PD_IMAGE}#g" \
-                                                            -e 's#hub.pingcap.net/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e "s#hub.pingcap.net/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
-                                                            -e 's#hub.pingcap.net/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#hub.pingcap.net/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e "s#hub.pingcap.net/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
-                                                            -e "s#hub.pingcap.net/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
-                                                            -e 's#hub.pingcap.net/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                            -e 's#hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e 's#hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e "s#hub.pingcap.net/qa/pd:master#${PD_IMAGE}#g" \
-                                                            -e "s#hub.pingcap.net/qa/tikv:master#${TIKV_IMAGE}#g" \
-                                                            -e "s#hub.pingcap.net/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
-                                                            -e "s#hub.pingcap.net/qa/tidb:master#${TIDB_IMAGE}#g" \
+                                                            -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
+                                                            -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e 's#${TIDB_IMAGE:[^}]*-failpoint}#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:master#${PD_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:master#${TIKV_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master#${TIDB_IMAGE}#g" \
                                                             {} +
                                                         rm -rf ~/.docker
                                                     '''

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -420,11 +420,14 @@ pipeline {
                                             def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
                                             def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
                                             def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
+                                            def tidbImage = "${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}"
+                                            def tidbFailpointImage = "${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint"
+                                            def tidbRuntimeImage = env.TEST_PATH == 'tidb-ci' ? tidbFailpointImage : tidbImage
                                             withEnv([
                                                 "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${pdBranch}",
                                                 "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${tikvBranch}",
-                                                "TIDB_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}",
-                                                "TIDB_FAILPOINT_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint",
+                                                "TIDB_IMAGE=${tidbRuntimeImage}",
+                                                "TIDB_FAILPOINT_IMAGE=${tidbFailpointImage}",
                                                 "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
                                             ]) {
                                                 withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -10,6 +10,8 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_build.yaml'
 final POD_INTEGRATIONTEST_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final dependency_dir = "/home/jenkins/agent/dependency"
+final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
+final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-it-build'
 Boolean proxy_cache_ready = false
 Boolean build_cache_ready = false
 String proxy_commit_hash = null
@@ -21,7 +23,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -43,27 +46,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                             println "tiflash_commit_hash: ${tiflash_commit_hash}"
 
@@ -369,7 +358,7 @@ pipeline {
                     sh label: "change permission", script: """
                         chown -R 1000:1000 ./
                     """
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
                        dir('tests/.build') {
                             sh label: "archive tiflash binary", script: """
                             cp -r ${WORKSPACE}/install/* ./
@@ -381,6 +370,7 @@ pipeline {
                         git show --oneline -s
                         rm -rf .git
                         rm -rf contrib
+                        rm -rf tests/fullstack-test-next-gen-columnar
                         du -sh ./
                         ls -alh
                         """
@@ -400,7 +390,8 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_INTEGRATIONTEST_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_INTEGRATIONTEST_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'docker'
                         retries 5
                         customWorkspace "/home/jenkins/agent/workspace/tiflash-integration-test"
@@ -414,8 +405,8 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir("${WORKSPACE}/tiflash") {
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
-                                    println "restore from cache key: ${prow.getCacheKey('binary', REFS, 'it-build')}"
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
+                                    println "restore from cache key: ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}"
                                     sh label: "debug info", script: """
                                     printenv
                                     pwd && ls -alh
@@ -429,9 +420,61 @@ pipeline {
                                             def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
                                             def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
                                             def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
-                                            sh label: "run integration tests", script: """
-                                            PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
-                                            """
+                                            withEnv([
+                                                "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${pdBranch}",
+                                                "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${tikvBranch}",
+                                                "TIDB_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}",
+                                                "TIDB_FAILPOINT_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint",
+                                                "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
+                                            ]) {
+                                                withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                                                    sh label: "prepare docker images", script: '''
+                                                        set -eux
+                                                        mkdir -p ~/.docker
+                                                        cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
+                                                        for i in $(seq 1 30); do
+                                                            if docker version; then
+                                                                break
+                                                            fi
+                                                            sleep 2
+                                                        done
+                                                        docker ps -a
+
+                                                        timeout 300 docker pull "${PD_IMAGE}"
+                                                        timeout 300 docker pull "${TIKV_IMAGE}"
+                                                        timeout 300 docker pull "${TIDB_IMAGE}"
+                                                        timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
+                                                        timeout 600 docker pull "${TIFLASH_IMAGE}"
+
+                                                        find ../docker . -name '*.yaml' -type f -exec sed -i \
+                                                            -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                                                            -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                                                            -e 's#hub.pingcap.net/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                                                            -e 's#hub.pingcap.net/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e "s#hub.pingcap.net/tikv/pd/image:master#${PD_IMAGE}#g" \
+                                                            -e 's#hub.pingcap.net/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e "s#hub.pingcap.net/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                                                            -e 's#hub.pingcap.net/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#hub.pingcap.net/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#hub.pingcap.net/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#hub.pingcap.net/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                                                            -e 's#hub.pingcap.net/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e 's#hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e 's#hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#hub.pingcap.net/qa/pd:master#${PD_IMAGE}#g" \
+                                                            -e "s#hub.pingcap.net/qa/tikv:master#${TIKV_IMAGE}#g" \
+                                                            -e "s#hub.pingcap.net/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#hub.pingcap.net/qa/tidb:master#${TIDB_IMAGE}#g" \
+                                                            {} +
+                                                        rm -rf ~/.docker
+                                                    '''
+                                                }
+
+                                                sh label: "run integration tests", script: """
+                                                PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
+                                                """
+                                            }
                                         }
                                     }
                                 }

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -330,25 +330,33 @@ pipeline {
                         sh label: "change permission", script: """
                             chown -R 1000:1000 ./
                         """
-                        cache(path: "./", includes: '**/*', key: prow.getCacheKey('ng-binary', REFS, 'ut-build')) {
+                        def binaryCacheKey = prow.getCacheKey('ng-binary', REFS, 'ut-build-artifacts')
+                        sh label: "prepare binary cache dir", script: """
+                            mkdir -p tests/.build
+                        """
+                        cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
+                            // Fallback for cases where build_cache_ready was not set before this stage.
+                            build_cache_ready = build_cache_ready || (sh(
+                                script: "test -x tests/.build/tiflash/gtests_dbms",
+                                returnStatus: true
+                            ) == 0)
+
                             if (build_cache_ready) {
-                                println "build cache exist, restore from cache key: ${prow.getCacheKey('ng-binary', REFS, 'ut-build')}"
+                                println "build cache exist, restore from cache key: ${binaryCacheKey}"
                                 sh """
-                                du -sh ./
-                                ls -alh ./
                                 ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             } else {
-                                println "build cache not exist, clean git repo for cache"
-                                sh label: "clean git repo", script: """
+                                println "build cache not exist, save build artifacts to cache"
+                                sh label: "copy build artifacts", script: """
                                 git status
                                 git show --oneline -s
-                                mkdir tests/.build
+                                rm -rf tests/.build
+                                mkdir -p tests/.build
                                 cp -r ${WORKSPACE}/install/* tests/.build/
-                                rm -rf .git
-                                rm -rf contrib
-                                du -sh ./
-                                ls -alh
+                                ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             }
                         }

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -20,7 +20,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -42,27 +43,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
 
                             // Get next-gen tiflash-proxy commit hash.
                             // For submodule, we need to enter the submodule directory and get the commit hash from there.

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -20,7 +20,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -42,27 +43,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
 
                             // Get tiflash-proxy commit hash.
                             // For submodule, we need to enter the submodule directory and get the commit hash from there.

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -329,31 +329,33 @@ pipeline {
                         sh label: "change permission", script: """
                             chown -R 1000:1000 ./
                         """
-                        cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'ut-build')) {
+                        def binaryCacheKey = prow.getCacheKey('binary', REFS, 'ut-build-artifacts')
+                        sh label: "prepare binary cache dir", script: """
+                            mkdir -p tests/.build
+                        """
+                        cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
                             // Fallback for cases where build_cache_ready was not set before this stage.
                             build_cache_ready = build_cache_ready || (sh(
-                                script: "test -x tests/.build/tiflash",
+                                script: "test -x tests/.build/tiflash/gtests_dbms",
                                 returnStatus: true
                             ) == 0)
 
                             if (build_cache_ready) {
-                                println "build cache exist, restore from cache key: ${prow.getCacheKey('binary', REFS, 'ut-build')}"
+                                println "build cache exist, restore from cache key: ${binaryCacheKey}"
                                 sh """
-                                du -sh ./
-                                ls -alh ./
                                 ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             } else {
-                                println "build cache not exist, clean git repo for cache"
-                                sh label: "clean git repo", script: """
+                                println "build cache not exist, save build artifacts to cache"
+                                sh label: "copy build artifacts", script: """
                                 git status
                                 git show --oneline -s
+                                rm -rf tests/.build
                                 mkdir -p tests/.build
                                 cp -r ${WORKSPACE}/install/* tests/.build/
-                                rm -rf .git
-                                rm -rf contrib
-                                du -sh ./
-                                ls -alh
+                                ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             }
                         }

--- a/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
@@ -20,7 +20,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -38,28 +39,16 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
+                    script {
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
+                        retry(2) {
                             sh """
-                            git config --global --add safe.directory "*"
-                            git version
                             git status
                             """
-                            prow.checkoutRefs(REFS, credentialsId = '', timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"
@@ -252,6 +241,7 @@ pipeline {
                             rm -rf ccache.tar
                             tar -cf ccache.tar .ccache
                             ls -alh ccache.tar
+                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
                             cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
                             cd -
                             """

--- a/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
@@ -20,7 +20,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -38,28 +39,16 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
+                    script {
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
+                        retry(2) {
                             sh """
-                            git config --global --add safe.directory "*"
-                            git version
                             git status
                             """
-                            prow.checkoutRefs(REFS, credentialsId = '', timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"
@@ -272,6 +261,7 @@ pipeline {
                             rm -rf ccache.tar
                             tar -cf ccache.tar .ccache
                             ls -alh ccache.tar
+                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
                             cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
                             cd -
                         """

--- a/pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml
@@ -5,7 +5,8 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
+      imagePullPolicy: Always
       command:
         - "/bin/bash"
         - "-c"
@@ -15,9 +16,11 @@ spec:
         requests:
           memory: 32Gi
           cpu: "12"
+          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
+          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -40,16 +43,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]
@@ -62,30 +55,15 @@ spec:
           memory: "4Gi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
       emptyDir: {}
     - name: "volume-7"
@@ -100,7 +78,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml
@@ -1,9 +1,12 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
+      imagePullPolicy: Always
       command:
         - "cat"
       tty: true
@@ -11,6 +14,7 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "12000m"
+          ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -33,42 +37,17 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
       emptyDir: {}
     - name: "volume-7"
@@ -83,7 +62,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml
@@ -5,7 +5,8 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
+      imagePullPolicy: Always
       command:
         - "/bin/bash"
         - "-c"
@@ -15,9 +16,11 @@ spec:
         requests:
           memory: 32Gi
           cpu: "12"
+          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
+          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -40,16 +43,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]
@@ -62,30 +55,15 @@ spec:
           memory: "4Gi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
       emptyDir: {}
     - name: "volume-7"
@@ -100,7 +78,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml
@@ -1,17 +1,26 @@
 apiVersion: "v1"
 kind: "Pod"
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
-    - image: "docker:18.09.6-dind"
+    - image: "docker:24.0.9-dind"
       imagePullPolicy: "IfNotPresent"
       name: "dockerd"
+      env:
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+        - name: DOCKER_DRIVER
+          value: overlay2
       resources:
         limits:
           memory: "32Gi"
           cpu: "16000m"
+          ephemeral-storage: 150Gi
         requests:
           memory: "10Gi"
           cpu: "5000m"
+          ephemeral-storage: 20Gi
       securityContext:
         privileged: true
       tty: false
@@ -22,14 +31,15 @@ spec:
         - mountPath: "/tmp"
           name: "volume-3"
           readOnly: false
-        - mountPath: "/home/jenkins/agent"
-          name: "workspace-volume"
-          readOnly: false
+        - mountPath: "/var/lib/docker"
+          name: "docker-graph"
     - command:
         - "cat"
       env:
         - name: "DOCKER_HOST"
           value: "tcp://localhost:2375"
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
       image: ghcr.io/pingcap-qe/ci/base:v2026.4.12-11-g402978f-go1.25
       imagePullPolicy: "Always"
       name: "docker"
@@ -37,6 +47,11 @@ spec:
         requests:
           memory: "8Gi"
           cpu: "5000m"
+          ephemeral-storage: 10Gi
+        limits:
+          memory: "16Gi"
+          cpu: "8000m"
+          ephemeral-storage: 50Gi
       tty: true
       volumeMounts:
         - mountPath: "/home/jenkins"
@@ -45,19 +60,23 @@ spec:
         - mountPath: "/tmp"
           name: "volume-3"
           readOnly: false
-        - mountPath: "/home/jenkins/agent"
-          name: "workspace-volume"
-          readOnly: false
   volumes:
     - emptyDir:
         medium: ""
       name: "volume-0"
     - emptyDir:
         medium: ""
-      name: "workspace-volume"
-    - emptyDir:
-        medium: ""
       name: "volume-3"
+    - name: "docker-graph"
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -67,7 +86,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml
@@ -1,9 +1,12 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
+      imagePullPolicy: Always
       command:
         - "cat"
       tty: true
@@ -12,6 +15,7 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "12000m"
+          ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -37,42 +41,17 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
       emptyDir: {}
     - name: "volume-7"

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -10,6 +10,8 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-pull_build.
 final POD_INTEGRATIONTEST_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final dependency_dir = "/home/jenkins/agent/dependency"
+final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
+final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-release-8.5-it-build'
 Boolean proxy_cache_ready = false
 Boolean build_cache_ready = false
 String proxy_commit_hash = null
@@ -19,7 +21,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -41,27 +44,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = '', timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                             println "tiflash_commit_hash: ${tiflash_commit_hash}"
                             dir("contrib/tiflash-proxy") {
@@ -332,7 +321,7 @@ pipeline {
                     sh label: "change permission", script: """
                         chown -R 1000:1000 ./
                     """
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
                        dir('tests/.build') {
                             sh label: "archive tiflash binary", script: """
                             cp -r ${WORKSPACE}/install/* ./
@@ -344,6 +333,7 @@ pipeline {
                         git show --oneline -s
                         rm -rf .git
                         rm -rf contrib
+                        rm -rf tests/fullstack-test-next-gen-columnar
                         du -sh ./
                         ls -alh
                         """
@@ -363,7 +353,8 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_INTEGRATIONTEST_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_INTEGRATIONTEST_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'docker'
                         retries 5
                         customWorkspace "/home/jenkins/agent/workspace/tiflash-integration-test"
@@ -377,8 +368,8 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir("${WORKSPACE}/tiflash") {
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
-                                    println "restore from cache key: ${prow.getCacheKey('binary', REFS, 'it-build')}"
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
+                                    println "restore from cache key: ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}"
                                     sh label: "debug info", script: """
                                     printenv
                                     pwd && ls -alh
@@ -392,9 +383,61 @@ pipeline {
                                             def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
                                             def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
                                             def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
-                                            sh label: "run integration tests", script: """
-                                            PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
-                                            """
+                                            withEnv([
+                                                "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${pdBranch}",
+                                                "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${tikvBranch}",
+                                                "TIDB_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}",
+                                                "TIDB_FAILPOINT_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint",
+                                                "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
+                                            ]) {
+                                                withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                                                    sh label: "prepare docker images", script: '''
+                                                        set -eux
+                                                        mkdir -p ~/.docker
+                                                        cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
+                                                        for i in $(seq 1 30); do
+                                                            if docker version; then
+                                                                break
+                                                            fi
+                                                            sleep 2
+                                                        done
+                                                        docker ps -a
+
+                                                        timeout 300 docker pull "${PD_IMAGE}"
+                                                        timeout 300 docker pull "${TIKV_IMAGE}"
+                                                        timeout 300 docker pull "${TIDB_IMAGE}"
+                                                        timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
+                                                        timeout 600 docker pull "${TIFLASH_IMAGE}"
+
+                                                        find ../docker . -name '*.yaml' -type f -exec sed -i \
+                                                            -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                                                            -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                                                            -e 's#hub.pingcap.net/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                                                            -e 's#hub.pingcap.net/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e "s#hub.pingcap.net/tikv/pd/image:master#${PD_IMAGE}#g" \
+                                                            -e 's#hub.pingcap.net/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e "s#hub.pingcap.net/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                                                            -e 's#hub.pingcap.net/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#hub.pingcap.net/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#hub.pingcap.net/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#hub.pingcap.net/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                                                            -e 's#hub.pingcap.net/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e 's#hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e 's#hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#hub.pingcap.net/qa/pd:master#${PD_IMAGE}#g" \
+                                                            -e "s#hub.pingcap.net/qa/tikv:master#${TIKV_IMAGE}#g" \
+                                                            -e "s#hub.pingcap.net/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#hub.pingcap.net/qa/tidb:master#${TIDB_IMAGE}#g" \
+                                                            {} +
+                                                        rm -rf ~/.docker
+                                                    '''
+                                                }
+
+                                                sh label: "run integration tests", script: """
+                                                PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
+                                                """
+                                            }
                                         }
                                     }
                                 }

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -410,25 +410,30 @@ pipeline {
                                                         timeout 600 docker pull "${TIFLASH_IMAGE}"
 
                                                         find ../docker . -name '*.yaml' -type f -exec sed -i \
-                                                            -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
-                                                            -e "s#hub.pingcap.net/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
-                                                            -e 's#hub.pingcap.net/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
-                                                            -e 's#hub.pingcap.net/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                            -e "s#hub.pingcap.net/tikv/pd/image:master#${PD_IMAGE}#g" \
-                                                            -e 's#hub.pingcap.net/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e "s#hub.pingcap.net/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
-                                                            -e 's#hub.pingcap.net/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#hub.pingcap.net/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e "s#hub.pingcap.net/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
-                                                            -e "s#hub.pingcap.net/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
-                                                            -e 's#hub.pingcap.net/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                            -e 's#hub.pingcap.net/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e 's#hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#hub.pingcap.net/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e "s#hub.pingcap.net/qa/pd:master#${PD_IMAGE}#g" \
-                                                            -e "s#hub.pingcap.net/qa/tikv:master#${TIKV_IMAGE}#g" \
-                                                            -e "s#hub.pingcap.net/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
-                                                            -e "s#hub.pingcap.net/qa/tidb:master#${TIDB_IMAGE}#g" \
+                                                            -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
+                                                            -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e 's#${TIDB_IMAGE:[^}]*-failpoint}#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:master#${PD_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:master#${TIKV_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master#${TIDB_IMAGE}#g" \
                                                             {} +
                                                         rm -rf ~/.docker
                                                     '''

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -18,7 +18,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -40,27 +41,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = '', timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -291,31 +291,33 @@ pipeline {
                         sh label: "change permission", script: """
                             chown -R 1000:1000 ./
                         """
-                        cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'ut-build')) {
+                        def binaryCacheKey = prow.getCacheKey('binary', REFS, 'ut-build-artifacts')
+                        sh label: "prepare binary cache dir", script: """
+                            mkdir -p tests/.build
+                        """
+                        cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
                             // Fallback for cases where build_cache_ready was not set before this stage.
                             build_cache_ready = build_cache_ready || (sh(
-                                script: "test -x tests/.build/tiflash",
+                                script: "test -x tests/.build/tiflash/gtests_dbms",
                                 returnStatus: true
                             ) == 0)
 
                             if (build_cache_ready) {
-                                println "build cache exist, restore from cache key: ${prow.getCacheKey('binary', REFS, 'ut-build')}"
+                                println "build cache exist, restore from cache key: ${binaryCacheKey}"
                                 sh """
-                                du -sh ./
-                                ls -alh ./
                                 ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             } else {
-                                println "build cache not exist, clean git repo for cache"
-                                sh label: "clean git repo", script: """
+                                println "build cache not exist, save build artifacts to cache"
+                                sh label: "copy build artifacts", script: """
                                 git status
                                 git show --oneline -s
+                                rm -rf tests/.build
                                 mkdir -p tests/.build
                                 cp -r ${WORKSPACE}/install/* tests/.build/
-                                rm -rf .git
-                                rm -rf contrib
-                                du -sh ./
-                                ls -alh
+                                ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             }
                         }

--- a/prow-jobs/pingcap/tiflash/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: pingcap/tiflash/merged_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: merged-unit-test # need change this after test pass.
       max_concurrency: 1
@@ -14,7 +14,7 @@ postsubmits:
     - name: pingcap/tiflash/merged_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: merged-build # need change this after test pass.
       max_concurrency: 1
@@ -24,7 +24,7 @@ postsubmits:
     - name: pingcap/tiflash/merged_build_next_gen
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: merged-build-next-gen
       max_concurrency: 1

--- a/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
@@ -14,7 +14,7 @@ presubmits:
     - <<: *brancher
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       context: pull-unit-next-gen
       decorate: false # need add this.
       name: pingcap/tiflash/pull_unit_next_gen
@@ -27,7 +27,7 @@ presubmits:
     - <<: *brancher
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       context: pull-integration-next-gen
       decorate: false # need add this.
       name: pingcap/tiflash/pull_integration_next_gen

--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -158,7 +158,7 @@ presubmits:
     - <<: *brancher
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       context: pull-unit-test
       decorate: false # need add this.
       name: pingcap/tiflash/pull_unit_test
@@ -171,7 +171,7 @@ presubmits:
     - <<: *brancher
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       context: pull-integration-test
       decorate: false # need add this.
       name: pingcap/tiflash/pull_integration_test

--- a/prow-jobs/pingcap/tiflash/release-8.5-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.5-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: pingcap/tiflash/release-8.5/merged_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: merged-unit-test
       max_concurrency: 1
@@ -14,7 +14,7 @@ postsubmits:
     - name: pingcap/tiflash/release-8.5/merged_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: merged-build
       max_concurrency: 1

--- a/prow-jobs/pingcap/tiflash/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.5-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -23,7 +23,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.5/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test


### PR DESCRIPTION
### changed

- Migrate TiFlash `latest` and `release-8.5` presubmit/postsubmit jobs to run on GCP.
- Update TiFlash Jenkins pod templates to use GCP-compatible builder images, storage, and resources.
- Replace remaining `hub.pingcap.net` runtime images in integration pipelines with GCP Artifact Registry / GHCR images.
- Update integration test image wiring for PD, TiKV, TiDB, TiDB failpoint, and TiFlash.
- Use the TiDB failpoint image for `tidb-ci` fail-point tests.
- Narrow TiFlash unit-test binary cache from the whole source workspace to `tests/.build` only, and use new cache keys to avoid restoring old unsafe workspace caches.

### Why

The previous TiFlash jobs were still using KSY-era configuration and internal image references that are not available from GCP runners. This aligns TiFlash CI with the existing GCP migration pattern used by TiDB, TiCDC, and PD.

### Validation

Replayed these jobs on Jenkins : 
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_integration_next_gen/23/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_integration_test/11/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_unit_next_gen/9/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_unit_test/6/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/merged_build/4/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/merged_build_next_gen/5/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/merged_unit_test/5/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/release-8.5/job/pull_unit_test/6/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/release-8.5/job/pull_integration_test/13/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/release-8.5/job/merged_unit_test/10/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/release-8.5/job/merged_build/4/stages/
