### PR TITLE
fix(pipelines/pingcap/tiflash): increase pull_unit_next_gen and pull_unit_test timeout to 120min

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     options {
-        timeout(time: 90, unit: 'MINUTES')
+        timeout(time: 120, unit: 'MINUTES')
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     options {
-        timeout(time: 90, unit: 'MINUTES')
+        timeout(time: 120, unit: 'MINUTES')
     }
     stages {
         stage('Checkout') {


### PR DESCRIPTION
## Summary

Increase the overall pipeline timeout for `pull_unit_next_gen` and `pull_unit_test` from 90min to 120min (2h) to accommodate longer build+test scenarios.

Jobs:
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_unit_next_gen
- https://prow.tidb.net/jenkins/job/pingcap/job/tiflash/job/pull_unit_test

## Changes

- `pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy:24`: `timeout(time: 90, unit: "MINUTES")` → `timeout(time: 120, unit: "MINUTES")`
- `pipelines/pingcap/tiflash/latest/pull_unit_test.groovy:24`: `timeout(time: 90, unit: "MINUTES")` → `timeout(time: 120, unit: "MINUTES")`

## Testing

- Verified the diff is a two-line change
- No syntax changes beyond the timeout values

## Risk

Low — only affects the timeout ceiling, no logic change.