### PR TITLE
fix(pipelines/pingcap/tiflash): use ci/base image for release-6.5 int…

### DIFF
--- a/pipelines/pingcap/tiflash/release-6.5/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-6.5/pod-pull_integration_test.yaml
@@ -49,7 +49,7 @@ spec:
           value: "/certs/client"
         - name: "DOCKER_TLS_VERIFY"
           value: "1"
-      image: "docker.io/library/docker:20.10.24"
+      image: "ghcr.io/pingcap-qe/ci/base:v2026.4.12-11-g402978f-go1.25"
       imagePullPolicy: "Always"
       name: "docker"
       resources:


### PR DESCRIPTION
## Summary
Fix `pull_integration_test` failure on `release-6.5` where all integration matrix legs fail with `./run.sh: not found` (exit 127).

Root cause: integration test client container uses `docker.io/library/docker:20.10.24` (Alpine, no `/bin/bash`), while `tests/*/run.sh` requires bash shebang.

## Change
Replace only the `docker` client container image with `ghcr.io/pingcap-qe/ci/base:v2026.4.12-11-g402978f-go1.25` (same as `latest` tiflash integration pod). Keep `dockerd` sidecar unchanged.

## Test plan
- [ ] Merge this PR
- [ ] On pingcap/tiflash PR, comment `/test pull-integration-test`
- [ ] Verify integration matrix (`tidb-ci`, `delta-merge-test`, `fullstack-test`, `fullstack-test2`) no longer fails at `./run.sh: not found`