### PR TITLE
ci(tikv/tikv): migrate jenkins jobs to GCP

### DIFF
--- a/pipelines/tikv/tikv/latest/pod-pull_integration_test.yaml
+++ b/pipelines/tikv/tikv/latest/pod-pull_integration_test.yaml
@@ -1,29 +1,32 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-master:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
+      imagePullPolicy: Always
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "6"
+          memory: 16Gi
+          cpu: "4"
         limits:
-          memory: 32Gi
-          cpu: "16"
+          memory: 24Gi
+          cpu: "8"
       securityContext:
         privileged: true
     - name: golang
-      image: hub.pingcap.net/jenkins/centos7_golang-1.21:latest
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: '4'
+          memory: 12Gi
+          cpu: "4"
         limits:
-          memory: 32Gi
-          cpu: "16"
+          memory: 16Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
@@ -43,7 +46,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/tikv/tikv/latest/pod-pull_integration_test.yaml
+++ b/pipelines/tikv/tikv/latest/pod-pull_integration_test.yaml
@@ -14,7 +14,7 @@ spec:
           cpu: "4"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
       securityContext:
         privileged: true
     - name: golang

--- a/pipelines/tikv/tikv/latest/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/latest/pod-pull_unit_test.yaml
@@ -17,7 +17,6 @@ spec:
         requests:
           memory: 24Gi
           cpu: "6"
-        # Keep limits unset: nextest uses tmpfs-backed scratch space and can spike.
       securityContext:
         privileged: true
       volumeMounts:

--- a/pipelines/tikv/tikv/latest/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/latest/pod-pull_unit_test.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
       image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
@@ -13,8 +15,9 @@ spec:
         - "cat"
       resources:
         requests:
-          memory: 8Gi
+          memory: 24Gi
           cpu: "6"
+        # Keep limits unset: nextest uses tmpfs-backed scratch space and can spike.
       securityContext:
         privileged: true
       volumeMounts:
@@ -40,7 +43,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/tikv/tikv/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/latest/pull_integration_test.groovy
@@ -10,17 +10,16 @@ prow.setPRDescription(REFS)
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIDB = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
+final SUPPORT_REPO_CACHE_REV = REFS.base_sha
 
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
         }
-    }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 50, unit: 'MINUTES')
@@ -32,12 +31,8 @@ pipeline {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
             }
@@ -59,12 +54,12 @@ pipeline {
             }
         }
         stage('Tests') {
-            stages{
+            stages {
                 stage('copr test') {
                     options { timeout(time: 30, unit: 'MINUTES') }
                     steps {
                         dir('tidb') {
-                            cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
+                            cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${SUPPORT_REPO_CACHE_REV}", restoreKeys: ['git/pingcap/tidb/rev-']) {
                                 retry(2) {
                                     script {
                                         component.checkoutSupportBatch('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
@@ -73,7 +68,7 @@ pipeline {
                             }
                         }
                         dir('copr-test') {
-                            cache(path: "./", includes: '**/*', key: "git/tikv/copr-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/tikv/copr-test/rev-']) {
+                            cache(path: "./", includes: '**/*', key: "git/tikv/copr-test/rev-${SUPPORT_REPO_CACHE_REV}", restoreKeys: ['git/tikv/copr-test/rev-']) {
                                 retry(2) {
                                     script {
                                         component.checkoutSupportBatch('https://github.com/tikv/copr-test.git', 'copr-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
@@ -92,14 +87,31 @@ pipeline {
                     }
                     post {
                         failure {
-                            echo "TODO: archive logs"
+                            sh label: 'Collect copr logs', script: """
+                                archive=log-copr-test.tar.gz
+                                tmp_file=\$(mktemp)
+                                for log_dir in "${WORKSPACE}/copr-test" "/tmp/tidb"; do
+                                    if [ -d "\${log_dir}" ]; then
+                                        find "\${log_dir}" -type f \\( -name "*.log" -o -name "*.out" -o -name "*.err" -o -name "nohup.out" \\) >> "\${tmp_file}"
+                                    fi
+                                done
+
+                                if [ -s "\${tmp_file}" ]; then
+                                    tar --warning=no-file-changed -czf "\${archive}" -T "\${tmp_file}" || true
+                                else
+                                    tar -czf "\${archive}" --files-from /dev/null
+                                fi
+                                rm -f "\${tmp_file}"
+                                ls -alh "\${archive}"
+                            """
+                            archiveArtifacts artifacts: 'log-copr-test.tar.gz', fingerprint: true
                         }
                     }
                 }
                 stage('compatible test') {
                     steps {
                         dir("tidb-test") {
-                            cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
+                            cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${SUPPORT_REPO_CACHE_REV}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
                                 retry(2) {
                                     script {
                                         component.checkoutSupportBatch('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
@@ -124,7 +136,24 @@ pipeline {
                     }
                     post {
                         failure {
-                            echo "TODO: archive logs"
+                            sh label: 'Collect compatible logs', script: """
+                                archive=log-compatible-test.tar.gz
+                                tmp_file=\$(mktemp)
+                                for log_dir in "${WORKSPACE}/tidb-test/compatible_test" "/tmp/tidb"; do
+                                    if [ -d "\${log_dir}" ]; then
+                                        find "\${log_dir}" -type f \\( -name "*.log" -o -name "*.out" -o -name "*.err" -o -name "nohup.out" \\) >> "\${tmp_file}"
+                                    fi
+                                done
+
+                                if [ -s "\${tmp_file}" ]; then
+                                    tar --warning=no-file-changed -czf "\${archive}" -T "\${tmp_file}" || true
+                                else
+                                    tar -czf "\${archive}" --files-from /dev/null
+                                fi
+                                rm -f "\${tmp_file}"
+                                ls -alh "\${archive}"
+                            """
+                            archiveArtifacts artifacts: 'log-compatible-test.tar.gz', fingerprint: true
                         }
                     }
                 }

--- a/pipelines/tikv/tikv/latest/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/latest/pull_unit_test.groovy
@@ -4,19 +4,24 @@
 
 final K8S_NAMESPACE = "jenkins-tikv"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final GIT_FULL_REPO_NAME = 'tikv/tikv'
 final POD_TEMPLATE_FILE = 'pipelines/tikv/tikv/latest/pod-pull_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+final SRC_DIR = 'tikv-src'
+final TARGET_DIR = 'tikv-target'
+final ARCHIVE_DIR = 'archives'
+final UNIT_TEST_DIR = 'unit-test'
+final TEST_ARTIFACTS = 'test-artifacts.tar.gz'
+final TEST_BINARIES_ARCHIVE = 'archive-test-binaries.tar'
 final EXTRA_NEXTEST_ARGS = "-j 8"
 
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
-            // workspaceVolume emptyDirWorkspaceVolume(memory: true)
         }
     }
     environment {
@@ -31,149 +36,148 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
-                sh """
-                    rm -rf /home/jenkins/tikv-src
+                sh label: 'Clean workspace', script: """
+                    rm -rf \
+                        ${WORKSPACE}/${SRC_DIR} \
+                        ${WORKSPACE}/${TARGET_DIR} \
+                        ${WORKSPACE}/${ARCHIVE_DIR} \
+                        ${WORKSPACE}/${UNIT_TEST_DIR}
                 """
                 dir("tikv") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
-                sh """
-                    pwd & ls -alh
-                    mv ./tikv \$HOME/tikv-src
-                    cd \$HOME/tikv-src
+                sh label: 'Prepare source tree', script: """
+                    pwd && ls -alh
+                    mv ./tikv ${WORKSPACE}/${SRC_DIR}
+                    cd ${WORKSPACE}/${SRC_DIR}
                     # Hotfix: some CI images may leave a non-directory target path.
-                    rm -rf \$HOME/tikv-src/target
-                    mkdir -p \$HOME/tikv-target
-                    ln -sfn \$HOME/tikv-target \$HOME/tikv-src/target
+                    rm -rf ${WORKSPACE}/${SRC_DIR}/target
+                    mkdir -p ${WORKSPACE}/${TARGET_DIR}
+                    ln -sfn ${WORKSPACE}/${TARGET_DIR} ${WORKSPACE}/${SRC_DIR}/target
                     pwd && ls -alh
                 """
             }
         }
         stage('lint') {
             steps {
-                dir("tikv") {
-                    retry(2) {
-                        sh label: 'Run lint: format', script: """
-                            cd \$HOME/tikv-src
-                            export RUSTFLAGS=-Dwarnings
-                            make format
-                            git diff --quiet || (git diff; echo Please make format and run tests before creating a PR; exit 1)
-                        """
-                        sh label: 'Run lint: clippy', script: """
-                            cd \$HOME/tikv-src
-                            export RUSTFLAGS=-Dwarnings
-                            export FAIL_POINT=1
-                            export ROCKSDB_SYS_SSE=1
-                            export RUST_BACKTRACE=1
-                            export LOG_LEVEL=INFO
+                retry(2) {
+                    sh label: 'Run lint: format', script: """
+                        cd ${WORKSPACE}/${SRC_DIR}
+                        export RUSTFLAGS=-Dwarnings
+                        make format
+                        git diff --quiet || (git diff; echo Please make format and run tests before creating a PR; exit 1)
+                    """
+                    sh label: 'Run lint: clippy', script: """
+                        cd ${WORKSPACE}/${SRC_DIR}
+                        export RUSTFLAGS=-Dwarnings
+                        export FAIL_POINT=1
+                        export ROCKSDB_SYS_SSE=1
+                        export RUST_BACKTRACE=1
+                        export LOG_LEVEL=INFO
 
-                            make clippy || (echo Please fix the clippy error; exit 1)
-                        """
-                    }
+                        make clippy || (echo Please fix the clippy error; exit 1)
+                    """
                 }
             }
         }
         stage('build') {
             steps {
-                dir("tikv") {
-                    retry(2) {
-                        sh label: 'Build test artifact', script: """
-                            cd \$HOME/tikv-src
-                            export RUSTFLAGS=-Dwarnings
-                            export FAIL_POINT=1
-                            export ROCKSDB_SYS_SSE=1
-                            export RUST_BACKTRACE=1
-                            export LOG_LEVEL=INFO
-                            export CARGO_INCREMENTAL=0
-                            export RUSTDOCFLAGS="-Z unstable-options --persist-doctests"
+                retry(2) {
+                    sh label: 'Build test artifact', script: """
+                        cd ${WORKSPACE}/${SRC_DIR}
+                        export RUSTFLAGS=-Dwarnings
+                        export FAIL_POINT=1
+                        export ROCKSDB_SYS_SSE=1
+                        export RUST_BACKTRACE=1
+                        export LOG_LEVEL=INFO
+                        export CARGO_INCREMENTAL=0
+                        export RUSTDOCFLAGS="-Z unstable-options --persist-doctests"
 
-                            set -e
-                            set -o pipefail
+                        set -e
+                        set -o pipefail
 
-                            # Build and generate a list of binaries
-                            CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
-                            # Cargo metadata
-                            cargo metadata --format-version 1 > test-metadata.json
-                            # cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
-                            wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
-                            python gen_test_binary_json.py
-                            cat test-binaries.json
+                        # Build and generate a list of binaries
+                        CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
+                        # Cargo metadata
+                        cargo metadata --format-version 1 > test-metadata.json
+                        cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
+                        export TIKV_SRC_DIR=${WORKSPACE}/${SRC_DIR}
+                        python gen_test_binary_json.py
+                        cat test-binaries.json
 
-                            # archive test artifacts
-                            ls -alh archive-test-binaries
-                            tar -cvf archive-test-binaries.tar archive-test-binaries
-                            ls -alh archive-test-binaries.tar
-                            tar czf test-artifacts.tar.gz test-binaries test-binaries.json test-metadata.json Cargo.toml cmd src tests components .config `ls target/*/deps/*plugin.so 2>/dev/null`
-                            ls -alh test-artifacts.tar.gz
-                            mkdir -p /home/jenkins/archives
-                            mv test-artifacts.tar.gz archive-test-binaries.tar /home/jenkins/archives/
-                        """
-                    }
+                        # archive test artifacts
+                        ls -alh archive-test-binaries
+                        tar -cvf ${TEST_BINARIES_ARCHIVE} archive-test-binaries
+                        ls -alh ${TEST_BINARIES_ARCHIVE}
+                        tar czf ${TEST_ARTIFACTS} test-binaries test-binaries.json test-metadata.json Cargo.toml cmd src tests components .config `ls target/*/deps/*plugin.so 2>/dev/null`
+                        ls -alh ${TEST_ARTIFACTS}
+                        mkdir -p ${WORKSPACE}/${ARCHIVE_DIR}
+                        mv ${TEST_ARTIFACTS} ${TEST_BINARIES_ARCHIVE} ${WORKSPACE}/${ARCHIVE_DIR}/
+                    """
                 }
             }
         }
         stage("Test") {
             options { timeout(time: 30, unit: 'MINUTES') }
             steps {
-                dir('/home/jenkins/agent/tikv-presubmit/unit-test') {
-                    sh label: "clean up", script: """
-                        rm -rf /home/jenkins/tikv-*
-                        ls -alh /home/jenkins/
-                        ln -s `pwd` \$HOME/tikv-src
+                dir("${WORKSPACE}/${UNIT_TEST_DIR}") {
+                    sh label: "Prepare unit test workspace", script: """
+                        rm -rf ${WORKSPACE}/${SRC_DIR} ${WORKSPACE}/${TARGET_DIR}
+                        ls -alh ${WORKSPACE}/
+                        ln -s `pwd` ${WORKSPACE}/${SRC_DIR}
                         mkdir -p target/debug
                         uname -a
                         df -h
                         free -hm
 
                         # prepare test artifacts
-                        cp /home/jenkins/archives/test-artifacts.tar.gz .
-                        cp /home/jenkins/archives/archive-test-binaries.tar .
-                        tar -xf test-artifacts.tar.gz
-                        tar xf archive-test-binaries.tar --strip-components=1
-                        rm -f test-artifacts.tar.gz archive-test-binaries.tar
+                        cp ${WORKSPACE}/${ARCHIVE_DIR}/${TEST_ARTIFACTS} .
+                        cp ${WORKSPACE}/${ARCHIVE_DIR}/${TEST_BINARIES_ARCHIVE} .
+                        tar -xf ${TEST_ARTIFACTS}
+                        tar xf ${TEST_BINARIES_ARCHIVE} --strip-components=1
+                        rm -f ${TEST_ARTIFACTS} ${TEST_BINARIES_ARCHIVE}
                         ls -la
                         ls -alh target/debug/deps/
                     """
-                    sh """
-                    ls -alh \$HOME/tikv-src
-                    ls -alh /home/jenkins/tikv-src/
-                    ls -alh /home/jenkins/tikv-src/target/debug/deps/
+                    sh label: "Run nextest", script: """
+                    ls -alh ${WORKSPACE}/${SRC_DIR}/
+                    ls -alh ${WORKSPACE}/${SRC_DIR}/target/debug/deps/
                     export RUSTFLAGS=-Dwarnings
                     export FAIL_POINT=1
                     export RUST_BACKTRACE=1
                     export MALLOC_CONF=prof:true,prof_active:false
                     # export CI=1  # TODO: remove this
-                    export LOG_FILE=/home/jenkins/tikv-src/target/my_test.log
+                    export LOG_FILE=${WORKSPACE}/${SRC_DIR}/target/my_test.log
 
-                    if cargo nextest run -P ci --binaries-metadata test-binaries.json --cargo-metadata test-metadata.json --partition count:1/2 ${EXTRA_NEXTEST_ARGS}; then
-                        echo "test pass"
-                    else
-                        # test failed
-                        gdb -c core.* -batch -ex "info threads" -ex "thread apply all bt"
-                        exit 1
-                    fi
-                    if cargo nextest run -P ci --binaries-metadata test-binaries.json --cargo-metadata test-metadata.json --partition count:2/2 ${EXTRA_NEXTEST_ARGS}; then
-                        echo "test pass"
-                    else
-                        # test failed
-                        gdb -c core.* -batch -ex "info threads" -ex "thread apply all bt"
-                        exit 1
-                    fi
+                    for partition in 1/2 2/2; do
+                        if cargo nextest run -P ci --binaries-metadata test-binaries.json --cargo-metadata test-metadata.json --partition count:\${partition} ${EXTRA_NEXTEST_ARGS}; then
+                            echo "partition \${partition} pass"
+                        else
+                            gdb -c core.* -batch -ex "info threads" -ex "thread apply all bt"
+                            exit 1
+                        fi
+                    done
                     """
                 }
             }
             post {
                 failure {
                     sh label: "collect logs", script: """
-                        ls /home/jenkins/tikv-src/target/
-                        tar -cvzf log-ut.tar.gz \$(find /home/jenkins/tikv-src/target/ -type f -name "*.log")
-                        ls -alh  log-ut.tar.gz
+                        log_dir=${WORKSPACE}/${SRC_DIR}/target
+                        tmp_file=\$(mktemp)
+                        if [ -d "\${log_dir}" ]; then
+                            find "\${log_dir}" -type f -name "*.log" > "\${tmp_file}"
+                        fi
+
+                        if [ -s "\${tmp_file}" ]; then
+                            tar --warning=no-file-changed -czf log-ut.tar.gz -T "\${tmp_file}" || true
+                        else
+                            tar -czf log-ut.tar.gz --files-from /dev/null
+                        fi
+                        rm -f "\${tmp_file}"
+                        ls -alh log-ut.tar.gz
                     """
                     archiveArtifacts artifacts: "log-ut.tar.gz", fingerprint: true
                 }

--- a/pipelines/tikv/tikv/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-8.5/pod-pull_unit_test.yaml
@@ -17,7 +17,6 @@ spec:
         requests:
           memory: 24Gi
           cpu: "6"
-        # Keep limits unset: nextest uses tmpfs-backed scratch space and can spike.
       securityContext:
         privileged: true
       volumeMounts:

--- a/pipelines/tikv/tikv/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-8.5/pod-pull_unit_test.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
       image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
@@ -13,8 +15,9 @@ spec:
         - "cat"
       resources:
         requests:
-          memory: 8Gi
+          memory: 24Gi
           cpu: "6"
+        # Keep limits unset: nextest uses tmpfs-backed scratch space and can spike.
       securityContext:
         privileged: true
       volumeMounts:
@@ -40,7 +43,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/tikv/tikv/release-8.5/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-8.5/pull_unit_test.groovy
@@ -4,19 +4,24 @@
 
 final K8S_NAMESPACE = "jenkins-tikv"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final GIT_FULL_REPO_NAME = 'tikv/tikv'
 final POD_TEMPLATE_FILE = 'pipelines/tikv/tikv/release-8.5/pod-pull_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+final SRC_DIR = 'tikv-src'
+final TARGET_DIR = 'tikv-target'
+final ARCHIVE_DIR = 'archives'
+final UNIT_TEST_DIR = 'unit-test'
+final TEST_ARTIFACTS = 'test-artifacts.tar.gz'
+final TEST_BINARIES_ARCHIVE = 'archive-test-binaries.tar'
 final EXTRA_NEXTEST_ARGS = "-j 8"
 
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'runner'
-            // workspaceVolume emptyDirWorkspaceVolume(memory: true)
         }
     }
     environment {
@@ -31,149 +36,148 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
-                sh """
-                    rm -rf /home/jenkins/tikv-src
+                sh label: 'Clean workspace', script: """
+                    rm -rf \
+                        ${WORKSPACE}/${SRC_DIR} \
+                        ${WORKSPACE}/${TARGET_DIR} \
+                        ${WORKSPACE}/${ARCHIVE_DIR} \
+                        ${WORKSPACE}/${UNIT_TEST_DIR}
                 """
                 dir("tikv") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
-                sh """
-                    pwd & ls -alh
-                    mv ./tikv \$HOME/tikv-src
-                    cd \$HOME/tikv-src
+                sh label: 'Prepare source tree', script: """
+                    pwd && ls -alh
+                    mv ./tikv ${WORKSPACE}/${SRC_DIR}
+                    cd ${WORKSPACE}/${SRC_DIR}
                     # Hotfix: some CI images may leave a non-directory target path.
-                    rm -rf \$HOME/tikv-src/target
-                    mkdir -p \$HOME/tikv-target
-                    ln -sfn \$HOME/tikv-target \$HOME/tikv-src/target
+                    rm -rf ${WORKSPACE}/${SRC_DIR}/target
+                    mkdir -p ${WORKSPACE}/${TARGET_DIR}
+                    ln -sfn ${WORKSPACE}/${TARGET_DIR} ${WORKSPACE}/${SRC_DIR}/target
                     pwd && ls -alh
                 """
             }
         }
         stage('lint') {
             steps {
-                dir("tikv") {
-                    retry(2) {
-                        sh label: 'Run lint: format', script: """
-                            cd \$HOME/tikv-src
-                            export RUSTFLAGS=-Dwarnings
-                            make format
-                            git diff --quiet || (git diff; echo Please make format and run tests before creating a PR; exit 1)
-                        """
-                        sh label: 'Run lint: clippy', script: """
-                            cd \$HOME/tikv-src
-                            export RUSTFLAGS=-Dwarnings
-                            export FAIL_POINT=1
-                            export ROCKSDB_SYS_SSE=1
-                            export RUST_BACKTRACE=1
-                            export LOG_LEVEL=INFO
+                retry(2) {
+                    sh label: 'Run lint: format', script: """
+                        cd ${WORKSPACE}/${SRC_DIR}
+                        export RUSTFLAGS=-Dwarnings
+                        make format
+                        git diff --quiet || (git diff; echo Please make format and run tests before creating a PR; exit 1)
+                    """
+                    sh label: 'Run lint: clippy', script: """
+                        cd ${WORKSPACE}/${SRC_DIR}
+                        export RUSTFLAGS=-Dwarnings
+                        export FAIL_POINT=1
+                        export ROCKSDB_SYS_SSE=1
+                        export RUST_BACKTRACE=1
+                        export LOG_LEVEL=INFO
 
-                            make clippy || (echo Please fix the clippy error; exit 1)
-                        """
-                    }
+                        make clippy || (echo Please fix the clippy error; exit 1)
+                    """
                 }
             }
         }
         stage('build') {
             steps {
-                dir("tikv") {
-                    retry(2) {
-                        sh label: 'Build test artifact', script: """
-                            cd \$HOME/tikv-src
-                            export RUSTFLAGS=-Dwarnings
-                            export FAIL_POINT=1
-                            export ROCKSDB_SYS_SSE=1
-                            export RUST_BACKTRACE=1
-                            export LOG_LEVEL=INFO
-                            export CARGO_INCREMENTAL=0
-                            export RUSTDOCFLAGS="-Z unstable-options --persist-doctests"
+                retry(2) {
+                    sh label: 'Build test artifact', script: """
+                        cd ${WORKSPACE}/${SRC_DIR}
+                        export RUSTFLAGS=-Dwarnings
+                        export FAIL_POINT=1
+                        export ROCKSDB_SYS_SSE=1
+                        export RUST_BACKTRACE=1
+                        export LOG_LEVEL=INFO
+                        export CARGO_INCREMENTAL=0
+                        export RUSTDOCFLAGS="-Z unstable-options --persist-doctests"
 
-                            set -e
-                            set -o pipefail
+                        set -e
+                        set -o pipefail
 
-                            # Build and generate a list of binaries
-                            CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
-                            # Cargo metadata
-                            cargo metadata --format-version 1 > test-metadata.json
-                            # cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
-                            wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
-                            python gen_test_binary_json.py
-                            cat test-binaries.json
+                        # Build and generate a list of binaries
+                        CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
+                        # Cargo metadata
+                        cargo metadata --format-version 1 > test-metadata.json
+                        cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
+                        export TIKV_SRC_DIR=${WORKSPACE}/${SRC_DIR}
+                        python gen_test_binary_json.py
+                        cat test-binaries.json
 
-                            # archive test artifacts
-                            ls -alh archive-test-binaries
-                            tar -cvf archive-test-binaries.tar archive-test-binaries
-                            ls -alh archive-test-binaries.tar
-                            tar czf test-artifacts.tar.gz test-binaries test-binaries.json test-metadata.json Cargo.toml cmd src tests components .config `ls target/*/deps/*plugin.so 2>/dev/null`
-                            ls -alh test-artifacts.tar.gz
-                            mkdir -p /home/jenkins/archives
-                            mv test-artifacts.tar.gz archive-test-binaries.tar /home/jenkins/archives/
-                        """
-                    }
+                        # archive test artifacts
+                        ls -alh archive-test-binaries
+                        tar -cvf ${TEST_BINARIES_ARCHIVE} archive-test-binaries
+                        ls -alh ${TEST_BINARIES_ARCHIVE}
+                        tar czf ${TEST_ARTIFACTS} test-binaries test-binaries.json test-metadata.json Cargo.toml cmd src tests components .config `ls target/*/deps/*plugin.so 2>/dev/null`
+                        ls -alh ${TEST_ARTIFACTS}
+                        mkdir -p ${WORKSPACE}/${ARCHIVE_DIR}
+                        mv ${TEST_ARTIFACTS} ${TEST_BINARIES_ARCHIVE} ${WORKSPACE}/${ARCHIVE_DIR}/
+                    """
                 }
             }
         }
         stage("Test") {
             options { timeout(time: 30, unit: 'MINUTES') }
             steps {
-                dir('/home/jenkins/agent/tikv-presubmit/unit-test') {
-                    sh label: "clean up", script: """
-                        rm -rf /home/jenkins/tikv-*
-                        ls -alh /home/jenkins/
-                        ln -s `pwd` \$HOME/tikv-src
+                dir("${WORKSPACE}/${UNIT_TEST_DIR}") {
+                    sh label: "Prepare unit test workspace", script: """
+                        rm -rf ${WORKSPACE}/${SRC_DIR} ${WORKSPACE}/${TARGET_DIR}
+                        ls -alh ${WORKSPACE}/
+                        ln -s `pwd` ${WORKSPACE}/${SRC_DIR}
                         mkdir -p target/debug
                         uname -a
                         df -h
                         free -hm
 
                         # prepare test artifacts
-                        cp /home/jenkins/archives/test-artifacts.tar.gz .
-                        cp /home/jenkins/archives/archive-test-binaries.tar .
-                        tar -xf test-artifacts.tar.gz
-                        tar xf archive-test-binaries.tar --strip-components=1
-                        rm -f test-artifacts.tar.gz archive-test-binaries.tar
+                        cp ${WORKSPACE}/${ARCHIVE_DIR}/${TEST_ARTIFACTS} .
+                        cp ${WORKSPACE}/${ARCHIVE_DIR}/${TEST_BINARIES_ARCHIVE} .
+                        tar -xf ${TEST_ARTIFACTS}
+                        tar xf ${TEST_BINARIES_ARCHIVE} --strip-components=1
+                        rm -f ${TEST_ARTIFACTS} ${TEST_BINARIES_ARCHIVE}
                         ls -la
                         ls -alh target/debug/deps/
                     """
-                    sh """
-                    ls -alh \$HOME/tikv-src
-                    ls -alh /home/jenkins/tikv-src/
-                    ls -alh /home/jenkins/tikv-src/target/debug/deps/
+                    sh label: "Run nextest", script: """
+                    ls -alh ${WORKSPACE}/${SRC_DIR}/
+                    ls -alh ${WORKSPACE}/${SRC_DIR}/target/debug/deps/
                     export RUSTFLAGS=-Dwarnings
                     export FAIL_POINT=1
                     export RUST_BACKTRACE=1
                     export MALLOC_CONF=prof:true,prof_active:false
                     # export CI=1  # TODO: remove this
-                    export LOG_FILE=/home/jenkins/tikv-src/target/my_test.log
+                    export LOG_FILE=${WORKSPACE}/${SRC_DIR}/target/my_test.log
 
-                    if cargo nextest run -P ci --binaries-metadata test-binaries.json --cargo-metadata test-metadata.json --partition count:1/2 ${EXTRA_NEXTEST_ARGS}; then
-                        echo "test pass"
-                    else
-                        # test failed
-                        gdb -c core.* -batch -ex "info threads" -ex "thread apply all bt"
-                        exit 1
-                    fi
-                    if cargo nextest run -P ci --binaries-metadata test-binaries.json --cargo-metadata test-metadata.json --partition count:2/2 ${EXTRA_NEXTEST_ARGS}; then
-                        echo "test pass"
-                    else
-                        # test failed
-                        gdb -c core.* -batch -ex "info threads" -ex "thread apply all bt"
-                        exit 1
-                    fi
+                    for partition in 1/2 2/2; do
+                        if cargo nextest run -P ci --binaries-metadata test-binaries.json --cargo-metadata test-metadata.json --partition count:\${partition} ${EXTRA_NEXTEST_ARGS}; then
+                            echo "partition \${partition} pass"
+                        else
+                            gdb -c core.* -batch -ex "info threads" -ex "thread apply all bt"
+                            exit 1
+                        fi
+                    done
                     """
                 }
             }
             post {
                 failure {
                     sh label: "collect logs", script: """
-                        ls /home/jenkins/tikv-src/target/
-                        tar -cvzf log-ut.tar.gz \$(find /home/jenkins/tikv-src/target/ -type f -name "*.log")
-                        ls -alh  log-ut.tar.gz
+                        log_dir=${WORKSPACE}/${SRC_DIR}/target
+                        tmp_file=\$(mktemp)
+                        if [ -d "\${log_dir}" ]; then
+                            find "\${log_dir}" -type f -name "*.log" > "\${tmp_file}"
+                        fi
+
+                        if [ -s "\${tmp_file}" ]; then
+                            tar --warning=no-file-changed -czf log-ut.tar.gz -T "\${tmp_file}" || true
+                        else
+                            tar -czf log-ut.tar.gz --files-from /dev/null
+                        fi
+                        rm -f "\${tmp_file}"
+                        ls -alh log-ut.tar.gz
                     """
                     archiveArtifacts artifacts: "log-ut.tar.gz", fingerprint: true
                 }

--- a/prow-jobs/tikv/tikv/latest-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/latest-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
       name: tikv/tikv/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       optional: false
@@ -28,7 +28,7 @@ presubmits:
       name: tikv/tikv/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       always_run: false # update here after test passed

--- a/prow-jobs/tikv/tikv/release-8.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.5-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: tikv/tikv/release-8.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test

--- a/scripts/tikv/tikv/gen_test_binary_json.py
+++ b/scripts/tikv/tikv/gen_test_binary_json.py
@@ -3,7 +3,8 @@ import json
 import os
 import shutil
 
-def move_file(full_source_path, src_base_dir="/home/jenkins/tikv-src", target_dir="archive-test-binaries"):
+def copy_file(full_source_path, src_base_dir=None, target_dir="archive-test-binaries"):
+    src_base_dir = src_base_dir or os.environ.get("TIKV_SRC_DIR", "/home/jenkins/tikv-src")
     # Function to copy files preserving the directory structure, excluding base_dir
     relative_path = os.path.relpath(full_source_path, src_base_dir)
     # Construct the full target path
@@ -13,10 +14,8 @@ def move_file(full_source_path, src_base_dir="/home/jenkins/tikv-src", target_di
     target_path_dir = os.path.dirname(full_target_path)
     if not os.path.exists(target_path_dir):
         os.makedirs(target_path_dir)
-    # Copy the file
     shutil.copy2(full_source_path, full_target_path)
-    shutil.move(full_source_path, full_source_path)
-    print("Moved %s to %s" % (full_source_path, full_target_path))
+    print("Copied %s to %s" % (full_source_path, full_target_path))
 
 merged_dict={ "rust-binaries": {} }
 visited_files=set()
@@ -37,7 +36,7 @@ with open('test-binaries', 'w') as writer:
                 visited_files.add(bin)
                 merged_dict["rust-binaries"][name] = meta
                 writer.write("%s\\n" % bin)
-                move_file(bin, )
+                copy_file(bin)
 
 with open('test-binaries.json', 'w') as f:
     json.dump(merged_dict, f)


### PR DESCRIPTION
## Summary
- migrate tikv/tikv latest and release-8.5 jenkins jobs to GCP
- refactor pipeline scripts
- fix historical bug for scripts/tikv/tikv/gen_test_binary_json.py

## Replay tests
- https://prow.tidb.net/jenkins/job/tikv/job/tikv/job/pull_unit_test/3/stages/
- https://prow.tidb.net/jenkins/job/tikv/job/tikv/job/release-8.5/job/pull_unit_test/3/stages/