### PR TITLE
refactor(pipelines/tidb-test): apply stash/unstash to release branch ghpr_integration_mysql_test

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -35,40 +35,25 @@ pipeline {
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, trunkBranch=REFS.base_ref, timeout=5, credentialsId="")
-                            }
+                        script {
+                            component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, trunkBranch=REFS.base_ref, timeout=5, credentialsId="")
                         }
                     }
+
+                    sh label: 'compile tidb-server', script: 'make'
                 }
                 dir("tidb-test") {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
-                }
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
-                            }
-                        }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
+                    container("utils") {
+                        dir('mysql_test/bin') {
+                            sh label: 'download tidb components', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
                             """
+                            sh "cp -v ${WORKSPACE}/tidb/bin/* ./"
+                        }
                     }
-                }
-                dir('tidb-test') {
-                    sh "cp ${WORKSPACE}/tidb/bin/* ./bin/ 2>/dev/null || (mkdir -p bin && cp ${WORKSPACE}/tidb/bin/* ./bin/)"
                     stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }
@@ -99,16 +84,20 @@ pipeline {
                         steps {
                             dir('tidb-test') {
                                 unstash name: WORKSPACE_STASH_NAME
-                                sh label: "start tikv", script: """
-                                    #!/usr/bin/env bash
-                                    echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
-                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                """
                                 dir('mysql_test') {
+                                    sh label: "check binary", script: """
+                                        pwd && ls -alh
+                                        chmod +x bin/*
+                                        ls bin/tidb-server && ./bin/tidb-server -V
+                                        ls bin/pd-server && ./bin/pd-server -V
+                                        ls bin/tikv-server && ./bin/tikv-server -V
+                                    """
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
                                         ./test.sh 1 ${PART}

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -54,6 +54,12 @@ pipeline {
                                 """
                             }
                         }
+                        sh label: "check binary", script: """
+                                pwd && ls -alh
+                                ls bin/tidb-server && ./bin/tidb-server -V
+                                ls bin/pd-server && ./bin/pd-server -V
+                                ls bin/tikv-server && ./bin/tikv-server -V
+                            """
                     }
                 }
                 dir('tidb-test') {
@@ -87,15 +93,12 @@ pipeline {
                         steps {
                             dir('tidb-test') {
                                 unstash name: 'tidb-test-workspace'
-                                sh label: "start tikv", script: """
-                                    #!/usr/bin/env bash
-                                    echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
-                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                """
                                 dir('mysql_test') {
                                     sh label: "CACHE_ENABLED ${CACHE_ENABLED}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
+                                        echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
                                         export CACHE_ENABLED=${CACHE_ENABLED}
                                         export TIKV_PATH="127.0.0.1:2379"

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -89,7 +89,7 @@ pipeline {
                                     sh label: "CACHE_ENABLED ${CACHE_ENABLED}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
-                                        echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export CACHE_ENABLED=${CACHE_ENABLED}

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -31,40 +31,24 @@ pipeline {
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}}", restoreKeys: ['git/pingcap/tidb/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, trunkBranch=REFS.base_ref, timeout=5, credentialsId="")
-                            }
+                        script {
+                            component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, trunkBranch=REFS.base_ref, timeout=5, credentialsId="")
                         }
                     }
+                    sh label: 'compile tidb-server', script: 'ls bin/tidb-server || make'
                 }
                 dir("tidb-test") {
                     script {
                         prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
                     }
-                }
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
-                            }
-                        }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
+                    container("utils") {
+                        dir('mysql_test/bin') {
+                            sh label: 'download tidb components', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
                             """
+                            sh "cp -v ${WORKSPACE}/tidb/bin/* ./"
+                        }
                     }
-                }
-                dir('tidb-test') {
-                    sh "cp ${WORKSPACE}/tidb/bin/* ./bin/ 2>/dev/null || (mkdir -p bin && cp ${WORKSPACE}/tidb/bin/* ./bin/)"
                     stash includes: '**/*', name: 'tidb-test-workspace'
                 }
             }
@@ -95,12 +79,19 @@ pipeline {
                             dir('tidb-test') {
                                 unstash name: 'tidb-test-workspace'
                                 dir('mysql_test') {
+                                    sh label: "check binary", script: """
+                                        pwd && ls -alh
+                                        chmod +x bin/*
+                                        ls bin/tidb-server && ./bin/tidb-server -V
+                                        ls bin/pd-server && ./bin/pd-server -V
+                                        ls bin/tikv-server && ./bin/tikv-server -V
+                                    """
                                     sh label: "CACHE_ENABLED ${CACHE_ENABLED}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
                                         echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export CACHE_ENABLED=${CACHE_ENABLED}
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -48,10 +48,11 @@ pipeline {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
                         container("utils") {
                             dir("bin") {
-                                sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    ls -alh .
-                                """
+                                retry(3) {
+                                    sh label: 'download tidb components', script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                    """
+                                }
                             }
                         }
                         sh label: "check binary", script: """

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/ghpr_integration_mysql_test.groovy
@@ -26,8 +26,8 @@ pipeline {
         timeout(time: 70, unit: 'MINUTES')
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 5, unit: 'MINUTES') }
+        stage('Checkout & Prepare') {
+            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}}", restoreKeys: ['git/pingcap/tidb/rev-']) {
@@ -39,18 +39,10 @@ pipeline {
                     }
                 }
                 dir("tidb-test") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
                     }
                 }
-            }
-        }
-        stage('Prepare') {
-            steps {
                 dir('tidb') {
                     cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
@@ -65,9 +57,8 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./mysql_test", includes: '**/*', key: "ws/tidb-test/mysql-test/rev-${REFS.pulls[0].sha}") {
-                        sh "touch ws-${BUILD_TAG}"
-                    }
+                    sh "cp ${WORKSPACE}/tidb/bin/* ./bin/ 2>/dev/null || (mkdir -p bin && cp ${WORKSPACE}/tidb/bin/* ./bin/)"
+                    stash includes: '**/*', name: 'tidb-test-workspace'
                 }
             }
         }
@@ -94,29 +85,18 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                                    sh label: "print version", script: """
-                                        pwd && ls -alh
-                                        ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && chmod +x bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && chmod +x bin/tikv-server && ./bin/tikv-server -V
-                                    """
-                                }
-                            }
-                            dir('tidb-test/mysql_test') {
-                                sh """
-                                    mkdir -p bin
-                                    mv ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                    ls -alh bin/
+                            dir('tidb-test') {
+                                unstash name: 'tidb-test-workspace'
+                                sh label: "start tikv", script: """
+                                    #!/usr/bin/env bash
+                                    echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                 """
-                                cache(path: "./", includes: '**/*', key: "ws/tidb-test/mysql-test/rev-${REFS.pulls[0].sha}") {
+                                dir('mysql_test') {
                                     sh label: "CACHE_ENABLED ${CACHE_ENABLED}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
                                         export CACHE_ENABLED=${CACHE_ENABLED}
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -31,40 +31,24 @@ pipeline {
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}}", restoreKeys: ['git/pingcap/tidb/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, trunkBranch=REFS.base_ref, timeout=5, credentialsId="")
-                            }
+                        script {
+                            component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, trunkBranch=REFS.base_ref, timeout=5, credentialsId="")
                         }
                     }
+                    sh label: 'compile tidb-server', script: 'ls bin/tidb-server || make'
                 }
                 dir("tidb-test") {
                     script {
                         prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
                     }
-                }
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
-                            }
-                        }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
+                    container("utils") {
+                        dir('mysql_test/bin') {
+                            sh label: 'download tidb components', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
                             """
+                            sh "cp -v ${WORKSPACE}/tidb/bin/* ./"
+                        }
                     }
-                }
-                dir('tidb-test') {
-                    sh "cp ${WORKSPACE}/tidb/bin/* ./bin/ 2>/dev/null || (mkdir -p bin && cp ${WORKSPACE}/tidb/bin/* ./bin/)"
                     stash includes: '**/*', name: 'tidb-test-workspace'
                 }
             }
@@ -99,12 +83,19 @@ pipeline {
                             dir('tidb-test') {
                                 unstash name: 'tidb-test-workspace'
                                 dir('mysql_test') {
+                                    sh label: "check binary", script: """
+                                        pwd && ls -alh
+                                        chmod +x bin/*
+                                        ls bin/tidb-server && ./bin/tidb-server -V
+                                        ls bin/pd-server && ./bin/pd-server -V
+                                        ls bin/tikv-server && ./bin/tikv-server -V
+                                    """
                                     sh label: "PART ${PART},CACHE_ENABLED ${CACHE_ENABLED}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
                                         echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export CACHE_ENABLED=${CACHE_ENABLED}
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -26,8 +26,8 @@ pipeline {
         timeout(time: 45, unit: 'MINUTES')
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 5, unit: 'MINUTES') }
+        stage('Checkout & Prepare') {
+            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}}", restoreKeys: ['git/pingcap/tidb/rev-']) {
@@ -39,18 +39,10 @@ pipeline {
                     }
                 }
                 dir("tidb-test") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
                     }
                 }
-            }
-        }
-        stage('Prepare') {
-            steps {
                 dir('tidb') {
                     cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
@@ -65,9 +57,8 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./mysql_test", includes: '**/*', key: "ws/tidb-test/mysql-test/rev-${REFS.pulls[0].sha}") {
-                        sh "touch ws-${BUILD_TAG}"
-                    }
+                    sh "cp ${WORKSPACE}/tidb/bin/* ./bin/ 2>/dev/null || (mkdir -p bin && cp ${WORKSPACE}/tidb/bin/* ./bin/)"
+                    stash includes: '**/*', name: 'tidb-test-workspace'
                 }
             }
         }
@@ -98,29 +89,18 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                                    sh label: "print version", script: """
-                                        pwd && ls -alh
-                                        ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && chmod +x bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && chmod +x bin/tikv-server && ./bin/tikv-server -V
-                                    """
-                                }
-                            }
-                            dir('tidb-test/mysql_test') {
-                                sh """
-                                    mkdir -p bin
-                                    mv ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                    ls -alh bin/
+                            dir('tidb-test') {
+                                unstash name: 'tidb-test-workspace'
+                                sh label: "start tikv", script: """
+                                    #!/usr/bin/env bash
+                                    echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                 """
-                                cache(path: "./", includes: '**/*', key: "ws/tidb-test/mysql-test/rev-${REFS.pulls[0].sha}") {
+                                dir('mysql_test') {
                                     sh label: "PART ${PART},CACHE_ENABLED ${CACHE_ENABLED}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
                                         export CACHE_ENABLED=${CACHE_ENABLED}
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -93,7 +93,7 @@ pipeline {
                                     sh label: "PART ${PART},CACHE_ENABLED ${CACHE_ENABLED}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
-                                        echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export CACHE_ENABLED=${CACHE_ENABLED}

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -54,6 +54,12 @@ pipeline {
                                 """
                             }
                         }
+                        sh label: "check binary", script: """
+                                pwd && ls -alh
+                                ls bin/tidb-server && ./bin/tidb-server -V
+                                ls bin/pd-server && ./bin/pd-server -V
+                                ls bin/tikv-server && ./bin/tikv-server -V
+                            """
                     }
                 }
                 dir('tidb-test') {
@@ -91,15 +97,12 @@ pipeline {
                         steps {
                             dir('tidb-test') {
                                 unstash name: 'tidb-test-workspace'
-                                sh label: "start tikv", script: """
-                                    #!/usr/bin/env bash
-                                    echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
-                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                """
                                 dir('mysql_test') {
                                     sh label: "PART ${PART},CACHE_ENABLED ${CACHE_ENABLED}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
+                                        echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
                                         export CACHE_ENABLED=${CACHE_ENABLED}
                                         export TIKV_PATH="127.0.0.1:2379"

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/ghpr_integration_mysql_test.groovy
@@ -48,10 +48,11 @@ pipeline {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make'
                         container("utils") {
                             dir("bin") {
-                                sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    ls -alh .
-                                """
+                                retry(3) {
+                                    sh label: 'download tidb components', script: """
+                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                    """
+                                }
                             }
                         }
                         sh label: "check binary", script: """

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
@@ -23,8 +23,8 @@ pipeline {
         timeout(time: 45, unit: 'MINUTES')
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 5, unit: 'MINUTES') }
+        stage('Checkout & Prepare') {
+            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
@@ -36,18 +36,10 @@ pipeline {
                     }
                 }
                 dir("tidb-test") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
                     }
                 }
-            }
-        }
-        stage('Prepare') {
-            steps {
                 dir('tidb') {
                     cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
                         sh label: 'tidb-server', script: 'make'
@@ -69,9 +61,8 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./mysql_test", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
-                        sh "touch ws-${BUILD_TAG}"
-                    }
+                    sh "cp ${WORKSPACE}/tidb/bin/* ./bin/ 2>/dev/null || (mkdir -p bin && cp ${WORKSPACE}/tidb/bin/* ./bin/)"
+                    stash includes: '**/*', name: 'tidb-test-workspace'
                 }
             }
         }
@@ -98,29 +89,18 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                                    sh label: "print version", script: """
-                                        pwd && ls -alh
-                                        ls bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && ./bin/tikv-server -V
-                                    """
-                                }
-                            }
-                            dir('tidb-test/mysql_test') {
-                                sh """
-                                    mkdir -p bin
-                                    mv ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                    ls -alh bin/
+                            dir('tidb-test') {
+                                unstash name: 'tidb-test-workspace'
+                                sh label: "start tikv", script: """
+                                    #!/usr/bin/env bash
+                                    echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                 """
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
+                                dir('mysql_test') {
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
                                         ./test.sh -blacklist=1 -part=${PART}

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
@@ -91,15 +91,12 @@ pipeline {
                         steps {
                             dir('tidb-test') {
                                 unstash name: 'tidb-test-workspace'
-                                sh label: "start tikv", script: """
-                                    #!/usr/bin/env bash
-                                    echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
-                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                """
                                 dir('mysql_test') {
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
+                                        echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
@@ -28,40 +28,24 @@ pipeline {
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, trunkBranch=REFS.base_ref, timeout=5, credentialsId="")
-                            }
+                        script {
+                            component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, trunkBranch=REFS.base_ref, timeout=5, credentialsId="")
                         }
                     }
+                    sh label: 'compile tidb-server', script: 'make'
                 }
                 dir("tidb-test") {
                     script {
                         prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
                     }
-                }
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
-                            }
-                        }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
+                    container("utils") {
+                        dir('mysql_test/bin') {
+                            sh label: 'download tidb components', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
                             """
+                            sh "cp -v ${WORKSPACE}/tidb/bin/* ./"
+                        }
                     }
-                }
-                dir('tidb-test') {
-                    sh "cp ${WORKSPACE}/tidb/bin/* ./bin/ 2>/dev/null || (mkdir -p bin && cp ${WORKSPACE}/tidb/bin/* ./bin/)"
                     stash includes: '**/*', name: 'tidb-test-workspace'
                 }
             }
@@ -92,12 +76,19 @@ pipeline {
                             dir('tidb-test') {
                                 unstash name: 'tidb-test-workspace'
                                 dir('mysql_test') {
+                                    sh label: "check binary", script: """
+                                        pwd && ls -alh
+                                        chmod +x bin/*
+                                        ls bin/tidb-server && ./bin/tidb-server -V
+                                        ls bin/pd-server && ./bin/pd-server -V
+                                        ls bin/tikv-server && ./bin/tikv-server -V
+                                    """
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
                                         echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
                                         ./test.sh -blacklist=1 -part=${PART}

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
@@ -86,7 +86,7 @@ pipeline {
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
-                                        echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
@@ -91,7 +91,7 @@ pipeline {
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
-                                        echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
@@ -27,8 +27,8 @@ pipeline {
         timeout(time: 45, unit: 'MINUTES')
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 5, unit: 'MINUTES') }
+        stage('Checkout & Prepare') {
+            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
@@ -40,18 +40,10 @@ pipeline {
                     }
                 }
                 dir("tidb-test") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                 }
-            }
-        }
-        stage('Prepare') {
-            steps {
                 dir('tidb') {
                     cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
                         sh label: 'tidb-server', script: 'make'
@@ -73,9 +65,8 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./mysql_test", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
-                        sh "touch ws-${BUILD_TAG}"
-                    }
+                    sh "cp ${WORKSPACE}/tidb/bin/* ./bin/ 2>/dev/null || (mkdir -p bin && cp ${WORKSPACE}/tidb/bin/* ./bin/)"
+                    stash includes: '**/*', name: 'tidb-test-workspace'
                 }
             }
         }
@@ -103,29 +94,18 @@ pipeline {
                 stages {
                     stage("Test") {
                         steps {
-                            dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                                    sh label: "print version", script: """
-                                        pwd && ls -alh
-                                        ls bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && ./bin/tikv-server -V
-                                    """
-                                }
-                            }
-                            dir('tidb-test/mysql_test') {
-                                sh """
-                                    mkdir -p bin
-                                    mv ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                    ls -alh bin/
+                            dir('tidb-test') {
+                                unstash name: 'tidb-test-workspace'
+                                sh label: "start tikv", script: """
+                                    #!/usr/bin/env bash
+                                    echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                 """
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
+                                dir('mysql_test') {
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
                                         ./test.sh -blacklist=1 -part=${PART}

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
@@ -32,40 +32,24 @@ pipeline {
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, trunkBranch=REFS.base_ref, timeout=5, credentialsId="")
-                            }
+                        script {
+                            component.checkoutWithMergeBase('https://github.com/pingcap/tidb.git', 'tidb', REFS.base_ref, REFS.pulls[0].title, trunkBranch=REFS.base_ref, timeout=5, credentialsId="")
                         }
                     }
+                    sh label: 'compile tidb-server', script: 'make'
                 }
                 dir("tidb-test") {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
-                }
-                dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
-                            }
-                        }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
+                    container("utils") {
+                        dir('mysql_test/bin') {
+                            sh label: 'download tidb components', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
                             """
+                            sh "cp -v ${WORKSPACE}/tidb/bin/* ./"
+                        }
                     }
-                }
-                dir('tidb-test') {
-                    sh "cp ${WORKSPACE}/tidb/bin/* ./bin/ 2>/dev/null || (mkdir -p bin && cp ${WORKSPACE}/tidb/bin/* ./bin/)"
                     stash includes: '**/*', name: 'tidb-test-workspace'
                 }
             }
@@ -97,12 +81,19 @@ pipeline {
                             dir('tidb-test') {
                                 unstash name: 'tidb-test-workspace'
                                 dir('mysql_test') {
+                                    sh label: "check binary", script: """
+                                        pwd && ls -alh
+                                        chmod +x bin/*
+                                        ls bin/tidb-server && ./bin/tidb-server -V
+                                        ls bin/pd-server && ./bin/pd-server -V
+                                        ls bin/tikv-server && ./bin/tikv-server -V
+                                    """
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
                                         echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
                                         ./test.sh -blacklist=1 -part=${PART}

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
@@ -96,15 +96,12 @@ pipeline {
                         steps {
                             dir('tidb-test') {
                                 unstash name: 'tidb-test-workspace'
-                                sh label: "start tikv", script: """
-                                    #!/usr/bin/env bash
-                                    echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
-                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                """
                                 dir('mysql_test') {
                                     sh label: "PART ${PART}", script: """
                                         #!/usr/bin/env bash
                                         ls -alh
+                                        echo '[storage]\\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"


### PR DESCRIPTION
Apply the verified stash/unstash workspace handoff pattern from `latest/` to release branches (6.0, 6.2, 7.1, 8.5) for `ghpr_integration_mysql_test`.

## Changes (per branch)

- Merge `Checkout` + `Prepare` stages into `Checkout & Prepare`
- Replace cache-based workspace handoff with stash/unstash
- Copy tidb binaries into `tidb-test/bin/` before stashing
- Run `start_tikv.sh` from `dir('tidb-test')` where `bin/` exists
- Fix `TIDB_SERVER_PATH` to `tidb-test/bin/tidb-server`

## Branch-specific differences preserved

| Branch | Part axis | Cache axis | Agent | OCI default | Test args | Timeout |
|---|---|---|---|---|---|---|
| 6.0 | - | CACHE_ENABLED | yamlFile | base_ref | `./test.sh` | 70min |
| 6.2 | PART | CACHE_ENABLED | yamlFile | base_ref | `-blacklist=1 -part=` | 45min |
| 7.1 | PART | - | yamlFile | master | `-blacklist=1 -part=` | 45min |
| 8.5 | PART | - | yaml+ciLabels | master | `-blacklist=1 -part=` | 45min |