### PR TITLE
ci(pingcap-qe/tidb-test): migrate jenkins jobs to GCP

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_build/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_build/pipeline.groovy
@@ -13,8 +13,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_build/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_build/pod.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -15,10 +15,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -86,8 +90,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'java'
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pod.yaml
@@ -5,25 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 8Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -15,10 +15,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -87,8 +91,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pod.yaml
@@ -5,14 +5,14 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -15,10 +15,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -91,8 +95,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'java'
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pod.yaml
@@ -5,25 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 8Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -15,10 +15,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')
@@ -88,8 +92,9 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pod.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -14,9 +14,13 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -86,8 +90,9 @@ pipeline {
                 agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'nodejs'
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pod.yaml
@@ -5,14 +5,14 @@ spec:
     runAsUser: 0
   containers:
     - name: nodejs
-      image: "hub.pingcap.net/ee/ci/base:v20230810-go1.23.0"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -15,10 +15,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -86,8 +90,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'python'
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pod.yaml
@@ -5,24 +5,24 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: python
-      image: "hub.pingcap.net/jenkins/django-tidb-test:latest"
+      image: us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/django-tidb-test:latest
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
@@ -13,8 +13,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -71,8 +72,9 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pod.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -18,13 +18,15 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
     environment {
         NEXT_GEN = '1'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -62,6 +64,12 @@ pipeline {
                     // Prepare component binaries.
                     dir('bin') {
                         container("utils") {
+                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                                sh label: "prepare docker auth", script: '''
+                                    mkdir -p ~/.docker
+                                    cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
+                                '''
+                            }
                             sh """
                                 script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
                                 chmod +x \$script
@@ -127,8 +135,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'java'
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pod.yaml
@@ -5,25 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 8Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -18,13 +18,15 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
     environment {
         NEXT_GEN = '1'
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')
@@ -62,6 +64,12 @@ pipeline {
                     // Prepare component binaries.
                     dir('bin') {
                         container("utils") {
+                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
+                                sh label: "prepare docker auth", script: '''
+                                    mkdir -p ~/.docker
+                                    cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
+                                '''
+                            }
                             sh """
                                 script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
                                 chmod +x \$script
@@ -92,8 +100,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pod.yaml
@@ -5,15 +5,15 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -13,10 +13,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')
@@ -89,8 +93,9 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pod.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -13,10 +13,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')
@@ -88,8 +92,9 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pod.yaml
@@ -5,27 +5,27 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 8Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
@@ -13,10 +13,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pod.yaml
@@ -5,29 +5,29 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-with-gcc11:1.23"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: mysql-client-test
-      image: "hub.pingcap.net/tiproxy-team/mysql-client-test"
+      image: us-docker.pkg.dev/pingcap-testing-account/internal/test/tiproxy-team/mysql-client-test:latest
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 1Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 16Gi
-          cpu: "8"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -13,10 +13,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')
@@ -86,8 +90,9 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pod.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -13,10 +13,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')
@@ -86,8 +90,9 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'ruby'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {
@@ -100,6 +105,25 @@ pipeline {
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
                                     container("ruby") {
+                                        sh label: "prepare ruby test deps", script: """
+                                            #!/usr/bin/env bash
+                                            set -euxo pipefail
+                                            if ! command -v mysql >/dev/null 2>&1 || ! dpkg-query -W default-libmysqlclient-dev >/dev/null 2>&1 || ! dpkg-query -W libsqlite3-dev >/dev/null 2>&1; then
+                                                apt-get update
+                                                DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \\
+                                                    default-mysql-client \\
+                                                    build-essential \\
+                                                    default-libmysqlclient-dev \\
+                                                    libsqlite3-dev \\
+                                                    pkg-config
+                                                rm -rf /var/lib/apt/lists/*
+                                            fi
+                                            if ! gem list -i bundler -v 2.3.17 >/dev/null 2>&1; then
+                                                gem install bundler -v 2.3.17
+                                            fi
+                                            command -v mysql
+                                            bundle -v
+                                        """
                                         sh label: "test_cmds=${TEST_CMDS} ", script: """
                                             #!/usr/bin/env bash
                                             ${TEST_CMDS}

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pod.yaml
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pod.yaml
@@ -5,27 +5,36 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: ruby
-      image: "hub.pingcap.net/jenkins/ruby27:latest"
+      image: us-docker.pkg.dev/pingcap-testing-account/dockerhub-remote/ruby:2.7
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 8Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: "6"
+      env:
+        - name: GEM_HOME
+          value: /tmp/rubygems
+        - name: BUNDLE_PATH
+          value: /tmp/rubygems
+        - name: BUNDLE_SILENCE_ROOT_WARNING
+          value: "1"
+        - name: PATH
+          value: /tmp/rubygems/bin:/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_build.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_build.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
@@ -14,10 +14,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -85,8 +89,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'java'
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
@@ -14,10 +14,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -86,8 +90,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
@@ -14,10 +14,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -90,8 +94,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'java'
                     }
                 }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
@@ -14,10 +14,14 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 45, unit: 'MINUTES')
@@ -87,8 +91,9 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -70,8 +71,9 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_build.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_common_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_common_test.yaml
@@ -5,25 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 8Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_integration_common_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_integration_common_test.yaml
@@ -5,14 +5,14 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_integration_jdbc_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_integration_jdbc_test.yaml
@@ -5,25 +5,25 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: "3"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
-          memory: 8Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_integration_mysql_test.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/pod-ghpr_mysql_test.yaml
@@ -5,17 +5,17 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/prow-jobs/pingcap-qe/tidb-test/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/latest-presubmits-next-gen.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_integration_jdbc_test_next_gen
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false
       optional: true
       branches:
@@ -18,7 +18,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_mysql_test_next_gen
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false
       optional: true
       run_if_changed: "mysql_test/.*"

--- a/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build
@@ -17,7 +17,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|jdbc_test)/.*"
       context: ci/common-test
@@ -29,7 +29,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|mybatis_test|jooq_test|tidb_jdbc_test)/.*"
       context: ci/integration-jdbc-test
@@ -41,7 +41,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_integration_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       run_if_changed: "randgen-test/.*"
       context: ci/integration-common-test
@@ -53,7 +53,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_integration_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test
@@ -65,7 +65,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test
@@ -77,7 +77,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       context: ci/integration-nodejs-test
@@ -89,7 +89,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       context: ci/integration-python-orm-test
@@ -101,7 +101,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_tiproxy_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -114,7 +114,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_tiproxy_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -127,7 +127,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_tiproxy_jdbc_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -140,7 +140,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_tiproxy_ruby_orm_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -153,7 +153,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_tiproxy_mysql_connector_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap-qe/tidb-test/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/release-8.5-presubmits.yaml
@@ -6,7 +6,7 @@ global_definitions:
     agent: jenkins
     decorate: false # need add this.
     labels:
-      master: "0"
+      master: "1"
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:


### PR DESCRIPTION
Issue Number ref : https://github.com/PingCAP-QE/ci/issues/4678

### Replay Test
- https://prow.tidb.net/jenkins/job/pingcap-qe/job/tidb-test/job/ghpr_build/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap-qe/job/tidb-test/job/ghpr_common_test/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap-qe/job/tidb-test/job/ghpr_integration_jdbc_test/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap-qe/job/tidb-test/job/ghpr_integration_python_orm_test/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap-qe/job/tidb-test/job/pull_integration_jdbc_test_next_gen/3/stages/
- https://prow.tidb.net/jenkins/job/pingcap-qe/job/tidb-test/job/release-8.5/job/ghpr_build/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap-qe/job/tidb-test/job/release-8.5/job/ghpr_common_test/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap-qe/job/tidb-test/job/release-8.5/job/ghpr_integration_common_test/2/stages/
- https://prow.tidb.net/jenkins/job/pingcap-qe/job/tidb-test/job/release-8.5/job/ghpr_integration_jdbc_test/2/stages/