### PR TITLE
ci(tiflash): migrate presubmit jobs to GCP

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
       imagePullPolicy: Always
       command:
         - "/bin/bash"
@@ -16,9 +16,11 @@ spec:
         requests:
           memory: 32Gi
           cpu: "12"
+          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
+          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -44,16 +46,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]
@@ -66,35 +58,17 @@ spec:
           memory: "4Gi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-7"
       emptyDir: {}
     - name: "volume-8"
@@ -109,7 +83,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
@@ -22,29 +22,8 @@ spec:
           cpu: "12"
           ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/libclara-cache"
-          name: "volume-6"
-          readOnly: false
         - mountPath: "/tmp"
-          name: "volume-7"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-8"
+          name: "tmp"
           readOnly: false
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
@@ -57,23 +36,8 @@ spec:
           cpu: "1"
           memory: "4Gi"
   volumes:
-    - name: "volume-0"
+    - name: "tmp"
       emptyDir: {}
-    - name: "volume-2"
-      emptyDir: {}
-    - name: "volume-1"
-      emptyDir: {}
-    - name: "volume-4"
-      emptyDir: {}
-    - name: "volume-5"
-      emptyDir: {}
-    - name: "volume-6"
-      emptyDir: {}
-    - name: "volume-7"
-      emptyDir: {}
-    - name: "volume-8"
-      emptyDir:
-        medium: Memory
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
@@ -14,12 +14,12 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 32Gi
-          cpu: "12"
+          memory: 24Gi
+          cpu: "6"
           ephemeral-storage: 20Gi
         limits:
-          memory: 48Gi
-          cpu: "12"
+          memory: 32Gi
+          cpu: "8"
           ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"

--- a/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
@@ -1,17 +1,26 @@
 apiVersion: "v1"
 kind: "Pod"
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
-    - image: "docker:18.09.6-dind"
+    - image: "docker:24.0.9-dind"
       imagePullPolicy: "IfNotPresent"
       name: "dockerd"
+      env:
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+        - name: DOCKER_DRIVER
+          value: overlay2
       resources:
         limits:
           memory: "32Gi"
           cpu: "16000m"
+          ephemeral-storage: 150Gi
         requests:
           memory: "12Gi"
           cpu: "5000m"
+          ephemeral-storage: 20Gi
       securityContext:
         privileged: true
       tty: false
@@ -19,11 +28,15 @@ spec:
         - mountPath: "/tmp"
           name: "volume-tmp"
           readOnly: false
+        - mountPath: "/var/lib/docker"
+          name: "docker-graph"
     - command:
         - "cat"
       env:
         - name: "DOCKER_HOST"
           value: "tcp://localhost:2375"
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
       image: ghcr.io/pingcap-qe/ci/base:v2026.4.12-11-g402978f-go1.25
       imagePullPolicy: "Always"
       name: "docker"
@@ -31,6 +44,11 @@ spec:
         requests:
           memory: "8Gi"
           cpu: "5000m"
+          ephemeral-storage: 10Gi
+        limits:
+          memory: "16Gi"
+          cpu: "8000m"
+          ephemeral-storage: 50Gi
       tty: true
       volumeMounts:
         - mountPath: "/tmp"
@@ -39,6 +57,16 @@ spec:
   volumes:
     - name: "volume-tmp"
       emptyDir: {}
+    - name: "docker-graph"
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -48,7 +76,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
@@ -15,11 +15,11 @@ spec:
       resources:
         limits:
           memory: "32Gi"
-          cpu: "16000m"
+          cpu: "16"
           ephemeral-storage: 150Gi
         requests:
           memory: "12Gi"
-          cpu: "5000m"
+          cpu: "5"
           ephemeral-storage: 20Gi
       securityContext:
         privileged: true

--- a/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
@@ -15,11 +15,11 @@ spec:
       resources:
         limits:
           memory: "32Gi"
-          cpu: "16"
+          cpu: "8"
           ephemeral-storage: 150Gi
         requests:
-          memory: "12Gi"
-          cpu: "5"
+          memory: "16Gi"
+          cpu: "4"
           ephemeral-storage: 20Gi
       securityContext:
         privileged: true
@@ -42,12 +42,12 @@ spec:
       name: "docker"
       resources:
         requests:
-          memory: "8Gi"
-          cpu: "5000m"
+          memory: "16Gi"
+          cpu: "4"
           ephemeral-storage: 10Gi
         limits:
-          memory: "16Gi"
-          cpu: "8000m"
+          memory: "32Gi"
+          cpu: "8"
           ephemeral-storage: 50Gi
       tty: true
       volumeMounts:

--- a/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
@@ -13,8 +13,8 @@ spec:
       # Notice: not set the resources limit, because limit will make unit test failed
       resources:
         requests:
-          memory: "32Gi"
-          cpu: "12"
+          memory: "24Gi"
+          cpu: "6"
           ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/tmp"
@@ -23,17 +23,12 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "tmp-memfs"
           readOnly: false
-        - mountPath: "/home/jenkins"
-          name: "jenkins-home"
-          readOnly: false
   volumes:
     - name: "tmp"
       emptyDir: {}
     - name: "tmp-memfs"
       emptyDir:
         medium: Memory
-    - name: "jenkins-home"
-      emptyDir: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
@@ -14,55 +14,25 @@ spec:
       resources:
         requests:
           memory: "32Gi"
-          cpu: "12000m"
+          cpu: "12"
           ephemeral-storage: 20Gi
       volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/libclara-cache"
-          name: "volume-6"
-          readOnly: false
         - mountPath: "/tmp"
-          name: "volume-7"
+          name: "tmp"
           readOnly: false
         - mountPath: "/tmp-memfs"
-          name: "volume-8"
+          name: "tmp-memfs"
           readOnly: false
         - mountPath: "/home/jenkins"
-          name: "volume-9"
+          name: "jenkins-home"
           readOnly: false
   volumes:
-    - name: "volume-0"
+    - name: "tmp"
       emptyDir: {}
-    - name: "volume-2"
-      emptyDir: {}
-    - name: "volume-1"
-      emptyDir: {}
-    - name: "volume-4"
-      emptyDir: {}
-    - name: "volume-5"
-      emptyDir: {}
-    - name: "volume-6"
-      emptyDir: {}
-    - name: "volume-7"
-      emptyDir: {}
-    - name: "volume-8"
+    - name: "tmp-memfs"
       emptyDir:
         medium: Memory
-    - name: "volume-9"
+    - name: "jenkins-home"
       emptyDir: {}
   affinity:
     nodeAffinity:

--- a/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml
@@ -1,9 +1,11 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:rocky8-llvm-17.0.6-v2"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
       imagePullPolicy: Always
       command:
         - "cat"
@@ -13,6 +15,7 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "12000m"
+          ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -41,47 +44,19 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-9"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/libclara-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-7"
       emptyDir: {}
     - name: "volume-8"

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -13,6 +13,9 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
 final OCI_TAG_TIDB = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
 final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
+final MINIO_VERSION = 'RELEASE.2025-07-23T15-54-02Z'
+final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
+final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-next-gen-it-build'
 
 Boolean proxy_cache_ready = false
 Boolean build_cache_ready = false
@@ -25,7 +28,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -47,27 +51,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                             println "tiflash_commit_hash: ${tiflash_commit_hash}"
 
@@ -374,7 +364,7 @@ pipeline {
                     sh label: "change permission", script: """
                         chown -R 1000:1000 ./
                     """
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('ng-binary', REFS, 'it-build')){
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
                        dir('tests/.build') {
                             sh label: "archive tiflash binary", script: """
                             cp -r ${WORKSPACE}/install/* ./
@@ -386,6 +376,7 @@ pipeline {
                         git show --oneline -s
                         rm -rf .git
                         rm -rf contrib
+                        rm -rf tests/fullstack-test-next-gen-columnar
                         du -sh ./
                         ls -alh
                         """
@@ -405,7 +396,8 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_INTEGRATIONTEST_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_INTEGRATIONTEST_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'docker'
                         retries 5
                         customWorkspace "/home/jenkins/agent/workspace/tiflash-integration-test"
@@ -419,23 +411,51 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir("${WORKSPACE}/tiflash") {
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('ng-binary', REFS, 'it-build')){
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
                                     dir("tests/${TEST_PATH}") {
                                         withEnv([
                                             "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${OCI_TAG_PD}",
                                             "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${OCI_TAG_TIKV}",
                                             "TIDB_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${OCI_TAG_TIDB}",
+                                            "MINIO_IMAGE=quay.io/minio/minio:${MINIO_VERSION}",
+                                            "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
                                         ]) {
                                             withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
                                                 sh label: "prepare docker images", script: '''
+                                                    set -eux
                                                     mkdir -p ~/.docker
-                                                    cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                                                    docker ps -a && docker version
+                                                    cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
+                                                    for i in $(seq 1 30); do
+                                                        if docker version; then
+                                                            break
+                                                        fi
+                                                        sleep 2
+                                                    done
+                                                    docker ps -a
 
-                                                    docker pull $PD_IMAGE
-                                                    docker pull $TIKV_IMAGE
-                                                    docker pull $TIDB_IMAGE
+                                                    timeout 300 docker pull "${PD_IMAGE}"
+                                                    timeout 300 docker pull "${TIKV_IMAGE}"
+                                                    timeout 300 docker pull "${TIDB_IMAGE}"
+                                                    timeout 300 docker pull "${MINIO_IMAGE}"
+                                                    timeout 600 docker pull "${TIFLASH_IMAGE}"
 
+                                                    find ../docker . -name '*.yaml' -type f -exec sed -i \
+                                                        -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
+                                                        -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
+                                                        -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
+                                                        -e 's#${MINIO_IMAGE:[^}]*}#'"${MINIO_IMAGE}"'#g' \
+                                                        -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/test-infra/minio:latest#${MINIO_IMAGE}#g" \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                        {} +
                                                     rm -rf ~/.docker
                                                 '''
                                             }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflash"
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_build.yaml'
 final POD_INTEGRATIONTEST_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml'
@@ -17,12 +16,8 @@ final MINIO_VERSION = 'RELEASE.2025-07-23T15-54-02Z'
 final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
 final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-next-gen-it-build'
 
-Boolean proxy_cache_ready = false
 Boolean build_cache_ready = false
-String proxy_commit_hash = null
 String tiflash_commit_hash = null
-Boolean libclara_cache_ready = false
-String libclara_commit_hash = null
 
 pipeline {
     agent {
@@ -40,7 +35,6 @@ pipeline {
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
@@ -60,17 +54,6 @@ pipeline {
                             sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                             println "tiflash_commit_hash: ${tiflash_commit_hash}"
-
-                            // Get next-gen tiflash-proxy commit hash.
-                            // For submodule, we need to enter the submodule directory and get the commit hash from there.
-                            dir("contrib/tiflash-proxy-next-gen") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
-
-                            // get clara commit hash
-                            libclara_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H" -- libs/libclara').trim()
-                            println "libclara_commit_hash: ${libclara_commit_hash}"
 
                             sh """
                             chown 1000:1000 -R ./
@@ -102,107 +85,21 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
+        stage("Prepare Ccache") {
             when {
                 expression { !build_cache_ready }
             }
-            parallel {
-                stage("Ccache") {
-                    steps {
-                    script {
-                        dir("tiflash") {
-                            sh label: "copy ccache if exist", script: """
-                            ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                            if [ -f \$ccache_tar_file ]; then
-                                echo "ccache found"
-                                cd /tmp
-                                cp -r \$ccache_tar_file ccache.tar
-                                tar -xf ccache.tar
-                                ls -lha /tmp
-                            else
-                                echo "ccache not found"
-                            fi
-                            """
-                            sh label: "config ccache", script: """
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
                             ccache -o cache_dir="/tmp/.ccache"
                             ccache -o max_size=2G
                             ccache -o hash_dir=false
                             ccache -o compression=true
                             ccache -o compression_level=6
-                            ccache -o read_only=true
+                            ccache -o read_only=false
                             ccache -z
-                            """
-                        }
-                    }
-                    }
-
-                }
-                stage("Proxy-Cache") {
-                    steps {
-                        script {
-                            def proxy_suffix = "amd64-linux-llvm-next-gen"
-                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-${proxy_suffix} && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-
-                            sh label: "copy proxy if exist", script: """
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
-                        }
-                    }
-                }
-                stage("Libclara Cache") {
-                    steps {
-                        script {
-                            def libclara_suffix = "amd64-linux-debug"
-                            libclara_cache_ready = sh(script: "test -d /home/jenkins/agent/libclara-cache/${libclara_commit_hash}-${libclara_suffix} && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "libclara_cache_ready: ${libclara_cache_ready}"
-
-                            sh label: "copy libclara if exist", script: """
-                            libclara_cache_dir="/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-${libclara_suffix}"
-                            if [ -d \$libclara_cache_dir ]; then
-                                echo "libclara cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                cp -r \$libclara_cache_dir/* ${WORKSPACE}/tiflash/libs/libclara-prebuilt/
-                                chmod +x ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
-                                chown -R 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                ls -R ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                            else
-                                echo "libclara cache not found"
-                            fi
-                            """
-                        }
-                    }
-                }
-                stage("Cargo-Cache") {
-                    steps {
-                        sh label: "link cargo cache", script: """
-                            mkdir -p ~/.cargo/registry
-                            mkdir -p ~/.cargo/git
-                            mkdir -p /home/jenkins/agent/rust/registry/cache
-                            mkdir -p /home/jenkins/agent/rust/registry/index
-                            mkdir -p /home/jenkins/agent/rust/git/db
-                            mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                            rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                            rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                            rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                            rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                            rm -rf ~/.rustup/tmp
-                            rm -rf ~/.rustup/toolchains
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                            ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                            ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
                         """
                     }
                 }
@@ -214,26 +111,8 @@ pipeline {
             }
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
                     def next_gen_flag = "-DENABLE_NEXT_GEN=ON"
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    def libclara_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy-next-gen/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy-next-gen/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy-next-gen/target/release/
-                        """
-                    }
-                    if (libclara_cache_ready) {
-                        libclara_flag = "-DLIBCLARA_CXXBRIDGE_DIR='${WORKSPACE}/tiflash/libs/libclara-prebuilt/cxxbridge' -DLIBCLARA_LIBRARY='${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so'"
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -241,7 +120,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} ${libclara_flag} ${next_gen_flag} \\
+                        cmake '${WORKSPACE}/tiflash' ${next_gen_flag} \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -250,8 +129,8 @@ pipeline {
                             -DENABLE_TESTS=false \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
-                            -DUSE_INTERNAL_LIBCLARA=${!libclara_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
+                            -DUSE_INTERNAL_LIBCLARA=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -309,48 +188,30 @@ pipeline {
             when {
                 expression { !build_cache_ready }
             }
-            parallel {
-                stage("Static Analysis"){
-                    steps {
-                        script {
-                            def generator = "Ninja"
-                            def include_flag = ""
-                            def fix_compile_commands = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/fix_compile_commands.py"
-                            def run_clang_tidy = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/run-clang-tidy.py"
-                            dir("${WORKSPACE}/build") {
-                                sh label: "debug diff files", script: """
-                                cat /tmp/tiflash-diff-files.json
-                                """
-                                sh label: "run clang tidy", script: """
-                                cat /tmp/tiflash-diff-files.json
-                                cmake "${WORKSPACE}/tiflash" \\
-                                    -DENABLE_TESTS=false \\
-                                    -DCMAKE_BUILD_TYPE=Debug \\
-                                    -DUSE_CCACHE=OFF \\
-                                    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \\
-                                    -DRUN_HAVE_STD_REGEX=0 \\
-                                    -G '${generator}'
-                                python3 ${fix_compile_commands} ${include_flag} \\
-                                    --file_path=compile_commands.json \\
-                                    --load_diff_files_from "/tmp/tiflash-diff-files.json"
-                                python3 ${run_clang_tidy} -p \$(realpath .) -j 12 --files ".*/tiflash/dbms/*"
-                                """
-                            }
-                        }
-                    }
-                }
-                stage("Upload Build Artifacts") {
-                    steps {
-                        dir("${WORKSPACE}/install") {
-                            sh label: "archive tiflash binary", script: """
-                            tar -czf 'tiflash.tar.gz' 'tiflash'
-                            """
-                            archiveArtifacts artifacts: "tiflash.tar.gz"
-                            sh """
-                            du -sh tiflash.tar.gz
-                            rm -rf tiflash.tar.gz
-                            """
-                        }
+            steps {
+                script {
+                    def generator = "Ninja"
+                    def include_flag = ""
+                    def fix_compile_commands = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/fix_compile_commands.py"
+                    def run_clang_tidy = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/run-clang-tidy.py"
+                    dir("${WORKSPACE}/build") {
+                        sh label: "debug diff files", script: """
+                        cat /tmp/tiflash-diff-files.json
+                        """
+                        sh label: "run clang tidy", script: """
+                        cat /tmp/tiflash-diff-files.json
+                        cmake "${WORKSPACE}/tiflash" \\
+                            -DENABLE_TESTS=false \\
+                            -DCMAKE_BUILD_TYPE=Debug \\
+                            -DUSE_CCACHE=OFF \\
+                            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \\
+                            -DRUN_HAVE_STD_REGEX=0 \\
+                            -G '${generator}'
+                        python3 ${fix_compile_commands} ${include_flag} \\
+                            --file_path=compile_commands.json \\
+                            --load_diff_files_from "/tmp/tiflash-diff-files.json"
+                        python3 ${run_clang_tidy} -p \$(realpath .) -j 12 --files ".*/tiflash/dbms/*"
+                        """
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -14,9 +14,9 @@ final OCI_TAG_TIDB = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "
 final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
 final MINIO_VERSION = 'RELEASE.2025-07-23T15-54-02Z'
 final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
-final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-next-gen-it-build'
+final WORKSPACE_STASH_NAME = 'tiflash-next-gen-it-workspace'
+final PARALLELISM = 12
 
-Boolean build_cache_ready = false
 String tiflash_commit_hash = null
 
 pipeline {
@@ -38,9 +38,6 @@ pipeline {
     }
     stages {
         stage('Checkout') {
-            when {
-                expression { !build_cache_ready }
-            }
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
@@ -64,9 +61,6 @@ pipeline {
             }
         }
         stage("License check") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     container('utils') {
@@ -86,9 +80,6 @@ pipeline {
             }
         }
         stage("Prepare Ccache") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     dir("tiflash") {
@@ -106,9 +97,6 @@ pipeline {
             }
         }
         stage("Configure Project") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     def generator = 'Ninja'
@@ -138,9 +126,6 @@ pipeline {
             }
         }
         stage("Format Check") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     def target_branch = REFS.base_ref
@@ -166,13 +151,10 @@ pipeline {
             }
         }
         stage("Build TiFlash") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh """
-                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel 12
+                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel ${PARALLELISM}
                     """
                     sh """
                     cmake --install '${WORKSPACE}/build' --component=tiflash-release --prefix='${WORKSPACE}/install/tiflash'
@@ -185,9 +167,6 @@ pipeline {
             }
         }
         stage("Post Build") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     def generator = "Ninja"
@@ -210,29 +189,25 @@ pipeline {
                         python3 ${fix_compile_commands} ${include_flag} \\
                             --file_path=compile_commands.json \\
                             --load_diff_files_from "/tmp/tiflash-diff-files.json"
-                        python3 ${run_clang_tidy} -p \$(realpath .) -j 12 --files ".*/tiflash/dbms/*"
+                        python3 ${run_clang_tidy} -p \$(realpath .) -j ${PARALLELISM} --files ".*/tiflash/dbms/*"
                         """
                     }
                 }
             }
         }
-        stage("Cache code and artifact") {
-            when {
-                expression { !build_cache_ready }
-            }
+        stage("Stash Test Workspace") {
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh label: "change permission", script: """
                         chown -R 1000:1000 ./
                     """
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
-                       dir('tests/.build') {
-                            sh label: "archive tiflash binary", script: """
+                    dir('tests/.build') {
+                        sh label: "archive tiflash binary", script: """
                             cp -r ${WORKSPACE}/install/* ./
                             pwd && ls -alh
-                            """
-                        }
-                        sh label: "clean unnecessary dirs", script: """
+                        """
+                    }
+                    sh label: "clean unnecessary dirs", script: """
                         git status
                         git show --oneline -s
                         rm -rf .git
@@ -240,8 +215,8 @@ pipeline {
                         rm -rf tests/fullstack-test-next-gen-columnar
                         du -sh ./
                         ls -alh
-                        """
-                    }
+                    """
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                 }
             }
         }
@@ -272,17 +247,17 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir("${WORKSPACE}/tiflash") {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
-                                    dir("tests/${TEST_PATH}") {
-                                        withEnv([
-                                            "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${OCI_TAG_PD}",
-                                            "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${OCI_TAG_TIKV}",
-                                            "TIDB_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${OCI_TAG_TIDB}",
-                                            "MINIO_IMAGE=quay.io/minio/minio:${MINIO_VERSION}",
-                                            "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
-                                        ]) {
-                                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                                sh label: "prepare docker images", script: '''
+                                unstash name: WORKSPACE_STASH_NAME
+                                dir("tests/${TEST_PATH}") {
+                                    withEnv([
+                                        "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${OCI_TAG_PD}",
+                                        "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${OCI_TAG_TIKV}",
+                                        "TIDB_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${OCI_TAG_TIDB}",
+                                        "MINIO_IMAGE=quay.io/minio/minio:${MINIO_VERSION}",
+                                        "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
+                                    ]) {
+                                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                                            sh label: "prepare docker images", script: '''
                                                     set -eux
                                                     mkdir -p ~/.docker
                                                     cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
@@ -319,10 +294,9 @@ pipeline {
                                                         {} +
                                                     rm -rf ~/.docker
                                                 '''
-                                            }
-
-                                            sh label: "run the tests", script: "TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ENABLE_NEXT_GEN=true ./run.sh"
                                         }
+
+                                        sh label: "run the tests", script: "TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ENABLE_NEXT_GEN=true ./run.sh"
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
@@ -3,12 +3,9 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflash"
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final BRANCH_ALIAS = 'latest'
-final COLUMNAR_JOB_NAME = 'pull_integration_next_gen_columnar'
-final POD_TEMPLATE_FILE_BUILD = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${COLUMNAR_JOB_NAME}/pod-build.yaml"
-final POD_TEMPLATE_FILE_TEST = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${COLUMNAR_JOB_NAME}/pod-test.yaml"
+final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-build.yaml'
+final POD_TEMPLATE_FILE_TEST = 'pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
@@ -28,7 +25,6 @@ pipeline {
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout & Build') {
@@ -55,38 +51,18 @@ pipeline {
                         }
                     }
                 }
-                stage('Prepare Cache') {
+                stage('Prepare Ccache') {
                     steps {
                         dir(REFS.repo) {
-                            sh label: "prepare local build cache", script: '''
+                            sh label: "configure ccache", script: '''
                                 set -eux
-                                git config --global --add safe.directory "*"
 
-                                mkdir -p /home/jenkins/agent/ccache
-                                ccache -o cache_dir="/home/jenkins/agent/ccache"
-                                ccache -o max_size=20G
+                                ccache -o cache_dir="/tmp/.ccache"
+                                ccache -o max_size=2G
                                 ccache -o hash_dir=false
                                 ccache -o compression=true
                                 ccache -o compression_level=6
                                 ccache -z
-
-                                mkdir -p ~/.cargo/registry ~/.cargo/git ~/.rustup
-                                mkdir -p /home/jenkins/agent/rust/registry/cache
-                                mkdir -p /home/jenkins/agent/rust/registry/index
-                                mkdir -p /home/jenkins/agent/rust/git/db
-                                mkdir -p /home/jenkins/agent/rust/git/checkouts
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-
-                                rm -rf ~/.cargo/registry/cache ~/.cargo/registry/index
-                                rm -rf ~/.cargo/git/db ~/.cargo/git/checkouts
-                                rm -rf ~/.rustup/tmp ~/.rustup/toolchains
-                                ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                                ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                                ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                                ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-                                ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                                ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
                             '''
                         }
                     }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
@@ -13,7 +13,8 @@ final OCI_TAG_TIDB = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "
 final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
 final MINIO_VERSION = 'RELEASE.2025-07-23T15-54-02Z'
 final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
-final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-next-gen-columnar'
+final WORKSPACE_STASH_NAME = 'tiflash-next-gen-columnar-workspace'
+final PARALLELISM = 12
 
 String tiflash_commit_hash = null
 
@@ -104,7 +105,7 @@ pipeline {
                                 """
                                 withEnv(['CARGO_NET_GIT_FETCH_WITH_CLI=true']) {
                                     sh label: "build tiflash", script: """
-                                        cmake --build '${WORKSPACE}/build' --target tiflash --parallel 12
+                                        cmake --build '${WORKSPACE}/build' --target tiflash --parallel ${PARALLELISM}
                                         cmake --install '${WORKSPACE}/build' --component=tiflash-release --prefix='${WORKSPACE}/install/tiflash'
                                         ccache -s
                                         ls -alh ${WORKSPACE}/install/tiflash
@@ -124,13 +125,12 @@ pipeline {
                                 rm -rf .git contrib ${WORKSPACE}/build
                                 du -sh . tests/.build || true
                             """
-                            cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
-                                sh label: "save test workspace", script: """
-                                    test -e tests/.build/tiflash
-                                    chmod +x tests/fullstack-test-next-gen-columnar/run.sh
-                                    test -x tests/fullstack-test-next-gen-columnar/run.sh
-                                """
-                            }
+                            sh label: "check test workspace", script: """
+                                test -e tests/.build/tiflash
+                                chmod +x tests/fullstack-test-next-gen-columnar/run.sh
+                                test -x tests/fullstack-test-next-gen-columnar/run.sh
+                            """
+                            stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                         }
                     }
                 }
@@ -162,9 +162,8 @@ pipeline {
                     stage('Test') {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
-                                    sh label: "check restored workspace", script: "test -e tests/.build/tiflash"
-                                }
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh label: "check restored workspace", script: "test -e tests/.build/tiflash"
                                 dir("tests/${TEST_PATH}") {
                                     withEnv([
                                         "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${OCI_TAG_PD}",

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-build.yaml
@@ -24,24 +24,9 @@ spec:
       volumeMounts:
         - mountPath: "/tmp"
           name: "tmp"
-        - mountPath: "/tmp-memfs"
-          name: "tmp-memfs"
-    - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
-      args: ["sleep", "infinity"]
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          cpu: "1"
-          memory: 4Gi
   volumes:
     - name: "tmp"
       emptyDir: {}
-    - name: "tmp-memfs"
-      emptyDir:
-        medium: Memory
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-build.yaml
@@ -14,12 +14,12 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 32Gi
-          cpu: "12"
+          memory: 24Gi
+          cpu: "6"
           ephemeral-storage: 20Gi
         limits:
-          memory: 64Gi
-          cpu: "12"
+          memory: 32Gi
+          cpu: "8"
           ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-test.yaml
@@ -17,12 +17,12 @@ spec:
       tty: false
       resources:
         requests:
-          memory: 12Gi
-          cpu: "5"
+          memory: 16Gi
+          cpu: "4"
           ephemeral-storage: 20Gi
         limits:
           memory: 32Gi
-          cpu: "16"
+          cpu: "8"
           ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"
@@ -41,11 +41,11 @@ spec:
           value: ""
       resources:
         requests:
-          memory: 8Gi
-          cpu: "5"
+          memory: 16Gi
+          cpu: "4"
           ephemeral-storage: 10Gi
         limits:
-          memory: 16Gi
+          memory: 32Gi
           cpu: "8"
           ephemeral-storage: 50Gi
       tty: true

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -10,6 +10,8 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_build.yaml'
 final POD_INTEGRATIONTEST_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final dependency_dir = "/home/jenkins/agent/dependency"
+final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
+final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-it-build'
 Boolean proxy_cache_ready = false
 Boolean build_cache_ready = false
 String proxy_commit_hash = null
@@ -21,7 +23,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -43,27 +46,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                             println "tiflash_commit_hash: ${tiflash_commit_hash}"
 
@@ -369,7 +358,7 @@ pipeline {
                     sh label: "change permission", script: """
                         chown -R 1000:1000 ./
                     """
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
                        dir('tests/.build') {
                             sh label: "archive tiflash binary", script: """
                             cp -r ${WORKSPACE}/install/* ./
@@ -381,6 +370,7 @@ pipeline {
                         git show --oneline -s
                         rm -rf .git
                         rm -rf contrib
+                        rm -rf tests/fullstack-test-next-gen-columnar
                         du -sh ./
                         ls -alh
                         """
@@ -400,7 +390,8 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_INTEGRATIONTEST_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_INTEGRATIONTEST_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'docker'
                         retries 5
                         customWorkspace "/home/jenkins/agent/workspace/tiflash-integration-test"
@@ -414,8 +405,8 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir("${WORKSPACE}/tiflash") {
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
-                                    println "restore from cache key: ${prow.getCacheKey('binary', REFS, 'it-build')}"
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
+                                    println "restore from cache key: ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}"
                                     sh label: "debug info", script: """
                                     printenv
                                     pwd && ls -alh
@@ -429,9 +420,69 @@ pipeline {
                                             def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
                                             def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
                                             def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
-                                            sh label: "run integration tests", script: """
-                                            PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
-                                            """
+                                            def tidbImage = "${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}"
+                                            def tidbFailpointImage = "${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint"
+                                            def tidbRuntimeImage = env.TEST_PATH == 'tidb-ci' ? tidbFailpointImage : tidbImage
+                                            withEnv([
+                                                "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${pdBranch}",
+                                                "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${tikvBranch}",
+                                                "TIDB_IMAGE=${tidbRuntimeImage}",
+                                                "TIDB_FAILPOINT_IMAGE=${tidbFailpointImage}",
+                                                "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
+                                            ]) {
+                                                withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                                                    sh label: "prepare docker images", script: '''
+                                                        set -eux
+                                                        mkdir -p ~/.docker
+                                                        cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
+                                                        for i in $(seq 1 30); do
+                                                            if docker version; then
+                                                                break
+                                                            fi
+                                                            sleep 2
+                                                        done
+                                                        docker ps -a
+
+                                                        timeout 300 docker pull "${PD_IMAGE}"
+                                                        timeout 300 docker pull "${TIKV_IMAGE}"
+                                                        timeout 300 docker pull "${TIDB_IMAGE}"
+                                                        timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
+                                                        timeout 600 docker pull "${TIFLASH_IMAGE}"
+
+                                                        find ../docker . -name '*.yaml' -type f -exec sed -i \
+                                                            -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
+                                                            -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e 's#${TIDB_IMAGE:[^}]*-failpoint}#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:master#${PD_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:master#${TIKV_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master#${TIDB_IMAGE}#g" \
+                                                            {} +
+                                                        rm -rf ~/.docker
+                                                    '''
+                                                }
+
+                                                sh label: "run integration tests", script: """
+                                                PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
+                                                """
+                                            }
                                         }
                                     }
                                 }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -4,20 +4,13 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflash"
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_build.yaml'
 final POD_INTEGRATIONTEST_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final dependency_dir = "/home/jenkins/agent/dependency"
 final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
 final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-it-build'
-Boolean proxy_cache_ready = false
-Boolean build_cache_ready = false
-String proxy_commit_hash = null
 String tiflash_commit_hash = null
-Boolean libclara_cache_ready = false
-String libclara_commit_hash = null
 
 pipeline {
     agent {
@@ -35,13 +28,9 @@ pipeline {
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
-            when {
-                expression { !build_cache_ready }
-            }
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
@@ -55,18 +44,6 @@ pipeline {
                             sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                             println "tiflash_commit_hash: ${tiflash_commit_hash}"
-
-                            // Get tiflash-proxy commit hash.
-                            // For submodule, we need to enter the submodule directory and get the commit hash from there.
-                            dir("contrib/tiflash-proxy") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
-
-                            // get clara commit hash
-                            libclara_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H" -- libs/libclara').trim()
-                            println "libclara_commit_hash: ${libclara_commit_hash}"
-
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -76,9 +53,6 @@ pipeline {
             }
         }
         stage("License check") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     container('utils') {
@@ -97,137 +71,27 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
-            when {
-                expression { !build_cache_ready }
-            }
-            parallel {
-                stage("Ccache") {
-                    steps {
-                    script {
-                        dir("tiflash") {
-                            sh label: "copy ccache if exist", script: """
-                            ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                            if [ -f \$ccache_tar_file ]; then
-                                echo "ccache found"
-                                cd /tmp
-                                cp -r \$ccache_tar_file ccache.tar
-                                tar -xf ccache.tar
-                                ls -lha /tmp
-                            else
-                                echo "ccache not found"
-                            fi
-                            """
-                            sh label: "config ccache", script: """
+        stage("Prepare Ccache") {
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
                             ccache -o cache_dir="/tmp/.ccache"
                             ccache -o max_size=2G
                             ccache -o hash_dir=false
                             ccache -o compression=true
                             ccache -o compression_level=6
-                            ccache -o read_only=true
+                            ccache -o read_only=false
                             ccache -z
-                            """
-                        }
-                    }
-                    }
-
-                }
-                stage("Proxy-Cache") {
-                    steps {
-                        script {
-                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-
-                            sh label: "copy proxy if exist", script: """
-                            proxy_suffix="amd64-linux-llvm"
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-\${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
-                        }
-                    }
-                }
-                stage("Libclara Cache") {
-                    steps {
-                        script {
-                            libclara_cache_ready = sh(script: "test -d /home/jenkins/agent/libclara-cache/${libclara_commit_hash}-amd64-linux-debug && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "libclara_cache_ready: ${libclara_cache_ready}"
-
-                            sh label: "copy libclara if exist", script: """
-                            libclara_suffix="amd64-linux-debug"
-                            libclara_cache_dir="/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-\${libclara_suffix}"
-                            if [ -d \$libclara_cache_dir ]; then
-                                echo "libclara cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                cp -r \$libclara_cache_dir/* ${WORKSPACE}/tiflash/libs/libclara-prebuilt/
-                                chmod +x ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
-                                chown -R 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                ls -R ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                            else
-                                echo "libclara cache not found"
-                            fi
-                            """
-                        }
-                    }
-                }
-                stage("Cargo-Cache") {
-                    steps {
-                        sh label: "link cargo cache", script: """
-                            mkdir -p ~/.cargo/registry
-                            mkdir -p ~/.cargo/git
-                            mkdir -p /home/jenkins/agent/rust/registry/cache
-                            mkdir -p /home/jenkins/agent/rust/registry/index
-                            mkdir -p /home/jenkins/agent/rust/git/db
-                            mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                            rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                            rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                            rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                            rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                            rm -rf ~/.rustup/tmp
-                            rm -rf ~/.rustup/toolchains
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                            ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                            ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
                         """
                     }
                 }
             }
         }
         stage("Configure Project") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    def libclara_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release/
-                        """
-                    }
-                    if (libclara_cache_ready) {
-                        libclara_flag = "-DLIBCLARA_CXXBRIDGE_DIR='${WORKSPACE}/tiflash/libs/libclara-prebuilt/cxxbridge' -DLIBCLARA_LIBRARY='${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so'"
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -235,7 +99,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} ${libclara_flag} \\
+                        cmake '${WORKSPACE}/tiflash' \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -244,8 +108,8 @@ pipeline {
                             -DENABLE_TESTS=false \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
-                            -DUSE_INTERNAL_LIBCLARA=${!libclara_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
+                            -DUSE_INTERNAL_LIBCLARA=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -253,9 +117,6 @@ pipeline {
             }
         }
         stage("Format Check") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     def target_branch = REFS.base_ref
@@ -281,9 +142,6 @@ pipeline {
             }
         }
         stage("Build TiFlash") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh """
@@ -300,59 +158,35 @@ pipeline {
             }
         }
         stage("Post Build") {
-            when {
-                expression { !build_cache_ready }
-            }
-            parallel {
-                stage("Static Analysis"){
-                    steps {
-                        script {
-                            def generator = "Ninja"
-                            def include_flag = ""
-                            def fix_compile_commands = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/fix_compile_commands.py"
-                            def run_clang_tidy = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/run-clang-tidy.py"
-                            dir("${WORKSPACE}/build") {
-                                sh label: "debug diff files", script: """
-                                cat /tmp/tiflash-diff-files.json
-                                """
-                                sh label: "run clang tidy", script: """
-                                cat /tmp/tiflash-diff-files.json
-                                cmake "${WORKSPACE}/tiflash" \\
-                                    -DENABLE_TESTS=false \\
-                                    -DCMAKE_BUILD_TYPE=Debug \\
-                                    -DUSE_CCACHE=OFF \\
-                                    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \\
-                                    -DRUN_HAVE_STD_REGEX=0 \\
-                                    -G '${generator}'
-                                python3 ${fix_compile_commands} ${include_flag} \\
-                                    --file_path=compile_commands.json \\
-                                    --load_diff_files_from "/tmp/tiflash-diff-files.json"
-                                python3 ${run_clang_tidy} -p \$(realpath .) -j 12 --files ".*/tiflash/dbms/*"
-                                """
-                            }
-                        }
-                    }
-                }
-                stage("Upload Build Artifacts") {
-                    steps {
-                        dir("${WORKSPACE}/install") {
-                            sh label: "archive tiflash binary", script: """
-                            tar -czf 'tiflash.tar.gz' 'tiflash'
-                            """
-                            archiveArtifacts artifacts: "tiflash.tar.gz"
-                            sh """
-                            du -sh tiflash.tar.gz
-                            rm -rf tiflash.tar.gz
-                            """
-                        }
+            steps {
+                script {
+                    def generator = "Ninja"
+                    def include_flag = ""
+                    def fix_compile_commands = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/fix_compile_commands.py"
+                    def run_clang_tidy = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/run-clang-tidy.py"
+                    dir("${WORKSPACE}/build") {
+                        sh label: "debug diff files", script: """
+                        cat /tmp/tiflash-diff-files.json
+                        """
+                        sh label: "run clang tidy", script: """
+                        cat /tmp/tiflash-diff-files.json
+                        cmake "${WORKSPACE}/tiflash" \\
+                            -DENABLE_TESTS=false \\
+                            -DCMAKE_BUILD_TYPE=Debug \\
+                            -DUSE_CCACHE=OFF \\
+                            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \\
+                            -DRUN_HAVE_STD_REGEX=0 \\
+                            -G '${generator}'
+                        python3 ${fix_compile_commands} ${include_flag} \\
+                            --file_path=compile_commands.json \\
+                            --load_diff_files_from "/tmp/tiflash-diff-files.json"
+                        python3 ${run_clang_tidy} -p \$(realpath .) -j 12 --files ".*/tiflash/dbms/*"
+                        """
                     }
                 }
             }
         }
         stage("Cache code and artifact") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh label: "change permission", script: """

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -9,7 +9,8 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_build.yaml'
 final POD_INTEGRATIONTEST_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
-final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-it-build'
+final WORKSPACE_STASH_NAME = 'tiflash-it-workspace'
+final PARALLELISM = 12
 String tiflash_commit_hash = null
 
 pipeline {
@@ -145,7 +146,7 @@ pipeline {
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh """
-                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel 12
+                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel ${PARALLELISM}
                     """
                     sh """
                     cmake --install '${WORKSPACE}/build' --component=tiflash-release --prefix='${WORKSPACE}/install/tiflash'
@@ -180,26 +181,25 @@ pipeline {
                         python3 ${fix_compile_commands} ${include_flag} \\
                             --file_path=compile_commands.json \\
                             --load_diff_files_from "/tmp/tiflash-diff-files.json"
-                        python3 ${run_clang_tidy} -p \$(realpath .) -j 12 --files ".*/tiflash/dbms/*"
+                        python3 ${run_clang_tidy} -p \$(realpath .) -j ${PARALLELISM} --files ".*/tiflash/dbms/*"
                         """
                     }
                 }
             }
         }
-        stage("Cache code and artifact") {
+        stage("Stash Test Workspace") {
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh label: "change permission", script: """
                         chown -R 1000:1000 ./
                     """
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
-                       dir('tests/.build') {
-                            sh label: "archive tiflash binary", script: """
+                    dir('tests/.build') {
+                        sh label: "archive tiflash binary", script: """
                             cp -r ${WORKSPACE}/install/* ./
                             pwd && ls -alh
-                            """
-                        }
-                        sh label: "clean unnecessary dirs", script: """
+                        """
+                    }
+                    sh label: "clean unnecessary dirs", script: """
                         git status
                         git show --oneline -s
                         rm -rf .git
@@ -207,8 +207,8 @@ pipeline {
                         rm -rf tests/fullstack-test-next-gen-columnar
                         du -sh ./
                         ls -alh
-                        """
-                    }
+                    """
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                 }
             }
         }
@@ -239,33 +239,32 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir("${WORKSPACE}/tiflash") {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
-                                    println "restore from cache key: ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}"
-                                    sh label: "debug info", script: """
-                                    printenv
-                                    pwd && ls -alh
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh label: "debug info", script: """
+                                printenv
+                                pwd && ls -alh
+                                """
+                                dir("tests/${TEST_PATH}") {
+                                    echo "path: ${pwd()}"
+                                    sh label: "debug docker info", script: """
+                                    docker ps -a && docker version
                                     """
-                                    dir("tests/${TEST_PATH}") {
-                                        echo "path: ${pwd()}"
-                                        sh label: "debug docker info", script: """
-                                        docker ps -a && docker version
-                                        """
-                                        script {
-                                            def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
-                                            def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
-                                            def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
-                                            def tidbImage = "${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}"
-                                            def tidbFailpointImage = "${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint"
-                                            def tidbRuntimeImage = env.TEST_PATH == 'tidb-ci' ? tidbFailpointImage : tidbImage
-                                            withEnv([
-                                                "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${pdBranch}",
-                                                "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${tikvBranch}",
-                                                "TIDB_IMAGE=${tidbRuntimeImage}",
-                                                "TIDB_FAILPOINT_IMAGE=${tidbFailpointImage}",
-                                                "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
-                                            ]) {
-                                                withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                                    sh label: "prepare docker images", script: '''
+                                    script {
+                                        def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+                                        def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+                                        def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
+                                        def tidbImage = "${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}"
+                                        def tidbFailpointImage = "${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint"
+                                        def tidbRuntimeImage = env.TEST_PATH == 'tidb-ci' ? tidbFailpointImage : tidbImage
+                                        withEnv([
+                                            "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${pdBranch}",
+                                            "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${tikvBranch}",
+                                            "TIDB_IMAGE=${tidbRuntimeImage}",
+                                            "TIDB_FAILPOINT_IMAGE=${tidbFailpointImage}",
+                                            "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
+                                        ]) {
+                                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                                                sh label: "prepare docker images", script: '''
                                                         set -eux
                                                         mkdir -p ~/.docker
                                                         cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
@@ -311,12 +310,11 @@ pipeline {
                                                             {} +
                                                         rm -rf ~/.docker
                                                     '''
-                                                }
+                                            }
 
-                                                sh label: "run integration tests", script: """
+                                            sh label: "run integration tests", script: """
                                                 PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
                                                 """
-                                            }
                                         }
                                     }
                                 }

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -20,7 +20,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -42,27 +43,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
 
                             // Get next-gen tiflash-proxy commit hash.
                             // For submodule, we need to enter the submodule directory and get the commit hash from there.
@@ -343,25 +330,33 @@ pipeline {
                         sh label: "change permission", script: """
                             chown -R 1000:1000 ./
                         """
-                        cache(path: "./", includes: '**/*', key: prow.getCacheKey('ng-binary', REFS, 'ut-build')) {
+                        def binaryCacheKey = prow.getCacheKey('ng-binary', REFS, 'ut-build-artifacts')
+                        sh label: "prepare binary cache dir", script: """
+                            mkdir -p tests/.build
+                        """
+                        cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
+                            // Fallback for cases where build_cache_ready was not set before this stage.
+                            build_cache_ready = build_cache_ready || (sh(
+                                script: "test -x tests/.build/tiflash/gtests_dbms",
+                                returnStatus: true
+                            ) == 0)
+
                             if (build_cache_ready) {
-                                println "build cache exist, restore from cache key: ${prow.getCacheKey('ng-binary', REFS, 'ut-build')}"
+                                println "build cache exist, restore from cache key: ${binaryCacheKey}"
                                 sh """
-                                du -sh ./
-                                ls -alh ./
                                 ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             } else {
-                                println "build cache not exist, clean git repo for cache"
-                                sh label: "clean git repo", script: """
+                                println "build cache not exist, save build artifacts to cache"
+                                sh label: "copy build artifacts", script: """
                                 git status
                                 git show --oneline -s
-                                mkdir tests/.build
+                                rm -rf tests/.build
+                                mkdir -p tests/.build
                                 cp -r ${WORKSPACE}/install/* tests/.build/
-                                rm -rf .git
-                                rm -rf contrib
-                                du -sh ./
-                                ls -alh
+                                ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             }
                         }

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -132,34 +132,6 @@ pipeline {
             }
         }
 
-        stage("Post Build") {
-            when {
-                expression { !build_cache_ready }
-            }
-            steps {
-                dir("${WORKSPACE}/build") {
-                    sh label: "archive build data", script: """
-                    tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
-                    """
-                    archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
-                    sh """
-                    du -sh build-data.tar.xz
-                    rm -rf build-data.tar.xz
-                    """
-                }
-                dir("${WORKSPACE}/tiflash") {
-                    sh label: "archive source patch", script: """
-                    tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
-                    """
-                    archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
-                    sh """
-                    du -sh source-patch.tar.xz
-                    rm -rf source-patch.tar.xz
-                    """
-                }
-            }
-        }
-
         stage("Unit Test Prepare") {
             steps {
                 script {

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -8,7 +8,6 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-Boolean build_cache_ready = false
 
 pipeline {
     agent {
@@ -26,9 +25,6 @@ pipeline {
     }
     stages {
         stage('Checkout') {
-            when {
-                expression { !build_cache_ready }
-            }
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
@@ -50,9 +46,6 @@ pipeline {
             }
         }
         stage("Prepare Ccache") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     dir("tiflash") {
@@ -70,9 +63,6 @@ pipeline {
             }
         }
         stage("Configure Project") {
-            when {
-                expression { !build_cache_ready }
-            }
             // TODO: need to simplify this part, all config and build logic should be in script in tiflash repo
             steps {
                 script {
@@ -103,9 +93,6 @@ pipeline {
             }
         }
         stage("Build TiFlash") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                 sh """
@@ -139,37 +126,15 @@ pipeline {
                         sh label: "change permission", script: """
                             chown -R 1000:1000 ./
                         """
-                        def binaryCacheKey = prow.getCacheKey('ng-binary', REFS, 'ut-build-artifacts')
-                        sh label: "prepare binary cache dir", script: """
+                        sh label: "copy build artifacts", script: """
+                            git status
+                            git show --oneline -s
+                            rm -rf tests/.build
                             mkdir -p tests/.build
-                            chown -R 1000:1000 tests/.build
+                            cp -r ${WORKSPACE}/install/* tests/.build/
+                            ls -alh tests/.build/
+                            du -sh tests/.build/
                         """
-                        cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
-                            // Fallback for cases where build_cache_ready was not set before this stage.
-                            build_cache_ready = build_cache_ready || (sh(
-                                script: "test -x tests/.build/tiflash/gtests_dbms",
-                                returnStatus: true
-                            ) == 0)
-
-                            if (build_cache_ready) {
-                                println "build cache exist, restore from cache key: ${binaryCacheKey}"
-                                sh """
-                                ls -alh tests/.build/
-                                du -sh tests/.build/
-                                """
-                            } else {
-                                println "build cache not exist, save build artifacts to cache"
-                                sh label: "copy build artifacts", script: """
-                                git status
-                                git show --oneline -s
-                                rm -rf tests/.build
-                                mkdir -p tests/.build
-                                cp -r ${WORKSPACE}/install/* tests/.build/
-                                ls -alh tests/.build/
-                                du -sh tests/.build/
-                                """
-                            }
-                        }
                     }
                 }
                 sh label: "link tiflash and tests", script: """

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -142,6 +142,7 @@ pipeline {
                         def binaryCacheKey = prow.getCacheKey('ng-binary', REFS, 'ut-build-artifacts')
                         sh label: "prepare binary cache dir", script: """
                             mkdir -p tests/.build
+                            chown -R 1000:1000 tests/.build
                         """
                         cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
                             // Fallback for cases where build_cache_ready was not set before this stage.

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -3,18 +3,12 @@
 // should triggerd for master branches
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-tiflash"  // TODO: need to adjust namespace after test
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
+final K8S_NAMESPACE = "jenkins-tiflash"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-final dependency_dir = "/home/jenkins/agent/dependency"
 Boolean build_cache_ready = false
-Boolean proxy_cache_ready = false
-String proxy_commit_hash = null
-Boolean libclara_cache_ready = false
-String libclara_commit_hash = null
 
 pipeline {
     agent {
@@ -27,12 +21,8 @@ pipeline {
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
     options {
         timeout(time: 90, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
@@ -51,17 +41,6 @@ pipeline {
                         retry(2) {
                             sh "git status"
 
-                            // Get next-gen tiflash-proxy commit hash.
-                            // For submodule, we need to enter the submodule directory and get the commit hash from there.
-                            dir("contrib/tiflash-proxy-next-gen") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
-
-                            // get clara commit hash
-                            libclara_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H" -- libs/libclara').trim()
-                            println "libclara_commit_hash: ${libclara_commit_hash}"
-
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -70,128 +49,22 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
+        stage("Prepare Ccache") {
             when {
                 expression { !build_cache_ready }
             }
-            parallel {
-                stage("Ccache") {
-                    steps {
-                    script {
-                        dir("tiflash") {
-                            sh label: "copy ccache if exist", script: """
-                            pwd
-                            ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                            if [ -f \$ccache_tar_file ]; then
-                                echo "ccache found"
-                                cd /tmp
-                                cp -r \$ccache_tar_file ccache.tar
-                                tar -xf ccache.tar
-                                ls -lha /tmp
-                            else
-                                echo "ccache not found"
-                            fi
-                            """
-                            sh label: "config ccache", script: """
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
                             ccache -o cache_dir="/tmp/.ccache"
                             ccache -o max_size=2G
                             ccache -o hash_dir=false
                             ccache -o compression=true
                             ccache -o compression_level=6
-                            ccache -o read_only=true
+                            ccache -o read_only=false
                             ccache -z
-                            """
-                        }
-                    }
-                    }
-                }
-                stage("Proxy-Cache") {
-                    steps {
-                        script {
-                            def proxy_suffix = "amd64-linux-llvm-next-gen"
-                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-${proxy_suffix} && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-
-                            sh label: "copy proxy if exist", script: """
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
-                            sh label: "link cargo cache", script: """
-                                mkdir -p ~/.cargo/registry
-                                mkdir -p ~/.cargo/git
-                                mkdir -p /home/jenkins/agent/rust/registry/cache
-                                mkdir -p /home/jenkins/agent/rust/registry/index
-                                mkdir -p /home/jenkins/agent/rust/git/db
-                                mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                                rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                                rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                                rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                                rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                                rm -rf ~/.rustup/tmp
-                                rm -rf ~/.rustup/toolchains
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                                ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                                ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
-                            """
-                        }
-                    }
-                }
-                stage("Libclara Cache") {
-                    steps {
-                        script {
-                            libclara_cache_ready = sh(script: "test -d /home/jenkins/agent/libclara-cache/${libclara_commit_hash}-amd64-linux-debug && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "libclara_cache_ready: ${libclara_cache_ready}"
-
-                            sh label: "copy libclara if exist", script: """
-                            libclara_suffix="amd64-linux-debug"
-                            libclara_cache_dir="/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-\${libclara_suffix}"
-                            if [ -d \$libclara_cache_dir ]; then
-                                echo "libclara cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                cp -r \$libclara_cache_dir/* ${WORKSPACE}/tiflash/libs/libclara-prebuilt/
-                                chmod +x ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
-                                chown -R 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                ls -R ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                            else
-                                echo "libclara cache not found"
-                            fi
-                            """
-                        }
-                    }
-                }
-            }
-        }
-        stage("Build Dependency and Utils") {
-            when {
-                expression { !build_cache_ready }
-            }
-            parallel {
-                stage("Cluster Manage") {
-                    steps {
-                    // NOTE: cluster_manager is deprecated since release-6.0 (include)
-                    echo "cluster_manager is deprecated"
-                    }
-                }
-                stage("TiFlash Proxy") {
-                    steps {
-                        script {
-                        if (proxy_cache_ready) {
-                            echo "skip becuase of cache"
-                        } else {
-                            echo "proxy cache not ready"
-                        }
-                        }
+                        """
                     }
                 }
             }
@@ -203,26 +76,8 @@ pipeline {
             // TODO: need to simplify this part, all config and build logic should be in script in tiflash repo
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
                     def next_gen_flag = "-DENABLE_NEXT_GEN=ON"
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    def libclara_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release/
-                        """
-                    }
-                    if (libclara_cache_ready) {
-                        libclara_flag = "-DLIBCLARA_CXXBRIDGE_DIR='${WORKSPACE}/tiflash/libs/libclara-prebuilt/cxxbridge' -DLIBCLARA_LIBRARY='${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so'"
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -230,7 +85,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} ${libclara_flag} ${next_gen_flag} \\
+                        cmake '${WORKSPACE}/tiflash' ${next_gen_flag} \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -239,8 +94,8 @@ pipeline {
                             -DENABLE_TESTS=true \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
-                            -DUSE_INTERNAL_LIBCLARA=${!libclara_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
+                            -DUSE_INTERNAL_LIBCLARA=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -281,44 +136,26 @@ pipeline {
             when {
                 expression { !build_cache_ready }
             }
-            parallel {
-                stage("Upload Build Artifacts") {
-                    steps {
-                        dir("${WORKSPACE}/install") {
-                            sh label: "archive tiflash binary", script: """
-                            tar -czf 'tiflash.tar.gz' 'tiflash'
-                            """
-                            archiveArtifacts artifacts: "tiflash.tar.gz"
-                            sh """
-                            du -sh tiflash.tar.gz
-                            rm -rf tiflash.tar.gz
-                            """
-                        }
-                    }
+            steps {
+                dir("${WORKSPACE}/build") {
+                    sh label: "archive build data", script: """
+                    tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
+                    """
+                    archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
+                    sh """
+                    du -sh build-data.tar.xz
+                    rm -rf build-data.tar.xz
+                    """
                 }
-                stage("Upload Build Data") {
-                    steps {
-                        dir("${WORKSPACE}/build") {
-                            sh label: "archive build data", script: """
-                            tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
-                            """
-                            archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
-                            sh """
-                            du -sh build-data.tar.xz
-                            rm -rf build-data.tar.xz
-                            """
-                        }
-                        dir("${WORKSPACE}/tiflash") {
-                            sh label: "archive source patch", script: """
-                            tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
-                            """
-                            archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
-                            sh """
-                            du -sh source-patch.tar.xz
-                            rm -rf source-patch.tar.xz
-                            """
-                        }
-                    }
+                dir("${WORKSPACE}/tiflash") {
+                    sh label: "archive source patch", script: """
+                    tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
+                    """
+                    archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
+                    sh """
+                    du -sh source-patch.tar.xz
+                    rm -rf source-patch.tar.xz
+                    """
                 }
             }
         }
@@ -367,12 +204,6 @@ pipeline {
                 ln -sf ${WORKSPACE}/tiflash/tests/.build/tiflash /tiflash
                 ln -sf ${WORKSPACE}/tiflash/tests /tests
                 """
-                dir("${WORKSPACE}/tiflash") {
-                    echo "temp skip here"
-                }
-                dir("${WORKSPACE}/build") {
-                    echo "temp skip here"
-                }
             }
         }
         stage("Run Tests") {

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -3,18 +3,12 @@
 // should triggerd for master branches
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-tiflash"  // TODO: need to adjust namespace after test
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
+final K8S_NAMESPACE = "jenkins-tiflash"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-final dependency_dir = "/home/jenkins/agent/dependency"
 Boolean build_cache_ready = false
-Boolean proxy_cache_ready = false
-String proxy_commit_hash = null
-Boolean libclara_cache_ready = false
-String libclara_commit_hash = null
 
 pipeline {
     agent {
@@ -27,12 +21,8 @@ pipeline {
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
     options {
         timeout(time: 90, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
@@ -51,17 +41,6 @@ pipeline {
                         retry(2) {
                             sh "git status"
 
-                            // Get tiflash-proxy commit hash.
-                            // For submodule, we need to enter the submodule directory and get the commit hash from there.
-                            dir("contrib/tiflash-proxy") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
-
-                            // get clara commit hash
-                            libclara_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H" -- libs/libclara').trim()
-                            println "libclara_commit_hash: ${libclara_commit_hash}"
-
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -70,128 +49,22 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
+        stage("Prepare Ccache") {
             when {
                 expression { !build_cache_ready }
             }
-            parallel {
-                stage("Ccache") {
-                    steps {
-                    script {
-                        dir("tiflash") {
-                            sh label: "copy ccache if exist", script: """
-                            pwd
-                            ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                            if [ -f \$ccache_tar_file ]; then
-                                echo "ccache found"
-                                cd /tmp
-                                cp -r \$ccache_tar_file ccache.tar
-                                tar -xf ccache.tar
-                                ls -lha /tmp
-                            else
-                                echo "ccache not found"
-                            fi
-                            """
-                            sh label: "config ccache", script: """
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
                             ccache -o cache_dir="/tmp/.ccache"
                             ccache -o max_size=2G
                             ccache -o hash_dir=false
                             ccache -o compression=true
                             ccache -o compression_level=6
-                            ccache -o read_only=true
+                            ccache -o read_only=false
                             ccache -z
-                            """
-                        }
-                    }
-                    }
-                }
-                stage("Proxy-Cache") {
-                    steps {
-                        script {
-                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-
-                            sh label: "copy proxy if exist", script: """
-                            proxy_suffix="amd64-linux-llvm"
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-\${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
-                            sh label: "link cargo cache", script: """
-                                mkdir -p ~/.cargo/registry
-                                mkdir -p ~/.cargo/git
-                                mkdir -p /home/jenkins/agent/rust/registry/cache
-                                mkdir -p /home/jenkins/agent/rust/registry/index
-                                mkdir -p /home/jenkins/agent/rust/git/db
-                                mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                                rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                                rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                                rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                                rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                                rm -rf ~/.rustup/tmp
-                                rm -rf ~/.rustup/toolchains
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                                ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                                ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
-                            """
-                        }
-                    }
-                }
-                stage("Libclara Cache") {
-                    steps {
-                        script {
-                            libclara_cache_ready = sh(script: "test -d /home/jenkins/agent/libclara-cache/${libclara_commit_hash}-amd64-linux-debug && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "libclara_cache_ready: ${libclara_cache_ready}"
-
-                            sh label: "copy libclara if exist", script: """
-                            libclara_suffix="amd64-linux-debug"
-                            libclara_cache_dir="/home/jenkins/agent/libclara-cache/${libclara_commit_hash}-\${libclara_suffix}"
-                            if [ -d \$libclara_cache_dir ]; then
-                                echo "libclara cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                cp -r \$libclara_cache_dir/* ${WORKSPACE}/tiflash/libs/libclara-prebuilt/
-                                chmod +x ${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so
-                                chown -R 1000:1000 ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                                ls -R ${WORKSPACE}/tiflash/libs/libclara-prebuilt
-                            else
-                                echo "libclara cache not found"
-                            fi
-                            """
-                        }
-                    }
-                }
-            }
-        }
-        stage("Build Dependency and Utils") {
-            when {
-                expression { !build_cache_ready }
-            }
-            parallel {
-                stage("Cluster Manage") {
-                    steps {
-                    // NOTE: cluster_manager is deprecated since release-6.0 (include)
-                    echo "cluster_manager is deprecated"
-                    }
-                }
-                stage("TiFlash Proxy") {
-                    steps {
-                        script {
-                        if (proxy_cache_ready) {
-                            echo "skip becuase of cache"
-                        } else {
-                            echo "proxy cache not ready"
-                        }
-                        }
+                        """
                     }
                 }
             }
@@ -203,25 +76,7 @@ pipeline {
             // TODO: need to simplify this part, all config and build logic should be in script in tiflash repo
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    def libclara_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release/
-                        """
-                    }
-                    if (libclara_cache_ready) {
-                        libclara_flag = "-DLIBCLARA_CXXBRIDGE_DIR='${WORKSPACE}/tiflash/libs/libclara-prebuilt/cxxbridge' -DLIBCLARA_LIBRARY='${WORKSPACE}/tiflash/libs/libclara-prebuilt/libclara_sharedd.so'"
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -229,7 +84,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} ${libclara_flag} \\
+                        cmake '${WORKSPACE}/tiflash' \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -238,8 +93,8 @@ pipeline {
                             -DENABLE_TESTS=true \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
-                            -DUSE_INTERNAL_LIBCLARA=${!libclara_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
+                            -DUSE_INTERNAL_LIBCLARA=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -280,44 +135,26 @@ pipeline {
             when {
                 expression { !build_cache_ready }
             }
-            parallel {
-                stage("Upload Build Artifacts") {
-                    steps {
-                        dir("${WORKSPACE}/install") {
-                            sh label: "archive tiflash binary", script: """
-                            tar -czf 'tiflash.tar.gz' 'tiflash'
-                            """
-                            archiveArtifacts artifacts: "tiflash.tar.gz"
-                            sh """
-                            du -sh tiflash.tar.gz
-                            rm -rf tiflash.tar.gz
-                            """
-                        }
-                    }
+            steps {
+                dir("${WORKSPACE}/build") {
+                    sh label: "archive build data", script: """
+                    tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
+                    """
+                    archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
+                    sh """
+                    du -sh build-data.tar.xz
+                    rm -rf build-data.tar.xz
+                    """
                 }
-                stage("Upload Build Data") {
-                    steps {
-                        dir("${WORKSPACE}/build") {
-                            sh label: "archive build data", script: """
-                            tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
-                            """
-                            archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
-                            sh """
-                            du -sh build-data.tar.xz
-                            rm -rf build-data.tar.xz
-                            """
-                        }
-                        dir("${WORKSPACE}/tiflash") {
-                            sh label: "archive source patch", script: """
-                            tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
-                            """
-                            archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
-                            sh """
-                            du -sh source-patch.tar.xz
-                            rm -rf source-patch.tar.xz
-                            """
-                        }
-                    }
+                dir("${WORKSPACE}/tiflash") {
+                    sh label: "archive source patch", script: """
+                    tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
+                    """
+                    archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
+                    sh """
+                    du -sh source-patch.tar.xz
+                    rm -rf source-patch.tar.xz
+                    """
                 }
             }
         }
@@ -366,12 +203,6 @@ pipeline {
                 ln -sf ${WORKSPACE}/tiflash/tests/.build/tiflash /tiflash
                 ln -sf ${WORKSPACE}/tiflash/tests /tests
                 """
-                dir("${WORKSPACE}/tiflash") {
-                    echo "temp skip here"
-                }
-                dir("${WORKSPACE}/build") {
-                    echo "temp skip here"
-                }
             }
         }
         stage("Run Tests") {

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -131,34 +131,6 @@ pipeline {
             }
         }
 
-        stage("Post Build") {
-            when {
-                expression { !build_cache_ready }
-            }
-            steps {
-                dir("${WORKSPACE}/build") {
-                    sh label: "archive build data", script: """
-                    tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
-                    """
-                    archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
-                    sh """
-                    du -sh build-data.tar.xz
-                    rm -rf build-data.tar.xz
-                    """
-                }
-                dir("${WORKSPACE}/tiflash") {
-                    sh label: "archive source patch", script: """
-                    tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
-                    """
-                    archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
-                    sh """
-                    du -sh source-patch.tar.xz
-                    rm -rf source-patch.tar.xz
-                    """
-                }
-            }
-        }
-
         stage("Unit Test Prepare") {
             steps {
                 script {

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -141,6 +141,7 @@ pipeline {
                         def binaryCacheKey = prow.getCacheKey('binary', REFS, 'ut-build-artifacts')
                         sh label: "prepare binary cache dir", script: """
                             mkdir -p tests/.build
+                            chown -R 1000:1000 tests/.build
                         """
                         cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
                             // Fallback for cases where build_cache_ready was not set before this stage.

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -8,7 +8,6 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-Boolean build_cache_ready = false
 
 pipeline {
     agent {
@@ -26,9 +25,6 @@ pipeline {
     }
     stages {
         stage('Checkout') {
-            when {
-                expression { !build_cache_ready }
-            }
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
@@ -50,9 +46,6 @@ pipeline {
             }
         }
         stage("Prepare Ccache") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     dir("tiflash") {
@@ -70,9 +63,6 @@ pipeline {
             }
         }
         stage("Configure Project") {
-            when {
-                expression { !build_cache_ready }
-            }
             // TODO: need to simplify this part, all config and build logic should be in script in tiflash repo
             steps {
                 script {
@@ -102,9 +92,6 @@ pipeline {
             }
         }
         stage("Build TiFlash") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                 sh """
@@ -138,37 +125,15 @@ pipeline {
                         sh label: "change permission", script: """
                             chown -R 1000:1000 ./
                         """
-                        def binaryCacheKey = prow.getCacheKey('binary', REFS, 'ut-build-artifacts')
-                        sh label: "prepare binary cache dir", script: """
+                        sh label: "copy build artifacts", script: """
+                            git status
+                            git show --oneline -s
+                            rm -rf tests/.build
                             mkdir -p tests/.build
-                            chown -R 1000:1000 tests/.build
+                            cp -r ${WORKSPACE}/install/* tests/.build/
+                            ls -alh tests/.build/
+                            du -sh tests/.build/
                         """
-                        cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
-                            // Fallback for cases where build_cache_ready was not set before this stage.
-                            build_cache_ready = build_cache_ready || (sh(
-                                script: "test -x tests/.build/tiflash/gtests_dbms",
-                                returnStatus: true
-                            ) == 0)
-
-                            if (build_cache_ready) {
-                                println "build cache exist, restore from cache key: ${binaryCacheKey}"
-                                sh """
-                                ls -alh tests/.build/
-                                du -sh tests/.build/
-                                """
-                            } else {
-                                println "build cache not exist, save build artifacts to cache"
-                                sh label: "copy build artifacts", script: """
-                                git status
-                                git show --oneline -s
-                                rm -rf tests/.build
-                                mkdir -p tests/.build
-                                cp -r ${WORKSPACE}/install/* tests/.build/
-                                ls -alh tests/.build/
-                                du -sh tests/.build/
-                                """
-                            }
-                        }
                     }
                 }
                 sh label: "link tiflash and tests", script: """

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -20,7 +20,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -42,27 +43,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
 
                             // Get tiflash-proxy commit hash.
                             // For submodule, we need to enter the submodule directory and get the commit hash from there.
@@ -342,31 +329,33 @@ pipeline {
                         sh label: "change permission", script: """
                             chown -R 1000:1000 ./
                         """
-                        cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'ut-build')) {
+                        def binaryCacheKey = prow.getCacheKey('binary', REFS, 'ut-build-artifacts')
+                        sh label: "prepare binary cache dir", script: """
+                            mkdir -p tests/.build
+                        """
+                        cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
                             // Fallback for cases where build_cache_ready was not set before this stage.
                             build_cache_ready = build_cache_ready || (sh(
-                                script: "test -x tests/.build/tiflash",
+                                script: "test -x tests/.build/tiflash/gtests_dbms",
                                 returnStatus: true
                             ) == 0)
 
                             if (build_cache_ready) {
-                                println "build cache exist, restore from cache key: ${prow.getCacheKey('binary', REFS, 'ut-build')}"
+                                println "build cache exist, restore from cache key: ${binaryCacheKey}"
                                 sh """
-                                du -sh ./
-                                ls -alh ./
                                 ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             } else {
-                                println "build cache not exist, clean git repo for cache"
-                                sh label: "clean git repo", script: """
+                                println "build cache not exist, save build artifacts to cache"
+                                sh label: "copy build artifacts", script: """
                                 git status
                                 git show --oneline -s
+                                rm -rf tests/.build
                                 mkdir -p tests/.build
                                 cp -r ${WORKSPACE}/install/* tests/.build/
-                                rm -rf .git
-                                rm -rf contrib
-                                du -sh ./
-                                ls -alh
+                                ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             }
                         }

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml
@@ -22,26 +22,8 @@ spec:
           cpu: "12"
           ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
         - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
+          name: "tmp"
           readOnly: false
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
@@ -54,21 +36,8 @@ spec:
           cpu: "1"
           memory: "4Gi"
   volumes:
-    - name: "volume-0"
+    - name: "tmp"
       emptyDir: {}
-    - name: "volume-2"
-      emptyDir: {}
-    - name: "volume-1"
-      emptyDir: {}
-    - name: "volume-4"
-      emptyDir: {}
-    - name: "volume-5"
-      emptyDir: {}
-    - name: "volume-6"
-      emptyDir: {}
-    - name: "volume-7"
-      emptyDir:
-        medium: Memory
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml
@@ -5,7 +5,8 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
+      imagePullPolicy: Always
       command:
         - "/bin/bash"
         - "-c"
@@ -15,9 +16,11 @@ spec:
         requests:
           memory: 32Gi
           cpu: "12"
+          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
+          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -40,16 +43,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]
@@ -62,30 +55,15 @@ spec:
           memory: "4Gi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
       emptyDir: {}
     - name: "volume-7"
@@ -100,7 +78,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml
@@ -14,12 +14,12 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 32Gi
-          cpu: "12"
+          memory: 24Gi
+          cpu: "6"
           ephemeral-storage: 20Gi
         limits:
-          memory: 48Gi
-          cpu: "12"
+          memory: 32Gi
+          cpu: "8"
           ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml
@@ -1,17 +1,26 @@
 apiVersion: "v1"
 kind: "Pod"
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
-    - image: "docker:18.09.6-dind"
+    - image: "docker:24.0.9-dind"
       imagePullPolicy: "IfNotPresent"
       name: "dockerd"
+      env:
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+        - name: DOCKER_DRIVER
+          value: overlay2
       resources:
         limits:
           memory: "32Gi"
           cpu: "16000m"
+          ephemeral-storage: 150Gi
         requests:
           memory: "10Gi"
           cpu: "5000m"
+          ephemeral-storage: 20Gi
       securityContext:
         privileged: true
       tty: false
@@ -22,14 +31,15 @@ spec:
         - mountPath: "/tmp"
           name: "volume-3"
           readOnly: false
-        - mountPath: "/home/jenkins/agent"
-          name: "workspace-volume"
-          readOnly: false
+        - mountPath: "/var/lib/docker"
+          name: "docker-graph"
     - command:
         - "cat"
       env:
         - name: "DOCKER_HOST"
           value: "tcp://localhost:2375"
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
       image: ghcr.io/pingcap-qe/ci/base:v2026.4.12-11-g402978f-go1.25
       imagePullPolicy: "Always"
       name: "docker"
@@ -37,6 +47,11 @@ spec:
         requests:
           memory: "8Gi"
           cpu: "5000m"
+          ephemeral-storage: 10Gi
+        limits:
+          memory: "16Gi"
+          cpu: "8000m"
+          ephemeral-storage: 50Gi
       tty: true
       volumeMounts:
         - mountPath: "/home/jenkins"
@@ -45,19 +60,23 @@ spec:
         - mountPath: "/tmp"
           name: "volume-3"
           readOnly: false
-        - mountPath: "/home/jenkins/agent"
-          name: "workspace-volume"
-          readOnly: false
   volumes:
     - emptyDir:
         medium: ""
       name: "volume-0"
     - emptyDir:
         medium: ""
-      name: "workspace-volume"
-    - emptyDir:
-        medium: ""
       name: "volume-3"
+    - name: "docker-graph"
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -67,7 +86,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml
@@ -15,21 +15,21 @@ spec:
       resources:
         limits:
           memory: "32Gi"
-          cpu: "16000m"
+          cpu: "16"
           ephemeral-storage: 150Gi
         requests:
           memory: "10Gi"
-          cpu: "5000m"
+          cpu: "5"
           ephemeral-storage: 20Gi
       securityContext:
         privileged: true
       tty: false
       volumeMounts:
         - mountPath: "/home/jenkins"
-          name: "volume-0"
+          name: "jenkins-home"
           readOnly: false
         - mountPath: "/tmp"
-          name: "volume-3"
+          name: "tmp"
           readOnly: false
         - mountPath: "/var/lib/docker"
           name: "docker-graph"
@@ -55,18 +55,18 @@ spec:
       tty: true
       volumeMounts:
         - mountPath: "/home/jenkins"
-          name: "volume-0"
+          name: "jenkins-home"
           readOnly: false
         - mountPath: "/tmp"
-          name: "volume-3"
+          name: "tmp"
           readOnly: false
   volumes:
     - emptyDir:
         medium: ""
-      name: "volume-0"
+      name: "jenkins-home"
     - emptyDir:
         medium: ""
-      name: "volume-3"
+      name: "tmp"
     - name: "docker-graph"
       ephemeral:
         volumeClaimTemplate:

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml
@@ -15,19 +15,16 @@ spec:
       resources:
         limits:
           memory: "32Gi"
-          cpu: "16"
+          cpu: "8"
           ephemeral-storage: 150Gi
         requests:
-          memory: "10Gi"
-          cpu: "5"
+          memory: "16Gi"
+          cpu: "4"
           ephemeral-storage: 20Gi
       securityContext:
         privileged: true
       tty: false
       volumeMounts:
-        - mountPath: "/home/jenkins"
-          name: "jenkins-home"
-          readOnly: false
         - mountPath: "/tmp"
           name: "tmp"
           readOnly: false
@@ -45,25 +42,19 @@ spec:
       name: "docker"
       resources:
         requests:
-          memory: "8Gi"
-          cpu: "5000m"
+          memory: "16Gi"
+          cpu: "4"
           ephemeral-storage: 10Gi
         limits:
-          memory: "16Gi"
-          cpu: "8000m"
+          memory: "32Gi"
+          cpu: "8"
           ephemeral-storage: 50Gi
       tty: true
       volumeMounts:
-        - mountPath: "/home/jenkins"
-          name: "jenkins-home"
-          readOnly: false
         - mountPath: "/tmp"
           name: "tmp"
           readOnly: false
   volumes:
-    - emptyDir:
-        medium: ""
-      name: "jenkins-home"
     - emptyDir:
         medium: ""
       name: "tmp"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml
@@ -13,8 +13,8 @@ spec:
       # Notice: not set the resources limit, because limit will make unit test failed
       resources:
         requests:
-          memory: "32Gi"
-          cpu: "12"
+          memory: "24Gi"
+          cpu: "6"
           ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/tmp"
@@ -23,17 +23,12 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "tmp-memfs"
           readOnly: false
-        - mountPath: "/home/jenkins"
-          name: "jenkins-home"
-          readOnly: false
   volumes:
     - name: "tmp"
       emptyDir: {}
     - name: "tmp-memfs"
       emptyDir:
         medium: Memory
-    - name: "jenkins-home"
-      emptyDir: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml
@@ -14,50 +14,25 @@ spec:
       resources:
         requests:
           memory: "32Gi"
-          cpu: "12000m"
+          cpu: "12"
           ephemeral-storage: 20Gi
       volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
         - mountPath: "/tmp"
-          name: "volume-6"
+          name: "tmp"
           readOnly: false
         - mountPath: "/tmp-memfs"
-          name: "volume-7"
+          name: "tmp-memfs"
           readOnly: false
         - mountPath: "/home/jenkins"
-          name: "volume-8"
+          name: "jenkins-home"
           readOnly: false
   volumes:
-    - name: "volume-0"
+    - name: "tmp"
       emptyDir: {}
-    - name: "volume-2"
-      emptyDir: {}
-    - name: "volume-1"
-      emptyDir: {}
-    - name: "volume-4"
-      emptyDir: {}
-    - name: "volume-5"
-      emptyDir: {}
-    - name: "volume-6"
-      emptyDir: {}
-    - name: "volume-7"
+    - name: "tmp-memfs"
       emptyDir:
         medium: Memory
-    - name: "volume-8"
+    - name: "jenkins-home"
       emptyDir: {}
   affinity:
     nodeAffinity:

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml
@@ -1,9 +1,12 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
+      imagePullPolicy: Always
       command:
         - "cat"
       tty: true
@@ -12,6 +15,7 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "12000m"
+          ephemeral-storage: 20Gi
       volumeMounts:
         - mountPath: "/home/jenkins/agent/rust"
           name: "volume-0"
@@ -37,42 +41,17 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/rust"
-        readOnly: false
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-2"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/dependency"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-1"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/ccache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-4"
-      nfs:
-        path: "/data/nvme1n1/nfs/git"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-5"
-      nfs:
-        path: "/data/nvme1n1/nfs/tiflash/proxy-cache"
-        readOnly: true
-        server: "10.2.12.82"
+      emptyDir: {}
     - name: "volume-6"
       emptyDir: {}
     - name: "volume-7"

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -9,8 +9,8 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-pull_build.
 final POD_INTEGRATIONTEST_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
-final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-release-8.5-it-build'
-Boolean build_cache_ready = false
+final WORKSPACE_STASH_NAME = 'tiflash-release-8.5-it-workspace'
+final PARALLELISM = 12
 String tiflash_commit_hash = null
 
 pipeline {
@@ -32,9 +32,6 @@ pipeline {
     }
     stages {
         stage('Checkout') {
-            when {
-                expression { !build_cache_ready }
-            }
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
@@ -57,9 +54,6 @@ pipeline {
             }
         }
         stage("Prepare Ccache") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     dir("tiflash") {
@@ -77,9 +71,6 @@ pipeline {
             }
         }
         stage("Configure Project") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     def generator = 'Ninja'
@@ -107,9 +98,6 @@ pipeline {
             }
         }
         stage("Format Check") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     def target_branch = REFS.base_ref
@@ -135,13 +123,10 @@ pipeline {
             }
         }
         stage("Build TiFlash") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh """
-                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel 12
+                    cmake --build '${WORKSPACE}/build' --target tiflash --parallel ${PARALLELISM}
                     """
                     sh """
                     cmake --install '${WORKSPACE}/build' --component=tiflash-release --prefix='${WORKSPACE}/install/tiflash'
@@ -154,9 +139,6 @@ pipeline {
             }
         }
         stage("License check") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     container('utils') {
@@ -176,9 +158,6 @@ pipeline {
             }
         }
         stage("Post Build") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     def generator = "Ninja"
@@ -190,7 +169,6 @@ pipeline {
                         cat /tmp/tiflash-diff-files.json
                         """
                         sh label: "run clang tidy", script: """
-                        NPROC=\$(nproc || grep -c ^processor /proc/cpuinfo || echo '1')
                         cat /tmp/tiflash-diff-files.json
                         cmake "${WORKSPACE}/tiflash" \\
                             -DENABLE_TESTS=false \\
@@ -202,29 +180,25 @@ pipeline {
                         python3 ${fix_compile_commands} ${include_flag} \\
                             --file_path=compile_commands.json \\
                             --load_diff_files_from "/tmp/tiflash-diff-files.json"
-                        python3 ${run_clang_tidy} -p \$(realpath .) -j \$NPROC --files ".*/tiflash/dbms/*"
+                        python3 ${run_clang_tidy} -p \$(realpath .) -j ${PARALLELISM} --files ".*/tiflash/dbms/*"
                         """
                     }
                 }
             }
         }
-        stage("Cache code and artifact") {
-            when {
-                expression { !build_cache_ready }
-            }
+        stage("Stash Test Workspace") {
             steps {
                 dir("${WORKSPACE}/tiflash") {
                     sh label: "change permission", script: """
                         chown -R 1000:1000 ./
                     """
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
-                       dir('tests/.build') {
-                            sh label: "archive tiflash binary", script: """
+                    dir('tests/.build') {
+                        sh label: "archive tiflash binary", script: """
                             cp -r ${WORKSPACE}/install/* ./
                             pwd && ls -alh
-                            """
-                        }
-                        sh label: "clean unnecessary dirs", script: """
+                        """
+                    }
+                    sh label: "clean unnecessary dirs", script: """
                         git status
                         git show --oneline -s
                         rm -rf .git
@@ -232,8 +206,8 @@ pipeline {
                         rm -rf tests/fullstack-test-next-gen-columnar
                         du -sh ./
                         ls -alh
-                        """
-                    }
+                    """
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                 }
             }
         }
@@ -264,30 +238,29 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir("${WORKSPACE}/tiflash") {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
-                                    println "restore from cache key: ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}"
-                                    sh label: "debug info", script: """
-                                    printenv
-                                    pwd && ls -alh
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh label: "debug info", script: """
+                                printenv
+                                pwd && ls -alh
+                                """
+                                dir("tests/${TEST_PATH}") {
+                                    echo "path: ${pwd()}"
+                                    sh label: "debug docker info", script: """
+                                    docker ps -a && docker version
                                     """
-                                    dir("tests/${TEST_PATH}") {
-                                        echo "path: ${pwd()}"
-                                        sh label: "debug docker info", script: """
-                                        docker ps -a && docker version
-                                        """
-                                        script {
-                                            def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
-                                            def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
-                                            def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
-                                            withEnv([
-                                                "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${pdBranch}",
-                                                "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${tikvBranch}",
-                                                "TIDB_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}",
-                                                "TIDB_FAILPOINT_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint",
-                                                "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
-                                            ]) {
-                                                withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                                    sh label: "prepare docker images", script: '''
+                                    script {
+                                        def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
+                                        def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
+                                        def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
+                                        withEnv([
+                                            "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${pdBranch}",
+                                            "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${tikvBranch}",
+                                            "TIDB_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}",
+                                            "TIDB_FAILPOINT_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint",
+                                            "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
+                                        ]) {
+                                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                                                sh label: "prepare docker images", script: '''
                                                         set -eux
                                                         mkdir -p ~/.docker
                                                         cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
@@ -333,12 +306,11 @@ pipeline {
                                                             {} +
                                                         rm -rf ~/.docker
                                                     '''
-                                                }
+                                            }
 
-                                                sh label: "run integration tests", script: """
+                                            sh label: "run integration tests", script: """
                                                 PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
                                                 """
-                                            }
                                         }
                                     }
                                 }

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -4,17 +4,13 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflash"
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml'
 final POD_INTEGRATIONTEST_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final dependency_dir = "/home/jenkins/agent/dependency"
 final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
 final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-release-8.5-it-build'
-Boolean proxy_cache_ready = false
 Boolean build_cache_ready = false
-String proxy_commit_hash = null
 String tiflash_commit_hash = null
 
 pipeline {
@@ -33,7 +29,6 @@ pipeline {
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
@@ -53,10 +48,6 @@ pipeline {
                             sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                             println "tiflash_commit_hash: ${tiflash_commit_hash}"
-                            dir("contrib/tiflash-proxy") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -65,84 +56,21 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
+        stage("Prepare Ccache") {
             when {
                 expression { !build_cache_ready }
             }
-            parallel {
-                stage("Ccache") {
-                    steps {
-                    script {
-                        dir("tiflash") {
-                            sh label: "copy ccache if exist", script: """
-                            ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/tiflash-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                            if [ -f \$ccache_tar_file ]; then
-                                echo "ccache found"
-                                cd /tmp
-                                cp -r \$ccache_tar_file ccache.tar
-                                tar -xf ccache.tar
-                                ls -lha /tmp
-                            else
-                                echo "ccache not found"
-                            fi
-                            """
-                            sh label: "config ccache", script: """
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
                             ccache -o cache_dir="/tmp/.ccache"
                             ccache -o max_size=2G
                             ccache -o hash_dir=false
                             ccache -o compression=true
                             ccache -o compression_level=6
-                            ccache -o read_only=true
+                            ccache -o read_only=false
                             ccache -z
-                            """
-                        }
-                    }
-                    }
-
-                }
-                stage("Proxy-Cache") {
-                    steps {
-                        script {
-                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-
-                            sh label: "copy proxy if exist", script: """
-                            proxy_suffix="amd64-linux-llvm"
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-\${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
-                        }
-                    }
-                }
-                stage("Cargo-Cache") {
-                    steps {
-                        sh label: "link cargo cache", script: """
-                            mkdir -p ~/.cargo/registry
-                            mkdir -p ~/.cargo/git
-                            mkdir -p /home/jenkins/agent/rust/registry/cache
-                            mkdir -p /home/jenkins/agent/rust/registry/index
-                            mkdir -p /home/jenkins/agent/rust/git/db
-                            mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                            rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                            rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                            rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                            rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                            rm -rf ~/.rustup/tmp
-                            rm -rf ~/.rustup/toolchains
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                            mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                            ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                            ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
                         """
                     }
                 }
@@ -154,21 +82,7 @@ pipeline {
             }
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release/
-                        """
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -176,7 +90,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
+                        cmake '${WORKSPACE}/tiflash' \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -185,7 +99,7 @@ pipeline {
                             -DENABLE_TESTS=false \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -265,49 +179,31 @@ pipeline {
             when {
                 expression { !build_cache_ready }
             }
-            parallel {
-                stage("Static Analysis"){
-                    steps {
-                        script {
-                            def generator = "Ninja"
-                            def include_flag = ""
-                            def fix_compile_commands = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/fix_compile_commands.py"
-                            def run_clang_tidy = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/run-clang-tidy.py"
-                            dir("${WORKSPACE}/build") {
-                                sh label: "debug diff files", script: """
-                                cat /tmp/tiflash-diff-files.json
-                                """
-                                sh label: "run clang tidy", script: """
-                                NPROC=\$(nproc || grep -c ^processor /proc/cpuinfo || echo '1')
-                                cat /tmp/tiflash-diff-files.json
-                                cmake "${WORKSPACE}/tiflash" \\
-                                    -DENABLE_TESTS=false \\
-                                    -DCMAKE_BUILD_TYPE=Debug \\
-                                    -DUSE_CCACHE=OFF \\
-                                    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \\
-                                    -DRUN_HAVE_STD_REGEX=0 \\
-                                    -G '${generator}'
-                                python3 ${fix_compile_commands} ${include_flag} \\
-                                    --file_path=compile_commands.json \\
-                                    --load_diff_files_from "/tmp/tiflash-diff-files.json"
-                                python3 ${run_clang_tidy} -p \$(realpath .) -j \$NPROC --files ".*/tiflash/dbms/*"
-                                """
-                            }
-                        }
-                    }
-                }
-                stage("Upload Build Artifacts") {
-                    steps {
-                        dir("${WORKSPACE}/install") {
-                            sh label: "archive tiflash binary", script: """
-                            tar -czf 'tiflash.tar.gz' 'tiflash'
-                            """
-                            archiveArtifacts artifacts: "tiflash.tar.gz"
-                            sh """
-                            du -sh tiflash.tar.gz
-                            rm -rf tiflash.tar.gz
-                            """
-                        }
+            steps {
+                script {
+                    def generator = "Ninja"
+                    def include_flag = ""
+                    def fix_compile_commands = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/fix_compile_commands.py"
+                    def run_clang_tidy = "${WORKSPACE}/tiflash/release-linux-llvm/scripts/run-clang-tidy.py"
+                    dir("${WORKSPACE}/build") {
+                        sh label: "debug diff files", script: """
+                        cat /tmp/tiflash-diff-files.json
+                        """
+                        sh label: "run clang tidy", script: """
+                        NPROC=\$(nproc || grep -c ^processor /proc/cpuinfo || echo '1')
+                        cat /tmp/tiflash-diff-files.json
+                        cmake "${WORKSPACE}/tiflash" \\
+                            -DENABLE_TESTS=false \\
+                            -DCMAKE_BUILD_TYPE=Debug \\
+                            -DUSE_CCACHE=OFF \\
+                            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \\
+                            -DRUN_HAVE_STD_REGEX=0 \\
+                            -G '${generator}'
+                        python3 ${fix_compile_commands} ${include_flag} \\
+                            --file_path=compile_commands.json \\
+                            --load_diff_files_from "/tmp/tiflash-diff-files.json"
+                        python3 ${run_clang_tidy} -p \$(realpath .) -j \$NPROC --files ".*/tiflash/dbms/*"
+                        """
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -10,6 +10,8 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-pull_build.
 final POD_INTEGRATIONTEST_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final dependency_dir = "/home/jenkins/agent/dependency"
+final TIFLASH_TEST_IMAGE = 'ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2'
+final TEST_WORKSPACE_CACHE_FOLDER = 'tiflash-release-8.5-it-build'
 Boolean proxy_cache_ready = false
 Boolean build_cache_ready = false
 String proxy_commit_hash = null
@@ -19,7 +21,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -41,27 +44,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = '', timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                             println "tiflash_commit_hash: ${tiflash_commit_hash}"
                             dir("contrib/tiflash-proxy") {
@@ -332,7 +321,7 @@ pipeline {
                     sh label: "change permission", script: """
                         chown -R 1000:1000 ./
                     """
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
                        dir('tests/.build') {
                             sh label: "archive tiflash binary", script: """
                             cp -r ${WORKSPACE}/install/* ./
@@ -344,6 +333,7 @@ pipeline {
                         git show --oneline -s
                         rm -rf .git
                         rm -rf contrib
+                        rm -rf tests/fullstack-test-next-gen-columnar
                         du -sh ./
                         ls -alh
                         """
@@ -363,7 +353,8 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_INTEGRATIONTEST_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_INTEGRATIONTEST_TEMPLATE_FILE, REFS)
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'docker'
                         retries 5
                         customWorkspace "/home/jenkins/agent/workspace/tiflash-integration-test"
@@ -377,8 +368,8 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir("${WORKSPACE}/tiflash") {
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'it-build')){
-                                    println "restore from cache key: ${prow.getCacheKey('binary', REFS, 'it-build')}"
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}") {
+                                    println "restore from cache key: ws/${BUILD_TAG}/${TEST_WORKSPACE_CACHE_FOLDER}"
                                     sh label: "debug info", script: """
                                     printenv
                                     pwd && ls -alh
@@ -392,9 +383,66 @@ pipeline {
                                             def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
                                             def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
                                             def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
-                                            sh label: "run integration tests", script: """
-                                            PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
-                                            """
+                                            withEnv([
+                                                "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${pdBranch}",
+                                                "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${tikvBranch}",
+                                                "TIDB_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}",
+                                                "TIDB_FAILPOINT_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint",
+                                                "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
+                                            ]) {
+                                                withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                                                    sh label: "prepare docker images", script: '''
+                                                        set -eux
+                                                        mkdir -p ~/.docker
+                                                        cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
+                                                        for i in $(seq 1 30); do
+                                                            if docker version; then
+                                                                break
+                                                            fi
+                                                            sleep 2
+                                                        done
+                                                        docker ps -a
+
+                                                        timeout 300 docker pull "${PD_IMAGE}"
+                                                        timeout 300 docker pull "${TIKV_IMAGE}"
+                                                        timeout 300 docker pull "${TIDB_IMAGE}"
+                                                        timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
+                                                        timeout 600 docker pull "${TIFLASH_IMAGE}"
+
+                                                        find ../docker . -name '*.yaml' -type f -exec sed -i \
+                                                            -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
+                                                            -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e 's#${TIDB_IMAGE:[^}]*-failpoint}#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:master#${PD_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:master#${TIKV_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master#${TIDB_IMAGE}#g" \
+                                                            {} +
+                                                        rm -rf ~/.docker
+                                                    '''
+                                                }
+
+                                                sh label: "run integration tests", script: """
+                                                PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
+                                                """
+                                            }
                                         }
                                     }
                                 }

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -8,7 +8,6 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-Boolean build_cache_ready = false
 
 pipeline {
     agent {
@@ -26,9 +25,6 @@ pipeline {
     }
     stages {
         stage('Checkout') {
-            when {
-                expression { !build_cache_ready }
-            }
             options { timeout(time: 15, unit: 'MINUTES') }
             steps {
                 dir("tiflash") {
@@ -49,9 +45,6 @@ pipeline {
             }
         }
         stage("Prepare Ccache") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 script {
                     dir("tiflash") {
@@ -69,9 +62,6 @@ pipeline {
             }
         }
         stage("Configure Project") {
-            when {
-                expression { !build_cache_ready }
-            }
             // TODO: need to simplify this part, all config and build logic should be in script in tiflash repo
             steps {
                 script {
@@ -100,9 +90,6 @@ pipeline {
             }
         }
         stage("Build TiFlash") {
-            when {
-                expression { !build_cache_ready }
-            }
             steps {
                 dir("${WORKSPACE}/tiflash") {
                 sh """
@@ -136,37 +123,15 @@ pipeline {
                         sh label: "change permission", script: """
                             chown -R 1000:1000 ./
                         """
-                        def binaryCacheKey = prow.getCacheKey('binary', REFS, 'ut-build-artifacts')
-                        sh label: "prepare binary cache dir", script: """
+                        sh label: "copy build artifacts", script: """
+                            git status
+                            git show --oneline -s
+                            rm -rf tests/.build
                             mkdir -p tests/.build
-                            chown -R 1000:1000 tests/.build
+                            cp -r ${WORKSPACE}/install/* tests/.build/
+                            ls -alh tests/.build/
+                            du -sh tests/.build/
                         """
-                        cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
-                            // Fallback for cases where build_cache_ready was not set before this stage.
-                            build_cache_ready = build_cache_ready || (sh(
-                                script: "test -x tests/.build/tiflash/gtests_dbms",
-                                returnStatus: true
-                            ) == 0)
-
-                            if (build_cache_ready) {
-                                println "build cache exist, restore from cache key: ${binaryCacheKey}"
-                                sh """
-                                ls -alh tests/.build/
-                                du -sh tests/.build/
-                                """
-                            } else {
-                                println "build cache not exist, save build artifacts to cache"
-                                sh label: "copy build artifacts", script: """
-                                git status
-                                git show --oneline -s
-                                rm -rf tests/.build
-                                mkdir -p tests/.build
-                                cp -r ${WORKSPACE}/install/* tests/.build/
-                                ls -alh tests/.build/
-                                du -sh tests/.build/
-                                """
-                            }
-                        }
                     }
                 }
                 sh label: "link tiflash and tests", script: """

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -129,34 +129,6 @@ pipeline {
             }
         }
 
-        stage("Post Build") {
-            when {
-                expression { !build_cache_ready }
-            }
-            steps {
-                dir("${WORKSPACE}/build") {
-                    sh label: "archive build data", script: """
-                    tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
-                    """
-                    archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
-                    sh """
-                    du -sh build-data.tar.xz
-                    rm -rf build-data.tar.xz
-                    """
-                }
-                dir("${WORKSPACE}/tiflash") {
-                    sh label: "archive source patch", script: """
-                    tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
-                    """
-                    archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
-                    sh """
-                    du -sh source-patch.tar.xz
-                    rm -rf source-patch.tar.xz
-                    """
-                }
-            }
-        }
-
         stage("Unit Test Prepare") {
             steps {
                 script {

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -139,6 +139,7 @@ pipeline {
                         def binaryCacheKey = prow.getCacheKey('binary', REFS, 'ut-build-artifacts')
                         sh label: "prepare binary cache dir", script: """
                             mkdir -p tests/.build
+                            chown -R 1000:1000 tests/.build
                         """
                         cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
                             // Fallback for cases where build_cache_ready was not set before this stage.

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -3,16 +3,12 @@
 // should triggerd for master branches
 @Library('tipipeline') _
 
-final K8S_NAMESPACE = "jenkins-tiflash"  // TODO: need to adjust namespace after test
-final GIT_FULL_REPO_NAME = 'pingcap/tiflash'
+final K8S_NAMESPACE = "jenkins-tiflash"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
-final dependency_dir = "/home/jenkins/agent/dependency"
 Boolean build_cache_ready = false
-Boolean proxy_cache_ready = false
-String proxy_commit_hash = null
 
 pipeline {
     agent {
@@ -25,12 +21,8 @@ pipeline {
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
     options {
         timeout(time: 90, unit: 'MINUTES')
-        parallelsAlwaysFailFast()
     }
     stages {
         stage('Checkout') {
@@ -48,10 +40,6 @@ pipeline {
                         prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
                         retry(2) {
                             sh "git status"
-                            dir("contrib/tiflash-proxy") {
-                                proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
-                                println "proxy_commit_hash: ${proxy_commit_hash}"
-                            }
                             sh """
                             chown 1000:1000 -R ./
                             """
@@ -60,104 +48,21 @@ pipeline {
                 }
             }
         }
-        stage("Prepare Cache") {
+        stage("Prepare Ccache") {
             when {
                 expression { !build_cache_ready }
             }
-            parallel {
-                stage("Ccache") {
-                    steps {
-                    script {
-                        dir("tiflash") {
-                            sh label: "copy ccache if exist", script: """
-                            pwd
-                            ccache_tar_file="/home/jenkins/agent/ccache/ccache-4.10.2/pagetools-tests-amd64-linux-llvm-debug-${REFS.base_ref}-failpoints.tar"
-                            if [ -f \$ccache_tar_file ]; then
-                                echo "ccache found"
-                                cd /tmp
-                                cp -r \$ccache_tar_file ccache.tar
-                                tar -xf ccache.tar
-                                ls -lha /tmp
-                            else
-                                echo "ccache not found"
-                            fi
-                            """
-                            sh label: "config ccache", script: """
+            steps {
+                script {
+                    dir("tiflash") {
+                        sh label: "config ccache", script: """
                             ccache -o cache_dir="/tmp/.ccache"
                             ccache -o max_size=2G
                             ccache -o hash_dir=false
                             ccache -o compression=true
                             ccache -o compression_level=6
-                            ccache -o read_only=true
+                            ccache -o read_only=false
                             ccache -z
-                            """
-                        }
-                    }
-                    }
-                }
-                stage("Proxy-Cache") {
-                    steps {
-                        script {
-                            proxy_cache_ready = sh(script: "test -f /home/jenkins/agent/proxy-cache/${proxy_commit_hash}-amd64-linux-llvm && echo 'true' || echo 'false'", returnStdout: true).trim() == 'true'
-                            println "proxy_cache_ready: ${proxy_cache_ready}"
-
-                            sh label: "copy proxy if exist", script: """
-                            proxy_suffix="amd64-linux-llvm"
-                            proxy_cache_file="/home/jenkins/agent/proxy-cache/${proxy_commit_hash}-\${proxy_suffix}"
-                            if [ -f \$proxy_cache_file ]; then
-                                echo "proxy cache found"
-                                mkdir -p ${WORKSPACE}/tiflash/libs/libtiflash-proxy
-                                cp \$proxy_cache_file ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chmod +x ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                                chown 1000:1000 ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so
-                            else
-                                echo "proxy cache not found"
-                            fi
-                            """
-                            sh label: "link cargo cache", script: """
-                                mkdir -p ~/.cargo/registry
-                                mkdir -p ~/.cargo/git
-                                mkdir -p /home/jenkins/agent/rust/registry/cache
-                                mkdir -p /home/jenkins/agent/rust/registry/index
-                                mkdir -p /home/jenkins/agent/rust/git/db
-                                mkdir -p /home/jenkins/agent/rust/git/checkouts
-
-                                rm -rf ~/.cargo/registry/cache && ln -s /home/jenkins/agent/rust/registry/cache ~/.cargo/registry/cache
-                                rm -rf ~/.cargo/registry/index && ln -s /home/jenkins/agent/rust/registry/index ~/.cargo/registry/index
-                                rm -rf ~/.cargo/git/db && ln -s /home/jenkins/agent/rust/git/db ~/.cargo/git/db
-                                rm -rf ~/.cargo/git/checkouts && ln -s /home/jenkins/agent/rust/git/checkouts ~/.cargo/git/checkouts
-
-                                rm -rf ~/.rustup/tmp
-                                rm -rf ~/.rustup/toolchains
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/tmp
-                                mkdir -p /home/jenkins/agent/rust/rustup-env/toolchains
-                                ln -s /home/jenkins/agent/rust/rustup-env/tmp ~/.rustup/tmp
-                                ln -s /home/jenkins/agent/rust/rustup-env/toolchains ~/.rustup/toolchains
-                            """
-                        }
-                    }
-                }
-            }
-        }
-        stage("Build Dependency and Utils") {
-            when {
-                expression { !build_cache_ready }
-            }
-            parallel {
-                stage("Cluster Manage") {
-                    steps {
-                    // NOTE: cluster_manager is deprecated since release-6.0 (include)
-                    echo "cluster_manager is deprecated"
-                    }
-                }
-                stage("TiFlash Proxy") {
-                    steps {
-                        script {
-                        if (proxy_cache_ready) {
-                            echo "skip becuase of cache"
-                        } else {
-                            echo "proxy cache not ready"
-                        }
                         }
                     }
                 }
@@ -170,21 +75,7 @@ pipeline {
             // TODO: need to simplify this part, all config and build logic should be in script in tiflash repo
             steps {
                 script {
-                    def toolchain = "llvm"
                     def generator = 'Ninja'
-                    def coverage_flag = ""
-                    def diagnostic_flag = ""
-                    def compatible_flag = ""
-                    def openssl_root_dir = ""
-                    def prebuilt_dir_flag = ""
-                    if (proxy_cache_ready) {
-                        // only for toolchain is llvm
-                        prebuilt_dir_flag = "-DPREBUILT_LIBS_ROOT='${WORKSPACE}/tiflash/contrib/tiflash-proxy/'"
-                        sh """
-                        mkdir -p ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release
-                        cp ${WORKSPACE}/tiflash/libs/libtiflash-proxy/libtiflash_proxy.so ${WORKSPACE}/tiflash/contrib/tiflash-proxy/target/release/
-                        """
-                    }
                     // create build dir and install dir
                     sh label: "create build & install dir", script: """
                     mkdir -p ${WORKSPACE}/build
@@ -192,7 +83,7 @@ pipeline {
                     """
                     dir("${WORKSPACE}/build") {
                         sh label: "configure project", script: """
-                        cmake '${WORKSPACE}/tiflash' ${prebuilt_dir_flag} ${coverage_flag} ${diagnostic_flag} ${compatible_flag} ${openssl_root_dir} \\
+                        cmake '${WORKSPACE}/tiflash' \\
                             -G '${generator}' \\
                             -DENABLE_FAILPOINTS=true \\
                             -DCMAKE_BUILD_TYPE=Debug \\
@@ -201,7 +92,7 @@ pipeline {
                             -DENABLE_TESTS=true \\
                             -DUSE_CCACHE=true \\
                             -DDEBUG_WITHOUT_DEBUG_INFO=true \\
-                            -DUSE_INTERNAL_TIFLASH_PROXY=${!proxy_cache_ready} \\
+                            -DUSE_INTERNAL_TIFLASH_PROXY=true \\
                             -DRUN_HAVE_STD_REGEX=0 \\
                         """
                     }
@@ -242,44 +133,26 @@ pipeline {
             when {
                 expression { !build_cache_ready }
             }
-            parallel {
-                stage("Upload Build Artifacts") {
-                    steps {
-                        dir("${WORKSPACE}/install") {
-                            sh label: "archive tiflash binary", script: """
-                            tar -czf 'tiflash.tar.gz' 'tiflash'
-                            """
-                            archiveArtifacts artifacts: "tiflash.tar.gz"
-                            sh """
-                            du -sh tiflash.tar.gz
-                            rm -rf tiflash.tar.gz
-                            """
-                        }
-                    }
+            steps {
+                dir("${WORKSPACE}/build") {
+                    sh label: "archive build data", script: """
+                    tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
+                    """
+                    archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
+                    sh """
+                    du -sh build-data.tar.xz
+                    rm -rf build-data.tar.xz
+                    """
                 }
-                stage("Upload Build Data") {
-                    steps {
-                        dir("${WORKSPACE}/build") {
-                            sh label: "archive build data", script: """
-                            tar -cavf build-data.tar.xz \$(find . -name "*.h" -o -name "*.cpp" -o -name "*.cc" -o -name "*.hpp" -o -name "*.gcno" -o -name "*.gcna")
-                            """
-                            archiveArtifacts artifacts: "build-data.tar.xz", allowEmptyArchive: true
-                            sh """
-                            du -sh build-data.tar.xz
-                            rm -rf build-data.tar.xz
-                            """
-                        }
-                        dir("${WORKSPACE}/tiflash") {
-                            sh label: "archive source patch", script: """
-                            tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
-                            """
-                            archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
-                            sh """
-                            du -sh source-patch.tar.xz
-                            rm -rf source-patch.tar.xz
-                            """
-                        }
-                    }
+                dir("${WORKSPACE}/tiflash") {
+                    sh label: "archive source patch", script: """
+                    tar -cavf source-patch.tar.xz \$(find . -name "*.pb.h" -o -name "*.pb.cc")
+                    """
+                    archiveArtifacts artifacts: "source-patch.tar.xz", allowEmptyArchive: true
+                    sh """
+                    du -sh source-patch.tar.xz
+                    rm -rf source-patch.tar.xz
+                    """
                 }
             }
         }
@@ -328,12 +201,6 @@ pipeline {
                 ln -sf ${WORKSPACE}/tiflash/tests/.build/tiflash /tiflash
                 ln -sf ${WORKSPACE}/tiflash/tests /tests
                 """
-                dir("${WORKSPACE}/tiflash") {
-                    echo "temp skip here"
-                }
-                dir("${WORKSPACE}/build") {
-                    echo "temp skip here"
-                }
             }
         }
         stage("Run Tests") {

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -18,7 +18,8 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
             retries 5
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
@@ -40,27 +41,13 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version
-                        git status
                         """
+                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
                         retry(2) {
-                            prow.checkoutRefs(REFS, credentialsId = '', timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
+                            sh "git status"
                             dir("contrib/tiflash-proxy") {
                                 proxy_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()
                                 println "proxy_commit_hash: ${proxy_commit_hash}"
@@ -304,31 +291,33 @@ pipeline {
                         sh label: "change permission", script: """
                             chown -R 1000:1000 ./
                         """
-                        cache(path: "./", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'ut-build')) {
+                        def binaryCacheKey = prow.getCacheKey('binary', REFS, 'ut-build-artifacts')
+                        sh label: "prepare binary cache dir", script: """
+                            mkdir -p tests/.build
+                        """
+                        cache(path: "tests/.build", includes: '**/*', key: binaryCacheKey) {
                             // Fallback for cases where build_cache_ready was not set before this stage.
                             build_cache_ready = build_cache_ready || (sh(
-                                script: "test -x tests/.build/tiflash",
+                                script: "test -x tests/.build/tiflash/gtests_dbms",
                                 returnStatus: true
                             ) == 0)
 
                             if (build_cache_ready) {
-                                println "build cache exist, restore from cache key: ${prow.getCacheKey('binary', REFS, 'ut-build')}"
+                                println "build cache exist, restore from cache key: ${binaryCacheKey}"
                                 sh """
-                                du -sh ./
-                                ls -alh ./
                                 ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             } else {
-                                println "build cache not exist, clean git repo for cache"
-                                sh label: "clean git repo", script: """
+                                println "build cache not exist, save build artifacts to cache"
+                                sh label: "copy build artifacts", script: """
                                 git status
                                 git show --oneline -s
+                                rm -rf tests/.build
                                 mkdir -p tests/.build
                                 cp -r ${WORKSPACE}/install/* tests/.build/
-                                rm -rf .git
-                                rm -rf contrib
-                                du -sh ./
-                                ls -alh
+                                ls -alh tests/.build/
+                                du -sh tests/.build/
                                 """
                             }
                         }

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -63,7 +63,7 @@ pipeline {
                             ccache -o compression_level=6
                             ccache -o read_only=false
                             ccache -z
-                        }
+                        """
                     }
                 }
             }

--- a/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
@@ -14,7 +14,7 @@ presubmits:
     - <<: *brancher
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       context: pull-unit-next-gen
       decorate: false # need add this.
       name: pingcap/tiflash/pull_unit_next_gen
@@ -27,7 +27,7 @@ presubmits:
     - <<: *brancher
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       context: pull-integration-next-gen
       decorate: false # need add this.
       name: pingcap/tiflash/pull_integration_next_gen

--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -158,7 +158,7 @@ presubmits:
     - <<: *brancher
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       context: pull-unit-test
       decorate: false # need add this.
       name: pingcap/tiflash/pull_unit_test
@@ -171,7 +171,7 @@ presubmits:
     - <<: *brancher
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       context: pull-integration-test
       decorate: false # need add this.
       name: pingcap/tiflash/pull_integration_test

--- a/prow-jobs/pingcap/tiflash/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.5-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -23,7 +23,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.5/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test


### PR DESCRIPTION
This PR contains the remaining TiFlash presubmit/pull job migration changes. It should be merged after the merged/postsubmit migration PR has been merged and observed for a few days.

Changes:
- migrate latest and release-8.5 TiFlash pull build/unit/integration jobs to GCP
- update pull job pod templates, images, and resources
- replace legacy runtime/test images with GCP/GHCR-accessible images
- adjust integration docker-compose image replacement and unit-test build cache handling

Validation:
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_integration_next_gen/28/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_integration_test/20/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_unit_next_gen/16/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_unit_test/10/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/release-8.5/job/pull_unit_test/10/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/release-8.5/job/pull_integration_test/18/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_integration_next_gen_columnar/10/stages/