### PR TITLE
fix(prow): add retry wrapper around cache step to survive interrupted cache save

### DIFF
--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -15,8 +15,8 @@ def checkoutPrivateRefsWithCacheLock(refs, credentialsId, timeout = 5, withSubmo
 def checkoutRefsWithCache(refs, timeout = 5, credentialsId = '', withSubmodule = false, gitBaseUrl = 'https://github.com') {
     final cacheKey = getCacheKey('git', refs)
     final restoreKeys = getRestoreKeys('git', refs)
-    cache(path: "./", includes: '**/*', key: cacheKey, restoreKeys: restoreKeys) {
-        retry(2) {
+    retry(3) {
+        cache(path: "./", includes: '**/*', key: cacheKey, restoreKeys: restoreKeys) {
             checkoutRefs(refs, credentialsId, timeout, withSubmodule, gitBaseUrl)
         }
     }
@@ -25,8 +25,8 @@ def checkoutRefsWithCache(refs, timeout = 5, credentialsId = '', withSubmodule =
 def checkoutPrivateRefsWithCache(refs, credentialsId, timeout = 5, withSubmodule = false, gitSshHost = 'github.com') {
     final cacheKey = getCacheKey('git', refs)
     final restoreKeys = getRestoreKeys('git', refs)
-    cache(path: "./", includes: '**/*', key: cacheKey, restoreKeys: restoreKeys) {
-        retry(2) {
+    retry(3) {
+        cache(path: "./", includes: '**/*', key: cacheKey, restoreKeys: restoreKeys) {
             checkoutPrivateRefs(refs, credentialsId, timeout, withSubmodule, gitSshHost)
         }
     }


### PR DESCRIPTION
## Problem

Multiple TiFlash CI jobs (`pull_unit_next_gen`, `pull_integration_next_gen`, `pull_integration_test`, `pull_unit_test`) intermittently fail with the same error during the Checkout stage:

```
java.lang.InterruptedException
    at hudson.remoting.Request.call(Request.java:179)
    at hudson.remoting.Channel.call(Channel.java:1107)
    at hudson.FilePath.act(FilePath.java:1217)
    at CacheStep$CacheStepExecution$1.onSuccess(CacheStep.java:124)
```

The checkout itself completes successfully, but when the `cache{}` block exits and the CacheStep plugin tries to save cache state back to the agent (via remoting), the call is interrupted — likely due to spot node preemption or network instability.

Affected builds (last checked):
- `pull_unit_next_gen` #68, #69, #72
- `pull_integration_next_gen` #85
- `pull_integration_test` #77
- `pull_unit_test` #67

## Root Cause

In `checkoutRefsWithCache` and `checkoutPrivateRefsWithCache`, the `retry(2)` only covers the checkout inside the `cache{}` block. If the cache **save** fails (in `onSuccess` callback), there is no retry protection — the build fails immediately.

## Fix

Add `retry(3)` around the `cache{}` block so that cache save failures (InterruptedException) trigger a retry. The inner `retry(2)` is removed since the outer retry already covers both cache and checkout failures.

On retry, the cache restore and checkout are nearly instant (data is already on disk), so the overhead is minimal.

```groovy
// Before
cache(path: "./", includes: '**/*', key: cacheKey, restoreKeys: restoreKeys) {
    retry(2) {
        checkoutRefs(refs, ...)
    }
}

// After
retry(3) {
    cache(path: "./", includes: '**/*', key: cacheKey, restoreKeys: restoreKeys) {
        checkoutRefs(refs, ...)
    }
}
```

## Validation

- `git diff --check` passed
- Jenkins pipeline syntax is mechanically valid (single-step replacement, no logic change outside the retry wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
