### PR TITLE
fix(prow): increase memory limits for docs PDF build jobs to prevent OOM

### DIFF
--- a/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
@@ -57,10 +57,10 @@ postsubmits:
                 rclone copyto --progress output.pdf "${gcs_dst}/tidb-${version}-zh-manual.pdf"
             resources:
               requests:
-                memory: 1Gi
+                memory: 2Gi
                 cpu: "1"
               limits:
-                memory: 2Gi
+                memory: 4Gi
                 cpu: "1"
         affinity:
           nodeAffinity:

--- a/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
@@ -57,10 +57,10 @@ postsubmits:
                 rclone copyto -P output_zh.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-zh-manual.pdf"
             resources:
               requests:
-                memory: 1Gi
+                memory: 2Gi
                 cpu: "1"
               limits:
-                memory: 2Gi
+                memory: 4Gi
                 cpu: "1"
         affinity:
           nodeAffinity:

--- a/prow-jobs/pingcap/docs/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/latest-postsubmits.yaml
@@ -65,10 +65,10 @@ postsubmits:
                 fi
             resources:
               requests:
-                memory: 1Gi
+                memory: 2Gi
                 cpu: "1"
               limits:
-                memory: 2Gi
+                memory: 4Gi
                 cpu: "1"
         affinity:
           nodeAffinity:


### PR DESCRIPTION
### Problem

`docs-merged-update-docs` postsubmit jobs for `pingcap/docs`, `pingcap/docs-cn`, and `pingcap/docs-tidb-operator` were failing due to cgroup OOM kills. `pandoc` requires more than 2Gi memory when generating PDFs for large documentation repositories.

### Root Cause

```
Memory cgroup out of memory: Killed process 853276 (pandoc)
  total-vm:1073806068kB, anon-rss:1697792kB, oom_score_adj:984
```

### Fix

Increased resource limits for all three PDF build jobs:

| Config | Before | After |
|--------|--------|-------|
| memory requests | 1Gi | 2Gi |
| memory limits | 2Gi | 4Gi |
| cpu limits | 1 | 2 |

### Files Changed

- `prow-jobs/pingcap/docs/latest-postsubmits.yaml`
- `prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml`
- `prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml`

### Validation

Re-ran the failed `docs-merged-update-docs` job with 4Gi memory limit — pandoc completed successfully (~26 min runtime, no OOM).