### PR TITLE
ci(tikv/tikv): fix pull-unit-test build error

### DIFF
--- a/pipelines/tikv/tikv/latest/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/latest/pull_unit_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                         CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
                         # Cargo metadata
                         cargo metadata --format-version 1 > test-metadata.json
-                        cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
+                        wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
                         export TIKV_SRC_DIR=${WORKSPACE}/${SRC_DIR}
                         python gen_test_binary_json.py
                         cat test-binaries.json

--- a/pipelines/tikv/tikv/release-8.5/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-8.5/pull_unit_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                         CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
                         # Cargo metadata
                         cargo metadata --format-version 1 > test-metadata.json
-                        cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
+                        wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
                         export TIKV_SRC_DIR=${WORKSPACE}/${SRC_DIR}
                         python gen_test_binary_json.py
                         cat test-binaries.json


### PR DESCRIPTION
## root cause
Only the TikV source code is checked out to ${WORKSPACE}/tikv-src in the ${WORKSPACE} of this job. 
The scripts/ directory from the PingCAP-QE/ci repository is not present in the runtime workspace, which causes the source path for the cp command to be missing. 

## fix
now download the script via wget at runtime to remove the dependency on ${WORKSPACE}/scripts/....