### PR TITLE
ci(ticdc): avoid regular integration jobs on nextgen branches

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -1,7 +1,6 @@
 global_definitions:
   branches: &branches
     - ^master$
-    - ^release-nextgen-\d+$
     - ^release-8\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
     - ^feature/.+
   skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|yaml|json)|Dockerfile|OWNERS|OWNERS_ALIASES)$"


### PR DESCRIPTION
### What changed

Remove `^release-nextgen-\d+$` from the regular TiCDC presubmit branch set in `prow-jobs/pingcap/ticdc/latest-presubmits.yaml`.

The next-gen presubmits in `prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml` still match `release-nextgen-*` branches.

### Why

TiCDC PRs targeting `release-nextgen-202603` currently trigger regular jobs such as `pull-cdc-pulsar-integration-light` when `/test all` is used. Those regular jobs download TiDB, PD, and TiKV artifacts from the normal `hub` OCI registry, but next-gen artifacts are handled by the `*_next_gen` pipelines through the `tidbx` registry.

This caused artifact lookup failures like:

`us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/tidb/package:release-nextgen-202603_linux_amd64: not found`

Ref: pingcap/ticdc#5203

### Verification

Parsed the Prow YAML locally and checked branch/trigger selection for `release-nextgen-202603`:

- Before this change, `/test all` selected the regular TiCDC integration jobs.
- After this change, `/test all` selects no regular TiCDC jobs on `release-nextgen-202603`.
- `/test next-gen` still selects the `*_next_gen` TiCDC integration jobs.
- `/test pull-cdc-pulsar-integration-light-next-gen` still selects `pull_cdc_pulsar_integration_light_next_gen`.
- `master`, `release-8.5`, and `feature/foo` still select the regular `/test all` jobs.

Also ran `git diff --check` for the changed file.