### PR TITLE
ci(prow): exclude hotfix branches from pull_syncdiff_integration_test

### DIFF
--- a/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
@@ -178,7 +178,8 @@ presubmits:
       context: pull-syncdiff-integration-test
       trigger: "(?m)^/test (?:.*? )?(pull-syncdiff-integration-test|all)(?: .*?)?$"
       rerun_command: "/test pull-syncdiff-integration-test"
-      branches: *branches
+      branches:
+        - ^release-8\.5(\.\d+)?$
 
     - name: pingcap/tiflow/release-8.5/ghpr_verify
       agent: jenkins


### PR DESCRIPTION
## Summary
Exclude hotfix branches from  CI job.

## Changes
- Modified : replaced shared  anchor with a specific branch filter  for the  job.

## Why
The shared  anchor regex  matches hotfix branches like . The  job should not run on hotfix branches.

## Testing
- Verified the new regex matches  and 
- Verified the new regex does NOT match 

## Risk
Low - only affects branch filtering for one CI job.