### PR TITLE
fix(pipelines): disable remote bazel cache for next-gen unit test

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pipeline.groovy
@@ -48,6 +48,17 @@ pipeline {
                     # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
                     sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
 
+                    # Temporarily disable remote cache usage to avoid stale AC/CAS entries.
+                    if [ -f .bazelrc ]; then
+                      sed -i '/^try-import \\/data\\/bazel$/d' .bazelrc
+                      grep -q '^build --noremote_accept_cached$' .bazelrc || echo 'build --noremote_accept_cached' >> .bazelrc
+                      grep -q '^build --noremote_upload_local_results$' .bazelrc || echo 'build --noremote_upload_local_results' >> .bazelrc
+                      grep -q '^test --noremote_accept_cached$' .bazelrc || echo 'test --noremote_accept_cached' >> .bazelrc
+                      grep -q '^test --noremote_upload_local_results$' .bazelrc || echo 'test --noremote_upload_local_results' >> .bazelrc
+                      grep -q '^run --noremote_accept_cached$' .bazelrc || echo 'run --noremote_accept_cached' >> .bazelrc
+                      grep -q '^run --noremote_upload_local_results$' .bazelrc || echo 'run --noremote_upload_local_results' >> .bazelrc
+                    fi
+
                     # Replay-only skip for flaky target in GCP replay (goleak on IMDS path).
                     # Guard this hotfix so newer branches that removed the package keep working.
                     if [ -f pkg/sessionctx/variable/tests/BUILD ] || [ -f pkg/sessionctx/variable/tests/BUILD.bazel ]; then


### PR DESCRIPTION
## Summary
- disable Bazel remote cache import for `pull_unit_test_next_gen`
- append `noremote_accept_cached` and `noremote_upload_local_results` overrides for build/test/run
- keep the change scoped to this job as an immediate mitigation for stale AC/CAS reads

## Context
Recent `pull_unit_test_next_gen` failures were repeatedly hitting missing remote digests from the GCS Bazel cache path. This job currently inherits remote cache settings via `tidb/.bazelrc -> try-import /data/bazel -> jenkins-tidb/bazel` ConfigMap.

As a short-term stopgap, this patch removes the `/data/bazel` import inside the job workspace and explicitly disables remote cache reads/writes for this pipeline only.

## Validation
- inspected the live `jenkins-tidb/bazel` ConfigMap and confirmed it sets `build --remote_cache=https://storage.googleapis.com/pingcap-ci-bazel-remote-cache-us-central1`
- traced `pull_unit_test_next_gen` to `build/jenkins_unit_test.sh -> make bazel_ci_test`
- verified this pipeline now patches `.bazelrc` before running the Bazel test path

## Test
- not run locally (pipeline-only change)
