### PR TITLE
ci(pingcap/tiproxy): migrate tiproxy jenkins jobs to GCP

### DIFF
--- a/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -91,9 +92,10 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'golang'
                     }
                 }
                 when {

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -89,9 +90,10 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        defaultContainer 'python'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'python'
                     }
                 }
                 when {

--- a/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -89,9 +90,10 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'golang'
                     }
                 }
                 when {

--- a/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -93,8 +94,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -138,8 +140,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_jdbc_test.yaml
@@ -5,27 +5,27 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 8Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_integration_python_orm_test.yaml
@@ -5,26 +5,26 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: python
-      image: "hub.pingcap.net/jenkins/django-tidb-test:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/django-tidb-test:latest"
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_mysql_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_mysql_test.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-merged_sqllogic_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-merged_sqllogic_test.yaml
@@ -3,21 +3,38 @@ kind: Pod
 spec:
   securityContext:
     fsGroup: 1000
+  initContainers:
+    - name: download-sqllogic
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      command:
+        - /bin/sh
+        - -c
+        - |
+          cd /git && \
+          oras pull us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/case-data/sqllogic:v20241212 && \
+          tar xzf sqllogictest_v20241212.tar.gz && \
+          rm sqllogictest_v20241212.tar.gz
+      volumeMounts:
+        - name: test-data
+          mountPath: /git
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
+      volumeMounts:
+        - name: test-data
+          mountPath: /git
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       tty: true
       resources:
         requests:
@@ -26,6 +43,12 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+      volumeMounts:
+        - name: test-data
+          mountPath: /git
+  volumes:
+    - name: test-data
+      emptyDir: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_common_test.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_jdbc_test.yaml
@@ -5,27 +5,27 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 8Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_nodejs_test.yaml
@@ -5,14 +5,14 @@ spec:
     runAsUser: 0
   containers:
     - name: nodejs
-      image: "hub.pingcap.net/ee/ci/base:v20230810-go1.23.0"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_python_orm_test.yaml
@@ -5,24 +5,24 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: python
-      image: "hub.pingcap.net/jenkins/django-tidb-test:latest"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/django-tidb-test:latest"
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_ruby_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_ruby_orm_test.yaml
@@ -5,27 +5,36 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: ruby
-      image: "hub.pingcap.net/jenkins/ruby27:latest"
+      image: "docker.io/library/ruby:2.7"
       tty: true
+      env:
+        - name: GEM_HOME
+          value: /tmp/rubygems
+        - name: BUNDLE_PATH
+          value: /tmp/rubygems
+        - name: BUNDLE_SILENCE_ROOT_WARNING
+          value: "1"
+        - name: PATH
+          value: /tmp/rubygems/bin:/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 8Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_integration_ruby_orm_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_integration_ruby_orm_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 24Gi
           cpu: "6"
     - name: ruby
-      image: "docker.io/library/ruby:2.7"
+      image: "us-docker.pkg.dev/pingcap-testing-account/dockerhub-remote/ruby:2.7"
       tty: true
       env:
         - name: GEM_HOME

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_connector_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_connector_test.yaml
@@ -5,29 +5,29 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-with-gcc11:1.23"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 1Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: mysql-client-test
-      image: "hub.pingcap.net/tiproxy-team/mysql-client-test"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/tiproxy-team/mysql-client-test:latest"
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 1Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 16Gi
-          cpu: "8"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_mysql_test.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tiproxy/latest/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tiproxy/latest/pod-pull_sqllogic_test.yaml
@@ -3,19 +3,36 @@ kind: Pod
 spec:
   securityContext:
     fsGroup: 1000
+  initContainers:
+    - name: download-sqllogic
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      command:
+        - /bin/sh
+        - -c
+        - |
+          cd /git && \
+          oras pull us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/case-data/sqllogic:v20241212 && \
+          tar xzf sqllogictest_v20241212.tar.gz && \
+          rm sqllogictest_v20241212.tar.gz
+      volumeMounts:
+        - name: test-data
+          mountPath: /git
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
+      volumeMounts:
+        - name: test-data
+          mountPath: /git
     - name: utils
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       tty: true
       resources:
         requests:
@@ -24,6 +41,12 @@ spec:
         limits:
           cpu: "1"
           memory: 4Gi
+      volumeMounts:
+        - name: test-data
+          mountPath: /git
+  volumes:
+    - name: test-data
+      emptyDir: {}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -92,9 +93,10 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'golang'
                     }
                 }
                 when {

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -91,9 +92,10 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'golang'
                     }
                 }
                 when {

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'nodejs'
         }
     }
@@ -90,8 +91,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'nodejs'
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -89,8 +90,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'python'
                     }
                 }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -89,9 +90,10 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        defaultContainer 'ruby'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'ruby'
                     }
                 }
                 when {
@@ -104,6 +106,25 @@ pipeline {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                                     container("ruby") {
+                                        sh label: "prepare ruby test deps", script: """
+                                            #!/usr/bin/env bash
+                                            set -euxo pipefail
+                                            if ! command -v mysql >/dev/null 2>&1 || ! dpkg-query -W default-libmysqlclient-dev >/dev/null 2>&1 || ! dpkg-query -W libsqlite3-dev >/dev/null 2>&1; then
+                                                apt-get update
+                                                DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \\
+                                                    default-mysql-client \\
+                                                    build-essential \\
+                                                    default-libmysqlclient-dev \\
+                                                    libsqlite3-dev \\
+                                                    pkg-config
+                                                rm -rf /var/lib/apt/lists/*
+                                            fi
+                                            if ! gem list -i bundler -v 2.3.17 >/dev/null 2>&1; then
+                                                gem install bundler -v 2.3.17
+                                            fi
+                                            command -v mysql
+                                            bundle -v
+                                        """
                                         sh label: "test_cmds=${TEST_CMDS} ", script: """
                                             #!/usr/bin/env bash
                                             ${TEST_CMDS}

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_connector_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_connector_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -89,9 +90,10 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                        defaultContainer 'golang'
                     }
                 }
                 when {

--- a/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -94,8 +95,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -139,8 +141,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/prow-jobs/pingcap/tiproxy/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiproxy/latest-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: pingcap/tiproxy/merged_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-mysql-test # need change this.
@@ -15,7 +15,7 @@ postsubmits:
     - name: pingcap/tiproxy/merged_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-python-orm-test # need change this.
@@ -26,7 +26,7 @@ postsubmits:
     - name: pingcap/tiproxy/merged_sqllogic_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-sqllogic-test # need change this.
@@ -37,7 +37,7 @@ postsubmits:
     - name: pingcap/tiproxy/merged_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-jdbc-test # need change this.

--- a/prow-jobs/pingcap/tiproxy/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiproxy/latest-presubmits.yaml
@@ -112,7 +112,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_mysql_connector_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -126,7 +126,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-mysql-test
@@ -139,7 +139,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-jdbc-test # need change this.
@@ -152,7 +152,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-common-test # need change this.
@@ -164,7 +164,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_ruby_orm_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-ruby-orm-test # need change this.
@@ -176,7 +176,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-nodejs-test
@@ -189,7 +189,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-python-orm-test
@@ -202,7 +202,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-sqllogic-test


### PR DESCRIPTION
Issue Number ref : https://github.com/PingCAP-QE/ci/issues/4678

### Replay Test
- https://prow.tidb.net/jenkins/job/pingcap/job/tiproxy/job/merged_integration_jdbc_test/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiproxy/job/merged_integration_python_orm_test/2/stages/ 
- https://prow.tidb.net/jenkins/job/pingcap/job/tiproxy/job/merged_mysql_test/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiproxy/job/merged_sqllogic_test/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiproxy/job/pull_mysql_connector_test/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap/job/tiproxy/job/pull_mysql_test/2/stages/