### PR TITLE
feat(pipelines): align tikv release-7.5 pipeline and pod template with 8.5

### DIFF
--- a/pipelines/tikv/tikv/release-7.5/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-7.5/pod-pull_unit_test.yaml
@@ -1,9 +1,12 @@
 apiVersion: v1
 kind: Pod
 spec:
+  securityContext:
+    fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-7.5:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
+      imagePullPolicy: Always
       tty: true
       command:
         - "/bin/sh"
@@ -12,7 +15,7 @@ spec:
         - "cat"
       resources:
         requests:
-          memory: 32Gi
+          memory: 24Gi
           cpu: "6"
       securityContext:
         privileged: true

--- a/pipelines/tikv/tikv/release-7.5/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-7.5/pull_unit_test.groovy
@@ -4,21 +4,25 @@
 
 final K8S_NAMESPACE = "jenkins-tikv"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final GIT_FULL_REPO_NAME = 'tikv/tikv'
 final POD_TEMPLATE_FILE = 'pipelines/tikv/tikv/release-7.5/pod-pull_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+final SRC_DIR = 'tikv-src'
+final TARGET_DIR = 'tikv-target'
+final ARCHIVE_DIR = 'archives'
+final UNIT_TEST_DIR = 'unit-test'
+final TEST_ARTIFACTS = 'test-artifacts.tar.gz'
+final TEST_BINARIES_ARCHIVE = 'archive-test-binaries.tar'
 final EXTRA_NEXTEST_ARGS = "-j 8"
-
 
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'hyperdisk-rwo')
             retries 2
             defaultContainer 'runner'
-            // workspaceVolume emptyDirWorkspaceVolume(memory: true)
         }
     }
     environment {
@@ -33,148 +37,148 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 5, unit: 'MINUTES') }
             steps {
-                sh """
-                    rm -rf /home/jenkins/tikv-src
+                sh label: 'Clean workspace', script: """
+                    rm -rf \
+                        ${WORKSPACE}/${SRC_DIR} \
+                        ${WORKSPACE}/${TARGET_DIR} \
+                        ${WORKSPACE}/${ARCHIVE_DIR} \
+                        ${WORKSPACE}/${UNIT_TEST_DIR}
                 """
                 dir("tikv") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
                     }
                 }
-                sh """
-                    pwd & ls -alh
-                    mv ./tikv \$HOME/tikv-src
-                    cd \$HOME/tikv-src
-                    ln -s \$HOME/tikv-target \$HOME/tikv-src/target
+                sh label: 'Prepare source tree', script: """
+                    pwd && ls -alh
+                    mv ./tikv ${WORKSPACE}/${SRC_DIR}
+                    cd ${WORKSPACE}/${SRC_DIR}
+                    # Hotfix: some CI images may leave a non-directory target path.
+                    rm -rf ${WORKSPACE}/${SRC_DIR}/target
+                    mkdir -p ${WORKSPACE}/${TARGET_DIR}
+                    ln -sfn ${WORKSPACE}/${TARGET_DIR} ${WORKSPACE}/${SRC_DIR}/target
                     pwd && ls -alh
                 """
             }
         }
         stage('lint') {
             steps {
-                dir("tikv") {
-                    retry(2) {
-                        sh label: 'Run lint: format', script: """
-                            cd \$HOME/tikv-src
-                            export RUSTFLAGS=-Dwarnings
-                            make format
-                            git diff --quiet || (git diff; echo Please make format and run tests before creating a PR; exit 1)
-                        """
-                        sh label: 'Run lint: clippy', script: """
-                            cd \$HOME/tikv-src
-                            export RUSTFLAGS=-Dwarnings
-                            export FAIL_POINT=1
-                            export ROCKSDB_SYS_SSE=1
-                            export RUST_BACKTRACE=1
-                            export LOG_LEVEL=INFO
-                            echo using gcc 8
-                            source /opt/rh/devtoolset-8/enable
-                            make clippy || (echo Please fix the clippy error; exit 1)
-                        """
-                    }
+                retry(2) {
+                    sh label: 'Run lint: format', script: """
+                        cd ${WORKSPACE}/${SRC_DIR}
+                        export RUSTFLAGS=-Dwarnings
+                        make format
+                        git diff --quiet || (git diff; echo Please make format and run tests before creating a PR; exit 1)
+                    """
+                    sh label: 'Run lint: clippy', script: """
+                        cd ${WORKSPACE}/${SRC_DIR}
+                        export RUSTFLAGS=-Dwarnings
+                        export FAIL_POINT=1
+                        export ROCKSDB_SYS_SSE=1
+                        export RUST_BACKTRACE=1
+                        export LOG_LEVEL=INFO
+
+                        make clippy || (echo Please fix the clippy error; exit 1)
+                    """
                 }
             }
         }
         stage('build') {
             steps {
-                dir("tikv") {
-                    retry(2) {
-                        sh label: 'Build test artifact', script: """
-                            cd \$HOME/tikv-src
-                            export RUSTFLAGS=-Dwarnings
-                            export FAIL_POINT=1
-                            export ROCKSDB_SYS_SSE=1
-                            export RUST_BACKTRACE=1
-                            export LOG_LEVEL=INFO
-                            export CARGO_INCREMENTAL=0
-                            export RUSTDOCFLAGS="-Z unstable-options --persist-doctests"
-                            echo using gcc 8
-                            source /opt/rh/devtoolset-8/enable
-                            set -e
-                            set -o pipefail
+                retry(2) {
+                    sh label: 'Build test artifact', script: """
+                        cd ${WORKSPACE}/${SRC_DIR}
+                        export RUSTFLAGS=-Dwarnings
+                        export FAIL_POINT=1
+                        export ROCKSDB_SYS_SSE=1
+                        export RUST_BACKTRACE=1
+                        export LOG_LEVEL=INFO
+                        export CARGO_INCREMENTAL=0
+                        export RUSTDOCFLAGS="-Z unstable-options --persist-doctests"
 
-                            # Build and generate a list of binaries
-                            CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
-                            # Cargo metadata
-                            cargo metadata --format-version 1 > test-metadata.json
-                            # cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
-                            wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
-                            python gen_test_binary_json.py
-                            cat test-binaries.json
+                        set -e
+                        set -o pipefail
 
-                            # archive test artifacts
-                            ls -alh archive-test-binaries
-                            tar -cvf archive-test-binaries.tar archive-test-binaries
-                            ls -alh archive-test-binaries.tar
-                            tar czf test-artifacts.tar.gz test-binaries test-binaries.json test-metadata.json Cargo.toml cmd src tests components .config `ls target/*/deps/*plugin.so 2>/dev/null`
-                            ls -alh test-artifacts.tar.gz
-                            mkdir -p /home/jenkins/archives
-                            mv test-artifacts.tar.gz archive-test-binaries.tar /home/jenkins/archives/
-                        """
-                    }
+                        # Build and generate a list of binaries
+                        CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
+                        # Cargo metadata
+                        cargo metadata --format-version 1 > test-metadata.json
+                        wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                        export TIKV_SRC_DIR=${WORKSPACE}/${SRC_DIR}
+                        python gen_test_binary_json.py
+                        cat test-binaries.json
+
+                        # archive test artifacts
+                        ls -alh archive-test-binaries
+                        tar -cvf ${TEST_BINARIES_ARCHIVE} archive-test-binaries
+                        ls -alh ${TEST_BINARIES_ARCHIVE}
+                        tar czf ${TEST_ARTIFACTS} test-binaries test-binaries.json test-metadata.json Cargo.toml cmd src tests components .config `ls target/*/deps/*plugin.so 2>/dev/null`
+                        ls -alh ${TEST_ARTIFACTS}
+                        mkdir -p ${WORKSPACE}/${ARCHIVE_DIR}
+                        mv ${TEST_ARTIFACTS} ${TEST_BINARIES_ARCHIVE} ${WORKSPACE}/${ARCHIVE_DIR}/
+                    """
                 }
             }
         }
         stage("Test") {
             options { timeout(time: 30, unit: 'MINUTES') }
             steps {
-                dir('/home/jenkins/agent/tikv-presubmit/unit-test') {
-                    sh label: "clean up", script: """
-                        rm -rf /home/jenkins/tikv-*
-                        ls -alh /home/jenkins/
-                        ln -s `pwd` \$HOME/tikv-src
+                dir("${WORKSPACE}/${UNIT_TEST_DIR}") {
+                    sh label: "Prepare unit test workspace", script: """
+                        rm -rf ${WORKSPACE}/${SRC_DIR} ${WORKSPACE}/${TARGET_DIR}
+                        ls -alh ${WORKSPACE}/
+                        ln -s `pwd` ${WORKSPACE}/${SRC_DIR}
                         mkdir -p target/debug
                         uname -a
                         df -h
                         free -hm
 
                         # prepare test artifacts
-                        cp /home/jenkins/archives/test-artifacts.tar.gz .
-                        cp /home/jenkins/archives/archive-test-binaries.tar .
-                        tar -xf test-artifacts.tar.gz
-                        tar xf archive-test-binaries.tar --strip-components=1
-                        rm -f test-artifacts.tar.gz archive-test-binaries.tar
+                        cp ${WORKSPACE}/${ARCHIVE_DIR}/${TEST_ARTIFACTS} .
+                        cp ${WORKSPACE}/${ARCHIVE_DIR}/${TEST_BINARIES_ARCHIVE} .
+                        tar -xf ${TEST_ARTIFACTS}
+                        tar xf ${TEST_BINARIES_ARCHIVE} --strip-components=1
+                        rm -f ${TEST_ARTIFACTS} ${TEST_BINARIES_ARCHIVE}
                         ls -la
                         ls -alh target/debug/deps/
                     """
-                    sh """
-                    ls -alh \$HOME/tikv-src
-                    ls -alh /home/jenkins/tikv-src/
-                    ls -alh /home/jenkins/tikv-src/target/debug/deps/
+                    sh label: "Run nextest", script: """
+                    ls -alh ${WORKSPACE}/${SRC_DIR}/
+                    ls -alh ${WORKSPACE}/${SRC_DIR}/target/debug/deps/
                     export RUSTFLAGS=-Dwarnings
                     export FAIL_POINT=1
                     export RUST_BACKTRACE=1
                     export MALLOC_CONF=prof:true,prof_active:false
                     # export CI=1  # TODO: remove this
-                    export LOG_FILE=/home/jenkins/tikv-src/target/my_test.log
+                    export LOG_FILE=${WORKSPACE}/${SRC_DIR}/target/my_test.log
 
-                    if cargo nextest run -P ci --binaries-metadata test-binaries.json --cargo-metadata test-metadata.json --partition count:1/2 ${EXTRA_NEXTEST_ARGS}; then
-                        echo "test pass"
-                    else
-                        # test failed
-                        gdb -c core.* -batch -ex "info threads" -ex "thread apply all bt"
-                        exit 1
-                    fi
-                    if cargo nextest run -P ci --binaries-metadata test-binaries.json --cargo-metadata test-metadata.json --partition count:2/2 ${EXTRA_NEXTEST_ARGS}; then
-                        echo "test pass"
-                    else
-                        # test failed
-                        gdb -c core.* -batch -ex "info threads" -ex "thread apply all bt"
-                        exit 1
-                    fi
+                    for partition in 1/2 2/2; do
+                        if cargo nextest run -P ci --binaries-metadata test-binaries.json --cargo-metadata test-metadata.json --partition count:\${partition} ${EXTRA_NEXTEST_ARGS}; then
+                            echo "partition \${partition} pass"
+                        else
+                            gdb -c core.* -batch -ex "info threads" -ex "thread apply all bt"
+                            exit 1
+                        fi
+                    done
                     """
                 }
             }
             post {
                 failure {
                     sh label: "collect logs", script: """
-                        ls /home/jenkins/tikv-src/target/
-                        tar -cvzf log-ut.tar.gz \$(find /home/jenkins/tikv-src/target/ -type f -name "*.log")
-                        ls -alh  log-ut.tar.gz
+                        log_dir=${WORKSPACE}/${SRC_DIR}/target
+                        tmp_file=\$(mktemp)
+                        if [ -d "\${log_dir}" ]; then
+                            find "\${log_dir}" -type f -name "*.log" > "\${tmp_file}"
+                        fi
+
+                        if [ -s "\${tmp_file}" ]; then
+                            tar --warning=no-file-changed -czf log-ut.tar.gz -T "\${tmp_file}" || true
+                        else
+                            tar -czf log-ut.tar.gz --files-from /dev/null
+                        fi
+                        rm -f "\${tmp_file}"
+                        ls -alh log-ut.tar.gz
                     """
                     archiveArtifacts artifacts: "log-ut.tar.gz", fingerprint: true
                 }


### PR DESCRIPTION
## Summary

Align tikv/tikv release-7.5 pull_unit_test pipeline and pod template with release-8.5 patterns for GCP migration. This is PR2 of 2 for [FLA-218](https://github.com/PingCAP-QE/ci/issues/218).

## Changes

### Pod template (`pod-pull_unit_test.yaml`)
- Image: `hub.pingcap.net/...` → `ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135` (GCP-compatible)
- Added pod-level `securityContext.fsGroup: 1000`
- Added `imagePullPolicy: Always`
- Memory: 32Gi → 24Gi (align with 8.5)

### Pipeline (`pull_unit_test.groovy`)
- `$HOME/tikv-src` → `${WORKSPACE}/tikv-src` (all hardcoded paths)
- `prow.checkoutRefs` → `prow.checkoutRefsWithCacheLock` (cache-safe)
- `emptyDir` → `genericEphemeralVolume` + `hyperdisk-rwo` (300Gi)
- Duplicate if/else partition blocks → `for partition in 1/2 2/2` loop
- Log archiving: safe fallback when no .log files exist
- Removed `devtoolset-8` sourcing (GCP images include gcc)
- Added named constants for directories and archive filenames

## Testing

- CI will verify pipeline execution on GCP cluster
- Follows proven release-8.5 patterns

## Risk

Medium risk — pipeline rewrite. Rollback: revert this PR to restore old pipeline. Key risk is toolchain compatibility (devtoolset-8 removal); GCP images include gcc natively.