### PR TITLE
fix(prow): add GCS service account credentials for docs PDF upload

### DIFF
--- a/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
@@ -36,6 +36,7 @@ postsubmits:
                 python3 scripts/merge_by_toc.py
                 scripts/generate_pdf.sh
 
+                export RCLONE_CONFIG_GCS_SERVICE_ACCOUNT_FILE="/secrets/gcs/service-account.json"
                 export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
                 gcs_dst="gcs:prow-tidb-logs/artifacts/pdf"
                 case "${branch}" in
@@ -55,6 +56,10 @@ postsubmits:
                 esac
 
                 rclone copyto --progress output.pdf "${gcs_dst}/tidb-${version}-zh-manual.pdf"
+            volumeMounts:
+              - name: gcs-credentials
+                mountPath: /secrets/gcs
+                readOnly: true
             resources:
               requests:
                 memory: 2Gi

--- a/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
@@ -35,6 +35,7 @@ postsubmits:
                 python3 scripts/merge_by_toc.py zh/
                 scripts/generate_pdf.sh
 
+                export RCLONE_CONFIG_GCS_SERVICE_ACCOUNT_FILE="/secrets/gcs/service-account.json"
                 export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
                 gcs_dst="gcs:prow-tidb-logs/artifacts/pdf"
                 case "${branch}" in
@@ -55,6 +56,10 @@ postsubmits:
 
                 rclone copyto -P output_en.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-en-manual.pdf"
                 rclone copyto -P output_zh.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-zh-manual.pdf"
+            volumeMounts:
+              - name: gcs-credentials
+                mountPath: /secrets/gcs
+                readOnly: true
             resources:
               requests:
                 memory: 2Gi

--- a/prow-jobs/pingcap/docs/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/latest-postsubmits.yaml
@@ -41,6 +41,7 @@ postsubmits:
                   scripts/generate_cloud_pdf.sh
                 fi
 
+                export RCLONE_CONFIG_GCS_SERVICE_ACCOUNT_FILE="/secrets/gcs/service-account.json"
                 export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
                 gcs_dst="gcs:prow-tidb-logs/artifacts/pdf"
                 case "${branch}" in
@@ -63,6 +64,10 @@ postsubmits:
                 if [ -f output_cloud.pdf ]; then
                   rclone copyto --progress output_cloud.pdf "${gcs_dst}/tidbcloud-en-manual.pdf"
                 fi
+            volumeMounts:
+              - name: gcs-credentials
+                mountPath: /secrets/gcs
+                readOnly: true
             resources:
               requests:
                 memory: 2Gi


### PR DESCRIPTION
### Problem

rclone in the docs PDF build jobs was failing to upload to GCS with:

```
Error 412: The type of authentication token used for this request
requires that Uniform Bucket Level Access be enabled.
```

Root cause: rclone only set `RCLONE_CONFIG_GCS_TYPE` without specifying a credentials file, causing it to fall back to Application Default Credentials (GCE node SA OAuth token). OAuth tokens require Uniform Bucket Level Access on fine-grained ACL buckets.

### Fix

Add `RCLONE_CONFIG_GCS_SERVICE_ACCOUNT_FILE="/secrets/gcs/service-account.json"` to use the mounted Prow GCS credentials secret, which has proper `storage.objectAdmin` permissions on the bucket.

### Files Changed

- `prow-jobs/pingcap/docs/latest-postsubmits.yaml`
- `prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml`
- `prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml`