### PR TITLE
feat(agents): add TiDB EOL engineering efficiency skill

### DIFF
--- a/.agents/skills/tidb-eol-engineering-efficiency/SKILL.md
+++ b/.agents/skills/tidb-eol-engineering-efficiency/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: tidb-eol-engineering-efficiency
+description: "Handle TiDB Engineering Efficiency EOL work for a TiDB minor version across PingCAP-QE/ci and ti-community-infra/configs. Here TiDB means the whole customer-facing TiDB product line, not only pingcap/tidb. Use when retiring release-X.Y support across product components, including patch and hotfix SDLC for vX.Y.Z: delete CI jobs and resources, remove periodic or cron jobs, remove release-X.Y, release-X.Y.Z, hotfix branch, and vX.Y.* ranges, deny affects-X.Y labeling, block merges to release-X.Y* branches, and remove maintained GitHub labels for that EOL version."
+---
+
+# TiDB EOL Engineering Efficiency
+
+## Scope
+
+This skill is for retiring one TiDB minor version such as `8.5`.
+Here, `TiDB` means the whole product service composed from multiple component repos, not just `pingcap/tidb`.
+
+Default repos:
+- current repo: `PingCAP-QE/ci`
+- sibling repo: `../../ti-community-infra/configs`
+
+Default product scope in `PingCAP-QE/ci`:
+- core database repos: `pingcap/tidb`, `tikv/tikv`, `tikv/pd`
+- data service components: `pingcap/tiflash`, `pingcap/tiflow`, `pingcap/ticdc`, `pingcap/tidb-binlog`
+- test and release-adjacent repos: `PingCAP-QE/tidb-test`, `pingcap/tidb-tools`, `pingcap/monitoring`
+- docs and delivery repos when they still carry EOL release routing: `pingcap/docs`, `pingcap/docs-cn`, related postsubmit sync jobs
+- internal mirrors or release-flow repos when present: `pingcap-inc/tidb`, `pingcap-inc/tiflow`, similar `pingcap-inc/*` entries
+
+Default version forms:
+- branch: `release-X.Y`
+- patch branch: `release-X.Y.Z`
+- patched branch prefix: `release-X.Y.`
+- dated hotfix branch: `release-X.Y-YYYYMMDD-vX.Y.Z`
+- feature branch prefix: `feature/release-X.Y-`
+- patch feature branch prefix: `feature/release-X.Y.Z-` and `feature_release-X.Y.Z-`
+- tag/version: `vX.Y.*`
+- labels: `affects-X.Y`, `may-affects-X.Y`, `needs-cherry-pick-release-X.Y`, `type/cherry-pick-for-release-X.Y`
+
+## Workflow
+
+1. Resolve the target version once.
+   - Keep `minor=X.Y`, `release_branch=release-X.Y`, and `minor_compact=XY` for names like `v85`.
+   - Treat the whole `vX.Y.*` family as retired, including patch tags and customer hotfix branches.
+2. Start with discovery.
+   - Run `.agents/skills/tidb-eol-engineering-efficiency/scripts/find_tidb_eol_candidates.sh X.Y`.
+   - Review the candidate list before deleting anything.
+3. Clean `PingCAP-QE/ci`.
+   - Search all release-managed TiDB product components, not only `pingcap/tidb`.
+   - Remove branch-dedicated Prow jobs for the EOL branch across affected component repos.
+   - Remove matching Jenkins job DSL and pipeline resources for the EOL branch across affected component repos.
+   - Remove periodic or cron Prow jobs tied to the EOL version across the product CI surface.
+   - Remove version-specific branch and tag ranges that keep the EOL line active for any TiDB product component.
+   - Remove patch and hotfix SDLC support for `vX.Y.Z`, including:
+     - `release-X.Y.Z` patch branches,
+     - `release-X.Y-YYYYMMDD-vX.Y.Z` hotfix branches,
+     - `feature/release-X.Y.Z-*` and `feature_release-X.Y.Z-*`,
+     - shared regex exclusions or special routing that preserve customer hotfix flows.
+   - Run `bash .ci/update-prow-job-kustomization.sh` after Prow file removals.
+4. Clean `ti-community-infra/configs`.
+   - Remove EOL version labels from `prow/config/external_plugins_config.yaml` for all affected TiDB product repos so users can no longer add them.
+   - Remove maintained label definitions for the EOL version from `prow/config/labels.yaml`.
+   - Regenerate `prow/config/labels.md`.
+   - Remove `release-X.Y`, `release-X.Y.`, and any version-specific patch or hotfix branch entries from the Prow config blocks that still allow merging to that branch family across the product repos.
+5. Validate both repos.
+   - Re-run targeted `rg` searches and confirm only intentional historical references remain.
+   - Report deleted files, edited policy blocks, and any ambiguous leftovers.
+
+## Guardrails
+
+- Delete only TiDB product resources dedicated to the EOL version. Do not touch trunk or still-supported minors.
+- If a file serves multiple versions, remove only the EOL entries instead of deleting the whole file.
+- Some repos are part of the product scope only indirectly, such as docs sync, monitoring, or QE test repos. Remove EOL routing only when it exists in active release automation.
+- Shared library logic and regexes may distinguish between release branches, patch branches, and dated hotfix branches. Remove the EOL-specific support without breaking still-supported minors.
+- In `ti-community-infra/configs/prow/config/config.yaml`, preserve broader branch patterns that still belong to maintained lines.
+- After label changes in `ti-community-infra/configs`, regenerate and verify the derived docs.
+- If the sibling `ti-community-infra/configs` checkout is missing, locate the local checkout first instead of guessing paths.
+
+## Read Next
+
+- For `PingCAP-QE/ci` search surfaces and validation, read [references/ci-repo.md](references/ci-repo.md).
+- For `ti-community-infra/configs` edit points and validation, read [references/ti-community-infra-configs.md](references/ti-community-infra-configs.md).

--- a/.agents/skills/tidb-eol-engineering-efficiency/agents/openai.yaml
+++ b/.agents/skills/tidb-eol-engineering-efficiency/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TiDB EOL Engineering Efficiency"
+  short_description: "Retire TiDB EOL versions across EE repos"
+  default_prompt: "Use $tidb-eol-engineering-efficiency to retire one TiDB product minor version across PingCAP-QE/ci and ti-community-infra/configs."

--- a/.agents/skills/tidb-eol-engineering-efficiency/references/ci-repo.md
+++ b/.agents/skills/tidb-eol-engineering-efficiency/references/ci-repo.md
@@ -1,0 +1,89 @@
+# `PingCAP-QE/ci` Reference
+
+For this skill, `TiDB` means the whole customer-facing TiDB product line. Search across all release-managed component repos that participate in TiDB service delivery.
+
+Also cover patch and hotfix SDLC removal for the retired minor:
+- patch branch: `release-X.Y.Z`
+- hotfix branch: `release-X.Y-YYYYMMDD-vX.Y.Z`
+- patch feature branch: `feature/release-X.Y.Z-*` and `feature_release-X.Y.Z-*`
+- patch tags: `vX.Y.Z`
+
+## Main edit surfaces
+
+- `prow-jobs/**`
+  - Product-component Prow job YAMLs such as:
+    - `prow-jobs/pingcap/tidb/`
+    - `prow-jobs/tikv/tikv/`
+    - `prow-jobs/tikv/pd/`
+    - `prow-jobs/pingcap/tiflash/`
+    - `prow-jobs/pingcap/tiflow/`
+    - `prow-jobs/pingcap-qe/tidb-test/`
+    - `prow-jobs/pingcap/monitoring/`
+    - `prow-jobs/pingcap/docs/` and `prow-jobs/pingcap/docs-cn/` when release sync still targets the EOL line
+    - `prow-jobs/pingcap-inc/*` mirrors when they are part of release automation
+- `jobs/**/release-X.Y/`
+  - Jenkins DSL for any product component still carrying the EOL release branch.
+- `pipelines/**/release-X.Y/`
+  - Pipeline Groovy files and pod templates for any product component still carrying the EOL release branch.
+- `prow-jobs/pingcap-qe/ci/periodics.yaml`
+  - Version-specific TiDB periodic jobs such as flaky-test reporters.
+- `prow-jobs/**/periodics.yaml`
+  - Search for any other TiDB product EOL periodic or cron-style Prow jobs.
+- `prow-jobs/kustomization.yaml`
+  - Generated after Prow file additions or removals.
+
+## Discovery commands
+
+Replace `X.Y` and `XY` with the target version.
+
+```bash
+rg -n "release-X\\.Y($|\\.)|release-X\\.Y-|feature[/_]release-X\\.Y([.-]|$)|vX\\.Y\\.[0-9]+|vXY" \
+  prow-jobs \
+  jobs \
+  pipelines
+```
+
+```bash
+find jobs -type d -path "*/release-X.Y" 2>/dev/null | sort
+find jobs -type d \( -path "*/release-X.Y.*" -o -path "*/release-X.Y-*" \) 2>/dev/null | sort
+find pipelines -type d -path "*/release-X.Y" 2>/dev/null | sort
+find pipelines -type d \( -path "*/release-X.Y.*" -o -path "*/release-X.Y-*" \) 2>/dev/null | sort
+```
+
+## Edit rules
+
+- Delete dedicated release-branch files and directories when they only serve `release-X.Y`.
+- Delete dedicated patch-branch and hotfix-branch files and directories when they only serve the retired `vX.Y.*` family.
+- Expect the EOL work to span multiple component repos in one change set.
+- In shared YAMLs, remove only the EOL entries:
+  - `branches`
+  - `run_if_changed`
+  - version-specific job names
+  - `cron` or `interval` jobs for the EOL line
+  - tag or branch regexes matching `release-X.Y`, `release-X.Y.Z`, dated hotfix branches, or `vX.Y.*`
+- Also review shared postsubmit flows that still target `release-X.Y`, for example sync or backport jobs in `common-postsubmits.yaml` or docs sync jobs.
+- Review hotfix-aware or patch-aware logic in shared libraries and pipelines. Existing patterns in this repo include:
+  - `release-X.Y-YYYYMMDD-vX.Y.Z`
+  - `feature/release-X.Y.Z-*`
+  - `feature_release-X.Y.Z-*`
+  - repo-specific special cases for hotfix support
+- Review generated names carefully. Some periodics use compact forms like `v85`.
+- Not every `vX.Y.*` hit should be deleted. Test assets or compatibility fixtures in still-maintained branches need manual review.
+
+## Validation
+
+```bash
+bash .ci/update-prow-job-kustomization.sh
+bash .ci/verify-jenkins-pipelines.sh
+```
+
+Then confirm no live config remains for the EOL line:
+
+```bash
+rg -n "release-X\\.Y($|\\.)|release-X\\.Y-|feature[/_]release-X\\.Y([.-]|$)|vX\\.Y\\.[0-9]+|vXY" \
+  prow-jobs \
+  jobs \
+  pipelines
+```
+
+Historical comments or cross-version test fixtures may remain outside the active CI paths. Call those out instead of deleting blindly.

--- a/.agents/skills/tidb-eol-engineering-efficiency/references/ti-community-infra-configs.md
+++ b/.agents/skills/tidb-eol-engineering-efficiency/references/ti-community-infra-configs.md
@@ -1,0 +1,76 @@
+# `ti-community-infra/configs` Reference
+
+## Repo root
+
+Prefer the sibling checkout at `../../ti-community-infra/configs` from `PingCAP-QE/ci`.
+
+## Main edit surfaces
+
+- `prow/config/external_plugins_config.yaml`
+  - Remove version-specific label allowlists so users cannot add EOL labels anymore.
+  - Do this for every TiDB product component repo still listed there, not just `pingcap/tidb`.
+  - Search for:
+    - `affects-X.Y`
+    - `may-affects-X.Y`
+    - `needs-cherry-pick-release-X.Y`
+    - `type/cherry-pick-for-release-X.Y`
+- `prow/config/labels.yaml`
+  - Remove maintained label definitions for the EOL version.
+- `prow/config/labels.md`
+  - Generated from `labels.yaml`; do not hand-edit.
+- `prow/config/config.yaml`
+  - Search all `release-X.Y` and `release-X.Y.` entries.
+  - Search patch and hotfix support entries too, including feature branches or patched-branch prefixes that keep `vX.Y.*` mergeable.
+  - Remove only the entries that keep the EOL branch family mergeable or otherwise treated as maintained across product repos such as `pingcap/tidb`, `tikv/tikv`, `tikv/pd`, `pingcap/tiflash`, `pingcap/tiflow`, `pingcap/monitoring`, docs repos, and QE repos when present.
+
+## Discovery commands
+
+Replace `X.Y` with the target version.
+
+```bash
+rg -n "affects-X\\.Y|may-affects-X\\.Y|needs-cherry-pick-release-X\\.Y|type/cherry-pick-for-release-X\\.Y|release-X\\.Y|release-X\\.Y\\.|feature/release-X\\.Y\\.[0-9]+|vX\\.Y\\.[0-9]+" \
+  prow/config/external_plugins_config.yaml \
+  prow/config/labels.yaml \
+  prow/config/config.yaml
+```
+
+## Edit rules
+
+- `external_plugins_config.yaml`
+  - Remove the EOL labels from every affected product-repo allowlist.
+  - The goal is denial by absence from `additional_labels` or other allowlists.
+- `labels.yaml`
+  - Remove every maintained label about the EOL version, not just `affects-X.Y`.
+  - Keep other versions untouched.
+- `config.yaml`
+  - Focus on Tide query blocks with `includedBranches` or `excludedBranches`.
+  - Remove exact EOL entries such as `release-X.Y` and patched-branch prefixes such as `release-X.Y.`.
+  - Also remove version-specific branch protection, patch-prefix, feature-branch, or context-map entries when they exist only to support that EOL branch or its hotfix flow.
+  - Do not broaden prefix rules by accident when deleting one line from a mixed block.
+
+## Validation
+
+Run from the `ti-community-infra/configs` repo root:
+
+```bash
+bash scripts/update-labels.sh
+bash scripts/verify-labels.sh
+```
+
+If `checkconfig` is available, also run:
+
+```bash
+checkconfig --plugin-config=prow/config/plugins.yaml --config-path=prow/config/config.yaml
+```
+
+Then confirm the EOL identifiers are gone from live config:
+
+```bash
+rg -n "affects-X\\.Y|may-affects-X\\.Y|needs-cherry-pick-release-X\\.Y|type/cherry-pick-for-release-X\\.Y|release-X\\.Y|release-X\\.Y\\.|feature/release-X\\.Y\\.[0-9]+|vX\\.Y\\.[0-9]+" \
+  prow/config/external_plugins_config.yaml \
+  prow/config/labels.yaml \
+  prow/config/config.yaml \
+  prow/config/labels.md
+```
+
+If a remaining match is purely historical commentary, mention it explicitly in the handoff.

--- a/.agents/skills/tidb-eol-engineering-efficiency/scripts/find_tidb_eol_candidates.sh
+++ b/.agents/skills/tidb-eol-engineering-efficiency/scripts/find_tidb_eol_candidates.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: find_tidb_eol_candidates.sh <minor> [ci-root] [infra-root]
+
+Examples:
+  find_tidb_eol_candidates.sh 8.5
+  find_tidb_eol_candidates.sh 8.5 /path/to/ci /path/to/ti-community-infra/configs
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+  usage
+  exit 1
+fi
+
+minor="$1"
+ci_root="${2:-$(pwd)}"
+infra_root="${3:-$ci_root/../../ti-community-infra/configs}"
+minor_regex="${minor//./\\.}"
+minor_compact="${minor//./}"
+
+print_section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+run_rg() {
+  local pattern="$1"
+  shift
+  rg -n --no-heading "$pattern" "$@" || true
+}
+
+print_section "Parameters"
+printf 'minor=%s\n' "$minor"
+printf 'ci_root=%s\n' "$ci_root"
+printf 'infra_root=%s\n' "$infra_root"
+
+print_section "Dedicated product-component release files in ci"
+find "$ci_root/prow-jobs" -type f \
+  \( -name "release-${minor}-*.yaml" -o -name "release-${minor}.yaml" \) 2>/dev/null | sort
+find "$ci_root/jobs" -type d -path "*/release-${minor}" -print 2>/dev/null | sort
+find "$ci_root/pipelines" -type d -path "*/release-${minor}" -print 2>/dev/null | sort
+
+print_section "Shared ci config references"
+printf 'Candidate search only: review vX.Y.* hits manually before deleting them.\n'
+run_rg "release-${minor_regex}($|\\\\.)|release-${minor_regex}-|feature[/_]release-${minor_regex}([.-]|$)|v${minor_regex}\\\\.[0-9]+|v${minor_compact}" \
+  "$ci_root/prow-jobs" \
+  "$ci_root/jobs" \
+  "$ci_root/pipelines"
+
+print_section "ti-community-infra/configs references"
+run_rg "affects-${minor_regex}|may-affects-${minor_regex}|needs-cherry-pick-release-${minor_regex}|type/cherry-pick-for-release-${minor_regex}|release-${minor_regex}|release-${minor_regex}\\\\.|feature/release-${minor_regex}\\\\.[0-9]+|v${minor_regex}\\\\.[0-9]+" \
+  "$infra_root/prow/config/external_plugins_config.yaml" \
+  "$infra_root/prow/config/labels.yaml" \
+  "$infra_root/prow/config/config.yaml" \
+  "$infra_root/prow/config/labels.md"


### PR DESCRIPTION
## Summary
- add a repo-local skill for TiDB Engineering Efficiency EOL work
- cover the full TiDB product scope rather than only pingcap/tidb
- include patch and hotfix SDLC retirement guidance plus a discovery helper script

## Validation
- `bash -n .agents/skills/tidb-eol-engineering-efficiency/scripts/find_tidb_eol_candidates.sh`
- `bash .agents/skills/tidb-eol-engineering-efficiency/scripts/find_tidb_eol_candidates.sh 8.5`
