### PR TITLE
ci(tiflash): require TiFlash columnar presubmit on supported branches

### DIFF
--- a/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
@@ -37,16 +37,21 @@ presubmits:
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(pull-integration-next-gen)(?: .*?)?$"
 
-    - <<: *brancher
-      agent: jenkins
+    - agent: jenkins
+      branches:
+        - ^master$
+        - ^release-nextgen-\d+$
+      # 2025 next-gen release branches do not support the columnar pipeline.
+      skip_branches:
+        - ^release-nextgen-2025\d+$
       labels:
         master: "1"
       context: pull-integration-next-gen-columnar
       decorate: false # need add this.
       name: pingcap/tiflash/pull_integration_next_gen_columnar
-      always_run: false
-      optional: true # optional because the columnar pipeline is still under development.
+      always_run: true
+      optional: false
       rerun_command: "/test pull-integration-next-gen-columnar"
-      # skip_if_only_changed: *skip_if_only_changed
+      skip_if_only_changed: *skip_if_only_changed
       skip_report: false
       trigger: "(?m)^/test (?:.*? )?(pull-integration-next-gen-columnar)(?: .*?)?$"

--- a/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml
@@ -49,7 +49,6 @@ presubmits:
       context: pull-integration-next-gen-columnar
       decorate: false # need add this.
       name: pingcap/tiflash/pull_integration_next_gen_columnar
-      always_run: true
       optional: false
       rerun_command: "/test pull-integration-next-gen-columnar"
       skip_if_only_changed: *skip_if_only_changed


### PR DESCRIPTION
## Summary
- make pull-integration-next-gen-columnar required and always-run on master and supported next-gen release branches
- exclude release-nextgen-2025* branches because they do not support the columnar pipeline
- enable skip_if_only_changed for consistency with other TiFlash next-gen presubmits

## Verification
- ruby -e 'require "yaml"; YAML.load_file("prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml")'
- git diff --check -- prow-jobs/pingcap/tiflash/latest-presubmits-next-gen.yaml

## Dependency
- https://github.com/pingcap/tidb/pull/69019
- https://github.com/pingcap/tiflash/pull/10892