### PR TITLE
refactor(pingcap/tiflow): unify checkout pattern and clean up unused variables

### DIFF
--- a/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -45,12 +45,8 @@ pipeline {
                         }
                         steps {
                             dir("tiflow") {
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                                    retry(2) {
-                                        script {
-                                            prow.checkoutRefs(REFS)
-                                        }
-                                    }
+                                script {
+                                    prow.checkoutRefsWithCacheLock(REFS)
                                 }
                                 sh label: "${TEST_CMD}", script: "make ${TEST_CMD}"
                             }

--- a/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -44,7 +44,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir("tiflow") {
+                            dir(REFS.repo) {
                                 script {
                                     prow.checkoutRefsWithCacheLock(REFS)
                                 }
@@ -53,7 +53,7 @@ pipeline {
                         }
                         post {
                             success {
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     script {
 
                                         def testConfigs = [
@@ -70,7 +70,7 @@ pipeline {
                             }
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     container(name: 'codecov') {
                                         script{
                                             def testConfigs = [

--- a/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/latest/ghpr_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
@@ -43,7 +43,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 script {
                                     prow.checkoutRefsWithCacheLock(REFS)
                                 }
@@ -52,7 +52,7 @@ pipeline {
                         }
                         post {
                             success {
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     script {
 
                                         def testConfigs = [
@@ -69,7 +69,7 @@ pipeline {
                                 script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
                             }
                             always {
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     container(name: 'codecov') {
                                         sh label: "upload junit report to codecov", script: """
                                         JUNIT_REPORT=\$(ls *-junit-report.xml)

--- a/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-merged_unit_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/merged_unit_test.groovy
@@ -44,12 +44,8 @@ pipeline {
                         }
                         steps {
                             dir('tiflow') {
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                                    retry(2) {
-                                        script {
-                                            prow.checkoutRefs(REFS)
-                                        }
-                                    }
+                                script {
+                                    prow.checkoutRefsWithCacheLock(REFS)
                                 }
                                 sh label: "${TEST_CMD}", script: "make ${TEST_CMD}"
                             }

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                     script {
                         cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'binary')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                     script {
                         cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'binary')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                     script {
                         cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'binary')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                     script {
                         cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'binary')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_pulsar_test.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_storage_test.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                     script {
                         cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'binary')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                     script {
                         cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'binary')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID, withSubmodule = true)
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                     script {
                         cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'binary')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                     script {
                         cdc.prepareIntegrationTestCommonBinariesWithCacheLock(REFS, 'binary')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_test.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -56,7 +56,7 @@ pipeline {
         stage('Checkout') {
             when { expression { !skipRemainingStages} }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -66,7 +66,7 @@ pipeline {
         stage("prepare") {
             when { expression { !skipRemainingStages} }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         retry(2) {
                             sh label: "build previous", script: """
@@ -128,7 +128,7 @@ pipeline {
         stage("Test") {
             when { expression { !skipRemainingStages} }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         sh label: "wait mysql ready", script: """
                             pwd && ls -alh
                             set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done

--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -57,12 +57,8 @@ pipeline {
             when { expression { !skipRemainingStages} }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_TIDB = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -34,12 +34,8 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -33,7 +33,7 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -75,7 +75,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -147,7 +147,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     sh label: "wait mysql ready", script: """
                                         pwd && ls -alh

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -34,7 +34,7 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -84,7 +84,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test-next-gen')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -156,7 +156,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm-next-gen") {
                                     sh label: "wait mysql ready", script: """
                                         pwd && ls -alh

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/latest/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_TIDB = component.computeArtifactNextGenOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -35,12 +35,8 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/latest/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_syncdiff_integration_test.groovy
@@ -32,14 +32,8 @@ pipeline {
         stage('Checkout') {
             steps {
                 dir(REFS.repo) {
-                    retry(3) {
-                        cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                            script {
-                                retry(2) {
-                                    prow.checkoutRefs(REFS, credentialsId = '', timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
-                                }
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}

--- a/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
@@ -4,7 +4,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.2/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
@@ -4,7 +4,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.5-fips/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}

--- a/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -56,7 +56,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -108,7 +108,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -56,7 +56,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -108,7 +108,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
@@ -54,7 +54,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -65,7 +65,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 25, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -104,7 +104,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
@@ -55,12 +55,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -79,7 +79,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -152,7 +152,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
@@ -4,7 +4,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.5/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/ghpr_verify.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -62,7 +62,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -90,7 +90,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -142,7 +142,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -90,7 +90,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -142,7 +142,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
@@ -54,7 +54,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -65,7 +65,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 35, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -124,7 +124,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
@@ -55,12 +55,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -100,7 +100,7 @@ pipeline {
                             }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -173,7 +173,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -88,7 +88,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -140,7 +140,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.1.0/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
@@ -29,7 +29,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}

--- a/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.1/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/ghpr_verify.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -88,7 +88,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -141,7 +141,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -88,7 +88,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -141,7 +141,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -88,7 +88,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -141,7 +141,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 35, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -121,7 +121,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -98,7 +98,7 @@ pipeline {
                             }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -171,7 +171,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
@@ -29,7 +29,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}

--- a/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.2/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 25, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -100,7 +100,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -76,7 +76,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -149,7 +149,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
@@ -29,7 +29,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}

--- a/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.3/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 25, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -100,7 +100,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -76,7 +76,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -149,7 +149,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}

--- a/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
@@ -4,7 +4,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.4/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
@@ -3,7 +3,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
@@ -28,12 +28,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -52,7 +52,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -105,7 +105,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
@@ -28,12 +28,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
@@ -3,7 +3,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -52,7 +52,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -105,7 +105,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
                         // build cdc, pulsar_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -101,7 +101,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     // TODO: currently we encounter some issue when using pulsar container to run shell script
                                     // so we comment out this part now.

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_pulsar_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 25, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -100,7 +100,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
@@ -53,12 +53,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
@@ -4,7 +4,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
@@ -52,7 +52,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -75,7 +75,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -148,7 +148,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
@@ -4,7 +4,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -62,7 +62,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -3,7 +3,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -28,12 +28,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -87,7 +87,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -140,7 +140,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -28,12 +28,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -87,7 +87,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -140,7 +140,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -3,7 +3,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -88,7 +88,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
                         // build cdc, pulsar_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -136,7 +136,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     // TODO: currently we encounter some issue when using pulsar container to run shell script
                                     // so we comment out this part now.

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -88,7 +88,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -141,7 +141,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 35, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -121,7 +121,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
@@ -53,12 +53,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
@@ -4,7 +4,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
@@ -52,7 +52,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -97,7 +97,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -170,7 +170,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
@@ -4,7 +4,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.6/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}

--- a/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
@@ -28,12 +28,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -52,7 +52,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -105,7 +105,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
@@ -3,7 +3,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
@@ -28,12 +28,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
@@ -3,7 +3,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -52,7 +52,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -105,7 +105,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
                         // build cdc, pulsar_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -101,7 +101,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     // TODO: currently we encounter some issue when using pulsar container to run shell script
                                     // so we comment out this part now.

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_pulsar_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 25, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -100,7 +100,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
@@ -53,12 +53,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
@@ -52,7 +52,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -75,7 +75,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -148,7 +148,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
@@ -4,7 +4,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
@@ -29,7 +29,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
@@ -73,7 +73,7 @@ pipeline {
                         }
                         post {
                             success {
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     script {
 
                                         def testConfigs = [

--- a/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.0/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
                         // build cdc, pulsar_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -101,7 +101,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_pulsar_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 25, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -100,7 +100,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -76,7 +76,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -149,7 +149,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
@@ -29,7 +29,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
@@ -73,7 +73,7 @@ pipeline {
                         }
                         post {
                             success {
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     script {
 
                                         def testConfigs = [

--- a/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.1/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/ghpr_verify.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -88,7 +88,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -141,7 +141,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -88,7 +88,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -141,7 +141,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -88,7 +88,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
                         // build cdc, pulsar_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -136,7 +136,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_pulsar_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -88,7 +88,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -141,7 +141,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 35, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -121,7 +121,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -98,7 +98,7 @@ pipeline {
                             }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -171,7 +171,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
@@ -29,7 +29,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
@@ -73,7 +73,7 @@ pipeline {
                         }
                         post {
                             success {
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     script {
 
                                         def testConfigs = [

--- a/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.2/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
                         // build cdc, pulsar_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -101,7 +101,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_pulsar_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 25, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -100,7 +100,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -76,7 +76,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -149,7 +149,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
@@ -29,7 +29,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
@@ -73,7 +73,7 @@ pipeline {
                         }
                         post {
                             success {
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     script {
 
                                         def testConfigs = [

--- a/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.3/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
                         // build cdc, pulsar_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -101,7 +101,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_pulsar_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 25, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -100,7 +100,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -76,7 +76,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -149,7 +149,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
@@ -29,7 +29,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
@@ -73,7 +73,7 @@ pipeline {
                         }
                         post {
                             success {
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     script {
 
                                         def testConfigs = [

--- a/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.4/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
                         // build cdc, pulsar_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -101,7 +101,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_pulsar_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -53,7 +53,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -106,7 +106,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 25, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -100,7 +100,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -76,7 +76,7 @@ pipeline {
                         """
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -149,7 +149,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
@@ -46,7 +46,7 @@ pipeline {
                         steps {
                             dir('tiflow') {
                                 script {
-                                    prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID)
+                                    prow.checkoutRefsWithCacheLock(REFS)
                                 }
                                 sh label: "${TEST_CMD}", script: """
                                     make ${TEST_CMD}

--- a/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
@@ -44,7 +44,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 script {
                                     prow.checkoutRefsWithCacheLock(REFS)
                                 }
@@ -55,7 +55,7 @@ pipeline {
                         }
                         post {
                             success {
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     script {
 
                                         def testConfigs = [

--- a/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/ghpr_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.5/pod-ghpr_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -43,7 +43,7 @@ pipeline {
                     steps {
                         dir("tiflow") {
                             script {
-                                prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
+                                prow.checkoutRefsWithCacheLock(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -41,7 +41,7 @@ pipeline {
                 stage('Checkout') {
                     options { timeout(time: 10, unit: 'MINUTES') }
                     steps {
-                        dir("tiflow") {
+                        dir(REFS.repo) {
                             script {
                                 prow.checkoutRefsWithCacheLock(REFS)
                             }
@@ -74,7 +74,7 @@ pipeline {
                                 }
                             }
                         }
-                        dir("tiflow") {
+                        dir(REFS.repo) {
                             cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                                 // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                                 // only build binarys if not exist, use the cached binarys if exist
@@ -136,7 +136,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 unstash name: WORKSPACE_STASH_NAME
                                 container("kafka") {
                                     timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_cdc_integration_kafka_test.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -43,7 +43,7 @@ pipeline {
                     steps {
                         dir("tiflow") {
                             script {
-                                prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
+                                prow.checkoutRefsWithCacheLock(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -41,7 +41,7 @@ pipeline {
                 stage('Checkout') {
                     options { timeout(time: 10, unit: 'MINUTES') }
                     steps {
-                        dir("tiflow") {
+                        dir(REFS.repo) {
                             script {
                                 prow.checkoutRefsWithCacheLock(REFS)
                             }
@@ -74,7 +74,7 @@ pipeline {
                                 }
                             }
                         }
-                        dir("tiflow") {
+                        dir(REFS.repo) {
                             cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                                 // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                                 // only build binarys if not exist, use the cached binarys if exist
@@ -136,7 +136,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 unstash name: WORKSPACE_STASH_NAME
                                 sh label: "${TEST_GROUP}", script: """
                                     rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_cdc_integration_mysql_test.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -43,7 +43,7 @@ pipeline {
                     steps {
                         dir("tiflow") {
                             script {
-                                prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
+                                prow.checkoutRefsWithCacheLock(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_cdc_integration_pulsar_test.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -41,7 +41,7 @@ pipeline {
                 stage('Checkout') {
                     options { timeout(time: 10, unit: 'MINUTES') }
                     steps {
-                        dir("tiflow") {
+                        dir(REFS.repo) {
                             script {
                                 prow.checkoutRefsWithCacheLock(REFS)
                             }
@@ -74,7 +74,7 @@ pipeline {
                                 }
                             }
                         }
-                        dir("tiflow") {
+                        dir(REFS.repo) {
                             cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
                                 // build cdc, pulsar_consumer, cdc.test for integration test
                                 // only build binarys if not exist, use the cached binarys if exist
@@ -131,7 +131,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 unstash name: WORKSPACE_STASH_NAME
                                 sh label: "${TEST_GROUP}", script: """
                                     rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_cdc_integration_storage_test.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -43,7 +43,7 @@ pipeline {
                     steps {
                         dir("tiflow") {
                             script {
-                                prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
+                                prow.checkoutRefsWithCacheLock(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -41,7 +41,7 @@ pipeline {
                 stage('Checkout') {
                     options { timeout(time: 10, unit: 'MINUTES') }
                     steps {
-                        dir("tiflow") {
+                        dir(REFS.repo) {
                             script {
                                 prow.checkoutRefsWithCacheLock(REFS)
                             }
@@ -74,7 +74,7 @@ pipeline {
                                 }
                             }
                         }
-                        dir("tiflow") {
+                        dir(REFS.repo) {
                             cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                                 // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                                 // only build binarys if not exist, use the cached binarys if exist
@@ -136,7 +136,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 unstash name: WORKSPACE_STASH_NAME
                                 sh label: "${TEST_GROUP}", script: """
                                     rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
@@ -55,7 +55,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -66,7 +66,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 35, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -127,7 +127,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
@@ -57,7 +57,7 @@ pipeline {
             steps {
                 dir("tiflow") {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -62,7 +62,7 @@ pipeline {
                     when { expression { !skipRemainingStages} }
                     options { timeout(time: 10, unit: 'MINUTES') }
                     steps {
-                        dir("tiflow") {
+                        dir(REFS.repo) {
                             script {
                                 prow.checkoutRefsWithCacheLock(REFS)
                             }
@@ -105,7 +105,7 @@ pipeline {
                                 """
                             }
                         }
-                        dir("tiflow") {
+                        dir(REFS.repo) {
                             cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                                 // build dm-master.test for integration test
                                 // only build binarys if not exist, use the cached binarys if exist
@@ -180,7 +180,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 unstash name: WORKSPACE_STASH_NAME
                                 timeout(time: 10, unit: 'MINUTES') {
                                     sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_test.yaml'
 final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_dm_integration_build.yaml'

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -64,7 +64,7 @@ pipeline {
                     steps {
                         dir("tiflow") {
                             script {
-                                prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true)
+                                prow.checkoutRefsWithCacheLock(REFS)
                             }
                         }
                     }

--- a/pipelines/pingcap/tiflow/release-8.5/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_syncdiff_integration_test.groovy
@@ -3,7 +3,6 @@
 @Library('tipipeline') _
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-8.5/pod-pull_syncdiff_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)

--- a/pipelines/pingcap/tiflow/release-8.5/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_syncdiff_integration_test.groovy
@@ -32,7 +32,7 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script {
-                        prow.checkoutRefsWithCacheLock(REFS, 5, GIT_CREDENTIALS_ID, true, 'https://github.com')
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -87,7 +87,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -140,7 +140,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     container("kafka") {
                                         timeout(time: 6, unit: 'MINUTES') {

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -87,7 +87,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -140,7 +140,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -87,7 +87,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
                         // build cdc, pulsar_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -135,7 +135,7 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_pulsar_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -4,7 +4,6 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -29,12 +29,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -28,7 +28,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -87,7 +87,7 @@ pipeline {
                         }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
                         // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -140,7 +140,7 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
                                     sh label: "${TEST_GROUP}", script: """
                                         rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -64,7 +64,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 35, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                         retry(2) {
                             sh label: "build previous", script: """
                                 echo "build binary for previous version"
@@ -121,7 +121,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 20, unit: 'MINUTES') }
             steps {
-                dir('tiflow') {
+                dir(REFS.repo) {
                         timeout(time: 10, unit: 'MINUTES') {
                             sh label: "wait mysql ready", script: """
                                 pwd && ls -alh

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -54,12 +54,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -53,7 +53,7 @@ pipeline {
             when { expression { !skipRemainingStages} }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -98,7 +98,7 @@ pipeline {
                             }
                     }
                 }
-                dir("tiflow") {
+                dir(REFS.repo) {
                     cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
                         // build dm-master.test for integration test
                         // only build binarys if not exist, use the cached binarys if exist
@@ -171,7 +171,7 @@ pipeline {
                                 """
                             }
 
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
                                     timeout(time: 10, unit: 'MINUTES') {
                                         sh label: "wait mysql ready", script: """

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_syncdiff_integration_test.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir(REFS.repo) {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        script {
-                            retry(2) {
-                                prow.checkoutRefs(REFS, credentialsId = '', timeout = 5, withSubmodule = true, gitBaseUrl = 'https://github.com')
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
@@ -29,7 +29,7 @@ pipeline {
         stage('Checkout') {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiflow") {
+                dir(REFS.repo) {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS)
                     }
@@ -63,7 +63,7 @@ pipeline {
                             CODECOV_TOKEN = credentials('codecov-token-tiflow')
                         }
                         steps {
-                            dir('tiflow') {
+                            dir(REFS.repo) {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
                                     sh label: "${TEST_CMD}", script: """
                                         make ${TEST_CMD}
@@ -73,7 +73,7 @@ pipeline {
                         }
                         post {
                             success {
-                                dir('tiflow') {
+                                dir(REFS.repo) {
                                     script {
 
                                         def testConfigs = [

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
@@ -5,7 +5,6 @@
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
-final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
@@ -30,12 +30,8 @@ pipeline {
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tiflow") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
-                        retry(2) {
-                            script {
-                                prow.checkoutRefs(REFS)
-                            }
-                        }
+                    script {
+                        prow.checkoutRefsWithCacheLock(REFS)
                     }
                 }
             }


### PR DESCRIPTION
## Summary

This PR refactors the tiflow pipeline checkout pattern to fix S3 409 conflicts and clean up unused variables.

### Changes

1. **Replace cache+retry+checkoutRefs with checkoutRefsWithCacheLock**
   - Replace the old pattern `cache → retry(2) → script → checkoutRefs` with `prow.checkoutRefsWithCacheLock(REFS)`
   - This adds a lock mechanism to prevent concurrent S3 cache operations that cause 409 conflicts
   - Affects 100+ files across all tiflow branches

2. **Remove unnecessary withSubmodule parameter**
   - tiflow repo has no `.gitmodules` file and doesn't use git submodules
   - Removed `withSubmodule = true` from syncdiff and CDC integration test files

3. **Remove unnecessary credentialsId parameter**
   - `pingcap/tiflow` is a public repo, cloning doesn't need credentials
   - Removed `credentialsId = GIT_CREDENTIALS_ID` from checkout calls

4. **Replace hardcoded dir("tiflow") with dir(REFS.repo)**
   - Decouples directory name from hardcoded string
   - Uses dynamic value from job spec

5. **Remove unused GIT_CREDENTIALS_ID variable**
   - Cleaned up 110 files that declared but never used `GIT_CREDENTIALS_ID`
   - Kept `GIT_CREDENTIALS_ID2` which is used for `getPrDiffFiles` calls

### Root Cause

The S3 409 error occurs when multiple Jenkins jobs concurrently access the same S3 cache resource:
```
com.amazonaws.services.s3.model.AmazonS3Exception: A conflicting conditional operation is currently in progress against this resource.
```

The `checkoutRefsWithCacheLock` method uses Jenkins `lock()` to serialize cache access, preventing these conflicts.

### Testing

- Verified all tiflow pipeline files have been updated
- Confirmed no remaining references to old patterns
- Checked that `GIT_CREDENTIALS_ID2` is preserved where needed