### PR TITLE
ci(scripts): fix tiflash layout permissions for extracted directory

### DIFF
--- a/scripts/artifacts/download_pingcap_oci_artifact.sh
+++ b/scripts/artifacts/download_pingcap_oci_artifact.sh
@@ -84,7 +84,7 @@ function prepare_tiflash_layout() {
         exit 1
     fi
 
-    chmod +x "${normalized_binary}"
+    chmod -R +x "${normalized_dir}"
     rm -rf "${extracted_dir}"
     ln -sfn "${normalized_binary}" "${extracted_dir}"
     echo "✅ prepared TiFlash binary symlink layout: ${extracted_dir} -> ${normalized_binary}"


### PR DESCRIPTION
change chmod from the binary file to the entire extracted directory to
ensure all files are executable
