### PR TITLE
ci(tiflash): migrate merged jobs to GCP

### DIFF
--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -3,8 +3,7 @@
 // should triggerd for master branches
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-tiflash"  // TODO: need to adjust namespace after test
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
+final K8S_NAMESPACE = "jenkins-tiflash"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-merged_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
@@ -26,7 +25,6 @@ pipeline {
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
@@ -51,47 +49,18 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
-            parallel {
-                stage("Ccache") {
-                    steps {
-                        script {
-                            dir("tiflash") {
-                                sh label: "config ccache", script: """
-                                ccache -o cache_dir="/tmp/.ccache"
-                                ccache -o max_size=2G
-                                ccache -o hash_dir=false
-                                ccache -o compression=true
-                                ccache -o compression_level=6
-                                ccache -o read_only=false
-                                ccache -z
-                                """
-                            }
-                        }
-                    }
-
-                }
-                stage("Cargo-Cache") {
-                    steps {
-                        sh label: "link cargo cache", script: """
-                            mkdir -p ~/.cargo/registry
-                            mkdir -p ~/.cargo/git
-                            mkdir -p /home/jenkins/agent/rust/registry/cache
-                            mkdir -p /home/jenkins/agent/rust/registry/index
-                            mkdir -p /home/jenkins/agent/rust/git/db
-                            mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                            rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                            rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                            rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                            rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                            rm -rf ~/.rustup/tmp
-                            rm -rf ~/.rustup/toolchains
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                            ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                            ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
+        stage("Prepare Ccache") {
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
+                        ccache -o cache_dir="/tmp/.ccache"
+                        ccache -o max_size=2G
+                        ccache -o hash_dir=false
+                        ccache -o compression=true
+                        ccache -o compression_level=6
+                        ccache -o read_only=false
+                        ccache -z
                         """
                     }
                 }
@@ -100,12 +69,7 @@ pipeline {
         stage("Configure Project") {
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -113,7 +77,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
+                        cmake '${WORKSPACE}/tiflash' \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -134,7 +98,7 @@ pipeline {
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh """
-                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel 12
+                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel ${PARALLELISM}
                     """
                     sh """
                     cmake --install '${WORKSPACE}/build' --component=tiflash-release --prefix='${WORKSPACE}/install/tiflash'
@@ -161,20 +125,6 @@ pipeline {
                             echo "skip license check"
                             exit 0
                         fi
-                    """
-                }
-            }
-        }
-        stage("Post Build") {
-            steps {
-                dir("${WORKSPACE}/install") {
-                    sh label: "archive tiflash binary", script: """
-                    tar -czf 'tiflash.tar.gz' 'tiflash'
-                    """
-                    archiveArtifacts artifacts: "tiflash.tar.gz"
-                    sh """
-                    du -sh tiflash.tar.gz
-                    rm -rf tiflash.tar.gz
                     """
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -9,18 +9,6 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-merged_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-final dependency_dir = "/home/jenkins/agent/dependency"
-final proxy_cache_dir = "/home/jenkins/agent/proxy-cache/refactor-pipelines"
-
-Boolean proxy_cache_ready = false
-String proxy_commit_hash = null
-Boolean update_proxy_cache = true
-
-Boolean libclara_cache_ready = false
-String libclara_commit_hash = null
-Boolean update_libclara_cache = true
-
-Boolean update_ccache = true
 
 pipeline {
     agent {
@@ -55,14 +43,6 @@ pipeline {
                             sh """
                             git status
                             """
-                            dir("contrib/tiflash-proxy") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
-
-                            libclara_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H" -- libs/libclara').trim()
-                            println "libclara_commit_hash: ${libclara_commit_hash}"
-
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -77,18 +57,6 @@ pipeline {
                     steps {
                         script {
                             dir("tiflash") {
-                                sh label: "copy ccache if exist", script: """
-                                ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                                if [ -f \$ccache_tar_file ]; then
-                                    echo "ccache found"
-                                    cd /tmp
-                                    cp -r \$ccache_tar_file ccache.tar
-                                    tar -xf ccache.tar
-                                    ls -lha /tmp
-                                else
-                                    echo "ccache not found"
-                                fi
-                                """
                                 sh label: "config ccache", script: """
                                 ccache -o cache_dir="/tmp/.ccache"
                                 ccache -o max_size=2G
@@ -102,51 +70,6 @@ pipeline {
                         }
                     }
 
-                }
-                stage("Proxy-Cache") {
-                    steps {
-                        script {
-                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-
-                            sh label: "copy proxy if exist", script: """
-                            proxy_suffix="amd64-linux-llvm"
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-\${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
-                        }
-                    }
-                }
-                stage("Libclara Cache") {
-                    steps {
-                        script {
-                            libclara_cache_ready = sh(script: "test -d /home/jenkins/agent/libclara-cache/${libclara_commit_hash}-amd64-linux-debug && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "libclara_cache_ready: ${libclara_cache_ready}"
-
-                            sh label: "copy libclara if exist", script: """
-                            libclara_suffix="amd64-linux-debug"
-                            libclara_cache_dir="/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-\${libclara_suffix}"
-                            if [ -d \$libclara_cache_dir ]; then
-                                echo "libclara cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                cp -r \$libclara_cache_dir/* ${WORKSPACE}/tiflash/libs/libclara-prebuilt/
-                                chmod +x ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
-                                chown -R 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                ls -R ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                            else
-                                echo "libclara cache not found"
-                            fi
-                            """
-                        }
-                    }
                 }
                 stage("Cargo-Cache") {
                     steps {
@@ -183,19 +106,6 @@ pipeline {
                     def diagnostic_flag = ""
                     def compatible_flag = ""
                     def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    def libclara_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release/
-                        """
-                    }
-                    if (libclara_cache_ready) {
-                        libclara_flag = "-DLIBCLARA_CXXBRIDGE_DIR='${WORKSPACE}/tiflash/libs/libclara-prebuilt/cxxbridge' -DLIBCLARA_LIBRARY='${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so'"
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -203,7 +113,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} ${libclara_flag} \\
+                        cmake '${WORKSPACE}/tiflash' ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -212,8 +122,8 @@ pipeline {
                             -DENABLE_TESTS=false \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
-                            -DUSE_INTERNAL_LIBCLARA=${!libclara_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
+                            -DUSE_INTERNAL_LIBCLARA=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -256,92 +166,16 @@ pipeline {
             }
         }
         stage("Post Build") {
-            parallel {
-                stage("Upload Build Artifacts") {
-                    steps {
-                        dir("${WORKSPACE}/install") {
-                            sh label: "archive tiflash binary", script: """
-                            tar -czf 'tiflash.tar.gz' 'tiflash'
-                            """
-                            archiveArtifacts artifacts: "tiflash.tar.gz"
-                            sh """
-                            du -sh tiflash.tar.gz
-                            rm -rf tiflash.tar.gz
-                            """
-                        }
-                    }
-                }
-                stage("Upload Ccache") {
-                    steps {
-                        dir("${WORKSPACE}/tiflash") {
-                            sh label: "upload ccache", script: """
-                            cd /tmp
-                            rm -rf ccache.tar
-                            tar -cf ccache.tar .ccache
-                            ls -alh ccache.tar
-                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
-                            cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
-                            cd -
-                            """
-                        }
-                    }
-                }
-                stage("Upload Proxy Cache") {
-                    steps {
-                        script {
-                            if (update_proxy_cache) {
-                                if (proxy_commit_hash && proxy_commit_hash =~ /^[0-9a-f]{40}$/) {
-                                    def proxy_suffix = "amd64-linux-llvm"
-                                    def cache_destination = "/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-${proxy_suffix}"
-
-                                    sh label: "upload proxy cache", script: """
-                                        if [ -f "${cache_destination}" ]; then
-                                            echo "Proxy cache already exists at ${cache_destination}, skip uploading"
-                                        elif [ -f "${WORKSPACE}/install/tiflash/libtiflash_proxy.so" ]; then
-                                            cp "${WORKSPACE}/install/tiflash/libtiflash_proxy.so" "${cache_destination}"
-                                            echo "Proxy cache uploaded to ${cache_destination}"
-                                        else
-                                            echo "Proxy library not found, cache not updated"
-                                        fi
-                                    """
-                                } else {
-                                    echo "Skip uploading proxy cache because commit hash '${proxy_commit_hash}' is not valid"
-                                }
-                            } else {
-                                echo "Skip because proxy cache refresh is disabled"
-                            }
-                        }
-                    }
-                }
-                stage("Upload Libclara Cache") {
-                    steps {
-                        script {
-                            if (update_libclara_cache) {
-                                if (libclara_commit_hash && libclara_commit_hash =~ /^[0-9a-f]{40}$/) {
-                                    def libclara_suffix = "amd64-linux-debug"
-                                    def cache_destination = "/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-${libclara_suffix}"
-
-                                    sh label: "upload libclara cache", script: """
-                                        if [ -d "${cache_destination}" ]; then
-                                            echo "Libclara cache already exists at ${cache_destination}, skip uploading"
-                                        elif [ -f "${WORKSPACE}/build/libs/libclara-cmake/libclara_sharedd.so" ]; then
-                                            mkdir -p "${cache_destination}_tmp"
-                                            cp "${WORKSPACE}/build/libs/libclara-cmake/libclara_sharedd.so" "${cache_destination}_tmp/"
-                                            cp -RL "${WORKSPACE}/build/libs/libclara-cmake/cxxbridge" "${cache_destination}_tmp/"
-                                            mv "${cache_destination}_tmp" "${cache_destination}"
-                                            echo "Libclara cache uploaded to ${cache_destination}"
-                                        else
-                                            echo "Libclara library not found in local build, cache not updated"
-                                        fi
-                                    """
-                                } else {
-                                    echo "Skip uploading libclara cache because commit hash '${libclara_commit_hash}' is not valid"
-                                }
-                            } else {
-                                echo "Skip because libclara cache refresh is disabled"
-                            }
-                        }
-                    }
+            steps {
+                dir("${WORKSPACE}/install") {
+                    sh label: "archive tiflash binary", script: """
+                    tar -czf 'tiflash.tar.gz' 'tiflash'
+                    """
+                    archiveArtifacts artifacts: "tiflash.tar.gz"
+                    sh """
+                    du -sh tiflash.tar.gz
+                    rm -rf tiflash.tar.gz
+                    """
                 }
             }
         }

--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -26,7 +26,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -44,28 +45,16 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
+                    script {
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        """
+                        prow.checkoutRefsWithCacheLock(REFS, 10, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        retry(2) {
                             sh """
-                            git config --global --add safe.directory "*"
-                            git version
                             git status
                             """
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 10, withSubmodule = true, gitBaseUrl = 'https://github.com')
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"
@@ -290,6 +279,7 @@ pipeline {
                             rm -rf ccache.tar
                             tar -cf ccache.tar .ccache
                             ls -alh ccache.tar
+                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
                             cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
                             cd -
                             """

--- a/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
@@ -3,8 +3,7 @@
 // should triggerd for master branches
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-tiflash"  // TODO: need to adjust namespace after test
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
+final K8S_NAMESPACE = "jenkins-tiflash"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-merged_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
@@ -26,7 +25,6 @@ pipeline {
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
@@ -51,47 +49,18 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
-            parallel {
-                stage("Ccache") {
-                    steps {
-                        script {
-                            dir("tiflash") {
-                                sh label: "config ccache", script: """
-                                ccache -o cache_dir="/tmp/.ccache"
-                                ccache -o max_size=2G
-                                ccache -o hash_dir=false
-                                ccache -o compression=true
-                                ccache -o compression_level=6
-                                ccache -o read_only=false
-                                ccache -z
-                                """
-                            }
-                        }
-                    }
-
-                }
-                stage("Cargo-Cache") {
-                    steps {
-                        sh label: "link cargo cache", script: """
-                            mkdir -p ~/.cargo/registry
-                            mkdir -p ~/.cargo/git
-                            mkdir -p /home/jenkins/agent/rust/registry/cache
-                            mkdir -p /home/jenkins/agent/rust/registry/index
-                            mkdir -p /home/jenkins/agent/rust/git/db
-                            mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                            rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                            rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                            rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                            rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                            rm -rf ~/.rustup/tmp
-                            rm -rf ~/.rustup/toolchains
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                            ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                            ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
+        stage("Prepare Ccache") {
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
+                        ccache -o cache_dir="/tmp/.ccache"
+                        ccache -o max_size=2G
+                        ccache -o hash_dir=false
+                        ccache -o compression=true
+                        ccache -o compression_level=6
+                        ccache -o read_only=false
+                        ccache -z
                         """
                     }
                 }
@@ -100,13 +69,8 @@ pipeline {
         stage("Configure Project") {
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
                     def next_gen_flag = "-DENABLE_NEXT_GEN=ON"
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -114,7 +78,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} ${next_gen_flag} \\
+                        cmake '${WORKSPACE}/tiflash' ${next_gen_flag} \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -135,7 +99,7 @@ pipeline {
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh """
-                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel 12
+                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel ${PARALLELISM}
                     """
                     sh """
                     cmake --install '${WORKSPACE}/build' --component=tiflash-release --prefix='${WORKSPACE}/install/tiflash'

--- a/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
@@ -26,7 +26,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -44,28 +45,16 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
+                    script {
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        """
+                        prow.checkoutRefsWithCacheLock(REFS, 10, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        retry(2) {
                             sh """
-                            git config --global --add safe.directory "*"
-                            git version
                             git status
                             """
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 10, withSubmodule = true, gitBaseUrl = 'https://github.com')
                             // Get next-gen tiflash-proxy commit hash.
                             // For submodule, we need to enter the submodule directory and get the commit hash from there.
                             dir("contrib/tiflash-proxy-next-gen") {
@@ -293,6 +282,7 @@ pipeline {
                             rm -rf ccache.tar
                             tar -cf ccache.tar .ccache
                             ls -alh ccache.tar
+                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
                             cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
                             cd -
                             """

--- a/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
@@ -9,18 +9,6 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-merged_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-final dependency_dir = "/home/jenkins/agent/dependency"
-final proxy_cache_dir = "/home/jenkins/agent/proxy-cache/refactor-pipelines"
-
-Boolean proxy_cache_ready = false
-String proxy_commit_hash = null
-Boolean update_proxy_cache = true
-
-Boolean libclara_cache_ready = false
-String libclara_commit_hash = null
-Boolean update_libclara_cache = true
-
-Boolean update_ccache = true
 
 pipeline {
     agent {
@@ -55,16 +43,6 @@ pipeline {
                             sh """
                             git status
                             """
-                            // Get next-gen tiflash-proxy commit hash.
-                            // For submodule, we need to enter the submodule directory and get the commit hash from there.
-                            dir("contrib/tiflash-proxy-next-gen") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
-
-                            libclara_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H" -- libs/libclara').trim()
-                            println "libclara_commit_hash: ${libclara_commit_hash}"
-
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -79,18 +57,6 @@ pipeline {
                     steps {
                         script {
                             dir("tiflash") {
-                                sh label: "copy ccache if exist", script: """
-                                ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                                if [ -f \$ccache_tar_file ]; then
-                                    echo "ccache found"
-                                    cd /tmp
-                                    cp -r \$ccache_tar_file ccache.tar
-                                    tar -xf ccache.tar
-                                    ls -lha /tmp
-                                else
-                                    echo "ccache not found"
-                                fi
-                                """
                                 sh label: "config ccache", script: """
                                 ccache -o cache_dir="/tmp/.ccache"
                                 ccache -o max_size=2G
@@ -104,51 +70,6 @@ pipeline {
                         }
                     }
 
-                }
-                stage("Proxy-Cache") {
-                    steps {
-                        script {
-                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm-next-gen && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-
-                            sh label: "copy proxy if exist", script: """
-                            proxy_suffix="amd64-linux-llvm-next-gen"
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-\${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
-                        }
-                    }
-                }
-                stage("Libclara Cache") {
-                    steps {
-                        script {
-                            libclara_cache_ready = sh(script: "test -d /home/jenkins/agent/libclara-cache/${libclara_commit_hash}-amd64-linux-debug && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "libclara_cache_ready: ${libclara_cache_ready}"
-
-                            sh label: "copy libclara if exist", script: """
-                            libclara_suffix="amd64-linux-debug"
-                            libclara_cache_dir="/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-\${libclara_suffix}"
-                            if [ -d \$libclara_cache_dir ]; then
-                                echo "libclara cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                cp -r \$libclara_cache_dir/* ${WORKSPACE}/tiflash/libs/libclara-prebuilt/
-                                chmod +x ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
-                                chown -R 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                ls -R ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                            else
-                                echo "libclara cache not found"
-                            fi
-                            """
-                        }
-                    }
                 }
                 stage("Cargo-Cache") {
                     steps {
@@ -186,19 +107,6 @@ pipeline {
                     def diagnostic_flag = ""
                     def compatible_flag = ""
                     def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    def libclara_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy-next-gen/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy-next-gen/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy-next-gen/target/release/
-                        """
-                    }
-                    if (libclara_cache_ready) {
-                        libclara_flag = "-DLIBCLARA_CXXBRIDGE_DIR='${WORKSPACE}/tiflash/libs/libclara-prebuilt/cxxbridge' -DLIBCLARA_LIBRARY='${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so'"
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -206,7 +114,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} ${libclara_flag} ${next_gen_flag} \\
+                        cmake '${WORKSPACE}/tiflash' ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} ${next_gen_flag} \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -215,8 +123,8 @@ pipeline {
                             -DENABLE_TESTS=false \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
-                            -DUSE_INTERNAL_LIBCLARA=${!libclara_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
+                            -DUSE_INTERNAL_LIBCLARA=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -255,96 +163,6 @@ pipeline {
                             exit 0
                         fi
                     """
-                }
-            }
-        }
-        stage("Post Build") {
-            parallel {
-                // stage("Upload Build Artifacts") {
-                //     steps {
-                //         dir("${WORKSPACE}/install") {
-                //             sh label: "archive tiflash binary", script: """
-                //             tar -czf 'tiflash.tar.gz' 'tiflash'
-                //             """
-                //             archiveArtifacts artifacts: "tiflash.tar.gz"
-                //             sh """
-                //             du -sh tiflash.tar.gz
-                //             rm -rf tiflash.tar.gz
-                //             """
-                //         }
-                //     }
-                // }
-                stage("Upload Ccache") {
-                    steps {
-                        dir("${WORKSPACE}/tiflash") {
-                            sh label: "upload ccache", script: """
-                            cd /tmp
-                            rm -rf ccache.tar
-                            tar -cf ccache.tar .ccache
-                            ls -alh ccache.tar
-                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
-                            cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
-                            cd -
-                            """
-                        }
-                    }
-                }
-                stage("Upload Proxy Cache") {
-                    steps {
-                        script {
-                            if (update_proxy_cache) {
-                                if (proxy_commit_hash && proxy_commit_hash =~ /^[0-9a-f]{40}$/) {
-                                    def proxy_suffix = "amd64-linux-llvm-next-gen"
-                                    def cache_destination = "/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-${proxy_suffix}"
-
-                                    sh label: "upload proxy cache", script: """
-                                        if [ -f "${cache_destination}" ]; then
-                                            echo "Proxy cache already exists at ${cache_destination}, skip uploading"
-                                        elif [ -f "${WORKSPACE}/install/tiflash/libtiflash_proxy.so" ]; then
-                                            cp "${WORKSPACE}/install/tiflash/libtiflash_proxy.so" "${cache_destination}"
-                                            echo "Proxy cache uploaded to ${cache_destination}"
-                                        else
-                                            echo "Proxy library not found, cache not updated"
-                                        fi
-                                    """
-                                } else {
-                                    echo "Skip uploading proxy cache because commit hash '${proxy_commit_hash}' is not valid"
-                                }
-                            } else {
-                                echo "Skip because proxy cache refresh is disabled"
-                            }
-                        }
-                    }
-                }
-                stage("Upload Libclara Cache") {
-                    steps {
-                        script {
-                            if (update_libclara_cache) {
-                                if (libclara_commit_hash && libclara_commit_hash =~ /^[0-9a-f]{40}$/) {
-                                    def libclara_suffix = "amd64-linux-debug"
-                                    def cache_destination = "/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-${libclara_suffix}"
-
-                                    sh label: "upload libclara cache", script: """
-                                        if [ -d "${cache_destination}" ]; then
-                                            echo "Libclara cache already exists at ${cache_destination}, skip uploading"
-                                        elif [ -f "${WORKSPACE}/build/libs/libclara-cmake/libclara_sharedd.so" ]; then
-                                            mkdir -p "${cache_destination}_tmp"
-                                            cp "${WORKSPACE}/build/libs/libclara-cmake/libclara_sharedd.so" "${cache_destination}_tmp/"
-                                            cp -RL "${WORKSPACE}/build/libs/libclara-cmake/cxxbridge" "${cache_destination}_tmp/"
-                                            mv "${cache_destination}_tmp" "${cache_destination}"
-                                            echo "Libclara cache uploaded to ${cache_destination}"
-                                        else
-                                            echo "Libclara library not found in local build, cache not updated"
-                                        fi
-                                    """
-                                } else {
-                                    echo "Skip uploading libclara cache because commit hash '${libclara_commit_hash}' is not valid"
-                                }
-                            } else {
-                                echo "Skip because libclara cache refresh is disabled"
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
@@ -20,7 +20,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -38,28 +39,16 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
+                    script {
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        """
+                        prow.checkoutRefsWithCacheLock(REFS, 10, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        retry(2) {
                             sh """
-                            git config --global --add safe.directory "*"
-                            git version
                             git status
                             """
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 10, withSubmodule = true, gitBaseUrl = 'https://github.com')
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"
@@ -300,9 +289,10 @@ pipeline {
                             rm -rf ccache.tar
                             tar -cf ccache.tar .ccache
                             ls -alh ccache.tar
+                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
                             cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
                             cd -
-                        """
+                            """
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
@@ -9,12 +9,6 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-final dependency_dir = "/home/jenkins/agent/dependency"
-final proxy_cache_dir = "/home/jenkins/agent/proxy-cache/refactor-pipelines"
-Boolean proxy_cache_ready = false
-String proxy_commit_hash = null
-Boolean libclara_cache_ready = false
-String libclara_commit_hash = null
 
 pipeline {
     agent {
@@ -49,10 +43,6 @@ pipeline {
                             sh """
                             git status
                             """
-                            dir("contrib/tiflash-proxy") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -67,19 +57,6 @@ pipeline {
                     steps {
                     script {
                         dir("tiflash") {
-                            sh label: "copy ccache if exist", script: """
-                            pwd & ls -alh
-                            ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                            if [ -f \$ccache_tar_file ]; then
-                                echo "ccache found"
-                                cd /tmp
-                                cp -r \$ccache_tar_file ccache.tar
-                                tar -xf ccache.tar
-                                ls -lha /tmp
-                            else
-                                echo "ccache not found"
-                            fi
-                            """
                             sh label: "config ccache", script: """
                             ccache -o cache_dir="/tmp/.ccache"
                             ccache -o max_size=2G
@@ -93,24 +70,9 @@ pipeline {
                     }
                     }
                 }
-                stage("Proxy-Cache") {
+                stage("Cargo-Cache") {
                     steps {
                         script {
-                            proxy_cache_ready = fileExists("/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm")
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-                            sh label: "copy proxy if exist", script: """
-                            proxy_suffix="amd64-linux-llvm"
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-\${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
                             sh label: "link cargo cache", script: """
                                 mkdir -p ~/.cargo/registry
                                 mkdir -p ~/.cargo/git
@@ -134,29 +96,6 @@ pipeline {
                         }
                     }
                 }
-                stage("Libclara Cache") {
-                    steps {
-                        script {
-                            libclara_cache_ready = sh(script: "test -d /home/jenkins/agent/libclara-cache/${libclara_commit_hash}-amd64-linux-debug && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "libclara_cache_ready: ${libclara_cache_ready}"
-
-                            sh label: "copy libclara if exist", script: """
-                            libclara_suffix="amd64-linux-debug"
-                            libclara_cache_dir="/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-\${libclara_suffix}"
-                            if [ -d \$libclara_cache_dir ]; then
-                                echo "libclara cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                cp -r \$libclara_cache_dir/* ${WORKSPACE}/tiflash/libs/libclara-prebuilt/
-                                chmod +x ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
-                                chown -R 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                ls -R ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                            else
-                                echo "libclara cache not found"
-                            fi
-                            """
-                        }
-                    }
-                }
             }
         }
         stage("Build Dependency and Utils") {
@@ -170,11 +109,7 @@ pipeline {
                 stage("TiFlash Proxy") {
                     steps {
                         script {
-                            if (proxy_cache_ready) {
-                                echo "skip becuase of cache"
-                            } else {
-                               echo "skip because proxy build is integrated(llvm)"
-                            }
+                            echo "skip because proxy build is integrated(llvm)"
                         }
                     }
                 }
@@ -190,19 +125,6 @@ pipeline {
                     def diagnostic_flag = ""
                     def compatible_flag = ""
                     def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    def libclara_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release/
-                        """
-                    }
-                    if (libclara_cache_ready) {
-                        libclara_flag = "-DLIBCLARA_CXXBRIDGE_DIR='${WORKSPACE}/tiflash/libs/libclara-prebuilt/cxxbridge' -DLIBCLARA_LIBRARY='${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so'"
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -210,7 +132,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} ${libclara_flag} \\
+                        cmake '${WORKSPACE}/tiflash' ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -219,8 +141,8 @@ pipeline {
                             -DENABLE_TESTS=true \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
-                            -DUSE_INTERNAL_LIBCLARA=${!libclara_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
+                            -DUSE_INTERNAL_LIBCLARA=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -280,19 +202,6 @@ pipeline {
                             """
                             archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
                         }
-                    }
-                }
-                stage("Upload Ccache") {
-                    steps {
-                        sh label: "upload ccache", script: """
-                            cd /tmp
-                            rm -rf ccache.tar
-                            tar -cf ccache.tar .ccache
-                            ls -alh ccache.tar
-                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
-                            cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
-                            cd -
-                            """
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
@@ -119,22 +119,6 @@ pipeline {
             }
         }
 
-        stage("Post Build") {
-            steps {
-                dir("${WORKSPACE}/build") {
-                    sh """
-                    tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
-                    """
-                    archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
-                }
-                dir("${WORKSPACE}/tiflash") {
-                    sh """
-                    tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
-                    """
-                    archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
-                }
-            }
-        }
         stage("Unit Test Prepare") {
             steps {
                 sh label: "link unit test dir", script: """

--- a/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
@@ -3,8 +3,7 @@
 // should triggerd for master branches
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-tiflash"  // TODO: need to adjust namespace after test
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
+final K8S_NAMESPACE = "jenkins-tiflash"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
@@ -21,12 +20,8 @@ pipeline {
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
     options {
         timeout(time: 120, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
@@ -51,66 +46,19 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
-            parallel {
-                stage("Ccache") {
-                    steps {
-                    script {
-                        dir("tiflash") {
-                            sh label: "config ccache", script: """
-                            ccache -o cache_dir="/tmp/.ccache"
-                            ccache -o max_size=2G
-                            ccache -o hash_dir=false
-                            ccache -o compression=true
-                            ccache -o compression_level=6
-                            ccache -o read_only=false
-                            ccache -z
-                            """
-                        }
-                    }
-                    }
-                }
-                stage("Cargo-Cache") {
-                    steps {
-                        script {
-                            sh label: "link cargo cache", script: """
-                                mkdir -p ~/.cargo/registry
-                                mkdir -p ~/.cargo/git
-                                mkdir -p /home/jenkins/agent/rust/registry/cache
-                                mkdir -p /home/jenkins/agent/rust/registry/index
-                                mkdir -p /home/jenkins/agent/rust/git/db
-                                mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                                rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                                rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                                rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                                rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                                rm -rf ~/.rustup/tmp
-                                rm -rf ~/.rustup/toolchains
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                                ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                                ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
-                            """
-                        }
-                    }
-                }
-            }
-        }
-        stage("Build Dependency and Utils") {
-            parallel {
-                stage("Cluster Manage") {
-                    steps {
-                        // NOTE: cluster_manager is deprecated since release-6.0 (include)
-                        echo "cluster_manager is deprecated"
-                    }
-                }
-                stage("TiFlash Proxy") {
-                    steps {
-                        script {
-                            echo "skip because proxy build is integrated(llvm)"
-                        }
+        stage("Prepare Ccache") {
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
+                        ccache -o cache_dir="/tmp/.ccache"
+                        ccache -o max_size=2G
+                        ccache -o hash_dir=false
+                        ccache -o compression=true
+                        ccache -o compression_level=6
+                        ccache -o read_only=false
+                        ccache -z
+                        """
                     }
                 }
             }
@@ -119,12 +67,7 @@ pipeline {
             // TODO: need to simplify this part, all config and build logic should be in script in tiflash repo
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -132,7 +75,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
+                        cmake '${WORKSPACE}/tiflash' \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -177,36 +120,21 @@ pipeline {
         }
 
         stage("Post Build") {
-            parallel {
-                stage("Archive Build Artifacts") {
-                    steps {
-                        dir("${WORKSPACE}/install") {
-                            sh """
-                            tar -czf 'tiflash.tar.gz' 'tiflash'
-                            """
-                            archiveArtifacts artifacts: "tiflash.tar.gz"
-                        }
-                    }
+            steps {
+                dir("${WORKSPACE}/build") {
+                    sh """
+                    tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
+                    """
+                    archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
                 }
-                stage("Archive Build Data") {
-                    steps {
-                        dir("${WORKSPACE}/build") {
-                            sh """
-                            tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
-                            """
-                            archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
-                        }
-                        dir("${WORKSPACE}/tiflash") {
-                            sh """
-                            tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
-                            """
-                            archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
-                        }
-                    }
+                dir("${WORKSPACE}/tiflash") {
+                    sh """
+                    tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
+                    """
+                    archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
                 }
             }
         }
-
         stage("Unit Test Prepare") {
             steps {
                 sh label: "link unit test dir", script: """

--- a/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
       imagePullPolicy: Always
       command:
         - "/bin/bash"
@@ -16,9 +16,11 @@ spec:
         requests:
           memory: 32Gi
           cpu: "12"
+          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
+          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -44,16 +46,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]
@@ -66,35 +58,17 @@ spec:
           memory: "4Gi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-7"
       emptyDir: {}
     - name: "volume-8"
@@ -109,7 +83,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
@@ -25,21 +25,6 @@ spec:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
           readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/libclara-cache"
-          name: "volume-6"
-          readOnly: false
         - mountPath: "/tmp"
           name: "volume-7"
           readOnly: false
@@ -58,16 +43,6 @@ spec:
           memory: "4Gi"
   volumes:
     - name: "volume-0"
-      emptyDir: {}
-    - name: "volume-2"
-      emptyDir: {}
-    - name: "volume-1"
-      emptyDir: {}
-    - name: "volume-4"
-      emptyDir: {}
-    - name: "volume-5"
-      emptyDir: {}
-    - name: "volume-6"
       emptyDir: {}
     - name: "volume-7"
       emptyDir: {}

--- a/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
@@ -22,14 +22,8 @@ spec:
           cpu: "12"
           ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
         - mountPath: "/tmp"
-          name: "volume-7"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-8"
+          name: "tmp"
           readOnly: false
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
@@ -42,13 +36,8 @@ spec:
           cpu: "1"
           memory: "4Gi"
   volumes:
-    - name: "volume-0"
+    - name: "tmp"
       emptyDir: {}
-    - name: "volume-7"
-      emptyDir: {}
-    - name: "volume-8"
-      emptyDir:
-        medium: Memory
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
@@ -16,21 +16,16 @@ spec:
           cpu: "12"
           ephemeral-storage: 20Gi
       volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
         - mountPath: "/tmp"
-          name: "volume-7"
+          name: "tmp"
           readOnly: false
         - mountPath: "/tmp-memfs"
-          name: "volume-8"
+          name: "tmp-memfs"
           readOnly: false
   volumes:
-    - name: "volume-0"
+    - name: "tmp"
       emptyDir: {}
-    - name: "volume-7"
-      emptyDir: {}
-    - name: "volume-8"
+    - name: "tmp-memfs"
       emptyDir:
         medium: Memory
   affinity:

--- a/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
@@ -13,26 +13,11 @@ spec:
       resources:
         requests:
           memory: "32Gi"
-          cpu: "12000m"
+          cpu: "12"
           ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/libclara-cache"
-          name: "volume-6"
           readOnly: false
         - mountPath: "/tmp"
           name: "volume-7"
@@ -42,16 +27,6 @@ spec:
           readOnly: false
   volumes:
     - name: "volume-0"
-      emptyDir: {}
-    - name: "volume-2"
-      emptyDir: {}
-    - name: "volume-1"
-      emptyDir: {}
-    - name: "volume-4"
-      emptyDir: {}
-    - name: "volume-5"
-      emptyDir: {}
-    - name: "volume-6"
       emptyDir: {}
     - name: "volume-7"
       emptyDir: {}

--- a/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
@@ -1,9 +1,11 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
       imagePullPolicy: Always
       command:
         - "cat"
@@ -12,6 +14,7 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "12000m"
+          ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -37,47 +40,19 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-7"
       emptyDir: {}
     - name: "volume-8"
@@ -92,7 +67,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
@@ -9,12 +9,6 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-final dependency_dir = "/home/jenkins/agent/dependency"
-final proxy_cache_dir = "/home/jenkins/agent/proxy-cache/refactor-pipelines"
-Boolean proxy_cache_ready = false
-Boolean update_proxy_cache = true
-Boolean update_ccache = true
-String proxy_commit_hash = null
 
 pipeline {
     agent {
@@ -49,10 +43,6 @@ pipeline {
                             sh """
                             git status
                             """
-                            dir("contrib/tiflash-proxy") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -67,18 +57,6 @@ pipeline {
                     steps {
                         script {
                             dir("tiflash") {
-                                sh label: "copy ccache if exist", script: """
-                                ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                                if [ -f \$ccache_tar_file ]; then
-                                    echo "ccache found"
-                                    cd /tmp
-                                    cp -r \$ccache_tar_file ccache.tar
-                                    tar -xf ccache.tar
-                                    ls -lha /tmp
-                                else
-                                    echo "ccache not found"
-                                fi
-                                """
                                 sh label: "config ccache", script: """
                                 ccache -o cache_dir="/tmp/.ccache"
                                 ccache -o max_size=2G
@@ -92,28 +70,6 @@ pipeline {
                         }
                     }
 
-                }
-                stage("Proxy-Cache") {
-                    steps {
-                        script {
-                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-
-                            sh label: "copy proxy if exist", script: """
-                            proxy_suffix="amd64-linux-llvm"
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-\${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
-                        }
-                    }
                 }
                 stage("Cargo-Cache") {
                     steps {
@@ -150,15 +106,6 @@ pipeline {
                     def diagnostic_flag = ""
                     def compatible_flag = ""
                     def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release/
-                        """
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -166,7 +113,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
+                        cmake '${WORKSPACE}/tiflash' ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -175,7 +122,7 @@ pipeline {
                             -DENABLE_TESTS=false \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -218,42 +165,16 @@ pipeline {
             }
         }
         stage("Post Build") {
-            parallel {
-                stage("Upload Build Artifacts") {
-                    steps {
-                        dir("${WORKSPACE}/install") {
-                            sh label: "archive tiflash binary", script: """
-                            tar -czf 'tiflash.tar.gz' 'tiflash'
-                            """
-                            archiveArtifacts artifacts: "tiflash.tar.gz"
-                            sh """
-                            du -sh tiflash.tar.gz
-                            rm -rf tiflash.tar.gz
-                            """
-                        }
-                    }
-                }
-                stage("Upload Ccache") {
-                    steps {
-                        dir("${WORKSPACE}/tiflash") {
-                            sh label: "upload ccache", script: """
-                            cd /tmp
-                            rm -rf ccache.tar
-                            tar -cf ccache.tar .ccache
-                            ls -alh ccache.tar
-                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
-                            cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
-                            cd -
-                            """
-                        }
-                    }
-                }
-                stage("Upload Proxy Cache") {
-                    steps {
-                        sh label: "upload proxy cache", script: """
-                            echo "TODO: upload proxy cache"
-                        """
-                    }
+            steps {
+                dir("${WORKSPACE}/install") {
+                    sh label: "archive tiflash binary", script: """
+                    tar -czf 'tiflash.tar.gz' 'tiflash'
+                    """
+                    archiveArtifacts artifacts: "tiflash.tar.gz"
+                    sh """
+                    du -sh tiflash.tar.gz
+                    rm -rf tiflash.tar.gz
+                    """
                 }
             }
         }

--- a/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
@@ -20,7 +20,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -38,28 +39,16 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
+                    script {
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
+                        retry(2) {
                             sh """
-                            git config --global --add safe.directory "*"
-                            git version
                             git status
                             """
-                            prow.checkoutRefs(REFS, credentialsId = '', timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"
@@ -252,6 +241,7 @@ pipeline {
                             rm -rf ccache.tar
                             tar -cf ccache.tar .ccache
                             ls -alh ccache.tar
+                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
                             cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
                             cd -
                             """

--- a/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
@@ -3,9 +3,7 @@
 // should triggerd for master branches
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-tiflash"  // TODO: need to adjust namespace after test
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final K8S_NAMESPACE = "jenkins-tiflash"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
@@ -26,7 +24,6 @@ pipeline {
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
@@ -51,47 +48,18 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
-            parallel {
-                stage("Ccache") {
-                    steps {
-                        script {
-                            dir("tiflash") {
-                                sh label: "config ccache", script: """
-                                ccache -o cache_dir="/tmp/.ccache"
-                                ccache -o max_size=2G
-                                ccache -o hash_dir=false
-                                ccache -o compression=true
-                                ccache -o compression_level=6
-                                ccache -o read_only=false
-                                ccache -z
-                                """
-                            }
-                        }
-                    }
-
-                }
-                stage("Cargo-Cache") {
-                    steps {
-                        sh label: "link cargo cache", script: """
-                            mkdir -p ~/.cargo/registry
-                            mkdir -p ~/.cargo/git
-                            mkdir -p /home/jenkins/agent/rust/registry/cache
-                            mkdir -p /home/jenkins/agent/rust/registry/index
-                            mkdir -p /home/jenkins/agent/rust/git/db
-                            mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                            rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                            rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                            rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                            rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                            rm -rf ~/.rustup/tmp
-                            rm -rf ~/.rustup/toolchains
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                            ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                            ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
+        stage("Prepare Ccache") {
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
+                        ccache -o cache_dir="/tmp/.ccache"
+                        ccache -o max_size=2G
+                        ccache -o hash_dir=false
+                        ccache -o compression=true
+                        ccache -o compression_level=6
+                        ccache -o read_only=false
+                        ccache -z
                         """
                     }
                 }
@@ -100,12 +68,7 @@ pipeline {
         stage("Configure Project") {
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -113,7 +76,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
+                        cmake '${WORKSPACE}/tiflash' \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -133,7 +96,7 @@ pipeline {
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh """
-                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel 12
+                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel ${PARALLELISM}
                     """
                     sh """
                     cmake --install '${WORKSPACE}/build' --component=tiflash-release --prefix='${WORKSPACE}/install/tiflash'
@@ -160,20 +123,6 @@ pipeline {
                             echo "skip license check"
                             exit 0
                         fi
-                    """
-                }
-            }
-        }
-        stage("Post Build") {
-            steps {
-                dir("${WORKSPACE}/install") {
-                    sh label: "archive tiflash binary", script: """
-                    tar -czf 'tiflash.tar.gz' 'tiflash'
-                    """
-                    archiveArtifacts artifacts: "tiflash.tar.gz"
-                    sh """
-                    du -sh tiflash.tar.gz
-                    rm -rf tiflash.tar.gz
                     """
                 }
             }

--- a/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
@@ -20,7 +20,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -38,28 +39,16 @@ pipeline {
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
-                    retry(2) {
-                        script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
+                    script {
+                        sh """
+                        git config --global --add safe.directory "*"
+                        git version
+                        """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
+                        retry(2) {
                             sh """
-                            git config --global --add safe.directory "*"
-                            git version
                             git status
                             """
-                            prow.checkoutRefs(REFS, credentialsId = '', timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"
@@ -272,6 +261,7 @@ pipeline {
                             rm -rf ccache.tar
                             tar -cf ccache.tar .ccache
                             ls -alh ccache.tar
+                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
                             cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
                             cd -
                         """

--- a/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
@@ -9,12 +9,6 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-final dependency_dir = "/home/jenkins/agent/dependency"
-final proxy_cache_dir = "/home/jenkins/agent/proxy-cache/refactor-pipelines"
-Boolean proxy_cache_ready = false
-Boolean update_proxy_cache = true
-Boolean update_ccache = true
-String proxy_commit_hash = null
 
 pipeline {
     agent {
@@ -49,10 +43,6 @@ pipeline {
                             sh """
                             git status
                             """
-                            dir("contrib/tiflash-proxy") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -67,19 +57,6 @@ pipeline {
                     steps {
                     script {
                         dir("tiflash") {
-                            sh label: "copy ccache if exist", script: """
-                            pwd & ls -alh
-                            ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                            if [ -f \$ccache_tar_file ]; then
-                                echo "ccache found"
-                                cd /tmp
-                                cp -r \$ccache_tar_file ccache.tar
-                                tar -xf ccache.tar
-                                ls -lha /tmp
-                            else
-                                echo "ccache not found"
-                            fi
-                            """
                             sh label: "config ccache", script: """
                             ccache -o cache_dir="/tmp/.ccache"
                             ccache -o max_size=2G
@@ -93,24 +70,9 @@ pipeline {
                     }
                     }
                 }
-                stage("Proxy-Cache") {
+                stage("Cargo-Cache") {
                     steps {
                         script {
-                            proxy_cache_ready = fileExists("/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm")
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-                            sh label: "copy proxy if exist", script: """
-                            proxy_suffix="amd64-linux-llvm"
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-\${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
                             sh label: "link cargo cache", script: """
                                 mkdir -p ~/.cargo/registry
                                 mkdir -p ~/.cargo/git
@@ -147,11 +109,7 @@ pipeline {
                 stage("TiFlash Proxy") {
                     steps {
                         script {
-                            if (proxy_cache_ready) {
-                                echo "skip becuase of cache"
-                            } else {
-                               echo "skip because proxy build is integrated(llvm)"
-                            }
+                            echo "skip because proxy build is integrated(llvm)"
                         }
                     }
                 }
@@ -167,15 +125,6 @@ pipeline {
                     def diagnostic_flag = ""
                     def compatible_flag = ""
                     def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release/
-                        """
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -183,7 +132,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
+                        cmake '${WORKSPACE}/tiflash' ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -192,7 +141,7 @@ pipeline {
                             -DENABLE_TESTS=true \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -252,19 +201,6 @@ pipeline {
                             """
                             archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
                         }
-                    }
-                }
-                stage("Upload Ccache") {
-                    steps {
-                        sh label: "upload ccache", script: """
-                            cd /tmp
-                            rm -rf ccache.tar
-                            tar -cf ccache.tar .ccache
-                            ls -alh ccache.tar
-                            mkdir -p /home/jenkins/agent/ccache/ccache-4.10.2
-                            cp ccache.tar /home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar
-                            cd -
-                        """
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
@@ -117,23 +117,6 @@ pipeline {
             }
         }
 
-        stage("Post Build") {
-            steps {
-                dir("${WORKSPACE}/build") {
-                    sh """
-                    tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
-                    """
-                    archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
-                }
-                dir("${WORKSPACE}/tiflash") {
-                    sh """
-                    tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
-                    """
-                    archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
-                }
-            }
-        }
-
         stage("Unit Test Prepare") {
             steps {
                 sh label: "link unit test dir", script: """

--- a/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
@@ -3,9 +3,7 @@
 // should triggerd for master branches
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-tiflash"  // TODO: need to adjust namespace after test
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final K8S_NAMESPACE = "jenkins-tiflash"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
@@ -21,12 +19,8 @@ pipeline {
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
     options {
         timeout(time: 120, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
@@ -51,66 +45,19 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
-            parallel {
-                stage("Ccache") {
-                    steps {
-                    script {
-                        dir("tiflash") {
-                            sh label: "config ccache", script: """
-                            ccache -o cache_dir="/tmp/.ccache"
-                            ccache -o max_size=2G
-                            ccache -o hash_dir=false
-                            ccache -o compression=true
-                            ccache -o compression_level=6
-                            ccache -o read_only=false
-                            ccache -z
-                            """
-                        }
-                    }
-                    }
-                }
-                stage("Cargo-Cache") {
-                    steps {
-                        script {
-                            sh label: "link cargo cache", script: """
-                                mkdir -p ~/.cargo/registry
-                                mkdir -p ~/.cargo/git
-                                mkdir -p /home/jenkins/agent/rust/registry/cache
-                                mkdir -p /home/jenkins/agent/rust/registry/index
-                                mkdir -p /home/jenkins/agent/rust/git/db
-                                mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                                rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                                rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                                rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                                rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                                rm -rf ~/.rustup/tmp
-                                rm -rf ~/.rustup/toolchains
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                                ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                                ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
-                            """
-                        }
-                    }
-                }
-            }
-        }
-        stage("Build Dependency and Utils") {
-            parallel {
-                stage("Cluster Manage") {
-                    steps {
-                        // NOTE: cluster_manager is deprecated since release-6.0 (include)
-                        echo "cluster_manager is deprecated"
-                    }
-                }
-                stage("TiFlash Proxy") {
-                    steps {
-                        script {
-                            echo "skip because proxy build is integrated(llvm)"
-                        }
+        stage("Prepare Ccache") {
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
+                        ccache -o cache_dir="/tmp/.ccache"
+                        ccache -o max_size=2G
+                        ccache -o hash_dir=false
+                        ccache -o compression=true
+                        ccache -o compression_level=6
+                        ccache -o read_only=false
+                        ccache -z
+                        """
                     }
                 }
             }
@@ -119,12 +66,7 @@ pipeline {
             // TODO: need to simplify this part, all config and build logic should be in script in tiflash repo
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -132,7 +74,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
+                        cmake '${WORKSPACE}/tiflash' \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -176,32 +118,18 @@ pipeline {
         }
 
         stage("Post Build") {
-            parallel {
-                stage("Archive Build Artifacts") {
-                    steps {
-                        dir("${WORKSPACE}/install") {
-                            sh """
-                            tar -czf 'tiflash.tar.gz' 'tiflash'
-                            """
-                            archiveArtifacts artifacts: "tiflash.tar.gz"
-                        }
-                    }
+            steps {
+                dir("${WORKSPACE}/build") {
+                    sh """
+                    tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
+                    """
+                    archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
                 }
-                stage("Archive Build Data") {
-                    steps {
-                        dir("${WORKSPACE}/build") {
-                            sh """
-                            tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
-                            """
-                            archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
-                        }
-                        dir("${WORKSPACE}/tiflash") {
-                            sh """
-                            tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
-                            """
-                            archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
-                        }
-                    }
+                dir("${WORKSPACE}/tiflash") {
+                    sh """
+                    tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
+                    """
+                    archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
                 }
             }
         }

--- a/pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml
@@ -5,7 +5,8 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
+      imagePullPolicy: Always
       command:
         - "/bin/bash"
         - "-c"
@@ -15,9 +16,11 @@ spec:
         requests:
           memory: 32Gi
           cpu: "12"
+          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
+          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -40,16 +43,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]
@@ -62,30 +55,15 @@ spec:
           memory: "4Gi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
       emptyDir: {}
     - name: "volume-7"
@@ -100,7 +78,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml
@@ -25,18 +25,6 @@ spec:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
           readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
         - mountPath: "/tmp"
           name: "volume-6"
           readOnly: false
@@ -55,14 +43,6 @@ spec:
           memory: "4Gi"
   volumes:
     - name: "volume-0"
-      emptyDir: {}
-    - name: "volume-2"
-      emptyDir: {}
-    - name: "volume-1"
-      emptyDir: {}
-    - name: "volume-4"
-      emptyDir: {}
-    - name: "volume-5"
       emptyDir: {}
     - name: "volume-6"
       emptyDir: {}

--- a/pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml
@@ -22,14 +22,8 @@ spec:
           cpu: "12"
           ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
         - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
+          name: "tmp"
           readOnly: false
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
@@ -42,13 +36,8 @@ spec:
           cpu: "1"
           memory: "4Gi"
   volumes:
-    - name: "volume-0"
+    - name: "tmp"
       emptyDir: {}
-    - name: "volume-6"
-      emptyDir: {}
-    - name: "volume-7"
-      emptyDir:
-        medium: Memory
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml
@@ -13,23 +13,11 @@ spec:
       resources:
         requests:
           memory: "32Gi"
-          cpu: "12000m"
+          cpu: "12"
           ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
           readOnly: false
         - mountPath: "/tmp"
           name: "volume-6"
@@ -39,14 +27,6 @@ spec:
           readOnly: false
   volumes:
     - name: "volume-0"
-      emptyDir: {}
-    - name: "volume-2"
-      emptyDir: {}
-    - name: "volume-1"
-      emptyDir: {}
-    - name: "volume-4"
-      emptyDir: {}
-    - name: "volume-5"
       emptyDir: {}
     - name: "volume-6"
       emptyDir: {}

--- a/pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml
@@ -16,21 +16,16 @@ spec:
           cpu: "12"
           ephemeral-storage: 20Gi
       volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
         - mountPath: "/tmp"
-          name: "volume-6"
+          name: "tmp"
           readOnly: false
         - mountPath: "/tmp-memfs"
-          name: "volume-7"
+          name: "tmp-memfs"
           readOnly: false
   volumes:
-    - name: "volume-0"
+    - name: "tmp"
       emptyDir: {}
-    - name: "volume-6"
-      emptyDir: {}
-    - name: "volume-7"
+    - name: "tmp-memfs"
       emptyDir:
         medium: Memory
   affinity:

--- a/pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml
@@ -1,9 +1,12 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
+      imagePullPolicy: Always
       command:
         - "cat"
       tty: true
@@ -11,6 +14,7 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "12000m"
+          ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -33,42 +37,17 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
       emptyDir: {}
     - name: "volume-7"
@@ -83,7 +62,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/prow-jobs/pingcap/tiflash/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: pingcap/tiflash/merged_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: merged-unit-test # need change this after test pass.
       max_concurrency: 1
@@ -14,7 +14,7 @@ postsubmits:
     - name: pingcap/tiflash/merged_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: merged-build # need change this after test pass.
       max_concurrency: 1
@@ -24,7 +24,7 @@ postsubmits:
     - name: pingcap/tiflash/merged_build_next_gen
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: merged-build-next-gen
       max_concurrency: 1

--- a/prow-jobs/pingcap/tiflash/release-8.5-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.5-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: pingcap/tiflash/release-8.5/merged_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: merged-unit-test
       max_concurrency: 1
@@ -14,7 +14,7 @@ postsubmits:
     - name: pingcap/tiflash/release-8.5/merged_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: merged-build
       max_concurrency: 1


### PR DESCRIPTION
Split from #4644.

This PR keeps only TiFlash merged/postsubmit job migration changes so they can be merged first and observed before moving presubmit jobs.

Changes:
- migrate latest and release-8.5 TiFlash merged build/unit jobs to GCP
- update merged job pod templates, images, and resources
- set latest and release-8.5 postsubmit job master labels for GCP
- switch Jenkins pod templates to GCP-compatible volumes and remove KS3/NFS dependencies
- remove stale cross-job cache restore/upload logic after replacing NFS with `emptyDir`
- keep only runtime scratch volumes used by the current pod, such as Cargo/Rust temp dirs, `/tmp`, and `/tmp-memfs`

Validation:
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/merged_build/10/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/merged_build_next_gen/10/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/merged_unit_test/12/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/release-8.5/job/merged_build/6/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/release-8.5/job/merged_unit_test/15/stages/