### PR TITLE
chore(prow-jobs): update tikv release-7.5 master label from 0 to 1

### DIFF
--- a/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - name: tikv/tikv/release-7.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -22,7 +22,7 @@ presubmits:
     - name: tikv/tikv/release-7.5/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       always_run: false  # update here after test passed


### PR DESCRIPTION
## Summary

Update tikv/tikv release-7.5 prow job master label from `"0"` to `"1"` to migrate CI from old-ksyun (金山云) to GCP.

## Changes

- `prow-jobs/tikv/tikv/release-7.5-presubmits.yaml`: `master: "0"` → `master: "1"` for both `pull_unit_test` and `pull_integration_test` jobs
- Kustomization verified via `.ci/update-prow-job-kustomization.sh` (no changes needed)

## Testing

- Ran `.ci/update-prow-job-kustomization.sh` — kustomization.yaml is up to date
- CI will verify scheduling on GCP cluster after merge

## Risk

Low risk — single label change. Rollback: revert the label to `"0"` if GCP scheduling issues arise.