### PR TITLE
ci(ticdc): add legacy safepoint integration tests

### DIFF
--- a/jobs/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint.groovy
@@ -1,0 +1,35 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/ticdc/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint.groovy
@@ -1,0 +1,35 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/ticdc/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint.groovy
@@ -1,0 +1,35 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/ticdc/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint.groovy
+++ b/jobs/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint.groovy
@@ -1,0 +1,34 @@
+// REF: https://<your-jenkins-server>/plugin/job-dsl/api-viewer/index.html
+// For trunk and latest release branches.
+pipelineJob('pingcap/ticdc/pull_cdc_storage_integration_light_next_gen_legacy_safepoint') {
+    logRotator {
+        daysToKeep(30)
+    }
+    parameters {
+        // Ref: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
+        stringParam("BUILD_ID")
+        stringParam("PROW_JOB_ID")
+        stringParam("JOB_SPEC")
+    }
+    definition {
+        cpsScm {
+            lightweight(true)
+            scriptPath("pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy")
+            scm {
+                git{
+                    remote {
+                        url('https://github.com/PingCAP-QE/ci.git')
+                    }
+                    branch('main')
+                    extensions {
+                        cloneOptions {
+                            depth(1)
+                            shallow(true)
+                            timeout(5)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,7 +25,6 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -1,0 +1,174 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final BRANCH_ALIAS = 'latest'
+final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod-test.yaml"
+final POD_TEMPLATE_FILE_BUILD = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod-build.yaml"
+final WORKSPACE_STASH_NAME = 'ticdc-workspace'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIDB = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIFLASH = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
+final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
+final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
+final OCI_TAG_ETCD = 'v3.5.15'
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_SCHEMA_REGISTRY = 'latest'
+
+prow.setPRDescription(REFS)
+pipeline {
+    agent none
+    environment {
+        // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        NEXT_GEN = 1
+        LEGACY_SAFEPOINT = 1
+    }
+    options {
+        timeout(time: 120, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
+            steps {
+                dir(REFS.repo) {
+                    // Checkout
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                    }
+                    // Build binaries
+                    script {
+                        cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'ng-binary')
+                        cdc.prepareIntegrationTestKafkaConsumerBinariesWithCacheLock(REFS, 'ng-binary')
+                        cdc.prepareIntegrationTestStorageConsumerBinariesWithCacheLock(REFS, 'ng-binary')
+                    }
+                    // Download other binaries
+                    container("utils") {
+                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                            sh label: "prepare docker auth", script: '''
+                                mkdir -p ~/.docker
+                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
+                            '''
+                        }
+                        dir("bin") {
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                        chmod +x \$script
+                                        \$script \
+                                            --pd=${OCI_TAG_PD} \
+                                            --pd-ctl=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tikv-worker=${OCI_TAG_TIKV} \
+                                            --tidb=${OCI_TAG_TIDB} \
+                                            --tiflash=${OCI_TAG_TIFLASH} \
+                                            --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
+                                            --minio=${OCI_TAG_MINIO} \
+                                            --etcdctl=${OCI_TAG_ETCD} \
+                                            --ycsb=${OCI_TAG_YCSB} \
+                                            --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
+                                    """
+                                }
+                            }
+                        }
+                    }
+                    sh label: "prepare", script: """
+                        ls -alh ./bin
+                    """
+                    // Stash the prepared workspace for downstream test stages.
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                }
+            }
+        }
+
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_GROUP'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08',
+                            'G09', 'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'golang'
+                    }
+                }
+                when {
+                    beforeAgent true
+                    expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) }
+                }
+                stages {
+                    stage("Test") {
+                        steps {
+                            dir(REFS.repo) {
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
+                                    }
+                                }
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_light_it_in_ci.sh kafka ${TEST_GROUP}
+                                """
+                            }
+                        }
+                        post {
+                            failure {
+                                sh label: "collect logs", script: """
+                                    ls /tmp/tidb_cdc_test/
+                                    log_files=\$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    if [ -n "\${log_files}" ]; then
+                                        tar --warning=no-file-changed -cvzf log-${TEST_GROUP}.tar.gz \${log_files}
+                                        ls -alh log-${TEST_GROUP}.tar.gz
+                                    else
+                                        echo "No log files found under /tmp/tidb_cdc_test/, skip tar"
+                                    fi
+                                """
+                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
+                            }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pod-build.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      tty: true
+      resources:
+        limits:
+          memory: 8Gi
+          cpu: "6"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pod-test.yaml
@@ -1,0 +1,151 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - image: wurstmeister/zookeeper
+      imagePullPolicy: IfNotPresent
+      name: zookeeper
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 4Gi
+        limits:
+          cpu: 1000m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+      command: [tini, --, bash]
+      imagePullPolicy: Always
+      name: golang
+      resources:
+        limits:
+          cpu: "6"
+          memory: 16Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - env:
+        - name: KAFKA_CREATE_TOPICS
+          value: big-message-test:1:1
+        - name: KAFKA_BROKER_ID
+          value: "1"
+        - name: KAFKA_SSL_KEYSTORE_PASSWORD
+          value: test1234
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: localhost:2181
+        - name: KAFKA_MESSAGE_MAX_BYTES
+          value: "11534336"
+        - name: KAFKA_REPLICA_FETCH_MAX_BYTES
+          value: "11534336"
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
+        - name: ZK
+          value: zk
+        - name: KAFKA_SSL_KEYSTORE_LOCATION
+          value: /tmp/kafka.server.keystore.jks
+        - name: KAFKA_SSL_KEY_PASSWORD
+          value: test1234
+        - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+          value: test1234
+        - name: KAFKA_LISTENERS
+          value: SSL://127.0.0.1:9093,PLAINTEXT://127.0.0.1:9092
+        - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+          value: /tmp/kafka.server.truststore.jks
+        - name: RACK_COMMAND
+          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+      image: wurstmeister/kafka:2.12-2.4.1
+      imagePullPolicy: IfNotPresent
+      name: kafka
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 6Gi
+        limits:
+          cpu: 2000m
+          memory: 6Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - env:
+        - name: KAFKA_SERVER
+          value: 127.0.0.1:9092
+        - name: ZOOKEEPER_SERVER
+          value: 127.0.0.1:2181
+        - name: DOWNSTREAM_DB_HOST
+          value: 127.0.0.1
+        - name: USE_FLAT_MESSAGE
+          value: "true"
+        - name: DOWNSTREAM_DB_PORT
+          value: "3306"
+        - name: DB_NAME
+          value: test
+      image: rustinliu/ticdc-canal-json-adapter:latest
+      imagePullPolicy: IfNotPresent
+      name: canal-adapter
+      # TODO: add resource limit
+      # can't add resource limit now, because canal-adapter will OOM
+      # issue: https://github.com/PingCAP-QE/ci/issues/1893
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 4Gi
+      tty: true
+      volumeMounts:
+        - mountPath: /tmp
+          name: volume-0
+    - name: mysql
+      image: quay.io/debezium/example-mysql:2.4
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: ""
+        - name: MYSQL_USER
+          value: mysqluser
+        - name: MYSQL_PASSWORD
+          value: mysqlpw
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "yes"
+        - name: MYSQL_TCP_PORT
+          value: "3310"
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 4Gi
+    - name: connect
+      image: quay.io/debezium/connect:2.4
+      env:
+        - name: BOOTSTRAP_SERVERS
+          value: "127.0.0.1:9092"
+        - name: GROUP_ID
+          value: "1"
+        - name: CONFIG_STORAGE_TOPIC
+          value: "my_connect_configs"
+        - name: OFFSET_STORAGE_TOPIC
+          value: "my_connect_offsets"
+        - name: STATUS_STORAGE_TOPIC
+          value: "my_connect_statuses"
+        - name: LANG
+          value: "C.UTF-8"
+      resources:
+        requests:
+          cpu: 2000m
+          memory: 4Gi
+  volumes:
+    - emptyDir: {}
+      name: volume-0
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -1,0 +1,158 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final BRANCH_ALIAS = 'latest'
+final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
+final WORKSPACE_STASH_NAME = 'ticdc-workspace'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIDB = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIFLASH = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
+final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
+final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
+final OCI_TAG_ETCD = 'v3.5.15'
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_SCHEMA_REGISTRY = 'latest'
+
+prow.setPRDescription(REFS)
+pipeline {
+    agent none
+    environment {
+        // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        NEXT_GEN = 1
+        LEGACY_SAFEPOINT = 1
+    }
+    options {
+        timeout(time: 120, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
+            steps {
+                dir(REFS.repo) {
+                    // Checkout
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                    }
+                    // Build common binaries (no job-specific binaries needed for mysql)
+                    script {
+                        cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'ng-binary')
+                    }
+                    // Download other binaries
+                    container("utils") {
+                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                            sh label: "prepare docker auth", script: '''
+                                mkdir -p ~/.docker
+                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
+                            '''
+                        }
+                        dir("bin") {
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                        chmod +x \$script
+                                        \$script \
+                                            --pd=${OCI_TAG_PD} \
+                                            --pd-ctl=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tikv-worker=${OCI_TAG_TIKV} \
+                                            --tidb=${OCI_TAG_TIDB} \
+                                            --tiflash=${OCI_TAG_TIFLASH} \
+                                            --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
+                                            --minio=${OCI_TAG_MINIO} \
+                                            --etcdctl=${OCI_TAG_ETCD} \
+                                            --ycsb=${OCI_TAG_YCSB} \
+                                            --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
+                                    """
+                                }
+                            }
+                        }
+                    }
+                    sh label: "prepare", script: """
+                        ls -alh ./bin
+                    """
+                    // Stash the prepared workspace for downstream test stages.
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                }
+            }
+        }
+
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_GROUP'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06', 'G07', 'G08', 'G09', 'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'golang'
+                    }
+                }
+                when {
+                    beforeAgent true
+                    expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) }
+                }
+                stages {
+                    stage("Test") {
+                        steps {
+                            dir(REFS.repo) {
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_light_it_in_ci.sh mysql ${TEST_GROUP}
+                                """
+                            }
+                        }
+                        post {
+                            failure {
+                                sh label: "collect logs", script: """
+                                    ls /tmp/tidb_cdc_test/
+                                    log_files=\$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    if [ -n "\${log_files}" ]; then
+                                        tar --warning=no-file-changed -cvzf log-${TEST_GROUP}.tar.gz \${log_files}
+                                        ls -alh log-${TEST_GROUP}.tar.gz
+                                    else
+                                        echo "No log files found under /tmp/tidb_cdc_test/, skip tar"
+                                    fi
+                                """
+                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
+                            }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -24,7 +24,6 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pod.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      tty: true
+      resources:
+        limits:
+          memory: 16Gi
+          cpu: "4"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -1,0 +1,161 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final BRANCH_ALIAS = 'latest'
+final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
+final WORKSPACE_STASH_NAME = 'ticdc-workspace'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIDB = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIFLASH = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
+final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
+final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
+final OCI_TAG_ETCD = 'v3.5.15'
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_SCHEMA_REGISTRY = 'latest'
+
+prow.setPRDescription(REFS)
+pipeline {
+    agent none
+    environment {
+        // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        NEXT_GEN = 1
+        LEGACY_SAFEPOINT = 1
+    }
+    options {
+        timeout(time: 120, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
+            steps {
+                dir(REFS.repo) {
+                    // Checkout
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                    }
+                    script {
+                        // Build common binaries
+                        cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'ng-binary')
+                        // Build job-specific binaries
+                        cdc.prepareIntegrationTestPulsarConsumerBinariesWithCacheLock(REFS, 'ng-binary')
+                    }
+                    // Download other binaries
+                    container("utils") {
+                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                            sh label: "prepare docker auth", script: '''
+                                mkdir -p ~/.docker
+                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
+                            '''
+                        }
+                        dir("bin") {
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                        chmod +x \$script
+                                        \$script \
+                                            --pd=${OCI_TAG_PD} \
+                                            --pd-ctl=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tikv-worker=${OCI_TAG_TIKV} \
+                                            --tidb=${OCI_TAG_TIDB} \
+                                            --tiflash=${OCI_TAG_TIFLASH} \
+                                            --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
+                                            --minio=${OCI_TAG_MINIO} \
+                                            --etcdctl=${OCI_TAG_ETCD} \
+                                            --ycsb=${OCI_TAG_YCSB} \
+                                            --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
+                                    """
+                                }
+                            }
+                        }
+                    }
+                    sh label: "prepare", script: """
+                        ls -alh ./bin
+                    """
+                    // Stash the prepared workspace for downstream test stages.
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                }
+            }
+        }
+
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_GROUP'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08', 'G09',
+                            'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'golang'
+                    }
+                }
+                when {
+                    beforeAgent true
+                    expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) }
+                }
+                stages {
+                    stage("Test") {
+                        steps {
+                            dir('ticdc') {
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_light_it_in_ci.sh pulsar ${TEST_GROUP}
+                                """
+                            }
+                        }
+                        post {
+                            failure {
+                                sh label: "collect logs", script: """
+                                    ls /tmp/tidb_cdc_test/
+                                    log_files=\$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    if [ -n "\${log_files}" ]; then
+                                        tar --warning=no-file-changed -cvzf log-${TEST_GROUP}.tar.gz \${log_files}
+                                        ls -alh log-${TEST_GROUP}.tar.gz
+                                    else
+                                        echo "No log files found under /tmp/tidb_cdc_test/, skip tar"
+                                    fi
+                                """
+                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
+                            }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -24,7 +24,6 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pod.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      tty: true
+      resources:
+        limits:
+          memory: 24Gi
+          cpu: "6"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,7 +25,6 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -1,0 +1,162 @@
+// REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+// Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for master branches
+@Library('tipipeline') _
+
+final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final BRANCH_ALIAS = 'latest'
+final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
+final WORKSPACE_STASH_NAME = 'ticdc-workspace'
+final REFS = readJSON(text: params.JOB_SPEC).refs
+
+final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIDB = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIFLASH = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
+final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
+final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
+final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
+final OCI_TAG_ETCD = 'v3.5.15'
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_SCHEMA_REGISTRY = 'latest'
+
+prow.setPRDescription(REFS)
+pipeline {
+    agent none
+    environment {
+        // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        NEXT_GEN = 1
+        LEGACY_SAFEPOINT = 1
+    }
+    options {
+        timeout(time: 120, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+    }
+    stages {
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
+            steps {
+                dir(REFS.repo) {
+                    // Checkout
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                    }
+                    // Build binaries
+                    script {
+                        cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'ng-binary')
+                        cdc.prepareIntegrationTestKafkaConsumerBinariesWithCacheLock(REFS, 'ng-binary')
+                        cdc.prepareIntegrationTestStorageConsumerBinariesWithCacheLock(REFS, 'ng-binary')
+                    }
+                    // Download other binaries
+                    container("utils") {
+                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                            sh label: "prepare docker auth", script: '''
+                                mkdir -p ~/.docker
+                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
+                            '''
+                        }
+                        dir("bin") {
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                        chmod +x \$script
+                                        \$script \
+                                            --pd=${OCI_TAG_PD} \
+                                            --pd-ctl=${OCI_TAG_PD} \
+                                            --tikv=${OCI_TAG_TIKV} \
+                                            --tikv-worker=${OCI_TAG_TIKV} \
+                                            --tidb=${OCI_TAG_TIDB} \
+                                            --tiflash=${OCI_TAG_TIFLASH} \
+                                            --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
+                                            --minio=${OCI_TAG_MINIO} \
+                                            --etcdctl=${OCI_TAG_ETCD} \
+                                            --ycsb=${OCI_TAG_YCSB} \
+                                            --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
+                                    """
+                                }
+                            }
+                        }
+                    }
+                    sh label: "prepare", script: """
+                        ls -alh ./bin
+                    """
+                    // Stash the prepared workspace for downstream test stages.
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                }
+            }
+        }
+
+        stage('Tests') {
+            matrix {
+                axes {
+                    axis {
+                        name 'TEST_GROUP'
+                        values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06',  'G07', 'G08', 'G09',
+                            'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
+                    }
+                }
+                agent{
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'golang'
+                    }
+                }
+                when {
+                    beforeAgent true
+                    expression { return !matrixCache.shouldSkip(REFS, 'Test', [test_group: env.TEST_GROUP]) }
+                }
+                stages {
+                    stage("Test") {
+                        steps {
+                            dir(REFS.repo) {
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_light_it_in_ci.sh storage ${TEST_GROUP}
+                                """
+                            }
+                        }
+                        post {
+                            failure {
+                                sh label: "collect logs", script: """
+                                    ls /tmp/tidb_cdc_test/
+                                    log_files=\$(find /tmp/tidb_cdc_test/ -type f -name "*.log")
+                                    if [ -n "\${log_files}" ]; then
+                                        tar --warning=no-file-changed -cvzf log-${TEST_GROUP}.tar.gz \${log_files}
+                                        ls -alh log-${TEST_GROUP}.tar.gz
+                                    else
+                                        echo "No log files found under /tmp/tidb_cdc_test/, skip tar"
+                                    fi
+                                """
+                                archiveArtifacts artifacts: "log-${TEST_GROUP}.tar.gz", fingerprint: true
+                            }
+                            success { script { matrixCache.markDone(REFS, 'Test', [test_group: env.TEST_GROUP]) } }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pod.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: golang
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      tty: true
+      resources:
+        limits:
+          memory: 16Gi
+          cpu: "6"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
@@ -24,6 +24,15 @@ presubmits:
       optional: true
 
     - <<: *jenkins_job
+      name: pingcap/ticdc/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint
+      # skip_if_only_changed: *skip_if_only_changed
+      context: pull-cdc-mysql-integration-light-next-gen-legacy-safepoint
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light-next-gen-legacy-safepoint|next-gen-mysql-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-mysql-integration-light-next-gen-legacy-safepoint"
+      branches: *branches
+      optional: true
+
+    - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy_next_gen
       # skip_if_only_changed: *skip_if_only_changed
       # run_before_merge: true
@@ -40,6 +49,15 @@ presubmits:
       context: pull-cdc-kafka-integration-light-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light-next-gen|next-gen-kafka|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-light-next-gen"
+      branches: *branches
+      optional: true
+
+    - <<: *jenkins_job
+      name: pingcap/ticdc/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint
+      # skip_if_only_changed: *skip_if_only_changed
+      context: pull-cdc-kafka-integration-light-next-gen-legacy-safepoint
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light-next-gen-legacy-safepoint|next-gen-kafka-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-kafka-integration-light-next-gen-legacy-safepoint"
       branches: *branches
       optional: true
 
@@ -64,6 +82,15 @@ presubmits:
       branches: *branches
 
     - <<: *jenkins_job
+      name: pingcap/ticdc/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint
+      # skip_if_only_changed: *skip_if_only_changed
+      context: pull-cdc-pulsar-integration-light-next-gen-legacy-safepoint
+      optional: true
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-light-next-gen-legacy-safepoint|next-gen-pulsar-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-pulsar-integration-light-next-gen-legacy-safepoint"
+      branches: *branches
+
+    - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_heavy_next_gen
       # skip_if_only_changed: *skip_if_only_changed
       # run_before_merge: true
@@ -80,6 +107,15 @@ presubmits:
       context: pull-cdc-storage-integration-light-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light-next-gen|next-gen-storage|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-light-next-gen"
+      branches: *branches
+      optional: true
+
+    - <<: *jenkins_job
+      name: pingcap/ticdc/pull_cdc_storage_integration_light_next_gen_legacy_safepoint
+      # skip_if_only_changed: *skip_if_only_changed
+      context: pull-cdc-storage-integration-light-next-gen-legacy-safepoint
+      trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light-next-gen-legacy-safepoint|next-gen-storage-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
+      rerun_command: "/test pull-cdc-storage-integration-light-next-gen-legacy-safepoint"
       branches: *branches
       optional: true
 


### PR DESCRIPTION
This PR introduces ticdc integration tests for the legacy safepoint.
These tests are the same as NEXT_GEN, with the only difference being that LEGACY SAFEPOINT is true.
see https://github.com/pingcap/ticdc/issues/5146