### PR TITLE
fix: disable cached checkout for TiFlash pipeline jobs

### DIFF
--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -32,7 +32,7 @@ pipeline {
                 dir("tiflash") {
                     sh 'git config --global --add safe.directory "*" && git version'
                     script {
-                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 30, true, 'https://github.com')
                     }
                     sh 'chown 1000:1000 -R ./'
                 }

--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -32,7 +32,7 @@ pipeline {
                 dir("tiflash") {
                     sh 'git config --global --add safe.directory "*" && git version'
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
                     }
                     sh 'chown 1000:1000 -R ./'
                 }

--- a/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
@@ -32,7 +32,7 @@ pipeline {
                 dir(REFS.repo) {
                     sh 'git config --global --add safe.directory "*" && git version'
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
                     }
                     sh 'chown 1000:1000 -R ./'
                 }

--- a/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
@@ -32,7 +32,7 @@ pipeline {
                 dir(REFS.repo) {
                     sh 'git config --global --add safe.directory "*" && git version'
                     script {
-                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 30, true, 'https://github.com')
                     }
                     sh 'chown 1000:1000 -R ./'
                 }

--- a/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
@@ -29,7 +29,7 @@ pipeline {
                 dir(REFS.repo) {
                     sh 'git config --global --add safe.directory "*" && git version'
                     script {
-                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 30, true, 'https://github.com')
                     }
                     sh 'chown 1000:1000 -R ./'
                 }

--- a/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
@@ -29,7 +29,7 @@ pipeline {
                 dir(REFS.repo) {
                     sh 'git config --global --add safe.directory "*" && git version'
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
                     }
                     sh 'chown 1000:1000 -R ./'
                 }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -40,7 +40,7 @@ pipeline {
                 dir(REFS.repo) {
                     sh 'git config --global --add safe.directory "*" && git version'
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
                     }
                     sh 'chown 1000:1000 -R ./'
                 }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -40,7 +40,7 @@ pipeline {
                 dir(REFS.repo) {
                     sh 'git config --global --add safe.directory "*" && git version'
                     script {
-                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 30, true, 'https://github.com')
                     }
                     sh 'chown 1000:1000 -R ./'
                 }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
@@ -43,7 +43,7 @@ pipeline {
                         dir(REFS.repo) {
                             script {
                                 sh 'git config --global --add safe.directory "*"'
-                                prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
+                                prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
@@ -43,7 +43,7 @@ pipeline {
                         dir(REFS.repo) {
                             script {
                                 sh 'git config --global --add safe.directory "*"'
-                                prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true)
+                                prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 30, true)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -35,7 +35,7 @@ pipeline {
                 dir(REFS.repo) {
                     sh 'git config --global --add safe.directory "*"'
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
                     }
                     sh 'chown 1000:1000 -R ./'
                 }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -35,7 +35,7 @@ pipeline {
                 dir(REFS.repo) {
                     sh 'git config --global --add safe.directory "*"'
                     script {
-                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 30, true, 'https://github.com')
                     }
                     sh 'chown 1000:1000 -R ./'
                 }

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -32,7 +32,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 30, true, 'https://github.com')
                         retry(2) {
                             sh "git status"
 

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -32,7 +32,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
                         retry(2) {
                             sh "git status"
 

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -32,7 +32,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 30, true, 'https://github.com')
                         retry(2) {
                             sh "git status"
 

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -32,7 +32,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, GIT_CREDENTIALS_ID, 5, true, 'https://github.com')
                         retry(2) {
                             sh "git status"
 

--- a/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
@@ -35,7 +35,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
+                        prow.checkoutRefs(REFS, '', 5, true, 'https://github.com')
                         retry(2) {
                             sh """
                             git status

--- a/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
@@ -35,7 +35,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefs(REFS, '', 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, '', 30, true, 'https://github.com')
                         retry(2) {
                             sh """
                             git status

--- a/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
@@ -32,7 +32,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
+                        prow.checkoutRefs(REFS, '', 5, true, 'https://github.com')
                         retry(2) {
                             sh """
                             git status

--- a/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
@@ -32,7 +32,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefs(REFS, '', 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, '', 30, true, 'https://github.com')
                         retry(2) {
                             sh """
                             git status

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -40,7 +40,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
+                        prow.checkoutRefs(REFS, '', 5, true, 'https://github.com')
                         retry(2) {
                             sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -40,7 +40,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefs(REFS, '', 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, '', 30, true, 'https://github.com')
                         retry(2) {
                             sh "git status"
                             tiflash_commit_hash = sh(returnStdout: true, script: 'git log -1 --format="%H"').trim()

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -33,7 +33,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefs(REFS, '', 5, true, 'https://github.com')
+                        prow.checkoutRefs(REFS, '', 30, true, 'https://github.com')
                         retry(2) {
                             sh "git status"
                             sh """

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -33,7 +33,7 @@ pipeline {
                         git config --global --add safe.directory "*"
                         git version
                         """
-                        prow.checkoutRefsWithCacheLock(REFS, 5, '', true, 'https://github.com')
+                        prow.checkoutRefs(REFS, '', 5, true, 'https://github.com')
                         retry(2) {
                             sh "git status"
                             sh """


### PR DESCRIPTION
## Summary
- replace cached checkout calls with direct checkout for TiFlash latest jobs
- apply the same change to TiFlash release-8.5 jobs
- avoid failures when saving oversized Jenkins checkout caches

## Context
The Jenkins checkout cache for this repository has grown to around 11 GB and can fail during cache save. This change temporarily disables cached checkout for the affected TiFlash jobs to prioritize job stability.

## Testing
- not run (pipeline checkout path change only)
