### PR TITLE
feat(tekton): add pluginGitRef plumbing for devbuilds (FLA-225 PR2)

### DIFF
--- a/tekton/v1/pipelines/pingcap-build-package-darwin.yaml
+++ b/tekton/v1/pipelines/pingcap-build-package-darwin.yaml
@@ -61,6 +61,12 @@ spec:
     - name: publisher-url
       description: The URL of the running publisher server
       default: https://publisher.pingcap.net
+    - name: pluginGitRef
+      description: >-
+        Explicit enterprise-plugin ref. When non-empty, the git-clone task
+        skips resolution and checks out this ref directly.
+      type: string
+      default: ""
   results:
     - name: pushed-binaries
       description: pushed binaries.
@@ -95,6 +101,8 @@ spec:
           value: "true"
         - name: external-git-ref
           value: $(params.git-ref)
+        - name: plugin-git-ref
+          value: $(params.pluginGitRef)
       workspaces:
         - name: output
           workspace: source

--- a/tekton/v1/pipelines/pingcap-build-package-linux.yaml
+++ b/tekton/v1/pipelines/pingcap-build-package-linux.yaml
@@ -60,6 +60,12 @@ spec:
     - name: publisher-url
       description: The URL of the running publisher server
       default: https://publisher.pingcap.net
+    - name: pluginGitRef
+      description: >-
+        Explicit enterprise-plugin ref. When non-empty, the git-clone task
+        skips resolution and checks out this ref directly.
+      type: string
+      default: ""
   results:
     - name: pushed-binaries
       description: pushed binaries.
@@ -98,6 +104,8 @@ spec:
           value: "true"
         - name: external-git-ref
           value: $(params.git-ref)
+        - name: plugin-git-ref
+          value: $(params.pluginGitRef)
       workspaces:
         - name: output
           workspace: source

--- a/tekton/v1/tasks/pingcap-git-clone.yaml
+++ b/tekton/v1/tasks/pingcap-git-clone.yaml
@@ -119,6 +119,13 @@ spec:
       description: The main repository git ref used to resolve the external repository revision.
       type: string
       default: ""
+    - name: plugin-git-ref
+      description: >-
+        Explicit enterprise-plugin ref (branch, tag, SHA). When non-empty,
+        the resolve-external step skips the resolution algorithm and uses this
+        value directly. Stripped of branch/ or tag/ prefix by CEL overlay.
+      type: string
+      default: ""
     - name: external-git-url
       description: URL of the external repository.
       type: string
@@ -312,6 +319,15 @@ spec:
       script: |
         #!/bin/sh
         set -eu
+
+        plugin_ref="$(params.plugin-git-ref)"
+        if [ -n "$plugin_ref" ]; then
+          printf "%s" "${plugin_ref}" > /workspace/pingcap-external-revision
+          printf "%s" "$(params.external-git-url)" > /workspace/pingcap-external-url
+          echo "external git url: $(cat /workspace/pingcap-external-url)"
+          echo "external git revision: $(cat /workspace/pingcap-external-revision)"
+          exit 0
+        fi
 
         origin_ref="$(params.external-git-ref)"
         if [ -z "$origin_ref" ]; then

--- a/tekton/v1/triggers/bindings/gcp-dev-build-params.yaml
+++ b/tekton/v1/triggers/bindings/gcp-dev-build-params.yaml
@@ -15,3 +15,4 @@ spec:
     - { name: registry, value: $(extensions.registry) }
     - { name: source-ws-size, value: $(extensions.resource-config.sourceWsSize) }
     - { name: timeout, value: $(extensions.resource-config.timeout) }
+    - { name: pluginGitRef, value: $(extensions.custom-params.plugin-git-ref) }

--- a/tekton/v1/triggers/bindings/ksy-dev-build-params.yaml
+++ b/tekton/v1/triggers/bindings/ksy-dev-build-params.yaml
@@ -15,6 +15,7 @@ spec:
     - { name: registry, value: $(extensions.registry) }
     - { name: source-ws-size, value: $(extensions.resource-config.sourceWsSize) }
     - { name: timeout, value: $(extensions.resource-config.timeout) }
+    - { name: pluginGitRef, value: $(extensions.custom-params.plugin-git-ref) }
     - name: git-instead-of
       value: >-
         https://github.com/ => http://git-cdn.cache.svc:8000/,

--- a/tekton/v1/triggers/templates/_/build-component-all-platforms.yaml
+++ b/tekton/v1/triggers/templates/_/build-component-all-platforms.yaml
@@ -44,6 +44,9 @@ spec:
         You can specify multiple `insteadOf` configurations separated by commas.
         For example: insteadof1 => new1, insteadof2 => new2
       default: ""
+    - name: pluginGitRef
+      description: Explicit enterprise-plugin ref. When non-empty, skips resolution.
+      default: ""
   resourcetemplates:
     - apiVersion: tekton.dev/v1
       kind: PipelineRun
@@ -85,6 +88,8 @@ spec:
             value: $(tt.params.publisher-url)
           - name: git-instead-of
             value: $(tt.params.git-instead-of)
+          - name: pluginGitRef
+            value: $(tt.params.pluginGitRef)
         taskRunTemplate:
           podTemplate:
             nodeSelector:
@@ -165,6 +170,8 @@ spec:
             value: $(tt.params.publisher-url)
           - name: git-instead-of
             value: $(tt.params.git-instead-of)
+          - name: pluginGitRef
+            value: $(tt.params.pluginGitRef)
         taskRunTemplate:
           podTemplate:
             nodeSelector:
@@ -247,6 +254,8 @@ spec:
             value: $(tt.params.publisher-url)
           - name: git-instead-of
             value: $(tt.params.git-instead-of)
+          - name: pluginGitRef
+            value: $(tt.params.pluginGitRef)
         timeouts:
           pipeline: $(tt.params.timeout)
         taskRunSpecs:
@@ -309,6 +318,8 @@ spec:
             value: $(tt.params.publisher-url)
           - name: git-instead-of
             value: $(tt.params.git-instead-of)
+          - name: pluginGitRef
+            value: $(tt.params.pluginGitRef)
         timeouts:
           pipeline: $(tt.params.timeout)
         taskRunSpecs:

--- a/tekton/v1/triggers/templates/_/build-component-darwin.yaml
+++ b/tekton/v1/triggers/templates/_/build-component-darwin.yaml
@@ -43,6 +43,9 @@ spec:
         You can specify multiple `insteadOf` configurations separated by commas.
         For example: insteadof1 => new1, insteadof2 => new2
       default: ""
+    - name: pluginGitRef
+      description: Explicit enterprise-plugin ref. When non-empty, skips resolution.
+      default: ""
   resourcetemplates:
     - apiVersion: tekton.dev/v1
       kind: PipelineRun
@@ -86,6 +89,8 @@ spec:
             value: $(tt.params.publisher-url)
           - name: git-instead-of
             value: $(tt.params.git-instead-of)
+          - name: pluginGitRef
+            value: $(tt.params.pluginGitRef)
         taskRunTemplate:
           podTemplate:
             nodeSelector:
@@ -152,6 +157,8 @@ spec:
             value: $(tt.params.publisher-url)
           - name: git-instead-of
             value: $(tt.params.git-instead-of)
+          - name: pluginGitRef
+            value: $(tt.params.pluginGitRef)
         taskRunTemplate:
           podTemplate:
             nodeSelector:

--- a/tekton/v1/triggers/templates/_/build-component-linux.yaml
+++ b/tekton/v1/triggers/templates/_/build-component-linux.yaml
@@ -45,6 +45,9 @@ spec:
         You can specify multiple `insteadOf` configurations separated by commas.
         For example: insteadof1 => new1, insteadof2 => new2
       default: ""
+    - name: pluginGitRef
+      description: Explicit enterprise-plugin ref. When non-empty, skips resolution.
+      default: ""
   resourcetemplates:
     - apiVersion: tekton.dev/v1
       kind: PipelineRun
@@ -86,6 +89,8 @@ spec:
             value: $(tt.params.publisher-url)
           - name: git-instead-of
             value: $(tt.params.git-instead-of)
+          - name: pluginGitRef
+            value: $(tt.params.pluginGitRef)
         taskRunTemplate:
           podTemplate:
             nodeSelector:
@@ -166,6 +171,8 @@ spec:
             value: $(tt.params.publisher-url)
           - name: git-instead-of
             value: $(tt.params.git-instead-of)
+          - name: pluginGitRef
+            value: $(tt.params.pluginGitRef)
         taskRunTemplate:
           podTemplate:
             nodeSelector:

--- a/tekton/v1/triggers/templates/_/build-component-single-platform.yaml
+++ b/tekton/v1/triggers/templates/_/build-component-single-platform.yaml
@@ -48,6 +48,9 @@ spec:
         You can specify multiple `insteadOf` configurations separated by commas.
         For example: insteadof1 => new1, insteadof2 => new2
       default: ""
+    - name: pluginGitRef
+      description: Explicit enterprise-plugin ref. When non-empty, skips resolution.
+      default: ""
   resourcetemplates:
     - apiVersion: tekton.dev/v1
       kind: PipelineRun
@@ -91,6 +94,8 @@ spec:
             value: $(tt.params.publisher-url)
           - name: git-instead-of
             value: $(tt.params.git-instead-of)
+          - name: pluginGitRef
+            value: $(tt.params.pluginGitRef)
         taskRunTemplate:
           podTemplate:
             nodeSelector:

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -137,6 +137,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -137,7 +137,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-branch-push.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-branch-push.yaml
@@ -137,7 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-branch-push.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-branch-push.yaml
@@ -137,6 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-pr-single-platform.yaml
@@ -137,6 +137,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-pr-single-platform.yaml
@@ -137,7 +137,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-pr.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-pr.yaml
@@ -137,7 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-pr.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-pr.yaml
@@ -137,6 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -139,7 +139,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -139,6 +139,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-tag-create.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-tag-create.yaml
@@ -137,7 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-tag-create.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/fake-github/fake-github-tag-create.yaml
@@ -137,6 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -139,7 +139,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -139,6 +139,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push.yaml
@@ -137,7 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push.yaml
@@ -137,6 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr-single-platform.yaml
@@ -139,7 +139,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr-single-platform.yaml
@@ -139,6 +139,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr.yaml
@@ -137,7 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr.yaml
@@ -137,6 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -141,7 +141,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -141,6 +141,7 @@ spec:
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
                   'os': header.canonical('ce-paramPlatform').split('/')[0],
                   'arch': header.canonical('ce-paramPlatform').split('/')[1],
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create.yaml
@@ -137,7 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
-                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('branch/', '').replace('tag/', ''),
                 }
             - key: component
               expression: >-

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create.yaml
@@ -137,6 +137,7 @@ spec:
                 {
                   'builder-image': header.canonical('ce-paramBuilderImage'),
                   'profile': header.canonical('ce-paramProfile') == '' ? 'release' : (header.canonical('ce-paramProfile') == 'community' ? 'release' : header.canonical('ce-paramProfile')),
+                  'plugin-git-ref': header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ''),
                 }
             - key: component
               expression: >-


### PR DESCRIPTION
## Summary

Add the full Tekton plumbing for `pluginGitRef` so that devbuilds can specify a custom enterprise-plugin ref that bypasses the `resolve-external` algorithm.

**Data flow**: CloudEvent `ce-paramPluginGitRef` → CEL overlay (strip `branch/`/`tag/` prefix) → TriggerBinding → TriggerTemplate → Pipeline → Task (`plugin-git-ref` param).

When `plugin-git-ref` is non-empty, the `resolve-external` step skips the entire resolution algorithm and uses the value directly. This is correct because `pluginGitRef` is a user-specified enterprise-plugin ref, not a main repo ref.

## Changes

**Task** (`pingcap-git-clone.yaml`):
- Added `plugin-git-ref` param (default `""`)
- Modified `resolve-external` step: when `plugin-git-ref` is non-empty, write it directly to `/workspace/pingcap-external-revision` and exit (skip resolution algorithm)

**Pipelines** (2 files):
- Added `pluginGitRef` pipeline param (default `""`) to `pingcap-build-package-linux` and `pingcap-build-package-darwin`
- Wired to task `plugin-git-ref` param in checkout task

**Templates** (4 files):
- Added `pluginGitRef` template param (default `""`) to `build-component-all-platforms`, `build-component-linux`, `build-component-darwin`, `build-component-single-platform`
- Wired to PipelineRun pipeline params

**Bindings** (2 files):
- Added `pluginGitRef` binding to `gcp-dev-build-params` and `ksy-dev-build-params` from `$(extensions.custom-params.plugin-git-ref)`

**Triggers** (12 files):
- Added CEL overlay `plugin-git-ref` to `custom-params` in all 12 fake-github triggers (env-gcp + env-prod2)
- Expression: `header.canonical('ce-paramPluginGitRef').replace('^(branch|tag)/', ')`

## Testing

- Verified YAML validity of all 21 modified files
- Verified data flow consistency: CE header → CEL → binding → template → pipeline → task param
- Verified backward compatibility: all new params default to `""`, so existing behavior is unchanged
- CI checks on this PR

## Risk

Low. All changes are additive with empty-string defaults. When `pluginGitRef` is not set, the existing `resolve-external` algorithm runs unchanged. Rollback: remove new params from task/pipeline/template/binding.

Refs: FLA-225 PR2 | Depends on: PingCAP-QE/ee-apps#531 (PR1, merged)