### PR TITLE
ci(tidb): migrate release 6.1-6.6 ghpr jobs to cloud

### DIFF
--- a/pipelines/pingcap/tidb/release-6.1/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_build.groovy
@@ -9,13 +9,13 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-ghpr_build.yam
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -28,18 +28,19 @@ pipeline {
             parallel {
                 stage('tidb') {
                     steps {
-                        dir('tidb') {
-                            cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                                retry(2) {
-                                    script {
-                                        prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                                    }
-                                }
+                        dir(REFS.repo) {
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                             }
                         }
                     }
                 }
                 stage("enterprise-plugin") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         dir("enterprise-plugin") {
                             cache(path: "./", includes: '**/*', key: "git/pingcap-inc/enterprise-plugin/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap-inc/enterprise-plugin/rev-']) {
@@ -54,25 +55,35 @@ pipeline {
                 }
             }
         }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
         stage("Build tidb-server and plugin"){
             parallel {
                 stage("Build tidb-server") {
                     stages {
                         stage("Build"){
                             steps {
-                                dir("tidb") {
-                                    sh """
-                                    make importer
-                                    WITH_CHECK=1 make TARGET=bin/tidb-server-check
-                                    make
-                                    """
+                                dir(REFS.repo) {
+                                    sh "make bazel_build"
                                 }
                             }
                             post {
-                                // TODO: statics and report logic should not put in pipelines.
-                                // Instead should only send a cloud event to a external service.
                                 always {
-                                    dir("tidb") {
+                                    dir(REFS.repo) {
                                         archiveArtifacts(
                                             artifacts: 'importer.log,tidb-server-check.log',
                                             allowEmptyArchive: true,
@@ -84,9 +95,14 @@ pipeline {
                     }
                 }
                 stage("Build plugins") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         timeout(time: 15, unit: 'MINUTES') {
-                            sh label: 'build pluginpkg tool', script: 'cd tidb/cmd/pluginpkg && go build'
+                            sh label: 'build pluginpkg tool', script: "cd ${REFS.repo}/cmd/pluginpkg && go build"
                         }
                         dir('enterprise-plugin/whitelist') {
                             sh label: 'build plugin whitelist', script: '''
@@ -102,25 +118,6 @@ pipeline {
                         }
                     }
                 }
-            }
-        }
-        stage("Test plugin") {
-            steps {
-                sh label: 'build tidb-server', script: 'make server -C tidb'
-                sh label: 'Test plugins', script: '''
-                  rm -rf /tmp/tidb
-                  rm -rf plugin-so
-                  mkdir -p plugin-so
-
-                  cp enterprise-plugin/audit/audit-1.so ./plugin-so/
-                  cp enterprise-plugin/whitelist/whitelist-1.so ./plugin-so/
-                  ./tidb/bin/tidb-server -plugin-dir=./plugin-so -plugin-load=audit-1,whitelist-1 > /tmp/loading-plugin.log 2>&1 &
-
-                  sleep 30
-                  ps aux | grep tidb-server
-                  cat /tmp/loading-plugin.log
-                  killall -9 -r tidb-server
-                '''
             }
         }
     }

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check.groovy
@@ -6,18 +6,21 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-ghpr_check.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        CI = "1"
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
@@ -26,21 +29,32 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
                 }
             }
         }
-        stage("Checks") {
-            // !!! concurrent go builds will encounter conflicts probabilistically.
+        stage('Hotfix bazel deps URL (temporary)') {
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
+        stage("Checks") {
+            steps {
+                dir(REFS.repo) {
                     sh script: 'make gogenerate check explaintest'
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_check2.groovy
@@ -6,21 +6,13 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-ghpr_check2.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
 prow.setPRDescription(REFS)
-
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
         timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
@@ -29,38 +21,48 @@ pipeline {
         OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
-        stage('Checkout') {
-            steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
-                    }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage("Prepare") {
             steps {
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
+                    }
+                    cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS)) {
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                     container("utils") {
                         dir("bin") {
-                            retry(3) {
-                                sh label: 'download tidb components', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                """
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                    """
+                                }
                             }
                         }
                     }
-                    // cache it for other pods
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                         sh """
-                            mv bin/tidb-server bin/explain_test_tidb-server
+                            mv bin/tidb-server bin/integration_test_tidb-server
                             touch rev-${REFS.pulls[0].sha}
                         """
                     }
@@ -73,17 +75,34 @@ pipeline {
                     axis {
                         name 'SCRIPT_AND_ARGS'
                         values(
-                            'integrationtest.sh y',
-                            'integrationtest.sh n',
+                            'integrationtest_with_tikv.sh y',
+                            'integrationtest_with_tikv.sh n',
+                            'run_real_tikv_tests.sh bazel_brietest',
+                            'run_real_tikv_tests.sh bazel_pessimistictest',
+                            'run_real_tikv_tests.sh bazel_sessiontest',
+                            'run_real_tikv_tests.sh bazel_statisticstest',
+                            'run_real_tikv_tests.sh bazel_txntest',
+                            'run_real_tikv_tests.sh bazel_addindextest',
+                            'run_real_tikv_tests.sh bazel_addindextest1',
+                            'run_real_tikv_tests.sh bazel_addindextest2',
+                            'run_real_tikv_tests.sh bazel_addindextest3',
+                            'run_real_tikv_tests.sh bazel_addindextest4',
+                            'run_real_tikv_tests.sh bazel_importintotest',
+                            'run_real_tikv_tests.sh bazel_importintotest2',
+                            'run_real_tikv_tests.sh bazel_importintotest3',
+                            'run_real_tikv_tests.sh bazel_importintotest4',
+                            'run_real_tikv_tests.sh bazel_pipelineddmltest',
+                            'run_real_tikv_tests.sh bazel_flashbacktest'
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -91,25 +110,61 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
-                        options { timeout(time: 50, unit: 'MINUTES') }
+                    stage('Test') {
+                        environment {
+                            CODECOV_TOKEN = credentials('codecov-token-tidb')
+                        }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
+                                    sh "ls -l rev-${REFS.pulls[0].sha}"
                                 }
-
+                                sh '''#!/usr/bin/env bash
+                                    set -euxo pipefail
+                                    if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
+                                        for f in WORKSPACE DEPS.bzl; do
+                                          [ -f "$f" ] || continue
+                                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                                        done
+                                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                                    fi
+                                '''
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
+                                sh """
+                                git diff .
+                                git status
+                                """
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }
                         post {
-                            failure {
-                                dir("checks-collation-enabled") {
-                                    archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
+                            always {
+                                dir(REFS.repo) {
+                                    junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
+                            unsuccessful {
+                                dir(REFS.repo) {
+                                    sh label: "archive log", script: """
+                                    str="$SCRIPT_AND_ARGS"
+                                    logs_dir="logs_\${str// /_}"
+                                    mkdir -p \${logs_dir}
+                                    mv pd*.log \${logs_dir} || true
+                                    mv tikv*.log \${logs_dir} || true
+                                    mv tests/integrationtest/integration-test.out \${logs_dir} || true
+                                    tar -czvf \${logs_dir}.tar.gz \${logs_dir} || true
+                                    """
+                                    archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
+                                }
+                            }
+                            success {
+                                dir(REFS.repo) {
+                                    script {
+                                        prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
+                                    }
+                                }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy
@@ -84,18 +84,19 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir(REFS.repo) {
-                                cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                            timeout(time: 25, unit: 'MINUTES') {
+                                dir(REFS.repo) {
+                                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                                        sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                                    }
                                 }
-                            }
-                            dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test'
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                dir('tidb-test') {
+                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                        sh 'ls mysql_test'
+                                        dir('mysql_test') {
+                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                        }
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_mysql_test.groovy
@@ -9,32 +9,27 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-ghpr_mysql_tes
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
-
-// TODO(wuhuizuo): tidb-test should delivered by docker image.
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
         timeout(time: 40, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 5, unit: 'MINUTES') }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
             steps {
-                dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {
@@ -46,27 +41,77 @@ pipeline {
                         }
                     }
                 }
-            }
-        }
-        stage('Prepare') {
-            steps {
-                dir('tidb') {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    '''
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
+                    }
+                }
+                dir('tidb-test') {
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                        sh 'touch ws-${BUILD_TAG}'
                     }
                 }
             }
         }
         stage('MySQL Tests') {
-            options { timeout(time: 25, unit: 'MINUTES') }
-            steps {
-                dir('tidb-test/mysql_test') {
-                    sh label: "mysql test", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh'
+            matrix {
+                axes {
+                    axis {
+                        name 'PART'
+                        values '1', '2', '3', '4'
+                    }
                 }
-            }
-            post{
-                failure {
-                    archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
+                agent {
+                    kubernetes {
+                        namespace K8S_NAMESPACE
+                        defaultContainer 'golang'
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                        retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
+                    }
+                }
+                when {
+                    beforeAgent true
+                    expression { return !matrixCache.shouldSkip(REFS, 'Test', [part: env.PART]) }
+                }
+                stages {
+                    stage("Test") {
+                        options { timeout(time: 25, unit: 'MINUTES') }
+                        steps {
+                            dir(REFS.repo) {
+                                cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                                }
+                            }
+                            dir('tidb-test') {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                    sh 'ls mysql_test'
+                                    dir('mysql_test') {
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                    }
+                                }
+                            }
+                        }
+                        post {
+                            always {
+                                junit(testResults: "**/result.xml", allowEmptyResults: true)
+                            }
+                            failure {
+                                archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
+                            }
+                            success {
+                                script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.1/ghpr_unit_test.groovy
@@ -3,68 +3,69 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.1/pod-ghpr_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '200Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
     }
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
+                }
+            }
+        }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
                 }
             }
         }
         stage('Test') {
             environment { TIDB_CODECOV_TOKEN = credentials('codecov-token-tidb') }
             steps {
-                dir('tidb') {
-                    sh """
-                    mkdir -p test_coverage
-                    make br_unit_test_in_verify_ci
-                    mv test_coverage/br_cov.unit_test.out test_coverage/br.coverage
-                    make dumpling_unit_test_in_verify_ci
-                    mv test_coverage/dumpling_cov.unit_test.out test_coverage/dumpling.coverage
-                    make gotest_in_verify_ci
-                    mv test_coverage/tidb_cov.unit_test.out test_coverage/tidb.coverage
-                    """
+                dir(REFS.repo) {
+                    sh './build/jenkins_unit_test.sh'
                 }
             }
             post {
-                 success {
-                    dir("tidb") {
-                        sh label: "upload coverage to codecov", script: """
-                        wget -q -O codecov https://uploader.codecov.io/v0.5.0/linux/codecov
-                        chmod +x codecov
-                        ./codecov --flags unit --dir test_coverage/ --token ${TIDB_CODECOV_TOKEN} --pr ${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --branch origin/pr/${REFS.pulls[0].number}
-                        """
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                        }
                     }
                 }
                 always {
-                    dir('tidb') {
-                        // archive test report to Jenkins.
-                        junit(testResults: "**/*-junit-report.xml", allowEmptyResults: true)
+                    dir(REFS.repo) {
+                        junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                     }
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_build.yaml
@@ -5,31 +5,69 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
+        requests:
+          cpu: "2"
+          memory: 16Gi
+          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "16"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          ephemeral-storage: 150Gi
       volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
+        - mountPath: /home/jenkins/.tidb
+          name: bazel-out-merged
+        - name: bazel-rc
+          mountPath: /data/
+          readOnly: true
+        - name: containerinfo
+          mountPath: /etc/containerinfo
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
+    - name: bazel-out-merged
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
+    - name: bazel-rc
+      configMap:
+        name: bazel
+    - name: containerinfo
+      downwardAPI:
+        items:
+          - path: cpu_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.cpu
+          - path: cpu_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.cpu
+          - path: mem_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.memory
+          - path: mem_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.memory
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check.yaml
@@ -5,10 +5,13 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
@@ -16,23 +19,45 @@ spec:
         limits:
           memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
       volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
+        - mountPath: /home/jenkins/.tidb
+          name: bazel-out-merged
+        - name: bazel-rc
+          mountPath: /data/
+          readOnly: true
+        - name: containerinfo
+          mountPath: /etc/containerinfo
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
+    - name: bazel-out-merged
+      emptyDir: {}
+    - name: bazel-rc
+      configMap:
+        name: bazel
+    - name: containerinfo
+      downwardAPI:
+        items:
+          - path: cpu_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.cpu
+          - path: cpu_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.cpu
+          - path: mem_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.memory
+          - path: mem_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.memory
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_check2.yaml
@@ -5,29 +5,38 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
-          cpu: "6"
+          cpu: "2"
+          ephemeral-storage: 20Gi
         limits:
-          memory: 24Gi
+          memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          ephemeral-storage: 120Gi
       volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
+        - mountPath: /home/jenkins/.tidb
+          name: bazel-out-merged
+        - name: bazel-rc
+          mountPath: /data/
+          readOnly: true
+        - name: containerinfo
+          mountPath: /etc/containerinfo
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:
@@ -36,14 +45,39 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
-
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
+    - name: bazel-out-merged
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
+    - name: bazel-rc
+      configMap:
+        name: bazel
+    - name: containerinfo
+      downwardAPI:
+        items:
+          - path: cpu_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.cpu
+          - path: cpu_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.cpu
+          - path: mem_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.memory
+          - path: mem_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.memory
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_mysql_test.yaml
@@ -5,9 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
-      securityContext:
-        privileged: true
+      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:
@@ -16,23 +14,6 @@ spec:
         limits:
           memory: 6Gi
           cpu: "3"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.1/pod-ghpr_unit_test.yaml
@@ -5,34 +5,69 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 48Gi
+          cpu: "24"
+          ephemeral-storage: 20Gi
         limits:
-          memory: 32Gi
-          cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          memory: 64Gi
+          cpu: "24"
+          ephemeral-storage: 300Gi
       volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
+        - mountPath: /home/jenkins/.tidb
+          name: bazel-out-merged
+        - name: bazel-rc
+          mountPath: /data/
+          readOnly: true
+        - name: containerinfo
+          mountPath: /etc/containerinfo
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
+    - name: bazel-out-merged
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
+    - name: bazel-rc
+      configMap:
+        name: bazel
+    - name: containerinfo
+      downwardAPI:
+        items:
+          - path: cpu_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.cpu
+          - path: cpu_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.cpu
+          - path: mem_limit
+            resourceFieldRef:
+              containerName: golang
+              resource: limits.memory
+          - path: mem_request
+            resourceFieldRef:
+              containerName: golang
+              resource: requests.memory
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_build.groovy
@@ -9,13 +9,13 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_build.yam
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -28,19 +28,19 @@ pipeline {
             parallel {
                 stage('tidb') {
                     steps {
-                        dir('tidb') {
-                            cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                                retry(2) {
-                                    script {
-                                        prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                                    }
-                                }
+                        dir(REFS.repo) {
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                             }
                         }
-                        sh 'echo -e "\ntry-import /data/bazel" >> tidb/.bazelrc'
                     }
                 }
                 stage("enterprise-plugin") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         dir("enterprise-plugin") {
                             cache(path: "./", includes: '**/*', key: "git/pingcap-inc/enterprise-plugin/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap-inc/enterprise-plugin/rev-']) {
@@ -55,21 +55,35 @@ pipeline {
                 }
             }
         }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
         stage("Build tidb-server and plugin"){
             parallel {
                 stage("Build tidb-server") {
                     stages {
                         stage("Build"){
                             steps {
-                                dir("tidb") {
+                                dir(REFS.repo) {
                                     sh "make bazel_build"
                                 }
                             }
                             post {
-                                // TODO: statics and report logic should not put in pipelines.
-                                // Instead should only send a cloud event to a external service.
                                 always {
-                                    dir("tidb") {
+                                    dir(REFS.repo) {
                                         archiveArtifacts(
                                             artifacts: 'importer.log,tidb-server-check.log',
                                             allowEmptyArchive: true,
@@ -81,9 +95,14 @@ pipeline {
                     }
                 }
                 stage("Build plugins") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         timeout(time: 15, unit: 'MINUTES') {
-                            sh label: 'build pluginpkg tool', script: 'cd tidb/cmd/pluginpkg && go build'
+                            sh label: 'build pluginpkg tool', script: "cd ${REFS.repo}/cmd/pluginpkg && go build"
                         }
                         dir('enterprise-plugin/whitelist') {
                             sh label: 'build plugin whitelist', script: '''

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check.groovy
@@ -6,18 +6,21 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_check.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        CI = "1"
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
@@ -26,22 +29,32 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
                 }
-                sh 'echo -e "\ntry-import /data/bazel" >> tidb/.bazelrc'
+            }
+        }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
             }
         }
         stage("Checks") {
-            // !!! concurrent go builds will encounter conflicts probabilistically.
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
                     sh script: 'make gogenerate check explaintest'
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -6,62 +6,63 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_check2.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
 prow.setPRDescription(REFS)
-
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     environment {
         OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
-        stage('Checkout') {
-            steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
-                    }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
                 }
-                sh 'echo -e "\ntry-import /data/bazel" >> tidb/.bazelrc'
             }
-        }
-        stage("Prepare") {
             steps {
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
+                    }
+                    cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS)) {
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                     container("utils") {
                         dir("bin") {
-                            retry(3) {
-                                sh label: 'download tidb components', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                """
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                    """
+                                }
                             }
                         }
                     }
-                    // cache it for other pods
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                         sh """
-                            mv bin/tidb-server bin/explain_test_tidb-server
+                            mv bin/tidb-server bin/integration_test_tidb-server
                             touch rev-${REFS.pulls[0].sha}
                         """
                     }
@@ -74,17 +75,34 @@ pipeline {
                     axis {
                         name 'SCRIPT_AND_ARGS'
                         values(
-                            'integrationtest.sh y',
-                            'integrationtest.sh n',
+                            'integrationtest_with_tikv.sh y',
+                            'integrationtest_with_tikv.sh n',
+                            'run_real_tikv_tests.sh bazel_brietest',
+                            'run_real_tikv_tests.sh bazel_pessimistictest',
+                            'run_real_tikv_tests.sh bazel_sessiontest',
+                            'run_real_tikv_tests.sh bazel_statisticstest',
+                            'run_real_tikv_tests.sh bazel_txntest',
+                            'run_real_tikv_tests.sh bazel_addindextest',
+                            'run_real_tikv_tests.sh bazel_addindextest1',
+                            'run_real_tikv_tests.sh bazel_addindextest2',
+                            'run_real_tikv_tests.sh bazel_addindextest3',
+                            'run_real_tikv_tests.sh bazel_addindextest4',
+                            'run_real_tikv_tests.sh bazel_importintotest',
+                            'run_real_tikv_tests.sh bazel_importintotest2',
+                            'run_real_tikv_tests.sh bazel_importintotest3',
+                            'run_real_tikv_tests.sh bazel_importintotest4',
+                            'run_real_tikv_tests.sh bazel_pipelineddmltest',
+                            'run_real_tikv_tests.sh bazel_flashbacktest'
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -92,25 +110,61 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
-                        options { timeout(time: 30, unit: 'MINUTES') }
+                    stage('Test') {
+                        environment {
+                            CODECOV_TOKEN = credentials('codecov-token-tidb')
+                        }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
+                                    sh "ls -l rev-${REFS.pulls[0].sha}"
                                 }
-
+                                sh '''#!/usr/bin/env bash
+                                    set -euxo pipefail
+                                    if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
+                                        for f in WORKSPACE DEPS.bzl; do
+                                          [ -f "$f" ] || continue
+                                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                                        done
+                                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                                    fi
+                                '''
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
+                                sh """
+                                git diff .
+                                git status
+                                """
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }
                         post {
-                            failure {
-                                dir("checks-collation-enabled") {
-                                    archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
+                            always {
+                                dir(REFS.repo) {
+                                    junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
+                            unsuccessful {
+                                dir(REFS.repo) {
+                                    sh label: "archive log", script: """
+                                    str="$SCRIPT_AND_ARGS"
+                                    logs_dir="logs_\${str// /_}"
+                                    mkdir -p \${logs_dir}
+                                    mv pd*.log \${logs_dir} || true
+                                    mv tikv*.log \${logs_dir} || true
+                                    mv tests/integrationtest/integration-test.out \${logs_dir} || true
+                                    tar -czvf \${logs_dir}.tar.gz \${logs_dir} || true
+                                    """
+                                    archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
+                                }
+                            }
+                            success {
+                                dir(REFS.repo) {
+                                    script {
+                                        prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
+                                    }
+                                }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -84,18 +84,19 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir(REFS.repo) {
-                                cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                            timeout(time: 25, unit: 'MINUTES') {
+                                dir(REFS.repo) {
+                                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                                        sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                                    }
                                 }
-                            }
-                            dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test'
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                dir('tidb-test') {
+                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                        sh 'ls mysql_test'
+                                        dir('mysql_test') {
+                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                        }
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -9,55 +9,52 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_mysql_tes
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
-
-// TODO(wuhuizuo): tidb-test should delivered by docker image.
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
         timeout(time: 40, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 10, unit: 'MINUTES') }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
             steps {
-                dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {
                     cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
                         retry(2) {
                             script {
-                                component.checkout('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                                component.checkoutSupportBatch('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
                             }
                         }
                     }
                 }
-                sh 'echo -e "\ntry-import /data/bazel" >> tidb/.bazelrc'
-            }
-        }
-        stage('Prepare') {
-            steps {
-                dir('tidb') {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    '''
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                 }
                 dir('tidb-test') {
-                    sh "git branch && git status"
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                         sh 'touch ws-${BUILD_TAG}'
                     }
@@ -72,12 +69,13 @@ pipeline {
                         values '1', '2', '3', '4'
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -88,28 +86,30 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                                     sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
                                 }
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                    sh 'ls mysql_test'
                                     dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
                                     }
                                 }
                             }
                         }
-                        post{
+                        post {
                             always {
-                                junit(testResults: "**/result.xml")
+                                junit(testResults: "**/result.xml", allowEmptyResults: true)
                             }
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
+                            success {
+                                script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_unit_test.groovy
@@ -3,61 +3,68 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.2/pod-ghpr_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '200Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
     }
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
                 }
-                sh 'echo -e "\ntry-import /data/bazel" >> tidb/.bazelrc'
+            }
+        }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
             }
         }
         stage('Test') {
             environment { TIDB_CODECOV_TOKEN = credentials('codecov-token-tidb') }
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
                     sh './build/jenkins_unit_test.sh'
                 }
             }
             post {
-                 success {
-                    dir("tidb") {
-                        sh label: "upload coverage to codecov", script: """
-                        mv coverage.dat test_coverage/coverage.dat
-                        wget -q -O codecov https://uploader.codecov.io/v0.5.0/linux/codecov
-                        chmod +x codecov
-                        ./codecov --flags unit --dir test_coverage/ --token ${TIDB_CODECOV_TOKEN} --pr ${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --branch origin/pr/${REFS.pulls[0].number}
-                        """
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                        }
                     }
                 }
                 always {
-                    dir('tidb') {
-                        // archive test report to Jenkins.
+                    dir(REFS.repo) {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_build.yaml
@@ -5,34 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:20220823"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          cpu: "2"
+          memory: 16Gi
+          ephemeral-storage: 20Gi
         limits:
-          memory: 24Gi
-          cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          memory: 64Gi
+          cpu: "16"
+          ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.18
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,22 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check.yaml
@@ -5,10 +5,13 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:20220823"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
@@ -16,23 +19,9 @@ spec:
         limits:
           memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.18
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,22 +34,11 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_check2.yaml
@@ -5,34 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:20220823"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
-          cpu: "6"
+          cpu: "2"
+          ephemeral-storage: 20Gi
         limits:
-          memory: 12Gi
+          memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          ephemeral-storage: 120Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.18
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,7 +36,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:
@@ -54,24 +45,20 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
-
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.18.5:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:
@@ -14,23 +14,6 @@ spec:
         limits:
           memory: 6Gi
           cpu: "3"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.2/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.2/pod-ghpr_unit_test.yaml
@@ -5,36 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      # TODO(wuhuizuo): using standard bazel build image to shrink the image size
-      # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "hub.pingcap.net/wangweizhen/tidb_image:20220823"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 48Gi
+          cpu: "24"
+          ephemeral-storage: 20Gi
         limits:
-          memory: 32Gi
-          cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          memory: 64Gi
+          cpu: "24"
+          ephemeral-storage: 300Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.18
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -47,22 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_build.groovy
@@ -9,13 +9,13 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.3/pod-ghpr_build.yam
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -28,18 +28,19 @@ pipeline {
             parallel {
                 stage('tidb') {
                     steps {
-                        dir('tidb') {
-                            cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                                retry(2) {
-                                    script {
-                                        prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                                    }
-                                }
+                        dir(REFS.repo) {
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                             }
                         }
                     }
                 }
                 stage("enterprise-plugin") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         dir("enterprise-plugin") {
                             cache(path: "./", includes: '**/*', key: "git/pingcap-inc/enterprise-plugin/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap-inc/enterprise-plugin/rev-']) {
@@ -54,21 +55,35 @@ pipeline {
                 }
             }
         }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
         stage("Build tidb-server and plugin"){
             parallel {
                 stage("Build tidb-server") {
                     stages {
                         stage("Build"){
                             steps {
-                                dir("tidb") {
+                                dir(REFS.repo) {
                                     sh "make bazel_build"
                                 }
                             }
                             post {
-                                // TODO: statics and report logic should not put in pipelines.
-                                // Instead should only send a cloud event to a external service.
                                 always {
-                                    dir("tidb") {
+                                    dir(REFS.repo) {
                                         archiveArtifacts(
                                             artifacts: 'importer.log,tidb-server-check.log',
                                             allowEmptyArchive: true,
@@ -80,9 +95,14 @@ pipeline {
                     }
                 }
                 stage("Build plugins") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         timeout(time: 15, unit: 'MINUTES') {
-                            sh label: 'build pluginpkg tool', script: 'cd tidb/cmd/pluginpkg && go build'
+                            sh label: 'build pluginpkg tool', script: "cd ${REFS.repo}/cmd/pluginpkg && go build"
                         }
                         dir('enterprise-plugin/whitelist') {
                             sh label: 'build plugin whitelist', script: '''

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check.groovy
@@ -6,18 +6,21 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.3/pod-ghpr_check.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        CI = "1"
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
@@ -26,21 +29,32 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
                 }
             }
         }
-        stage("Checks") {
-            // !!! concurrent go builds will encounter conflicts probabilistically.
+        stage('Hotfix bazel deps URL (temporary)') {
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
+        stage("Checks") {
+            steps {
+                dir(REFS.repo) {
                     sh script: 'make gogenerate check explaintest'
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -6,61 +6,63 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.3/pod-ghpr_check2.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
 prow.setPRDescription(REFS)
-
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     environment {
         OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
-        stage('Checkout') {
-            steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
-                    }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage("Prepare") {
             steps {
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
+                    }
+                    cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS)) {
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                     container("utils") {
                         dir("bin") {
-                            retry(3) {
-                                sh label: 'download tidb components', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                """
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                    """
+                                }
                             }
                         }
                     }
-                    // cache it for other pods
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                         sh """
-                            mv bin/tidb-server bin/explain_test_tidb-server
+                            mv bin/tidb-server bin/integration_test_tidb-server
                             touch rev-${REFS.pulls[0].sha}
                         """
                     }
@@ -73,23 +75,34 @@ pipeline {
                     axis {
                         name 'SCRIPT_AND_ARGS'
                         values(
-                            'integrationtest.sh y',
-                            'integrationtest.sh n',
+                            'integrationtest_with_tikv.sh y',
+                            'integrationtest_with_tikv.sh n',
                             'run_real_tikv_tests.sh bazel_brietest',
                             'run_real_tikv_tests.sh bazel_pessimistictest',
                             'run_real_tikv_tests.sh bazel_sessiontest',
                             'run_real_tikv_tests.sh bazel_statisticstest',
                             'run_real_tikv_tests.sh bazel_txntest',
                             'run_real_tikv_tests.sh bazel_addindextest',
+                            'run_real_tikv_tests.sh bazel_addindextest1',
+                            'run_real_tikv_tests.sh bazel_addindextest2',
+                            'run_real_tikv_tests.sh bazel_addindextest3',
+                            'run_real_tikv_tests.sh bazel_addindextest4',
+                            'run_real_tikv_tests.sh bazel_importintotest',
+                            'run_real_tikv_tests.sh bazel_importintotest2',
+                            'run_real_tikv_tests.sh bazel_importintotest3',
+                            'run_real_tikv_tests.sh bazel_importintotest4',
+                            'run_real_tikv_tests.sh bazel_pipelineddmltest',
+                            'run_real_tikv_tests.sh bazel_flashbacktest'
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -97,25 +110,61 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
-                        options { timeout(time: 30, unit: 'MINUTES') }
+                    stage('Test') {
+                        environment {
+                            CODECOV_TOKEN = credentials('codecov-token-tidb')
+                        }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
+                                    sh "ls -l rev-${REFS.pulls[0].sha}"
                                 }
-
+                                sh '''#!/usr/bin/env bash
+                                    set -euxo pipefail
+                                    if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
+                                        for f in WORKSPACE DEPS.bzl; do
+                                          [ -f "$f" ] || continue
+                                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                                        done
+                                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                                    fi
+                                '''
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
+                                sh """
+                                git diff .
+                                git status
+                                """
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }
                         post {
-                            failure {
-                                dir("checks-collation-enabled") {
-                                    archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
+                            always {
+                                dir(REFS.repo) {
+                                    junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
+                            unsuccessful {
+                                dir(REFS.repo) {
+                                    sh label: "archive log", script: """
+                                    str="$SCRIPT_AND_ARGS"
+                                    logs_dir="logs_\${str// /_}"
+                                    mkdir -p \${logs_dir}
+                                    mv pd*.log \${logs_dir} || true
+                                    mv tikv*.log \${logs_dir} || true
+                                    mv tests/integrationtest/integration-test.out \${logs_dir} || true
+                                    tar -czvf \${logs_dir}.tar.gz \${logs_dir} || true
+                                    """
+                                    archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
+                                }
+                            }
+                            success {
+                                dir(REFS.repo) {
+                                    script {
+                                        prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
+                                    }
+                                }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
@@ -84,18 +84,19 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir(REFS.repo) {
-                                cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                            timeout(time: 25, unit: 'MINUTES') {
+                                dir(REFS.repo) {
+                                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                                        sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                                    }
                                 }
-                            }
-                            dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test'
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                dir('tidb-test') {
+                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                        sh 'ls mysql_test'
+                                        dir('mysql_test') {
+                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                        }
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
@@ -9,54 +9,52 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.3/pod-ghpr_mysql_tes
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
-
-// TODO(wuhuizuo): tidb-test should delivered by docker image.
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
         timeout(time: 40, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 10, unit: 'MINUTES') }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
             steps {
-                dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {
                     cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
                         retry(2) {
                             script {
-                                component.checkout('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                                component.checkoutSupportBatch('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
                             }
                         }
                     }
                 }
-            }
-        }
-        stage('Prepare') {
-            steps {
-                dir('tidb') {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    '''
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                 }
                 dir('tidb-test') {
-                    sh "git branch && git status"
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                         sh 'touch ws-${BUILD_TAG}'
                     }
@@ -71,12 +69,13 @@ pipeline {
                         values '1', '2', '3', '4'
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -87,28 +86,30 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                                     sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
                                 }
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                    sh 'ls mysql_test'
                                     dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
                                     }
                                 }
                             }
                         }
-                        post{
+                        post {
                             always {
-                                junit(testResults: "**/result.xml")
+                                junit(testResults: "**/result.xml", allowEmptyResults: true)
                             }
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
+                            success {
+                                script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_unit_test.groovy
@@ -3,60 +3,68 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.3/pod-ghpr_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '200Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
     }
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
+                }
+            }
+        }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
                 }
             }
         }
         stage('Test') {
             environment { TIDB_CODECOV_TOKEN = credentials('codecov-token-tidb') }
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
                     sh './build/jenkins_unit_test.sh'
                 }
             }
             post {
-                 success {
-                    dir("tidb") {
-                        sh label: "upload coverage to codecov", script: """
-                        mv coverage.dat test_coverage/coverage.dat
-                        wget -q -O codecov https://uploader.codecov.io/v0.5.0/linux/codecov
-                        chmod +x codecov
-                        ./codecov --flags unit --dir test_coverage/ --token ${TIDB_CODECOV_TOKEN} --pr ${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --branch origin/pr/${REFS.pulls[0].number}
-                        """
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                        }
                     }
                 }
                 always {
-                    dir('tidb') {
-                        // archive test report to Jenkins.
+                    dir(REFS.repo) {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_build.yaml
@@ -5,34 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920220922"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          cpu: "2"
+          memory: 16Gi
+          ephemeral-storage: 20Gi
         limits:
-          memory: 24Gi
-          cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          memory: 64Gi
+          cpu: "16"
+          ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,22 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check.yaml
@@ -5,10 +5,13 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920220922"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
@@ -16,23 +19,9 @@ spec:
         limits:
           memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,22 +34,11 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_check2.yaml
@@ -5,34 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920220922"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
-          cpu: "6"
+          cpu: "2"
+          ephemeral-storage: 20Gi
         limits:
-          memory: 12Gi
+          memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          ephemeral-storage: 120Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,7 +36,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:
@@ -54,24 +45,20 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
-
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:
@@ -14,23 +14,6 @@ spec:
         limits:
           memory: 6Gi
           cpu: "3"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.3/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.3/pod-ghpr_unit_test.yaml
@@ -5,36 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      # TODO(wuhuizuo): using standard bazel build image to shrink the image size
-      # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920220922"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 48Gi
+          cpu: "24"
+          ephemeral-storage: 20Gi
         limits:
-          memory: 32Gi
-          cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          memory: 64Gi
+          cpu: "24"
+          ephemeral-storage: 300Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -47,22 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_build.groovy
@@ -9,13 +9,13 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.4/pod-ghpr_build.yam
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -28,18 +28,19 @@ pipeline {
             parallel {
                 stage('tidb') {
                     steps {
-                        dir('tidb') {
-                            cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                                retry(2) {
-                                    script {
-                                        prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                                    }
-                                }
+                        dir(REFS.repo) {
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                             }
                         }
                     }
                 }
                 stage("enterprise-plugin") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         dir("enterprise-plugin") {
                             cache(path: "./", includes: '**/*', key: "git/pingcap-inc/enterprise-plugin/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap-inc/enterprise-plugin/rev-']) {
@@ -54,21 +55,35 @@ pipeline {
                 }
             }
         }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
         stage("Build tidb-server and plugin"){
             parallel {
                 stage("Build tidb-server") {
                     stages {
                         stage("Build"){
                             steps {
-                                dir("tidb") {
+                                dir(REFS.repo) {
                                     sh "make bazel_build"
                                 }
                             }
                             post {
-                                // TODO: statics and report logic should not put in pipelines.
-                                // Instead should only send a cloud event to a external service.
                                 always {
-                                    dir("tidb") {
+                                    dir(REFS.repo) {
                                         archiveArtifacts(
                                             artifacts: 'importer.log,tidb-server-check.log',
                                             allowEmptyArchive: true,
@@ -80,9 +95,14 @@ pipeline {
                     }
                 }
                 stage("Build plugins") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         timeout(time: 15, unit: 'MINUTES') {
-                            sh label: 'build pluginpkg tool', script: 'cd tidb/cmd/pluginpkg && go build'
+                            sh label: 'build pluginpkg tool', script: "cd ${REFS.repo}/cmd/pluginpkg && go build"
                         }
                         dir('enterprise-plugin/whitelist') {
                             sh label: 'build plugin whitelist', script: '''

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_check.groovy
@@ -6,18 +6,21 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.4/pod-ghpr_check.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        CI = "1"
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
@@ -26,21 +29,32 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
                 }
             }
         }
-        stage("Checks") {
-            // !!! concurrent go builds will encounter conflicts probabilistically.
+        stage('Hotfix bazel deps URL (temporary)') {
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
+        stage("Checks") {
+            steps {
+                dir(REFS.repo) {
                     sh script: 'make gogenerate check explaintest'
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
@@ -6,61 +6,63 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.4/pod-ghpr_check2.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
 prow.setPRDescription(REFS)
-
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     environment {
         OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
-        stage('Checkout') {
-            steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
-                    }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage("Prepare") {
             steps {
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
+                    }
+                    cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS)) {
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                     container("utils") {
                         dir("bin") {
-                            retry(3) {
-                                sh label: 'download tidb components', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                """
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                    """
+                                }
                             }
                         }
                     }
-                    // cache it for other pods
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                         sh """
-                            mv bin/tidb-server bin/explain_test_tidb-server
+                            mv bin/tidb-server bin/integration_test_tidb-server
                             touch rev-${REFS.pulls[0].sha}
                         """
                     }
@@ -73,23 +75,34 @@ pipeline {
                     axis {
                         name 'SCRIPT_AND_ARGS'
                         values(
-                            'integrationtest.sh y',
-                            'integrationtest.sh n',
+                            'integrationtest_with_tikv.sh y',
+                            'integrationtest_with_tikv.sh n',
                             'run_real_tikv_tests.sh bazel_brietest',
                             'run_real_tikv_tests.sh bazel_pessimistictest',
                             'run_real_tikv_tests.sh bazel_sessiontest',
                             'run_real_tikv_tests.sh bazel_statisticstest',
                             'run_real_tikv_tests.sh bazel_txntest',
                             'run_real_tikv_tests.sh bazel_addindextest',
+                            'run_real_tikv_tests.sh bazel_addindextest1',
+                            'run_real_tikv_tests.sh bazel_addindextest2',
+                            'run_real_tikv_tests.sh bazel_addindextest3',
+                            'run_real_tikv_tests.sh bazel_addindextest4',
+                            'run_real_tikv_tests.sh bazel_importintotest',
+                            'run_real_tikv_tests.sh bazel_importintotest2',
+                            'run_real_tikv_tests.sh bazel_importintotest3',
+                            'run_real_tikv_tests.sh bazel_importintotest4',
+                            'run_real_tikv_tests.sh bazel_pipelineddmltest',
+                            'run_real_tikv_tests.sh bazel_flashbacktest'
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -97,25 +110,61 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
-                        options { timeout(time: 30, unit: 'MINUTES') }
+                    stage('Test') {
+                        environment {
+                            CODECOV_TOKEN = credentials('codecov-token-tidb')
+                        }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
+                                    sh "ls -l rev-${REFS.pulls[0].sha}"
                                 }
-
+                                sh '''#!/usr/bin/env bash
+                                    set -euxo pipefail
+                                    if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
+                                        for f in WORKSPACE DEPS.bzl; do
+                                          [ -f "$f" ] || continue
+                                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                                        done
+                                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                                    fi
+                                '''
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
+                                sh """
+                                git diff .
+                                git status
+                                """
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }
                         post {
-                            failure {
-                                dir("checks-collation-enabled") {
-                                    archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
+                            always {
+                                dir(REFS.repo) {
+                                    junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
+                            unsuccessful {
+                                dir(REFS.repo) {
+                                    sh label: "archive log", script: """
+                                    str="$SCRIPT_AND_ARGS"
+                                    logs_dir="logs_\${str// /_}"
+                                    mkdir -p \${logs_dir}
+                                    mv pd*.log \${logs_dir} || true
+                                    mv tikv*.log \${logs_dir} || true
+                                    mv tests/integrationtest/integration-test.out \${logs_dir} || true
+                                    tar -czvf \${logs_dir}.tar.gz \${logs_dir} || true
+                                    """
+                                    archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
+                                }
+                            }
+                            success {
+                                dir(REFS.repo) {
+                                    script {
+                                        prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
+                                    }
+                                }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
@@ -84,18 +84,19 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir(REFS.repo) {
-                                cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                            timeout(time: 25, unit: 'MINUTES') {
+                                dir(REFS.repo) {
+                                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                                        sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                                    }
                                 }
-                            }
-                            dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test'
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                dir('tidb-test') {
+                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                        sh 'ls mysql_test'
+                                        dir('mysql_test') {
+                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                        }
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
@@ -9,54 +9,52 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.4/pod-ghpr_mysql_tes
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
-
-// TODO(wuhuizuo): tidb-test should delivered by docker image.
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
         timeout(time: 40, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 10, unit: 'MINUTES') }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
             steps {
-                dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {
                     cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
                         retry(2) {
                             script {
-                                component.checkout('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, GIT_CREDENTIALS_ID)
+                                component.checkoutSupportBatch('git@github.com:PingCAP-QE/tidb-test.git', 'tidb-test', REFS.base_ref, REFS.pulls[0].title, REFS, GIT_CREDENTIALS_ID)
                             }
                         }
                     }
                 }
-            }
-        }
-        stage('Prepare') {
-            steps {
-                dir('tidb') {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    '''
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                 }
                 dir('tidb-test') {
-                    sh "git branch && git status"
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                         sh 'touch ws-${BUILD_TAG}'
                     }
@@ -71,12 +69,13 @@ pipeline {
                         values '1', '2', '3', '4'
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -87,28 +86,30 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                                     sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
                                 }
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                    sh 'ls mysql_test'
                                     dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
                                     }
                                 }
                             }
                         }
-                        post{
+                        post {
                             always {
-                                junit(testResults: "**/result.xml")
+                                junit(testResults: "**/result.xml", allowEmptyResults: true)
                             }
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
+                            success {
+                                script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_unit_test.groovy
@@ -3,60 +3,68 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.4/pod-ghpr_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '200Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
     options {
-        timeout(time: 60, unit: 'MINUTES')
+        timeout(time: 90, unit: 'MINUTES')
     }
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
+                }
+            }
+        }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
                 }
             }
         }
         stage('Test') {
             environment { TIDB_CODECOV_TOKEN = credentials('codecov-token-tidb') }
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
                     sh './build/jenkins_unit_test.sh'
                 }
             }
             post {
-                 success {
-                    dir("tidb") {
-                        sh label: "upload coverage to codecov", script: """
-                        mv coverage.dat test_coverage/coverage.dat
-                        wget -q -O codecov https://uploader.codecov.io/v0.5.0/linux/codecov
-                        chmod +x codecov
-                        ./codecov --flags unit --dir test_coverage/ --token ${TIDB_CODECOV_TOKEN} --pr ${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --branch origin/pr/${REFS.pulls[0].number}
-                        """
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                        }
                     }
                 }
                 always {
-                    dir('tidb') {
-                        // archive test report to Jenkins.
+                    dir(REFS.repo) {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_build.yaml
@@ -5,34 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920221103"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          cpu: "2"
+          memory: 16Gi
+          ephemeral-storage: 20Gi
         limits:
-          memory: 24Gi
-          cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          memory: 64Gi
+          cpu: "16"
+          ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,22 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check.yaml
@@ -5,10 +5,13 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920221103"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
@@ -16,23 +19,9 @@ spec:
         limits:
           memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,22 +34,11 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_check2.yaml
@@ -5,34 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920221103"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
-          cpu: "6"
+          cpu: "2"
+          ephemeral-storage: 20Gi
         limits:
-          memory: 12Gi
+          memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          ephemeral-storage: 120Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,7 +36,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:
@@ -54,24 +45,20 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
-
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:
@@ -14,23 +14,6 @@ spec:
         limits:
           memory: 6Gi
           cpu: "3"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.4/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.4/pod-ghpr_unit_test.yaml
@@ -5,36 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      # TODO(wuhuizuo): using standard bazel build image to shrink the image size
-      # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920221103"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 48Gi
+          cpu: "24"
+          ephemeral-storage: 20Gi
         limits:
-          memory: 32Gi
-          cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          memory: 64Gi
+          cpu: "24"
+          ephemeral-storage: 300Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -47,22 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_build.groovy
@@ -9,13 +9,13 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yam
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -29,17 +29,18 @@ pipeline {
                 stage('tidb') {
                     steps {
                         dir(REFS.repo) {
-                            cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                                retry(2) {
-                                    script {
-                                        prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                                    }
-                                }
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                             }
                         }
                     }
                 }
                 stage("enterprise-plugin") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         dir("enterprise-plugin") {
                             cache(path: "./", includes: '**/*', key: "git/pingcap-inc/enterprise-plugin/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap-inc/enterprise-plugin/rev-']) {
@@ -54,6 +55,22 @@ pipeline {
                 }
             }
         }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
         stage("Build tidb-server and plugin"){
             parallel {
                 stage("Build tidb-server") {
@@ -61,20 +78,16 @@ pipeline {
                         stage("Build"){
                             steps {
                                 dir(REFS.repo) {
-                                    sh """
-                                    sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
-                                    git diff .
-                                    git status
-                                    """
                                     sh "make bazel_build"
                                 }
                             }
                             post {
-                                // TODO: statics and report logic should not put in pipelines.
-                                // Instead should only send a cloud event to a external service.
                                 always {
                                     dir(REFS.repo) {
-                                        archiveArtifacts(artifacts: 'importer.log,tidb-server-check.log', allowEmptyArchive: true)
+                                        archiveArtifacts(
+                                            artifacts: 'importer.log,tidb-server-check.log',
+                                            allowEmptyArchive: true,
+                                        )
                                     }
                                 }
                             }
@@ -82,9 +95,14 @@ pipeline {
                     }
                 }
                 stage("Build plugins") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         timeout(time: 15, unit: 'MINUTES') {
-                            sh label: 'build pluginpkg tool', script: 'cd tidb/cmd/pluginpkg && go build'
+                            sh label: 'build pluginpkg tool', script: "cd ${REFS.repo}/cmd/pluginpkg && go build"
                         }
                         dir('enterprise-plugin/whitelist') {
                             sh label: 'build plugin whitelist', script: '''
@@ -100,25 +118,6 @@ pipeline {
                         }
                     }
                 }
-            }
-        }
-        stage("Test plugin") {
-            steps {
-                sh label: 'build tidb-server', script: 'make server -C tidb'
-                sh label: 'Test plugins', script: '''
-                  rm -rf /tmp/tidb
-                  rm -rf plugin-so
-                  mkdir -p plugin-so
-
-                  cp enterprise-plugin/audit/audit-1.so ./plugin-so/
-                  cp enterprise-plugin/whitelist/whitelist-1.so ./plugin-so/
-                  ./tidb/bin/tidb-server -plugin-dir=./plugin-so -plugin-load=audit-1,whitelist-1 > /tmp/loading-plugin.log 2>&1 &
-
-                  sleep 30
-                  ps aux | grep tidb-server
-                  cat /tmp/loading-plugin.log
-                  killall -9 -r tidb-server
-                '''
             }
         }
     }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check.groovy
@@ -6,18 +6,21 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        CI = "1"
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
@@ -26,22 +29,32 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
                 }
             }
         }
-        stage("Checks") {
-            // !!! concurrent go builds will encounter conflicts probabilistically.
+        stage('Hotfix bazel deps URL (temporary)') {
             steps {
-                dir('tidb') {
-                    sh label: 'fix bazel', script: 'rm -rf /home/jenkins/.cache/bazel/_bazel_jenkins/install/a09dbb90c658248f08f9aa0eba11997d'
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
+        stage("Checks") {
+            steps {
+                dir(REFS.repo) {
                     sh script: 'make gogenerate check explaintest'
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -6,20 +6,13 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
-prow.setPRDescription(REFS)
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
+prow.setPRDescription(REFS)
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
         timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
@@ -28,38 +21,48 @@ pipeline {
         OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
-        stage('Checkout') {
-            steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
-                    }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage("Prepare") {
             steps {
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
+                    }
+                    cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS)) {
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                     container("utils") {
                         dir("bin") {
-                            retry(3) {
-                                sh label: 'download tidb components', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                """
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                    """
+                                }
                             }
                         }
                     }
-                    // cache it for other pods
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                         sh """
-                            mv bin/tidb-server bin/explain_test_tidb-server
+                            mv bin/tidb-server bin/integration_test_tidb-server
                             touch rev-${REFS.pulls[0].sha}
                         """
                     }
@@ -72,23 +75,34 @@ pipeline {
                     axis {
                         name 'SCRIPT_AND_ARGS'
                         values(
-                            'integrationtest.sh y',
-                            'integrationtest.sh n',
+                            'integrationtest_with_tikv.sh y',
+                            'integrationtest_with_tikv.sh n',
                             'run_real_tikv_tests.sh bazel_brietest',
                             'run_real_tikv_tests.sh bazel_pessimistictest',
                             'run_real_tikv_tests.sh bazel_sessiontest',
                             'run_real_tikv_tests.sh bazel_statisticstest',
                             'run_real_tikv_tests.sh bazel_txntest',
                             'run_real_tikv_tests.sh bazel_addindextest',
+                            'run_real_tikv_tests.sh bazel_addindextest1',
+                            'run_real_tikv_tests.sh bazel_addindextest2',
+                            'run_real_tikv_tests.sh bazel_addindextest3',
+                            'run_real_tikv_tests.sh bazel_addindextest4',
+                            'run_real_tikv_tests.sh bazel_importintotest',
+                            'run_real_tikv_tests.sh bazel_importintotest2',
+                            'run_real_tikv_tests.sh bazel_importintotest3',
+                            'run_real_tikv_tests.sh bazel_importintotest4',
+                            'run_real_tikv_tests.sh bazel_pipelineddmltest',
+                            'run_real_tikv_tests.sh bazel_flashbacktest'
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -96,17 +110,27 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
-                        options { timeout(time: 50, unit: 'MINUTES') }
+                    stage('Test') {
+                        environment {
+                            CODECOV_TOKEN = credentials('codecov-token-tidb')
+                        }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
+                                    sh "ls -l rev-${REFS.pulls[0].sha}"
                                 }
-
+                                sh '''#!/usr/bin/env bash
+                                    set -euxo pipefail
+                                    if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
+                                        for f in WORKSPACE DEPS.bzl; do
+                                          [ -f "$f" ] || continue
+                                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                                        done
+                                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                                    fi
+                                '''
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
                                 sh """
-                                sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
                                 git diff .
                                 git status
                                 """
@@ -114,12 +138,33 @@ pipeline {
                             }
                         }
                         post {
-                            failure {
-                                dir("checks-collation-enabled") {
-                                    archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
+                            always {
+                                dir(REFS.repo) {
+                                    junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
+                            unsuccessful {
+                                dir(REFS.repo) {
+                                    sh label: "archive log", script: """
+                                    str="$SCRIPT_AND_ARGS"
+                                    logs_dir="logs_\${str// /_}"
+                                    mkdir -p \${logs_dir}
+                                    mv pd*.log \${logs_dir} || true
+                                    mv tikv*.log \${logs_dir} || true
+                                    mv tests/integrationtest/integration-test.out \${logs_dir} || true
+                                    tar -czvf \${logs_dir}.tar.gz \${logs_dir} || true
+                                    """
+                                    archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
+                                }
+                            }
+                            success {
+                                dir(REFS.repo) {
+                                    script {
+                                        prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
+                                    }
+                                }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
@@ -84,18 +84,19 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir(REFS.repo) {
-                                cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                            timeout(time: 25, unit: 'MINUTES') {
+                                dir(REFS.repo) {
+                                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                                        sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                                    }
                                 }
-                            }
-                            dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test'
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                dir('tidb-test') {
+                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                        sh 'ls mysql_test'
+                                        dir('mysql_test') {
+                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                        }
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
@@ -9,32 +9,27 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.5/pod-ghpr_mysql_tes
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 prow.setPRDescription(REFS)
-
-// TODO(wuhuizuo): tidb-test should delivered by docker image.
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
         timeout(time: 40, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 10, unit: 'MINUTES') }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
             steps {
-                dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {
@@ -46,17 +41,20 @@ pipeline {
                         }
                     }
                 }
-            }
-        }
-        stage('Prepare') {
-            steps {
-                dir('tidb') {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    '''
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                 }
                 dir('tidb-test') {
-                    sh "git branch && git status"
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                         sh 'touch ws-${BUILD_TAG}'
                     }
@@ -71,12 +69,13 @@ pipeline {
                         values '1', '2', '3', '4'
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -87,28 +86,30 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                                     sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
                                 }
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                    sh 'ls mysql_test'
                                     dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
                                     }
                                 }
                             }
                         }
-                        post{
+                        post {
                             always {
-                                junit(testResults: "**/result.xml")
+                                junit(testResults: "**/result.xml", allowEmptyResults: true)
                             }
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
+                            success {
+                                script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_unit_test.groovy
@@ -3,19 +3,19 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 
 prow.setPRDescription(REFS)
-
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '200Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -26,30 +26,33 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
                 }
             }
         }
-        stage('Test') {
-            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
+        stage('Hotfix bazel deps URL (temporary)') {
             steps {
                 dir(REFS.repo) {
-                    sh """
-                        sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
-                        git diff .
-                        git status
-                    """
-                    sh '''#! /usr/bin/env bash
-                        set -o pipefail
-
-                        ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
-                        '''
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
+        stage('Test') {
+            environment { TIDB_CODECOV_TOKEN = credentials('codecov-token-tidb') }
+            steps {
+                dir(REFS.repo) {
+                    sh './build/jenkins_unit_test.sh'
                 }
             }
             post {
@@ -63,13 +66,7 @@ pipeline {
                 always {
                     dir(REFS.repo) {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
-                        archiveArtifacts(artifacts: 'bazel-test.log', fingerprint: false, allowEmptyArchive: true)
                     }
-                    sh label: "Parse flaky test case results", script: './scripts/plugins/analyze-go-test-from-bazel-output.sh tidb/bazel-test.log || true'
-                    script {
-                        prow.sendTestCaseRunReport("${REFS.org}/${REFS.repo}", "${REFS.base_ref}")
-                    }
-                    archiveArtifacts(artifacts: 'bazel-*.log, bazel-*.json', fingerprint: false, allowEmptyArchive: true)
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
@@ -5,28 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920231127"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
+        requests:
+          cpu: "2"
+          memory: 16Gi
+          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "16"
+          ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-        - mountPath: /share/.cache/bazel-repository-cache
-          name: bazel-repository-cache
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -39,25 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
-    - name: bazel-repository-cache
-      persistentVolumeClaim:
-        claimName: bazel-repository-cache
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:
@@ -86,7 +77,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml
@@ -5,10 +5,13 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920231127"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
@@ -16,23 +19,9 @@ spec:
         limits:
           memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,22 +34,11 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
@@ -5,28 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920231127"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
+        requests:
+          memory: 8Gi
+          cpu: "2"
+          ephemeral-storage: 20Gi
         limits:
           memory: 32Gi
           cpu: "8"
+          ephemeral-storage: 120Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-        - mountPath: /share/.cache/bazel-repository-cache
-          name: bazel-repository-cache
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -39,7 +36,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:
@@ -48,27 +45,20 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
-
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
-    - name: bazel-repository-cache
-      persistentVolumeClaim:
-        claimName: bazel-repository-cache
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:
@@ -97,7 +87,3 @@ spec:
                 operator: In
                 values:
                   - amd64
-              - key: ci-nvme-high-performance
-                operator: In
-                values:
-                  - "true"

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:
@@ -14,23 +14,6 @@ spec:
         limits:
           memory: 6Gi
           cpu: "3"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
@@ -5,30 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      # TODO(wuhuizuo): using standard bazel build image to shrink the image size
-      # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920231127"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 48Gi
+          cpu: "24"
+          ephemeral-storage: 20Gi
+        limits:
+          memory: 64Gi
+          cpu: "24"
+          ephemeral-storage: 300Gi
       volumeMounts:
-        - mountPath: /share/.cache/bazel-repository-cache
-          name: bazel-repository-cache
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -41,25 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-repository-cache
-      persistentVolumeClaim:
-        claimName: bazel-repository-cache
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_build.groovy
@@ -8,12 +8,14 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.6/pod-ghpr_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -26,18 +28,19 @@ pipeline {
             parallel {
                 stage('tidb') {
                     steps {
-                        dir('tidb') {
-                            cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                                retry(2) {
-                                    script {
-                                        prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                                    }
-                                }
+                        dir(REFS.repo) {
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                             }
                         }
                     }
                 }
                 stage("enterprise-plugin") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         dir("enterprise-plugin") {
                             cache(path: "./", includes: '**/*', key: "git/pingcap-inc/enterprise-plugin/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap-inc/enterprise-plugin/rev-']) {
@@ -52,21 +55,35 @@ pipeline {
                 }
             }
         }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
         stage("Build tidb-server and plugin"){
             parallel {
                 stage("Build tidb-server") {
                     stages {
                         stage("Build"){
                             steps {
-                                dir("tidb") {
+                                dir(REFS.repo) {
                                     sh "make bazel_build"
                                 }
                             }
                             post {
-                                // TODO: statics and report logic should not put in pipelines.
-                                // Instead should only send a cloud event to a external service.
                                 always {
-                                    dir("tidb") {
+                                    dir(REFS.repo) {
                                         archiveArtifacts(
                                             artifacts: 'importer.log,tidb-server-check.log',
                                             allowEmptyArchive: true,
@@ -78,9 +95,14 @@ pipeline {
                     }
                 }
                 stage("Build plugins") {
+                    when {
+                        expression {
+                            return REFS.base_ref !=~ /^feature[\/_].*/
+                        }
+                    }
                     steps {
                         timeout(time: 15, unit: 'MINUTES') {
-                            sh label: 'build pluginpkg tool', script: 'cd tidb/cmd/pluginpkg && go build'
+                            sh label: 'build pluginpkg tool', script: "cd ${REFS.repo}/cmd/pluginpkg && go build"
                         }
                         dir('enterprise-plugin/whitelist') {
                             sh label: 'build plugin whitelist', script: '''

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_check.groovy
@@ -6,16 +6,21 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.6/pod-ghpr_check.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        CI = "1"
     }
     options {
         timeout(time: 30, unit: 'MINUTES')
@@ -24,21 +29,32 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
                 }
             }
         }
-        stage("Checks") {
-            // !!! concurrent go builds will encounter conflicts probabilistically.
+        stage('Hotfix bazel deps URL (temporary)') {
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
+                }
+            }
+        }
+        stage("Checks") {
+            steps {
+                dir(REFS.repo) {
                     sh script: 'make gogenerate check explaintest'
                 }
             }

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
@@ -6,59 +6,63 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 
+prow.setPRDescription(REFS)
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     environment {
         OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     stages {
-        stage('Checkout') {
-            steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
-                    }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage("Prepare") {
             steps {
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || go build -o bin/tidb-server ./tidb-server'
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
+                    }
+                    cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS)) {
+                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                     container("utils") {
                         dir("bin") {
-                            retry(3) {
-                                sh label: 'download tidb components', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                """
+                            script {
+                                retry(2) {
+                                    sh label: "download tidb components", script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                    """
+                                }
                             }
                         }
                     }
-                    // cache it for other pods
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                         sh """
-                            mv bin/tidb-server bin/explain_test_tidb-server
+                            mv bin/tidb-server bin/integration_test_tidb-server
                             touch rev-${REFS.pulls[0].sha}
                         """
                     }
@@ -71,23 +75,34 @@ pipeline {
                     axis {
                         name 'SCRIPT_AND_ARGS'
                         values(
-                            'integrationtest.sh y',
-                            'integrationtest.sh n',
+                            'integrationtest_with_tikv.sh y',
+                            'integrationtest_with_tikv.sh n',
                             'run_real_tikv_tests.sh bazel_brietest',
                             'run_real_tikv_tests.sh bazel_pessimistictest',
                             'run_real_tikv_tests.sh bazel_sessiontest',
                             'run_real_tikv_tests.sh bazel_statisticstest',
                             'run_real_tikv_tests.sh bazel_txntest',
                             'run_real_tikv_tests.sh bazel_addindextest',
+                            'run_real_tikv_tests.sh bazel_addindextest1',
+                            'run_real_tikv_tests.sh bazel_addindextest2',
+                            'run_real_tikv_tests.sh bazel_addindextest3',
+                            'run_real_tikv_tests.sh bazel_addindextest4',
+                            'run_real_tikv_tests.sh bazel_importintotest',
+                            'run_real_tikv_tests.sh bazel_importintotest2',
+                            'run_real_tikv_tests.sh bazel_importintotest3',
+                            'run_real_tikv_tests.sh bazel_importintotest4',
+                            'run_real_tikv_tests.sh bazel_pipelineddmltest',
+                            'run_real_tikv_tests.sh bazel_flashbacktest'
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -95,25 +110,61 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
-                        options { timeout(time: 30, unit: 'MINUTES') }
+                    stage('Test') {
+                        environment {
+                            CODECOV_TOKEN = credentials('codecov-token-tidb')
+                        }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
+                                    sh "ls -l rev-${REFS.pulls[0].sha}"
                                 }
-
+                                sh '''#!/usr/bin/env bash
+                                    set -euxo pipefail
+                                    if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
+                                        for f in WORKSPACE DEPS.bzl; do
+                                          [ -f "$f" ] || continue
+                                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                                        done
+                                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                                    fi
+                                '''
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
+                                sh """
+                                git diff .
+                                git status
+                                """
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }
                         post {
-                            failure {
-                                dir("checks-collation-enabled") {
-                                    archiveArtifacts(artifacts: 'pd*.log, tikv*.log, explain-test.out', allowEmptyArchive: true)
+                            always {
+                                dir(REFS.repo) {
+                                    junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                                 }
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) } }
+                            unsuccessful {
+                                dir(REFS.repo) {
+                                    sh label: "archive log", script: """
+                                    str="$SCRIPT_AND_ARGS"
+                                    logs_dir="logs_\${str// /_}"
+                                    mkdir -p \${logs_dir}
+                                    mv pd*.log \${logs_dir} || true
+                                    mv tikv*.log \${logs_dir} || true
+                                    mv tests/integrationtest/integration-test.out \${logs_dir} || true
+                                    tar -czvf \${logs_dir}.tar.gz \${logs_dir} || true
+                                    """
+                                    archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
+                                }
+                            }
+                            success {
+                                dir(REFS.repo) {
+                                    script {
+                                        prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
+                                    }
+                                }
+                                script { matrixCache.markDone(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
@@ -84,18 +84,19 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir(REFS.repo) {
-                                cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
-                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                            timeout(time: 25, unit: 'MINUTES') {
+                                dir(REFS.repo) {
+                                    cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
+                                        sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
+                                    }
                                 }
-                            }
-                            dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test'
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                dir('tidb-test') {
+                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
+                                        sh 'ls mysql_test'
+                                        dir('mysql_test') {
+                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
+                                        }
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
@@ -8,31 +8,28 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.6/pod-ghpr_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
-// TODO(wuhuizuo): tidb-test should delivered by docker image.
+prow.setPRDescription(REFS)
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
+    agent none
     options {
         timeout(time: 40, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 10, unit: 'MINUTES') }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
             steps {
-                dir("tidb") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
                 dir("tidb-test") {
@@ -44,17 +41,20 @@ pipeline {
                         }
                     }
                 }
-            }
-        }
-        stage('Prepare') {
-            steps {
-                dir('tidb') {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    '''
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                 }
                 dir('tidb-test') {
-                    sh "git branch && git status"
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
                         sh 'touch ws-${BUILD_TAG}'
                     }
@@ -69,12 +69,13 @@ pipeline {
                         values '1', '2', '3', '4'
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '100Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -85,28 +86,30 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 25, unit: 'MINUTES') }
                         steps {
-                            dir('tidb') {
+                            dir(REFS.repo) {
                                 cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                                     sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server'
                                 }
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                    sh 'ls mysql_test'
                                     dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
                                     }
                                 }
                             }
                         }
-                        post{
+                        post {
                             always {
-                                junit(testResults: "**/result.xml")
+                                junit(testResults: "**/result.xml", allowEmptyResults: true)
                             }
                             failure {
                                 archiveArtifacts(artifacts: 'tidb-test/mysql_test/mysql-test.out*', allowEmptyArchive: true)
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } }
+                            success {
+                                script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) }
+                            }
                         }
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_unit_test.groovy
@@ -3,17 +3,19 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tidb"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'pingcap/tidb'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb/release-6.6/pod-ghpr_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final GIT_CREDENTIALS_ID = ''
 
+prow.setPRDescription(REFS)
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '200Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -23,38 +25,46 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                dir('tidb') {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID)
-                            }
-                        }
+                dir(REFS.repo) {
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
                     }
+                }
+            }
+        }
+        stage('Hotfix bazel deps URL (temporary)') {
+            steps {
+                dir(REFS.repo) {
+                    sh '''#!/usr/bin/env bash
+                    set -euxo pipefail
+                    for f in WORKSPACE DEPS.bzl; do
+                      [ -f "$f" ] || continue
+                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
+                    done
+                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
+                    grep -n '^check:' Makefile | head -n 3 || true
+                    '''
                 }
             }
         }
         stage('Test') {
             environment { TIDB_CODECOV_TOKEN = credentials('codecov-token-tidb') }
             steps {
-                dir('tidb') {
+                dir(REFS.repo) {
                     sh './build/jenkins_unit_test.sh'
                 }
             }
             post {
-                 success {
-                    dir("tidb") {
-                        sh label: "upload coverage to codecov", script: """
-                        mv coverage.dat test_coverage/coverage.dat
-                        wget -q -O codecov https://uploader.codecov.io/v0.5.0/linux/codecov
-                        chmod +x codecov
-                        ./codecov --flags unit --dir test_coverage/ --token ${TIDB_CODECOV_TOKEN} --pr ${REFS.pulls[0].number} --sha ${REFS.pulls[0].sha} --branch origin/pr/${REFS.pulls[0].number}
-                        """
+                success {
+                    dir(REFS.repo) {
+                        script {
+                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage.dat')
+                        }
                     }
                 }
                 always {
-                    dir('tidb') {
-                        // archive test report to Jenkins.
+                    dir(REFS.repo) {
                         junit(testResults: "**/bazel.xml", allowEmptyResults: true)
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_build.yaml
@@ -5,31 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920230207"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
+        requests:
+          cpu: "2"
+          memory: 16Gi
+          ephemeral-storage: 20Gi
         limits:
-          memory: 24Gi
-          cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          memory: 64Gi
+          cpu: "16"
+          ephemeral-storage: 150Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -42,22 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check.yaml
@@ -5,10 +5,13 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920230207"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi
@@ -16,23 +19,9 @@ spec:
         limits:
           memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,22 +34,11 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
       emptyDir: {}
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_check2.yaml
@@ -5,31 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920230207"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
+        requests:
+          memory: 8Gi
+          cpu: "2"
+          ephemeral-storage: 20Gi
         limits:
           memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          ephemeral-storage: 120Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -42,7 +36,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:
@@ -51,24 +45,20 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
-
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 150Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:
@@ -14,23 +14,6 @@ spec:
         limits:
           memory: 6Gi
           cpu: "3"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.6/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.6/pod-ghpr_unit_test.yaml
@@ -5,33 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      # TODO(wuhuizuo): using standard bazel build image to shrink the image size
-      # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920230207"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
       securityContext:
         privileged: true
       tty: true
+      env:
+        - name: GOPROXY
+          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
+          memory: 48Gi
+          cpu: "24"
+          ephemeral-storage: 20Gi
+        limits:
+          memory: 64Gi
+          cpu: "24"
+          ephemeral-storage: 300Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -44,22 +36,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:

--- a/prow-jobs/pingcap/tidb/release-6.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.1-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -20,7 +20,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/ghpr_check
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -31,7 +31,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/ghpr_check2
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -42,7 +42,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -53,7 +53,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -64,7 +64,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -77,7 +77,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -90,7 +90,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_integration_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -102,7 +102,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -115,7 +115,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_e2e_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -128,7 +128,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -141,7 +141,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -154,7 +154,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -167,7 +167,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_tiflash_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -180,7 +180,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_integration_tidb_tools_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -193,7 +193,7 @@ presubmits:
     - name: pingcap/tidb/release-6.1/pull_integration_binlog_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-6.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.2-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     - name: pingcap/tidb/release-6.2/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -17,7 +17,7 @@ presubmits:
     - name: pingcap/tidb/release-6.2/ghpr_check
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -28,7 +28,7 @@ presubmits:
     - name: pingcap/tidb/release-6.2/ghpr_check2
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -39,7 +39,7 @@ presubmits:
     - name: pingcap/tidb/release-6.2/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -50,7 +50,7 @@ presubmits:
     - name: pingcap/tidb/release-6.2/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test

--- a/prow-jobs/pingcap/tidb/release-6.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.3-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     - name: pingcap/tidb/release-6.3/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -16,7 +16,7 @@ presubmits:
     - name: pingcap/tidb/release-6.3/ghpr_check
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -27,7 +27,7 @@ presubmits:
     - name: pingcap/tidb/release-6.3/ghpr_check2
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -38,7 +38,7 @@ presubmits:
     - name: pingcap/tidb/release-6.3/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -49,7 +49,7 @@ presubmits:
     - name: pingcap/tidb/release-6.3/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test

--- a/prow-jobs/pingcap/tidb/release-6.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.4-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     - name: pingcap/tidb/release-6.4/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -16,7 +16,7 @@ presubmits:
     - name: pingcap/tidb/release-6.4/ghpr_check
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -27,7 +27,7 @@ presubmits:
     - name: pingcap/tidb/release-6.4/ghpr_check2
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -38,7 +38,7 @@ presubmits:
     - name: pingcap/tidb/release-6.4/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -49,7 +49,7 @@ presubmits:
     - name: pingcap/tidb/release-6.4/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test

--- a/prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -22,7 +22,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_check
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -33,7 +33,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_check2
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -44,7 +44,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -55,7 +55,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -66,7 +66,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -79,7 +79,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -92,7 +92,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -104,7 +104,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -117,7 +117,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -130,7 +130,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_e2e_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -143,7 +143,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -156,7 +156,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -169,7 +169,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -182,7 +182,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_tiflash_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -195,7 +195,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_tidb_tools_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -208,7 +208,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_binlog_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-6.6-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.6-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap/tidb/release-6.6/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -15,7 +15,7 @@ presubmits:
     - name: pingcap/tidb/release-6.6/ghpr_check
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -26,7 +26,7 @@ presubmits:
     - name: pingcap/tidb/release-6.6/ghpr_check2
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -37,7 +37,7 @@ presubmits:
     - name: pingcap/tidb/release-6.6/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -48,7 +48,7 @@ presubmits:
     - name: pingcap/tidb/release-6.6/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test


### PR DESCRIPTION
## Summary
- migrate TiDB release-6.1 to release-6.6 ghpr pipeline implementations and pod templates to the cloud runner pattern
- replace IDC PVC-based pod templates with GCP-compatible workspace and ephemeral volume wiring
- align checkout and replay path with the cloud-compatible Jenkins pipeline structure used on newer branches

## Validation
- Jenkins pipeline lint for modified release-6.1 to release-6.6 ghpr Groovy files
- YAML parse for modified pod templates
- replay validation for release-6.5 ghpr jobs will be added in follow-up updates on this PR
