### PR TITLE
ci(release-8.5): disable mysql ssl mode in dm and br pods

### DIFF
--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -20,6 +20,18 @@ spec:
       volumeMounts:
         - mountPath: "/tmp/tidb"
           name: "tidb-temp-dir-volume"
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - |
+                chmod 1777 /tmp/tidb
+                cat > /home/jenkins/.my.cnf <<'EOF'
+                [client]
+                ssl-mode=DISABLED
+                EOF
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -27,7 +27,6 @@ spec:
               - /bin/sh
               - -c
               - |
-                chmod 1777 /tmp/tidb
                 cat > /home/jenkins/.my.cnf <<'EOF'
                 [client]
                 ssl-mode=DISABLED

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -27,6 +27,7 @@ spec:
               - /bin/sh
               - -c
               - |
+                mkdir -p /home/jenkins
                 cat > /home/jenkins/.my.cnf <<'EOF'
                 [client]
                 ssl-mode=DISABLED

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml
@@ -3,18 +3,6 @@ kind: Pod
 spec:
   securityContext:
     fsGroup: 1000
-  initContainers:
-    - name: init-mysql-config
-      image: "alpine:3.23"
-      command:
-        - sh
-        - -c
-        - |
-          echo "[client]" > /mysql-config/.my.cnf
-          echo "ssl-mode=DISABLED" >> /mysql-config/.my.cnf
-      volumeMounts:
-        - mountPath: "/mysql-config"
-          name: "mysql-config-volume"
   containers:
     - name: golang
       image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
@@ -26,10 +14,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      volumeMounts:
-        - mountPath: "/home/jenkins/.my.cnf"
-          name: "mysql-config-volume"
-          subPath: ".my.cnf"
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - |
+                cat > /home/jenkins/.my.cnf <<'EOF'
+                [client]
+                ssl-mode=DISABLED
+                EOF
     - name: mysql1
       image: 'hub.pingcap.net/jenkins/mysql:5.7'
       tty: true
@@ -68,9 +63,6 @@ spec:
         - "--gtid-mode=ON"
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
-  volumes:
-    - name: mysql-config-volume
-      emptyDir: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml
@@ -21,6 +21,7 @@ spec:
               - /bin/sh
               - -c
               - |
+                mkdir -p /home/jenkins
                 cat > /home/jenkins/.my.cnf <<'EOF'
                 [client]
                 ssl-mode=DISABLED

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
@@ -3,18 +3,6 @@ kind: Pod
 spec:
   securityContext:
     fsGroup: 1000
-  initContainers:
-    - name: init-mysql-config
-      image: "alpine:3.23"
-      command:
-        - sh
-        - -c
-        - |
-          echo "[client]" > /mysql-config/.my.cnf
-          echo "ssl-mode=DISABLED" >> /mysql-config/.my.cnf
-      volumeMounts:
-        - mountPath: "/mysql-config"
-          name: "mysql-config-volume"
   containers:
     - name: golang
       image: "hub.pingcap.net/jenkins/golang-tini:1.23"
@@ -28,10 +16,17 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      volumeMounts:
-        - mountPath: "/home/jenkins/.my.cnf"
-          name: "mysql-config-volume"
-          subPath: ".my.cnf"
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - |
+                cat > /home/jenkins/.my.cnf <<'EOF'
+                [client]
+                ssl-mode=DISABLED
+                EOF
     - name: mysql1
       image: "hub.pingcap.net/jenkins/mysql:5.7"
       tty: true
@@ -70,9 +65,6 @@ spec:
         - "--gtid-mode=ON"
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
-  volumes:
-    - name: mysql-config-volume
-      emptyDir: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
@@ -23,6 +23,7 @@ spec:
               - /bin/sh
               - -c
               - |
+                mkdir -p /home/jenkins
                 cat > /home/jenkins/.my.cnf <<'EOF'
                 [client]
                 ssl-mode=DISABLED


### PR DESCRIPTION
## Summary
- switch the release-8.5 tiflow DM compatibility and integration pods from init-container wiring to `golang` `postStart` hooks that write `/home/jenkins/.my.cnf`
- add the same MySQL client ssl-disable setup to the `pingcap/tidb` release-8.5 BR integration pod via `postStart`
- keep the BR temp-dir permission preparation in that BR `postStart` hook while removing the extra mysql-config volume scaffolding from the tiflow pods

## Testing
- ruby -e 'require "yaml"; YAML.load_file("ci/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml"); puts "ok"'
- ruby -e 'require "yaml"; YAML.load_file("ci/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml"); puts "ok"'
- ruby -e 'require "yaml"; YAML.load_file("ci/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml"); puts "ok"'
- sh .ci/verify-k8s-pod-yaml.sh pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml