### PR TITLE
feat(tekton): use ConfigMap volumes for delivery configs

### DIFF
--- a/tekton/v1/pipelines/pingcap-build-package-linux.yaml
+++ b/tekton/v1/pipelines/pingcap-build-package-linux.yaml
@@ -82,6 +82,11 @@ spec:
     - name: cypress-cache
       description: cache for cypress installation files when building frontend projects.
       optional: true
+    - name: delivery-config
+      optional: true
+      description: >
+        ConfigMap volume containing delivery.yaml and related scripts.
+        When provided, tasks read from this workspace instead of downloading from GitHub.
   tasks:
     - name: checkout
       retries: 2
@@ -245,3 +250,6 @@ spec:
           value: $(tasks.build-images.results.pushed)
         - name: src-type
           value: images-info
+      workspaces:
+        - name: delivery-config
+          workspace: delivery-config

--- a/tekton/v1/pipelines/pingcap-release-ga.yaml
+++ b/tekton/v1/pipelines/pingcap-release-ga.yaml
@@ -27,6 +27,11 @@ spec:
     - name: s3-secrets
     - name: github
       description: for creating github release
+    - name: delivery-config
+      optional: true
+      description: >
+        ConfigMap volume containing delivery.yaml and related scripts.
+        When provided, tasks read from this workspace instead of downloading from GitHub.
   tasks:
     - name: ga-tag-oci-artifacts
       params:
@@ -40,6 +45,9 @@ spec:
           value: $(params.publisher-url)
       taskRef:
         name: tag-and-deliver-rc2ga-on-oci-artifacts
+      workspaces:
+        - name: delivery-config
+          workspace: delivery-config
     - name: create-releases
       runAfter: [ga-tag-oci-artifacts]
       taskRef:
@@ -68,6 +76,9 @@ spec:
           value: https://github.com/PingCAP-QE/artifacts/raw/main/packages/delivery.yaml
       taskRef:
         name: wait-delivery-images
+      workspaces:
+        - name: delivery-config
+          workspace: delivery-config
     - name: compose-offline-pkgs-amd64-community
       runAfter: [wait-delivery-tiup]
       taskRef: { name: pingcap-compose-offline-pkgs }

--- a/tekton/v1/tasks/delivery/pingcap-deliver-images.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-deliver-images.yaml
@@ -12,6 +12,12 @@ metadata:
     tekton.dev/displayName: "PingCAP product image delivery"
     tekton.dev/platforms: "linux/amd64,linux/arm64"
 spec:
+  workspaces:
+    - name: delivery-config
+      optional: true
+      description: >
+        ConfigMap volume containing delivery.yaml and gen-delivery-image-commands.ts.
+        When provided, files are read from this workspace instead of downloading from GitHub.
   params:
     - name: src
     - name: src-type
@@ -44,19 +50,33 @@ spec:
         #!/bin/sh
         set -e
 
-        wget -O delivery.yaml $(params.delivery-config-url)
+        config_dir="$(workspaces.delivery-config.path)"
+        if [ -n "$config_dir" ] && [ -f "$config_dir/delivery.yaml" ]; then
+          echo "Using delivery.yaml from ConfigMap workspace"
+          cp "$config_dir/delivery.yaml" delivery.yaml
+        else
+          echo "ConfigMap not available, falling back to download"
+          wget -O delivery.yaml $(params.delivery-config-url)
+        fi
+        if [ -n "$config_dir" ] && [ -f "$config_dir/gen-delivery-image-commands.ts" ]; then
+          echo "Using gen-delivery-image-commands.ts from ConfigMap workspace"
+          generator_script="$config_dir/gen-delivery-image-commands.ts"
+        else
+          echo "ConfigMap not available, falling back to download"
+          generator_script="$(params.generator-script-url)"
+        fi
         script="/workspace/delivery.sh"
         targetsInfo="/workspace/delivery-targets.yaml"
         img_src="$(params.src)"
         if [ "$(params.src-type)" = "image-url" ]; then
-          deno run --allow-read --allow-write "$(params.generator-script-url)" \
+          deno run --allow-read --allow-write "$generator_script" \
             --image_url="$img_src" \
             --yaml_file=delivery.yaml \
             --outfile=$script \
             --images_outfile=$targetsInfo
         elif [ "$(params.src-type)" = "images-info" ]; then
           echo "$img_src" > /workspace/src.txt
-          deno run --allow-read --allow-write "$(params.generator-script-url)" \
+          deno run --allow-read --allow-write "$generator_script" \
             --images_file="/workspace/src.txt" \
             --yaml_file=delivery.yaml \
             --outfile=$script \

--- a/tekton/v1/tasks/release/tag-and-delivery-rc2ga-on-oci-artifacts.yaml
+++ b/tekton/v1/tasks/release/tag-and-delivery-rc2ga-on-oci-artifacts.yaml
@@ -5,6 +5,12 @@ metadata:
   name: tag-and-deliver-rc2ga-on-oci-artifacts
 spec:
   description: include images and non-image artifacts.
+  workspaces:
+    - name: delivery-config
+      optional: true
+      description: >
+        ConfigMap volume containing delivery.yaml and gen-delivery-image-commands.ts.
+        When provided, files are read from this workspace instead of downloading from GitHub.
   params:
     - name: rc-version
       description: >
@@ -88,11 +94,25 @@ spec:
         # prepare the images info file
         yq -r '.images[]' /workspace/results.yaml | awk -F: '{print "- { repo: " $1 ", tag: " $2, "}"}' | tee /workspace/images.yaml
 
-        # prepare the delivery script
-        wget -O delivery.yaml $(params.delivery-config-url)
+        # prepare the delivery script - try ConfigMap workspace first, fall back to download
+        config_dir="$(workspaces.delivery-config.path)"
+        if [ -n "$config_dir" ] && [ -f "$config_dir/delivery.yaml" ]; then
+          echo "Using delivery.yaml from ConfigMap workspace"
+          cp "$config_dir/delivery.yaml" delivery.yaml
+        else
+          echo "ConfigMap not available, falling back to download"
+          wget -O delivery.yaml $(params.delivery-config-url)
+        fi
+        if [ -n "$config_dir" ] && [ -f "$config_dir/gen-delivery-image-commands.ts" ]; then
+          echo "Using gen-delivery-image-commands.ts from ConfigMap workspace"
+          generator_script="$config_dir/gen-delivery-image-commands.ts"
+        else
+          echo "ConfigMap not available, falling back to download"
+          generator_script="$(params.generator-script-url)"
+        fi
         script="/workspace/delivery.sh"
         targetsInfo="/workspace/delivery-targets.yaml"
-        deno run --allow-read --allow-write "$(params.generator-script-url)" \
+        deno run --allow-read --allow-write "$generator_script" \
           --images_file="/workspace/images.yaml" \
           --yaml_file=delivery.yaml \
           --outfile=$script \

--- a/tekton/v1/tasks/release/wait-delivery-images.yaml
+++ b/tekton/v1/tasks/release/wait-delivery-images.yaml
@@ -7,6 +7,12 @@ spec:
   description: |
     Wait for images delivery to complete.
     This task should be run with service account with `pull-images` permission on the OCI registry.
+  workspaces:
+    - name: delivery-config
+      optional: true
+      description: >
+        ConfigMap volume containing delivery.yaml and get-delivery-target-images.ts.
+        When provided, files are read from this workspace instead of downloading from GitHub.
   params:
     - name: version
       type: string
@@ -21,10 +27,18 @@ spec:
     - name: compute
       image: docker.io/denoland/deno:alpine-2.1.4
       script: |
+        config_dir="$(workspaces.delivery-config.path)"
+        if [ -n "$config_dir" ] && [ -f "$config_dir/delivery.yaml" ]; then
+          echo "Using delivery.yaml from ConfigMap workspace"
+          config_path="$config_dir/delivery.yaml"
+        else
+          echo "ConfigMap not available, falling back to URL"
+          config_path="$(params.delivery-config)"
+        fi
         deno run --allow-all https://github.com/PingCAP-QE/artifacts/raw/main/packages/scripts/get-delivery-target-images.ts \
           --version="$(params.version)" \
           --registry="$(params.oci-registry)" \
-          --config="$(params.delivery-config)" \
+          --config="$config_path" \
           --save_to=/workspace/target-images.yaml
     - name: wait
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c


### PR DESCRIPTION
## Summary

Add optional `delivery-config` workspace to Tekton tasks that download delivery configs from GitHub at runtime. When the ConfigMap workspace is bound, files are read from the mount instead of downloading, eliminating the network dependency failure point. GitHub URL params are kept as optional fallback.

## Changes

**Tasks modified:**
- `tekton/v1/tasks/delivery/pingcap-deliver-images.yaml` — added workspace + config-first-then-fallback logic for `delivery.yaml` and `gen-delivery-image-commands.ts`
- `tekton/v1/tasks/release/tag-and-delivery-rc2ga-on-oci-artifacts.yaml` — same pattern for `deliver-images` step
- `tekton/v1/tasks/release/wait-delivery-images.yaml` — workspace for `delivery.yaml`, passes local path to deno script

**Pipelines updated with workspace bindings:**
- `tekton/v1/pipelines/pingcap-release-ga.yaml` — `delivery-config` workspace passed to `ga-tag-oci-artifacts` and `wait-delivery-images` tasks
- `tekton/v1/pipelines/pingcap-build-package-linux.yaml` — `delivery-config` workspace passed to `deliver-images` task

## Testing

- Tasks remain backward-compatible: when workspace is not bound, they fall back to existing GitHub download behavior
- ConfigMap `delivery-config` (from PR1/PR2 FluxCD setup) must be present in `ee-cd` namespace for the workspace to work
- Existing CI/CD pipelines unaffected

## Risk

Low. All workspaces are `optional: true`. No breaking changes to existing task signatures or params. Rollback: revert this PR.