### PR TITLE
ci(prow): add client-go next-gen integration presubmit

### DIFF
--- a/prow-jobs/kustomization.yaml
+++ b/prow-jobs/kustomization.yaml
@@ -125,6 +125,7 @@ configMapGenerator:
       - ti-community-infra_periodics.yaml=ti-community-infra/periodics.yaml
       - ti-community-infra_prow_presubmits.yaml=ti-community-infra/prow/presubmits.yaml
       - tidbcloud_cloud-storage-engine_latest-presubmits-next-gen.yaml=tidbcloud/cloud-storage-engine/latest-presubmits-next-gen.yaml
+      - tikv_client-go_latest-presubmits.yaml=tikv/client-go/latest-presubmits.yaml
       - tikv_community_postsubmits.yaml=tikv/community/postsubmits.yaml
       - tikv_community_presubmits.yaml=tikv/community/presubmits.yaml
       - tikv_copr-test_latest-presubmits.yaml=tikv/copr-test/latest-presubmits.yaml

--- a/prow-jobs/kustomization.yaml
+++ b/prow-jobs/kustomization.yaml
@@ -125,6 +125,7 @@ configMapGenerator:
       - ti-community-infra_periodics.yaml=ti-community-infra/periodics.yaml
       - ti-community-infra_prow_presubmits.yaml=ti-community-infra/prow/presubmits.yaml
       - tidbcloud_cloud-storage-engine_latest-presubmits-next-gen.yaml=tidbcloud/cloud-storage-engine/latest-presubmits-next-gen.yaml
+      - tikv_client-go_latest-postsubmits.yaml=tikv/client-go/latest-postsubmits.yaml
       - tikv_client-go_latest-presubmits.yaml=tikv/client-go/latest-presubmits.yaml
       - tikv_community_postsubmits.yaml=tikv/community/postsubmits.yaml
       - tikv_community_presubmits.yaml=tikv/community/presubmits.yaml

--- a/prow-jobs/tikv/client-go/latest-postsubmits.yaml
+++ b/prow-jobs/tikv/client-go/latest-postsubmits.yaml
@@ -21,14 +21,13 @@ global_definitions:
   next_gen_tikv_image: &next_gen_tikv_image "gcr.io/pingcap-public/dbaas/tikv:dedicated-next-gen@sha256:1bc3230be7c83294798d6e56b7b5b2996d2f64f48ac8abf092bdd3b85d3dcc22"
   minio_image: &minio_image "minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
 
-# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
-presubmits:
+# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Postsubmit
+postsubmits:
   tikv/client-go:
     - <<: [*brancher, *kubernetes_job]
-      name: pull-client-go-integration-next-gen-tikv
+      name: client-go-integration-next-gen-tikv
       skip_if_only_changed: *skip_if_only_changed
-      trigger: "(?m)^/test (?:.*? )?(pull-client-go-integration-next-gen-tikv|all)(?: .*?)?$"
-      rerun_command: "/test pull-client-go-integration-next-gen-tikv"
+      max_concurrency: 1
       timeout: 45m
       spec:
         affinity: *affinity
@@ -77,18 +76,6 @@ presubmits:
             args:
               - |
                 set -euo pipefail
-
-                maybe_skip_labeled_pr() {
-                  if [[ -z "${PULL_NUMBER:-}" || -z "${REPO_OWNER:-}" || -z "${REPO_NAME:-}" ]]; then
-                    return
-                  fi
-
-                  local labels_url="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/issues/${PULL_NUMBER}/labels?per_page=100"
-                  if curl -fsSL --retry 3 --retry-delay 2 "${labels_url}" | grep -q '"name"[[:space:]]*:[[:space:]]*"skip-integration-tests"'; then
-                    echo "PR #${PULL_NUMBER} has the skip-integration-tests label; skipping next-gen integration tests."
-                    exit 0
-                  fi
-                }
 
                 dump_logs() {
                   for log_file in minio.log pd.log tikv.log; do
@@ -153,7 +140,6 @@ presubmits:
                   return 1
                 }
 
-                maybe_skip_labeled_pr
                 trap cleanup EXIT
 
                 go version | grep 'go1.25.8'

--- a/prow-jobs/tikv/client-go/latest-presubmits.yaml
+++ b/prow-jobs/tikv/client-go/latest-presubmits.yaml
@@ -1,0 +1,136 @@
+global_definitions:
+  brancher: &brancher
+    branches:
+      - ^master$
+      - ^feature/.*$
+  skip_if_only_changed: &skip_if_only_changed "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+  affinity: &affinity
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+  kubernetes_job: &kubernetes_job
+    agent: kubernetes
+    decorate: true
+
+# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
+presubmits:
+  tikv/client-go:
+    - <<: [*brancher, *kubernetes_job]
+      name: pull-client-go-integration-next-gen-tikv
+      skip_if_only_changed: *skip_if_only_changed
+      trigger: "(?m)^/test (?:.*? )?(pull-client-go-integration-next-gen-tikv|all)(?: .*?)?$"
+      rerun_command: "/test pull-client-go-integration-next-gen-tikv"
+      timeout: 45m
+      spec:
+        affinity: *affinity
+        containers:
+          - name: test
+            image: golang:1.25.8
+            command: [bash, -ce]
+            args:
+              - |
+                set -euo pipefail
+
+                maybe_skip_labeled_pr() {
+                  if [[ -z "${PULL_NUMBER:-}" || -z "${REPO_OWNER:-}" || -z "${REPO_NAME:-}" ]]; then
+                    return
+                  fi
+
+                  local labels_url="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/issues/${PULL_NUMBER}/labels?per_page=100"
+                  if curl -fsSL --retry 3 --retry-delay 2 "${labels_url}" | grep -q '"name"[[:space:]]*:[[:space:]]*"skip-integration-tests"'; then
+                    echo "PR #${PULL_NUMBER} has the skip-integration-tests label; skipping next-gen integration tests."
+                    exit 0
+                  fi
+                }
+
+                dump_logs() {
+                  for log_file in minio.log pd.log tikv.log; do
+                    echo "--- ${log_file} ---"
+                    tail -n 200 "${log_file}" || echo "${log_file} not found"
+                  done
+                }
+
+                cleanup() {
+                  local status=$?
+                  if [[ ${status} -ne 0 ]]; then
+                    dump_logs
+                  fi
+                  for pid in "${TIKV_PID:-}" "${PD_PID:-}" "${MINIO_PID:-}"; do
+                    if [[ -n "${pid}" ]]; then
+                      kill "${pid}" 2>/dev/null || true
+                    fi
+                  done
+                  exit "${status}"
+                }
+
+                extract_file_from_image() {
+                  local image=$1
+                  local source_path=$2
+                  local destination=$3
+                  local tarball
+                  tarball=$(mktemp)
+
+                  crane --platform=linux/amd64 export "${image}" "${tarball}"
+
+                  for candidate in "${source_path#/}" "./${source_path#/}" "${source_path}"; do
+                    if tar -tf "${tarball}" "${candidate}" >/dev/null 2>&1; then
+                      tar -xOf "${tarball}" "${candidate}" > "${destination}"
+                      chmod +x "${destination}"
+                      rm -f "${tarball}"
+                      return
+                    fi
+                  done
+
+                  echo "${source_path} was not found in ${image}; first archive entries:" >&2
+                  tar -tf "${tarball}" | sed -n '1,120p' >&2
+                  rm -f "${tarball}"
+                  return 1
+                }
+
+                maybe_skip_labeled_pr
+                trap cleanup EXIT
+
+                go version
+                export GOBIN="${PWD}/.tools/bin"
+                export PATH="${GOBIN}:${PATH}"
+                mkdir -p "${GOBIN}"
+                go install gotest.tools/gotestsum@v1.13.0
+                go install github.com/google/go-containerregistry/cmd/crane@v0.21.6
+
+                cd integration_tests
+                mkdir -p tikv-data "${HOME}/serverless_s3/cse-test"
+
+                curl -fsSL --retry 3 --retry-delay 2 -o minio https://dl.min.io/server/minio/release/linux-amd64/minio
+                chmod +x minio
+
+                extract_file_from_image pingcap/pd:nightly /pd-server pd-server
+                extract_file_from_image gcr.io/pingcap-public/dbaas/tikv:dedicated-next-gen /tikv-server tikv-server
+
+                MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin ./minio server "${HOME}/serverless_s3" > minio.log 2>&1 &
+                MINIO_PID=$!
+                sleep 5
+
+                ./pd-server --config pd_next_gen.toml > pd.log 2>&1 &
+                PD_PID=$!
+                sleep 5
+
+                ./tikv-server -C tikv_next_gen.toml --pd-endpoints="127.0.0.1:2379" --addr="127.0.0.1:20160" --data-dir="${PWD}/tikv-data" > tikv.log 2>&1 &
+                TIKV_PID=$!
+
+                echo "Waiting for MinIO, PD, and Next-Gen TiKV to start..."
+                sleep 15
+                dump_logs
+
+                gotestsum --format short-verbose -- -parallel 1 -tags=nextgen --with-tikv --keyspace-name='keyspace1'
+            resources:
+              requests:
+                cpu: "4"
+                memory: 8Gi
+              limits:
+                cpu: "8"
+                memory: 16Gi


### PR DESCRIPTION
Summary
- Add Prow K8s jobs for `tikv/client-go` to replace the GitHub Actions `integration-next-gen-tikv` coverage.

Changes
- Adds presubmit `pull-client-go-integration-next-gen-tikv` for `master` and `feature/*` PRs.
- Adds matching postsubmit `client-go-integration-next-gen-tikv` for direct pushes to `master` and `feature/*`.
- Uses a pinned internal Go 1.25.8 CI base image and immutable PD, Next-Gen TiKV, and MinIO image digests.
- Uses checksum-verified `gotestsum` v1.13.0 and preserves the `skip-integration-tests` label behavior for presubmits.
- Updates `prow-jobs/kustomization.yaml` for the new job configs.

Testing
- `PATH=/tmp/ci-tools/bin:$PATH .ci/update-prow-job-kustomization.sh`
- `/tmp/ci-tools/bin/checkconfig --plugin-config=../configs/prow/config/plugins.yaml --config-path=../configs/prow/config/config.yaml --job-config-path=/tmp/flatten-prow-jobs/`

Risk
- Medium: the runtime still depends on pulling immutable external image digests and a checksum-verified gotestsum release artifact from CI networking.
- Rollback: revert this PR to remove the new Prow job configs.

Closes FLA-183
