### PR TITLE
revert(tiflow): remove release-8.5 dm mysql ssl override

### DIFF
--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml
@@ -14,18 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      lifecycle:
-        postStart:
-          exec:
-            command:
-              - /bin/sh
-              - -c
-              - |
-                mkdir -p /home/jenkins
-                cat > /home/jenkins/.my.cnf <<'EOF'
-                [client]
-                ssl-mode=DISABLED
-                EOF
     - name: mysql1
       image: 'hub.pingcap.net/jenkins/mysql:5.7'
       tty: true

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml
@@ -16,18 +16,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      lifecycle:
-        postStart:
-          exec:
-            command:
-              - /bin/sh
-              - -c
-              - |
-                mkdir -p /home/jenkins
-                cat > /home/jenkins/.my.cnf <<'EOF'
-                [client]
-                ssl-mode=DISABLED
-                EOF
     - name: mysql1
       image: "hub.pingcap.net/jenkins/mysql:5.7"
       tty: true


### PR DESCRIPTION
## Summary
- revert the release-8.5 tiflow DM pod changes from #4649 and #4650
- remove the postStart hook that writes /home/jenkins/.my.cnf
- restore the two tiflow pod templates to their pre-#4649 state

## Testing
- ruby -e 'require "yaml"; YAML.load_file("pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml"); YAML.load_file("pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml"); puts "yaml ok"'
- sh .ci/verify-k8s-pod-yaml.sh pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml

## Context
- Jenkins failure: https://do.pingcap.net/jenkins/blue/organizations/jenkins/pingcap%2Ftiflow%2Frelease-8.5%2Fpull_dm_integration_test/detail/pull_dm_integration_test/454/pipeline/
- Related PRs: #4649 #4650
