### PR TITLE
fix(jobs): remove deprecated extensions wrapper and githubProjectUrl

### DIFF
--- a/jobs/pingcap-inc/aa_folder.groovy
+++ b/jobs/pingcap-inc/aa_folder.groovy
@@ -11,14 +11,12 @@ folder('pingcap-inc') {
                             scm {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
-                                    extensions {
-                                        cloneOption {
-                                            depth(1)
-                                            shallow(true)
-                                            noTags(true)
-                                            reference('/var/lib/scm-git/ci')
-                                            timeout(5)
-                                        }
+                                    cloneOption {
+                                        depth(1)
+                                        shallow(true)
+                                        noTags(true)
+                                        reference('/var/lib/scm-git/ci')
+                                        timeout(5)
                                     }
                                 }
                             }

--- a/jobs/pingcap-qe/aa_folder.groovy
+++ b/jobs/pingcap-qe/aa_folder.groovy
@@ -11,14 +11,12 @@ folder('pingcap-qe') {
                             scm {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
-                                    extensions {
-                                        cloneOption {
-                                            depth(1)
-                                            shallow(true)
-                                            noTags(true)
-                                            reference('/var/lib/scm-git/ci')
-                                            timeout(5)
-                                        }
+                                    cloneOption {
+                                        depth(1)
+                                        shallow(true)
+                                        noTags(true)
+                                        reference('/var/lib/scm-git/ci')
+                                        timeout(5)
                                     }
                                 }
                             }

--- a/jobs/pingcap/aa_folder.groovy
+++ b/jobs/pingcap/aa_folder.groovy
@@ -11,14 +11,12 @@ folder('pingcap') {
                             scm {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
-                                    extensions {
-                                        cloneOption {
-                                            depth(1)
-                                            shallow(true)
-                                            noTags(true)
-                                            reference('/var/lib/scm-git/ci')
-                                            timeout(5)
-                                        }
+                                    cloneOption {
+                                        depth(1)
+                                        shallow(true)
+                                        noTags(true)
+                                        reference('/var/lib/scm-git/ci')
+                                        timeout(5)
                                     }
                                 }
                             }

--- a/jobs/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen.groovy
@@ -10,10 +10,6 @@ pipelineJob('pingcap/ticdc/pull_cdc_storage_integration_light_next_gen') {
         stringParam("PROW_JOB_ID")
         stringParam("JOB_SPEC")
     }
-    properties {
-        githubProjectUrl("https://github.com/pingcap/ticdc")
-    }
-
     definition {
         cpsScm {
             lightweight(true)

--- a/jobs/ti-community-infra/aa_folder.groovy
+++ b/jobs/ti-community-infra/aa_folder.groovy
@@ -10,14 +10,12 @@ folder('ti-community-infra') {
                             scm {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
-                                    extensions {
-                                        cloneOption {
-                                            depth(1)
-                                            shallow(true)
-                                            noTags(true)
-                                            reference('/var/lib/scm-git/ci')
-                                            timeout(5)
-                                        }
+                                    cloneOption {
+                                        depth(1)
+                                        shallow(true)
+                                        noTags(true)
+                                        reference('/var/lib/scm-git/ci')
+                                        timeout(5)
                                     }
                                 }
                             }

--- a/jobs/tidbcloud/aa_folder.groovy
+++ b/jobs/tidbcloud/aa_folder.groovy
@@ -11,14 +11,12 @@ folder('tidbcloud') {
                             scm {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
-                                    extensions {
-                                        cloneOption {
-                                            depth(1)
-                                            shallow(true)
-                                            noTags(true)
-                                            reference('/var/lib/scm-git/ci')
-                                            timeout(5)
-                                        }
+                                    cloneOption {
+                                        depth(1)
+                                        shallow(true)
+                                        noTags(true)
+                                        reference('/var/lib/scm-git/ci')
+                                        timeout(5)
                                     }
                                 }
                             }

--- a/jobs/tikv/aa_folder.groovy
+++ b/jobs/tikv/aa_folder.groovy
@@ -11,14 +11,12 @@ folder('tikv') {
                             scm {
                                 git {
                                     remote('https://github.com/PingCAP-QE/ci')
-                                    extensions {
-                                        cloneOption {
-                                            depth(1)
-                                            shallow(true)
-                                            noTags(true)
-                                            reference('/var/lib/scm-git/ci')
-                                            timeout(5)
-                                        }
+                                    cloneOption {
+                                        depth(1)
+                                        shallow(true)
+                                        noTags(true)
+                                        reference('/var/lib/scm-git/ci')
+                                        timeout(5)
                                     }
                                 }
                             }


### PR DESCRIPTION
Fix deprecation warnings from the Jenkins seed job (#31).

### Changes

- **`jobs/pingcap-inc/aa_folder.groovy`**: Remove deprecated `extensions { }` wrapper, call `cloneOption` directly inside `git { }`.
- **`jobs/ti-community-infra/aa_folder.groovy`**: Same as above.
- **`jobs/tidbcloud/aa_folder.groovy`**: Same as above.
- **`jobs/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen.groovy`**: Remove `githubProjectUrl` — it requires the GitHub plugin 1.12.0+ which is not installed on the Jenkins instance. This setting is cosmetic (GitHub project link on job page) and has no functional impact.

### Before / After

Seed job console: https://prow.tidb.net/jenkins/job/seed/31/consoleText