### PR TITLE
feat(configs): add kustomization for error-log-review ConfigMap

### DIFF
--- a/configs/error-log-review/kustomization.yaml
+++ b/configs/error-log-review/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: error-log-review-config
+    options:
+      disableNameSuffixHash: true
+    files:
+      - config.yaml


### PR DESCRIPTION
## Summary

Add `kustomization.yaml` with `configMapGenerator` for `error-log-review-config` ConfigMap. This enables FluxCD to generate ConfigMaps that can be mounted in Tekton task pods.

## Changes

- Added `configs/error-log-review/kustomization.yaml` with configMapGenerator entry
- Contains `config.yaml` for error log review configuration

## Testing

- Verified kustomize build generates the expected ConfigMap
- No existing configs are affected (additive change only)

## Risk

Low - additive change only. Existing error-log-review config is unchanged.

## Related

- FLA-210 PR2: FluxCD ConfigMap generation for CI configs
- FLA-180: CD config map requirement