### PR TITLE
fix(pipelines/tidb-test): move unstash outside dir() to fix double-nesting

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -99,8 +99,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
                                 container("java") {
                                     sh label: "test_params=${TEST_PARAMS} ", script: """
                                         #!/usr/bin/env bash

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -99,8 +99,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
                                 sh label: "test_params=${TEST_PARAMS} ", script: """
                                     #!/usr/bin/env bash
                                     params_array=(\${TEST_PARAMS})

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -103,8 +103,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
                                 container("java") {
                                     sh label: "test_params=${TEST_PARAMS} ", script: """
                                         #!/usr/bin/env bash

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -99,20 +99,18 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
-                                dir('mysql_test') {
-                                    sh label: "PART ${PART}", script: """
-                                        #!/usr/bin/env bash
-                                        ls -alh
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
-                                        export TIKV_PATH="127.0.0.1:2379"
-                                        export TIDB_TEST_STORE_NAME="tikv"
-                                        ./test.sh 1 ${PART}
-                                    """
-                                }
+                            unstash name: WORKSPACE_STASH_NAME
+                            dir('tidb-test/mysql_test') {
+                                sh label: "PART ${PART}", script: """
+                                    #!/usr/bin/env bash
+                                    ls -alh
+                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
+                                    export TIKV_PATH="127.0.0.1:2379"
+                                    export TIDB_TEST_STORE_NAME="tikv"
+                                    ./test.sh 1 ${PART}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -98,8 +98,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
                                 sh """
                                     mkdir -p bin
                                     cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -98,8 +98,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
                                 sh label: "test_params=${TEST_PARAMS} ", script: """
                                     #!/bin/bash
                                     set -- \${TEST_PARAMS}

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
@@ -79,15 +79,13 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
-                                dir('mysql_test') {
-                                    sh label: "part ${PART}", script: """
-                                    export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
-                                    export TIDB_TEST_STORE_NAME="unistore"
-                                    ./test.sh 1 ${PART}
-                                    """
-                                }
+                            unstash name: WORKSPACE_STASH_NAME
+                            dir('tidb-test/mysql_test') {
+                                sh label: "part ${PART}", script: """
+                                export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
+                                export TIDB_TEST_STORE_NAME="unistore"
+                                ./test.sh 1 ${PART}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -139,8 +139,8 @@ pipeline {
                 stages {
                     stage('Test') {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir(REFS.repo) {
-                                unstash name: WORKSPACE_STASH_NAME
                                 sh 'chmod +x bin/{tidb-server,pd-server,tikv-server,tikv-worker}'
                                 sh label: "store=${STORE} test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
                                     params_array=(\${TEST_PARAMS})

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -104,8 +104,8 @@ pipeline {
                 stages {
                     stage('Test') {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir(REFS.repo) {
-                                unstash name: WORKSPACE_STASH_NAME
                                 sh 'ls mysql_test && chmod +x bin/{tidb-server,pd-server,tikv-server,tikv-worker}'
                                 sh label: "store=${STORE} part=${PART}", script: """#!/usr/bin/env bash
                                     if [ "$STORE" == "tikv" ]; then

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -100,8 +100,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
                                 sh label: "test_cmds=${TEST_CMDS} ", script: """
                                     #!/usr/bin/env bash
                                     ${TEST_CMDS}

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -99,8 +99,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
                                 container("java") {
                                     sh label: "test_cmds=${TEST_CMDS} ", script: """
                                         #!/usr/bin/env bash

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
@@ -79,8 +79,8 @@ pipeline {
             }
             steps {
                 container('mysql-client-test') {
+                    unstash name: WORKSPACE_STASH_NAME
                     dir('tidb-test') {
-                        unstash name: WORKSPACE_STASH_NAME
                         sh label: "run test", script: """
                             #!/usr/bin/env bash
                             make mysql_client_test WITH_TIPROXY=1

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -97,8 +97,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
                                 sh label: "PART ${PART}", script: """
                                     #!/usr/bin/env bash
                                     make deploy-mysqltest ARGS="-b -x y -s tikv -p ${PART}"

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -97,8 +97,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
+                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
-                                unstash name: WORKSPACE_STASH_NAME
                                 container("ruby") {
                                     sh label: "prepare ruby test deps", script: """
                                         #!/usr/bin/env bash


### PR DESCRIPTION
## Problem

Refactored all 15 `pipelines/pingcap-qe/tidb-test/latest/*/pipeline.groovy` files to use stash/unstash for workspace handoff between the `Checkout & Prepare` stage and parallel Test stages.

However, the stash is created at the **workspace root** (outside any `dir()` block), so it contains paths with the `tidb-test/` prefix (e.g., `tidb-test/mysql_test/test.sh`). In the Test stage, the `unstash` was placed **inside** `dir('tidb-test')` or `dir(REFS.repo)`, causing files to be extracted to a double-nested path like `tidb-test/tidb-test/mysql_test/test.sh`.

This results in `./test.sh: No such file or directory` (exit code 127) for all parallel matrix branches.

**Failing job**: https://prow.tidb.net/jenkins/job/pingcap-qe/job/tidb-test/job/ghpr_mysql_test/12

## Fix

Move `unstash name: WORKSPACE_STASH_NAME` outside the `dir()` wrapper in the Test stage, so files are extracted at the workspace root where the stash paths naturally resolve to the correct locations.

## Affected pipelines (14 of 15)

| Pipeline | Pattern |
|---|---|
| `ghpr_mysql_test` | `unstash` out of `dir('tidb-test')` |
| `ghpr_common_test` | same |
| `ghpr_integration_common_test` | same |
| `ghpr_integration_jdbc_test` | same |
| `ghpr_integration_mysql_test` | same (+ merged nested `dir('mysql_test')`) |
| `ghpr_integration_nodejs_test` | same |
| `ghpr_integration_python_orm_test` | same |
| `pull_tiproxy_common_test` | same |
| `pull_tiproxy_jdbc_test` | same |
| `pull_tiproxy_mysql_connector_test` | same |
| `pull_tiproxy_mysql_test` | same |
| `pull_tiproxy_ruby_orm_test` | same |
| `pull_integration_jdbc_test_next_gen` | `unstash` out of `dir(REFS.repo)` |
| `pull_mysql_test_next_gen` | same |

`ghpr_build` is not affected (no stash/unstash pattern).