### PR TITLE
ci(tekton): replace internal2-do.pingcap.net/dl with prow.tidb.net/dl

### DIFF
--- a/tekton/v1/tasks/release/pingcap-upload-enterprise-plugins.yaml
+++ b/tekton/v1/tasks/release/pingcap-upload-enterprise-plugins.yaml
@@ -30,7 +30,7 @@ spec:
         - name: FILE_SERVER_URL
           value: "http://fileserver.pingcap.net"
         - name: DL_SERVER_URL
-          value: "https://internal2-do.pingcap.net/dl"
+          value: "https://prow.tidb.net/dl"
       script: |
         #!/usr/bin/env bash
         set -e

--- a/tekton/v1/tasks/release/pingcap-upload-offline-package.yaml
+++ b/tekton/v1/tasks/release/pingcap-upload-offline-package.yaml
@@ -54,7 +54,7 @@ spec:
         bucket_name=$(cat $(workspaces.s3-secrets.path)/bucket_name)
 
         repo="$(params.oci-repo)"
-        dl_svr_url="https://internal2-do.pingcap.net/dl"
+        dl_svr_url="https://prow.tidb.net/dl"
         FILE_SERVER_URL="http://fileserver.pingcap.net"
 
         tag="$(params.version)-$(params.edition)_$(params.os)_$(params.arch)"


### PR DESCRIPTION
## Summary

Replace all occurrences of `internal2-do.pingcap.net/dl` with `prow.tidb.net/dl` in Tekton task definitions.

## Changes

- `tekton/v1/tasks/release/pingcap-upload-offline-package.yaml`: Replace `dl_svr_url` value
- `tekton/v1/tasks/release/pingcap-upload-enterprise-plugins.yaml`: Replace `DL_SERVER_URL` env value

## Testing

- Verified no other occurrences of `internal-do.pingcap.net/dl` or `internal2-do.pingcap.net/dl` in the ci repo

## Risk

Low - simple string replacement in CI configuration files. No functional logic changes.

Refs: FLA-200
