### PR TITLE
fix(pipelines/tidb-test): stash from within dir() blocks to fix unstash failures

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -68,7 +68,7 @@ pipeline {
                             """
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('JDBC Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -71,7 +71,7 @@ pipeline {
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -11,6 +11,7 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
+final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 pipeline {
     agent none
@@ -67,8 +68,11 @@ pipeline {
                                 ls bin/tikv-server && ./bin/tikv-server -V
                             """
                     }
+                    stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                dir('tidb-test') {
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                }
             }
         }
         stage('JDBC Tests') {
@@ -99,8 +103,11 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
+                            dir('tidb') {
+                                unstash name: TIDB_BIN_STASH_NAME
+                            }
                             dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
                                 container("java") {
                                     sh label: "test_params=${TEST_PARAMS} ", script: """
                                         #!/usr/bin/env bash

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -71,7 +71,7 @@ pipeline {
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -68,7 +68,7 @@ pipeline {
                             """
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -11,6 +11,7 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
+final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 pipeline {
     agent none
@@ -67,8 +68,11 @@ pipeline {
                                 ls bin/tikv-server && ./bin/tikv-server -V
                             """
                     }
+                    stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                dir('tidb-test') {
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                }
             }
         }
         stage('Tests') {
@@ -99,8 +103,11 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
+                            dir('tidb') {
+                                unstash name: TIDB_BIN_STASH_NAME
+                            }
                             dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
                                 sh label: "test_params=${TEST_PARAMS} ", script: """
                                     #!/usr/bin/env bash
                                     params_array=(\${TEST_PARAMS})

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -11,6 +11,7 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
+final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 pipeline {
     agent none
@@ -67,8 +68,11 @@ pipeline {
                                 ls bin/tikv-server && ./bin/tikv-server -V
                             """
                     }
+                    stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                dir('tidb-test') {
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                }
             }
         }
         stage('JDBC Tests') {
@@ -103,8 +107,11 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
+                            dir('tidb') {
+                                unstash name: TIDB_BIN_STASH_NAME
+                            }
                             dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
                                 container("java") {
                                     sh label: "test_params=${TEST_PARAMS} ", script: """
                                         #!/usr/bin/env bash

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -68,7 +68,7 @@ pipeline {
                             """
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('JDBC Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -71,7 +71,7 @@ pipeline {
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -72,7 +72,7 @@ pipeline {
                         sh "touch ws-${BUILD_TAG}"
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('MySQL Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -11,7 +11,6 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
-final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 pipeline {
     agent none
@@ -69,10 +68,7 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./mysql_test", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
-                        sh "touch ws-${BUILD_TAG}"
-                    }
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -11,6 +11,7 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
+final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 pipeline {
     agent none
@@ -71,8 +72,8 @@ pipeline {
                     cache(path: "./mysql_test", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
                         sh "touch ws-${BUILD_TAG}"
                     }
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('MySQL Tests') {
@@ -99,18 +100,20 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
-                            dir('tidb-test/mysql_test') {
-                                sh label: "PART ${PART}", script: """
-                                    #!/usr/bin/env bash
-                                    ls -alh
-                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
-                                    export TIKV_PATH="127.0.0.1:2379"
-                                    export TIDB_TEST_STORE_NAME="tikv"
-                                    ./test.sh 1 ${PART}
-                                """
+                            dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
+                                dir('mysql_test') {
+                                    sh label: "PART ${PART}", script: """
+                                        #!/usr/bin/env bash
+                                        ls -alh
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
+                                        export TIKV_PATH="127.0.0.1:2379"
+                                        export TIDB_TEST_STORE_NAME="tikv"
+                                        ./test.sh 1 ${PART}
+                                    """
+                                }
                             }
                         }
                         post{

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -11,6 +11,7 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
+final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 pipeline {
     agent none
@@ -66,8 +67,11 @@ pipeline {
                             ls bin/tikv-server && ./bin/tikv-server -V
                         """
                     }
+                    stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                dir('tidb-test') {
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                }
             }
         }
         stage('Node.js Tests') {
@@ -98,8 +102,11 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
+                            dir('tidb') {
+                                unstash name: TIDB_BIN_STASH_NAME
+                            }
                             dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
                                 sh """
                                     mkdir -p bin
                                     cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -70,7 +70,7 @@ pipeline {
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -67,7 +67,7 @@ pipeline {
                         """
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('Node.js Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -67,7 +67,7 @@ pipeline {
                             """
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -11,6 +11,7 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
 final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
+final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 pipeline {
     agent none
@@ -66,8 +67,11 @@ pipeline {
                                 ls bin/tikv-server && ./bin/tikv-server -V
                             """
                     }
+                    stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                dir('tidb-test') {
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                }
             }
         }
         stage('Tests') {
@@ -98,8 +102,11 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
+                            dir('tidb') {
+                                unstash name: TIDB_BIN_STASH_NAME
+                            }
                             dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
                                 sh label: "test_params=${TEST_PARAMS} ", script: """
                                     #!/bin/bash
                                     set -- \${TEST_PARAMS}

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -70,7 +70,7 @@ pipeline {
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
@@ -52,7 +52,7 @@ pipeline {
                         sh "touch ws-${BUILD_TAG}"
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('MySQL Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
@@ -50,10 +50,7 @@ pipeline {
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {
-                    cache(path: "./mysql_test", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
-                        sh "touch ws-${BUILD_TAG}"
-                    }
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
@@ -9,6 +9,7 @@ final K8S_NAMESPACE = "jenkins-tidb"
 final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod.yaml"
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
+final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 pipeline {
     agent none
@@ -46,13 +47,14 @@ pipeline {
                     cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
                         sh label: 'tidb-server', script: 'make'
                     }
+                    stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {
                     cache(path: "./mysql_test", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
                         sh "touch ws-${BUILD_TAG}"
                     }
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('MySQL Tests') {
@@ -79,13 +81,18 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
-                            dir('tidb-test/mysql_test') {
-                                sh label: "part ${PART}", script: """
-                                export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
-                                export TIDB_TEST_STORE_NAME="unistore"
-                                ./test.sh 1 ${PART}
-                                """
+                            dir('tidb') {
+                                unstash name: TIDB_BIN_STASH_NAME
+                            }
+                            dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: """
+                                    export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
+                                    export TIDB_TEST_STORE_NAME="unistore"
+                                    ./test.sh 1 ${PART}
+                                    """
+                                }
                             }
                         }
                         post{

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -73,7 +73,7 @@ pipeline {
                         }
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -12,6 +12,7 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
 final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
+final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 
 prow.setPRDescription(REFS)
@@ -72,8 +73,8 @@ pipeline {
                             sh "cp ${WORKSPACE}/tidb/bin/* ./"
                         }
                     }
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('Tests') {
@@ -139,8 +140,8 @@ pipeline {
                 stages {
                     stage('Test') {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
                             dir(REFS.repo) {
+                                unstash name: WORKSPACE_STASH_NAME
                                 sh 'chmod +x bin/{tidb-server,pd-server,tikv-server,tikv-worker}'
                                 sh label: "store=${STORE} test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
                                     params_array=(\${TEST_PARAMS})

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -12,7 +12,6 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
 final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
-final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 
 prow.setPRDescription(REFS)
@@ -73,7 +72,7 @@ pipeline {
                             sh "cp ${WORKSPACE}/tidb/bin/* ./"
                         }
                     }
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -73,7 +73,7 @@ pipeline {
                         }
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -12,6 +12,7 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
 final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
+final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 
 prow.setPRDescription(REFS)
@@ -72,8 +73,8 @@ pipeline {
                             sh "cp ${WORKSPACE}/tidb/bin/* ./"
                         }
                     }
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('Tests') {
@@ -104,8 +105,8 @@ pipeline {
                 stages {
                     stage('Test') {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
                             dir(REFS.repo) {
+                                unstash name: WORKSPACE_STASH_NAME
                                 sh 'ls mysql_test && chmod +x bin/{tidb-server,pd-server,tikv-server,tikv-worker}'
                                 sh label: "store=${STORE} part=${PART}", script: """#!/usr/bin/env bash
                                     if [ "$STORE" == "tikv" ]; then

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -12,7 +12,6 @@ final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "master-nextgen")
 final OCI_TAG_TIKV = (REFS.base_ref ==~ /release-nextgen-.*/ ? REFS.base_ref : "cloud-engine-nextgen")
 final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
-final TIDB_BIN_STASH_NAME = 'tidb-bin'
 
 
 prow.setPRDescription(REFS)
@@ -73,7 +72,7 @@ pipeline {
                             sh "cp ${WORKSPACE}/tidb/bin/* ./"
                         }
                     }
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -69,8 +69,8 @@ pipeline {
                             """
                         }
                     }
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('MySQL Tests') {
@@ -100,8 +100,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
                                 sh label: "test_cmds=${TEST_CMDS} ", script: """
                                     #!/usr/bin/env bash
                                     ${TEST_CMDS}

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -69,7 +69,7 @@ pipeline {
                             """
                         }
                     }
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -70,7 +70,7 @@ pipeline {
                         }
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('MySQL Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -70,7 +70,7 @@ pipeline {
                         }
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('JDBC Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -69,7 +69,7 @@ pipeline {
                             """
                         }
                     }
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -69,8 +69,8 @@ pipeline {
                             """
                         }
                     }
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('JDBC Tests') {
@@ -99,8 +99,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
                                 container("java") {
                                     sh label: "test_cmds=${TEST_CMDS} ", script: """
                                         #!/usr/bin/env bash

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
@@ -63,8 +63,8 @@ pipeline {
                     ./bin/tidb-server -V
                     ./bin/tiproxy --version
                     """
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('MySQL Connector Tests') {
@@ -79,8 +79,8 @@ pipeline {
             }
             steps {
                 container('mysql-client-test') {
-                    unstash name: WORKSPACE_STASH_NAME
                     dir('tidb-test') {
+                        unstash name: WORKSPACE_STASH_NAME
                         sh label: "run test", script: """
                             #!/usr/bin/env bash
                             make mysql_client_test WITH_TIPROXY=1

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
@@ -64,7 +64,7 @@ pipeline {
                     ./bin/tiproxy --version
                     """
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('MySQL Connector Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
@@ -63,7 +63,7 @@ pipeline {
                     ./bin/tidb-server -V
                     ./bin/tiproxy --version
                     """
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -69,8 +69,8 @@ pipeline {
                             """
                         }
                     }
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('MySQL Tests') {
@@ -97,8 +97,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
                                 sh label: "PART ${PART}", script: """
                                     #!/usr/bin/env bash
                                     make deploy-mysqltest ARGS="-b -x y -s tikv -p ${PART}"

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -69,7 +69,7 @@ pipeline {
                             """
                         }
                     }
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -70,7 +70,7 @@ pipeline {
                         }
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('MySQL Tests') {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -69,8 +69,8 @@ pipeline {
                             """
                         }
                     }
+                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
                 }
-                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('ORM Tests') {
@@ -97,8 +97,8 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            unstash name: WORKSPACE_STASH_NAME
                             dir('tidb-test') {
+                                unstash name: WORKSPACE_STASH_NAME
                                 container("ruby") {
                                     sh label: "prepare ruby test deps", script: """
                                         #!/usr/bin/env bash

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -69,7 +69,7 @@ pipeline {
                             """
                         }
                     }
-                    stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME
+                    stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
         }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -70,7 +70,7 @@ pipeline {
                         }
                     }
                 }
-                stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
+                stash includes: '**/*', excludes: '**/.git', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
             }
         }
         stage('ORM Tests') {


### PR DESCRIPTION
## Problem

PR #4716 refactored tidb-test pipelines to use stash/unstash for workspace handoff. Two issues:

1. **Double-nesting**: Stash created at workspace root (containing `tidb-test/` prefix), but unstash inside `dir('tidb-test')` caused files to land at `tidb-test/tidb-test/...`
2. **`.git` conflict**: Stash included `.git/` from both ci repo and tidb-test repo. When unstash ran on new agent pods (which already had ci repo's `.git/`), it caused `java.nio.file.AccessDeniedException` on `.git/objects/pack/` files.

## Fix

Stash from **within** `dir()` blocks so paths are relative to that directory:

- `dir('tidb') { ...; stash includes: 'bin/**', name: 'tidb-bin' }` — stashes only `tidb/bin/`
- `dir('tidb-test') { ...; stash includes: '**/*', name: 'tidb-test-workspace' }` — stashes tidb-test content
- Test stage: unstash into matching `dir()` blocks

This avoids both the double-nesting and `.git` conflicts since each stash only contains that repo's own files.

## Cleanup

- Removed `excludes: '**/.git'` (no longer needed)
- Removed `cache(path: ./mysql_test)` blocks (replaced by stash/unstash)
- Removed unused `TIDB_BIN_STASH_NAME` constant from pipelines that don't need separate tidb/bin stash

## Affected pipelines (14)

All pipelines in `pipelines/pingcap-qe/tidb-test/latest/` except `ghpr_build` (no stash/unstash).