### PR TITLE
ci(tikv/pd): migrate release-8.5 jenkins job to GCP

### DIFF
--- a/pipelines/tikv/pd/release-8.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/release-8.5/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-8.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/release-8.5/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-8.5/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-8.5/pull_integration_copr_test.groovy
@@ -3,17 +3,19 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-pd"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
+final GIT_CREDENTIALS_ID = ''
 final GIT_FULL_REPO_NAME = 'tikv/pd'
 final POD_TEMPLATE_FILE = 'pipelines/tikv/pd/release-8.5/pod-pull_integration_copr_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -29,12 +31,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("pd") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb") {

--- a/prow-jobs/tikv/pd/release-8.5-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-8.5-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
     - name: tikv/pd/release-8.5/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-copr-test


### PR DESCRIPTION
## Summary

Migrate `tikv/pd` release-8.5 Jenkins presubmit jobs from KS cloud to GCP.