### PR TITLE
ci(ticdc): replace workspace cache with stash for heavy mysql IT

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -9,6 +9,7 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final BRANCH_ALIAS = 'latest'
 final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod-test.yaml"
 final POD_TEMPLATE_FILE_BUILD = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod-build.yaml"
+final WORKSPACE_STASH_NAME = 'ticdc-workspace'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIDB = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
@@ -76,12 +77,11 @@ pipeline {
                             }
                         }
                     }
-                    // Cache for downstream test stages.
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                        sh label: "prepare", script: """
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        ls -alh ./bin
+                    """
+                    // Stash the prepared workspace for downstream test stages.
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                 }
             }
         }
@@ -111,18 +111,17 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                                    sh """
-                                        ln -sf /usr/bin/jq ./bin/jq
-                                        make check_third_party_binary
-                                        ls -alh ./bin
-                                        ./bin/tidb-server -V
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tiflash --version
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
 
-                                    """
-                                }
+                                """
                                 sh label: "${TEST_GROUP}", script: """
                                     ./tests/integration_tests/run_heavy_it_in_ci.sh mysql ${TEST_GROUP}
                                 """


### PR DESCRIPTION
## Summary
- replace the prepare-stage workspace cache with a single stash
- replace the test-stage mutable cache restore with unstash for each matrix shard
- preserve dotfiles and repo metadata in the stashed workspace via useDefaultExcludes: false

## Testing
- git diff --check

Ref: FLA-171