### PR TITLE
refactor(tekton): split tidbx trigger and add tag filter for ops

### DIFF
--- a/tekton/v1/tasks/delivery/pingcap-notify-to-update-ops-tidbx.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-notify-to-update-ops-tidbx.yaml
@@ -44,8 +44,11 @@ spec:
       when:
         - input: "$(params.stage)"
           operator: in
-          values: ["prod"]
-      args: ["$(params.stage)", "$(params.images)", "/workspace/ops-tickets.txt"]
+          values: ["prod", "dev"]
+      args:
+        - "$(params.stage)"
+        - "$(params.images)"
+        - /workspace/ops-tickets.txt
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -206,7 +209,11 @@ spec:
         main "$@"
 
     - name: notify-in-lark-channel
-      args: ["$(params.stage)", "$(params.images)", "$(params.target_images)", "/workspace/ops-tickets.txt"]
+      args:
+        - "$(params.stage)"
+        - "$(params.images)"
+        - "$(params.target_images)"
+        - /workspace/ops-tickets.txt
       script: |
         #!/usr/bin/env bash
         set -euo pipefail

--- a/tekton/v1/triggers/triggers/env-gcp/_/notify/update-ops-when-tidbx-image-distributed-to-clouds.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/notify/update-ops-when-tidbx-image-distributed-to-clouds.yaml
@@ -1,7 +1,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
-  name: notified-successful-image-delivery-cloud-tidbx
+  name: update-ops-when-tidbx-image-distributed-to-clouds
   labels:
     type: github-issue-comment
 spec:
@@ -10,10 +10,16 @@ spec:
       ref: { name: cel }
       params:
         - name: filter
+          # Filter conditions (all must pass):
+          # 1. Comment body contains a META JSON block (<!-- META={...} -->)
+          # 2. The META block has a non-empty "images" array
+          # 3. Every image tag matches one of: vX.Y.Z, vX.Y.Z-nextgen, vX.Y.Z-nextgen.YYYYMM.N
           value: >-
             body.comment.body.matches('<!--\\s*META={.+?\\s*-->')
             &&
             size(body.comment.body.split('<!--')[1].split('-->')[0].replace('META=', '').parseJSON().images) > 0
+            &&
+            body.comment.body.split('<!--')[1].split('-->')[0].replace('META=', '').parseJSON().images.all(img, img.matches('.*:v[0-9]+[.][0-9]+[.][0-9]+(-nextgen([.][0-9]{6}[.][0-9]+)?)?'))
         - name: overlays
           value:
             - key: images
@@ -56,13 +62,3 @@ spec:
               - name: ops-config
                 secret:
                   secretName: image-delivery-ops-config-tidbx
-        - apiVersion: tekton.dev/v1
-          kind: TaskRun
-          metadata:
-            generateName: pingcap-notify-to-add-image-records-to-tcms-
-          spec:
-            taskRef:
-              name: pingcap-notify-to-update-tcms-tidbx
-            params:
-              - name: images
-                value: $(tt.params.images)

--- a/tekton/v1/triggers/triggers/env-gcp/_/notify/update-tcms-when-tidbx-image-distributed-to-clouds.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/notify/update-tcms-when-tidbx-image-distributed-to-clouds.yaml
@@ -1,0 +1,40 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: update-tcms-when-tidbx-image-distributed-to-clouds
+  labels:
+    type: github-issue-comment
+spec:
+  interceptors:
+    - name: filter on github repo and comment content
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.comment.body.matches('<!--\\s*META={.+?\\s*-->')
+            &&
+            size(body.comment.body.split('<!--')[1].split('-->')[0].replace('META=', '').parseJSON().images) > 0
+        - name: overlays
+          value:
+            - key: images
+              expression: body.comment.body.split('<!--')[1].split('-->')[0].replace('META=', '').parseJSON().images.marshalJSON()
+
+  bindings:
+    - ref: github-issue-comment
+    - { name: images, value: $(extensions.images) }
+
+  template:
+    spec:
+      params:
+        - name: images
+      resourceTemplates:
+        - apiVersion: tekton.dev/v1
+          kind: TaskRun
+          metadata:
+            generateName: pingcap-notify-to-add-image-records-to-tcms-
+          spec:
+            taskRef:
+              name: pingcap-notify-to-update-tcms-tidbx
+            params:
+              - name: images
+                value: $(tt.params.images)

--- a/tekton/v1/triggers/triggers/env-gcp/kustomization.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/kustomization.yaml
@@ -14,8 +14,9 @@ resources:
   - _/github-pr-labeled-with-lgtm.yaml
   - _/github-pr-labeled-with-needs-ok-to-test.yaml
   - _/github-tag-build-community-linux-fts.yaml
-  - _/notify/notified-successful-image-delivery-cloud-tidbx.yaml
   - _/notify/notified-successful-image-delivery-tidbx.yaml
+  - _/notify/update-ops-when-tidbx-image-distributed-to-clouds.yaml
+  - _/notify/update-tcms-when-tidbx-image-distributed-to-clouds.yaml
   - pingcap-inc/ticdc/git-create-tag.yaml
   - pingcap-inc/ticdc/git-push.yaml
   - pingcap-inc/tici/git-create-tag.yaml


### PR DESCRIPTION
## Summary

Refactors the tidbx image delivery notification triggers to improve separation of concerns and add release-tag filtering.

## Changes

### 1. Split combined trigger into two focused triggers

The previous `notified-successful-image-delivery-cloud-tidbx` trigger spawned both an ops-update **and** a TCMS-update TaskRun in a single trigger. This meant both tasks shared the same filter conditions, which is not ideal — TCMS should record all image deliveries, but ops should only act on release images.

- **`update-ops-when-tidbx-image-distributed-to-clouds`** (renamed from `notified-successful-image-delivery-cloud-tidbx`)
  - Triggers `pingcap-notify-to-update-ops-tidbx` TaskRun
- **`update-tcms-when-tidbx-image-distributed-to-clouds`** (new)
  - Triggers `pingcap-notify-to-update-tcms-tidbx` TaskRun

### 2. Add image tag validation to ops trigger

The ops trigger now validates that **every** image tag matches one of:
- `vX.Y.Z` (e.g. `v7.5.1`)
- `vX.Y.Z-nextgen` (e.g. `v7.5.1-nextgen`)
- `vX.Y.Z-nextgen.YYYYMM.N` (e.g. `v7.5.1-nextgen.202601.1`)

Non-release tags (e.g. `v7.5.1-rc`, `latest`) are filtered out and will not trigger ops updates.

### 3. Enable ops update for dev stage

The `update-ops-config` step in `pingcap-notify-to-update-ops-tidbx` now runs for both `prod` and `dev` stages (previously only `prod`).

### 4. Update kustomization

`kustomization.yaml` updated to reference the two new trigger files and remove the old one.

## Files changed

| File | Change |
|------|--------|
| `tekton/v1/triggers/.../update-ops-when-tidbx-image-distributed-to-clouds.yaml` | Renamed + tag filter + split |
| `tekton/v1/triggers/.../update-tcms-when-tidbx-image-distributed-to-clouds.yaml` | New (TCMS extracted from old trigger) |
| `tekton/v1/tasks/delivery/pingcap-notify-to-update-ops-tidbx.yaml` | Enable dev stage |
| `tekton/v1/triggers/triggers/env-gcp/kustomization.yaml` | Update references |
