### PR TITLE
ci(release-8.5): disable mysql ssl mode in dm pods

### DIFF
--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml
@@ -3,6 +3,18 @@ kind: Pod
 spec:
   securityContext:
     fsGroup: 1000
+  initContainers:
+    - name: init-mysql-config
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      command:
+        - sh
+        - -c
+        - |
+          echo "[client]" > /mysql-config/.my.cnf
+          echo "ssl-mode=DISABLED" >> /mysql-config/.my.cnf
+      volumeMounts:
+        - mountPath: "/mysql-config"
+          name: "mysql-config-volume"
   containers:
     - name: golang
       image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
@@ -14,6 +26,10 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
+      volumeMounts:
+        - mountPath: "/home/jenkins/.my.cnf"
+          name: "mysql-config-volume"
+          subPath: ".my.cnf"
     - name: mysql1
       image: 'hub.pingcap.net/jenkins/mysql:5.7'
       tty: true
@@ -52,6 +68,9 @@ spec:
         - "--gtid-mode=ON"
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
+  volumes:
+    - name: mysql-config-volume
+      emptyDir: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "alpine:3.23"
       command:
         - sh
         - -c

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
@@ -3,6 +3,18 @@ kind: Pod
 spec:
   securityContext:
     fsGroup: 1000
+  initContainers:
+    - name: init-mysql-config
+      image: "hub.pingcap.net/jenkins/golang-tini:1.23"
+      command:
+        - sh
+        - -c
+        - |
+          echo "[client]" > /mysql-config/.my.cnf
+          echo "ssl-mode=DISABLED" >> /mysql-config/.my.cnf
+      volumeMounts:
+        - mountPath: "/mysql-config"
+          name: "mysql-config-volume"
   containers:
     - name: golang
       image: "hub.pingcap.net/jenkins/golang-tini:1.23"
@@ -16,6 +28,10 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
+      volumeMounts:
+        - mountPath: "/home/jenkins/.my.cnf"
+          name: "mysql-config-volume"
+          subPath: ".my.cnf"
     - name: mysql1
       image: "hub.pingcap.net/jenkins/mysql:5.7"
       tty: true
@@ -54,6 +70,9 @@ spec:
         - "--gtid-mode=ON"
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
+  volumes:
+    - name: mysql-config-volume
+      emptyDir: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "hub.pingcap.net/jenkins/golang-tini:1.23"
+      image: "alpine:3.23"
       command:
         - sh
         - -c


### PR DESCRIPTION
## Summary
- switch the release-8.5 tiflow DM compatibility and integration pods from init-container wiring to `golang` `postStart` hooks that write `/home/jenkins/.my.cnf`
- add the same MySQL client ssl-disable setup to the `pingcap/tidb` release-8.5 BR integration pod via `postStart`
- keep the BR temp-dir permission preparation in that BR `postStart` hook while removing the extra mysql-config volume scaffolding from the tiflow pods

## Testing
- ruby -e 'require "yaml"; YAML.load_file("ci/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml"); puts "ok"'
- ruby -e 'require "yaml"; YAML.load_file("ci/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml"); puts "ok"'
- ruby -e 'require "yaml"; YAML.load_file("ci/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml"); puts "ok"'
- sh .ci/verify-k8s-pod-yaml.sh pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml