### PR TITLE
ci(prow): migrate docs postsubmit PDF upload from COS to GCS

### DIFF
--- a/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
@@ -36,7 +36,7 @@ postsubmits:
                 python3 scripts/merge_by_toc.py
                 scripts/generate_pdf.sh
 
-                export RCLONE_CONFIG_GCS_TYPE=google cloud storage
+                export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
                 export RCLONE_CONFIG_GCS_BUCKET=prow-tidb-logs
                 gcs_dst="gcs:artifacts/pdf"
                 case "${branch}" in

--- a/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
@@ -37,8 +37,7 @@ postsubmits:
                 scripts/generate_pdf.sh
 
                 export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
-                export RCLONE_CONFIG_GCS_BUCKET=prow-tidb-logs
-                gcs_dst="gcs:artifacts/pdf"
+                gcs_dst="gcs:prow-tidb-logs/artifacts/pdf"
                 case "${branch}" in
                   master)
                     version="dev"

--- a/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
@@ -36,7 +36,7 @@ postsubmits:
                 python3 scripts/merge_by_toc.py
                 scripts/generate_pdf.sh
 
-                dst="${TENCENTCLOUD_RCLONE_CONN:?missing TENCENTCLOUD_RCLONE_CONN}:${TENCENTCLOUD_BUCKET_ID:?missing TENCENTCLOUD_BUCKET_ID}/pdf"
+                gcs_dst="gs://prow-tidb-logs/artifacts/pdf"
                 case "${branch}" in
                   master)
                     version="dev"
@@ -53,18 +53,7 @@ postsubmits:
                     ;;
                 esac
 
-                rclone copyto --progress output.pdf "${dst}/tidb-${version}-zh-manual.pdf"
-            env:
-              - name: TENCENTCLOUD_RCLONE_CONN
-                valueFrom:
-                  secretKeyRef:
-                    name: docs-cn
-                    key: tencent-ak
-              - name: TENCENTCLOUD_BUCKET_ID
-                valueFrom:
-                  secretKeyRef:
-                    name: docs-cn
-                    key: tencent-bn
+                gsutil cp output.pdf "${gcs_dst}/tidb-${version}-zh-manual.pdf"
             resources:
               requests:
                 memory: 1Gi

--- a/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
@@ -36,7 +36,9 @@ postsubmits:
                 python3 scripts/merge_by_toc.py
                 scripts/generate_pdf.sh
 
-                gcs_dst="gs://prow-tidb-logs/artifacts/pdf"
+                export RCLONE_CONFIG_GCS_TYPE=google cloud storage
+                export RCLONE_CONFIG_GCS_BUCKET=prow-tidb-logs
+                gcs_dst="gcs:artifacts/pdf"
                 case "${branch}" in
                   master)
                     version="dev"
@@ -53,7 +55,7 @@ postsubmits:
                     ;;
                 esac
 
-                gsutil cp output.pdf "${gcs_dst}/tidb-${version}-zh-manual.pdf"
+                rclone copyto --progress output.pdf "${gcs_dst}/tidb-${version}-zh-manual.pdf"
             resources:
               requests:
                 memory: 1Gi

--- a/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
                 python3 scripts/merge_by_toc.py zh/
                 scripts/generate_pdf.sh
 
-                export RCLONE_CONFIG_GCS_TYPE=google cloud storage
+                export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
                 export RCLONE_CONFIG_GCS_BUCKET=prow-tidb-logs
                 gcs_dst="gcs:artifacts/pdf"
                 case "${branch}" in

--- a/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
@@ -36,8 +36,7 @@ postsubmits:
                 scripts/generate_pdf.sh
 
                 export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
-                export RCLONE_CONFIG_GCS_BUCKET=prow-tidb-logs
-                gcs_dst="gcs:artifacts/pdf"
+                gcs_dst="gcs:prow-tidb-logs/artifacts/pdf"
                 case "${branch}" in
                   main)
                     version="dev"

--- a/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
                 python3 scripts/merge_by_toc.py zh/
                 scripts/generate_pdf.sh
 
-                dst="${TENCENTCLOUD_RCLONE_CONN:?missing TENCENTCLOUD_RCLONE_CONN}:${TENCENTCLOUD_BUCKET_ID:?missing TENCENTCLOUD_BUCKET_ID}/pdf"
+                gcs_dst="gs://prow-tidb-logs/artifacts/pdf"
                 case "${branch}" in
                   main)
                     version="dev"
@@ -52,19 +52,8 @@ postsubmits:
                     ;;
                 esac
 
-                rclone copyto -P output_en.pdf "${dst}/tidb-in-kubernetes-${version}-en-manual.pdf"
-                rclone copyto -P output_zh.pdf "${dst}/tidb-in-kubernetes-${version}-zh-manual.pdf"
-            env:
-              - name: TENCENTCLOUD_RCLONE_CONN
-                valueFrom:
-                  secretKeyRef:
-                    name: docs-cn
-                    key: tencent-ak
-              - name: TENCENTCLOUD_BUCKET_ID
-                valueFrom:
-                  secretKeyRef:
-                    name: docs-cn
-                    key: tencent-bn
+                gsutil cp output_en.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-en-manual.pdf"
+                gsutil cp output_zh.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-zh-manual.pdf"
             resources:
               requests:
                 memory: 1Gi

--- a/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
@@ -35,7 +35,9 @@ postsubmits:
                 python3 scripts/merge_by_toc.py zh/
                 scripts/generate_pdf.sh
 
-                gcs_dst="gs://prow-tidb-logs/artifacts/pdf"
+                export RCLONE_CONFIG_GCS_TYPE=google cloud storage
+                export RCLONE_CONFIG_GCS_BUCKET=prow-tidb-logs
+                gcs_dst="gcs:artifacts/pdf"
                 case "${branch}" in
                   main)
                     version="dev"
@@ -52,8 +54,8 @@ postsubmits:
                     ;;
                 esac
 
-                gsutil cp output_en.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-en-manual.pdf"
-                gsutil cp output_zh.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-zh-manual.pdf"
+                rclone copyto -P output_en.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-en-manual.pdf"
+                rclone copyto -P output_zh.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-zh-manual.pdf"
             resources:
               requests:
                 memory: 1Gi

--- a/prow-jobs/pingcap/docs/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/latest-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
                   scripts/generate_cloud_pdf.sh
                 fi
 
-                dst="${TENCENTCLOUD_RCLONE_CONN:?missing TENCENTCLOUD_RCLONE_CONN}:${TENCENTCLOUD_BUCKET_ID:?missing TENCENTCLOUD_BUCKET_ID}/pdf"
+                gcs_dst="gs://prow-tidb-logs/artifacts/pdf"
                 case "${branch}" in
                   master)
                     version="dev"
@@ -58,21 +58,10 @@ postsubmits:
                     ;;
                 esac
 
-                rclone copyto --progress output.pdf "${dst}/tidb-${version}-en-manual.pdf"
+                gsutil cp output.pdf "${gcs_dst}/tidb-${version}-en-manual.pdf"
                 if [ -f output_cloud.pdf ]; then
-                  rclone copyto --progress output_cloud.pdf "${dst}/tidbcloud-en-manual.pdf"
+                  gsutil cp output_cloud.pdf "${gcs_dst}/tidbcloud-en-manual.pdf"
                 fi
-            env:
-              - name: TENCENTCLOUD_RCLONE_CONN
-                valueFrom:
-                  secretKeyRef:
-                    name: docs-cn
-                    key: tencent-ak
-              - name: TENCENTCLOUD_BUCKET_ID
-                valueFrom:
-                  secretKeyRef:
-                    name: docs-cn
-                    key: tencent-bn
             resources:
               requests:
                 memory: 1Gi

--- a/prow-jobs/pingcap/docs/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/latest-postsubmits.yaml
@@ -42,8 +42,7 @@ postsubmits:
                 fi
 
                 export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
-                export RCLONE_CONFIG_GCS_BUCKET=prow-tidb-logs
-                gcs_dst="gcs:artifacts/pdf"
+                gcs_dst="gcs:prow-tidb-logs/artifacts/pdf"
                 case "${branch}" in
                   master)
                     version="dev"

--- a/prow-jobs/pingcap/docs/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/latest-postsubmits.yaml
@@ -41,7 +41,9 @@ postsubmits:
                   scripts/generate_cloud_pdf.sh
                 fi
 
-                gcs_dst="gs://prow-tidb-logs/artifacts/pdf"
+                export RCLONE_CONFIG_GCS_TYPE=google cloud storage
+                export RCLONE_CONFIG_GCS_BUCKET=prow-tidb-logs
+                gcs_dst="gcs:artifacts/pdf"
                 case "${branch}" in
                   master)
                     version="dev"
@@ -58,9 +60,9 @@ postsubmits:
                     ;;
                 esac
 
-                gsutil cp output.pdf "${gcs_dst}/tidb-${version}-en-manual.pdf"
+                rclone copyto --progress output.pdf "${gcs_dst}/tidb-${version}-en-manual.pdf"
                 if [ -f output_cloud.pdf ]; then
-                  gsutil cp output_cloud.pdf "${gcs_dst}/tidbcloud-en-manual.pdf"
+                  rclone copyto --progress output_cloud.pdf "${gcs_dst}/tidbcloud-en-manual.pdf"
                 fi
             resources:
               requests:

--- a/prow-jobs/pingcap/docs/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/latest-postsubmits.yaml
@@ -41,7 +41,7 @@ postsubmits:
                   scripts/generate_cloud_pdf.sh
                 fi
 
-                export RCLONE_CONFIG_GCS_TYPE=google cloud storage
+                export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
                 export RCLONE_CONFIG_GCS_BUCKET=prow-tidb-logs
                 gcs_dst="gcs:artifacts/pdf"
                 case "${branch}" in


### PR DESCRIPTION
## Summary

Migrate PDF upload target for docs/docs-cn/docs-tidb-operator postsubmit ProwJobs from TencentCloud COS to same-region GCS bucket.

## Changes

- **docs/latest-postsubmits.yaml**: Replace rclone copyto to COS with gsutil cp to `gs://prow-tidb-logs/artifacts/pdf/`
- **docs-cn/latest-postsubmits.yaml**: Same change
- **docs-tidb-operator/latest-postsubmits.yaml**: Same change (both en/zh PDFs)

All three jobs:
- Remove `TENCENTCLOUD_RCLONE_CONN` and `TENCENTCLOUD_BUCKET_ID` environment variables
- Remove `docs-cn` K8s secret references
- Use `gsutil cp` which automatically picks up GCS credentials from `decorate: true`

## Testing

- Verify jobs run successfully after merge
- PDFs appear at `gs://prow-tidb-logs/artifacts/pdf/` with correct filenames

## Risk

Low. GCS credentials are auto-injected by Prow's `decorate: true`. No new secrets needed. Rollback is a simple revert.
