### PR TITLE
revert(prow): restore COS upload for docs PDF jobs and use kce-pingcap-cicd cluster

### DIFF
--- a/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   pingcap/docs-cn:
     - name: docs-cn-merged-update-docs
       agent: kubernetes
-      cluster: default
+      cluster: kce-pingcap-cicd
       decorate: true
       decoration_config:
         timeout: 60m
@@ -36,9 +36,7 @@ postsubmits:
                 python3 scripts/merge_by_toc.py
                 scripts/generate_pdf.sh
 
-                export RCLONE_CONFIG_GCS_SERVICE_ACCOUNT_FILE="/secrets/gcs/service-account.json"
-                export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
-                gcs_dst="gcs:prow-tidb-logs/artifacts/pdf"
+                dst="${TENCENTCLOUD_RCLONE_CONN:?missing TENCENTCLOUD_RCLONE_CONN}:${TENCENTCLOUD_BUCKET_ID:?missing TENCENTCLOUD_BUCKET_ID}/pdf"
                 case "${branch}" in
                   master)
                     version="dev"
@@ -55,11 +53,18 @@ postsubmits:
                     ;;
                 esac
 
-                rclone copyto --progress output.pdf "${gcs_dst}/tidb-${version}-zh-manual.pdf"
-            volumeMounts:
-              - name: gcs-credentials
-                mountPath: /secrets/gcs
-                readOnly: true
+                rclone copyto --progress output.pdf "${dst}/tidb-${version}-zh-manual.pdf"
+            env:
+              - name: TENCENTCLOUD_RCLONE_CONN
+                valueFrom:
+                  secretKeyRef:
+                    name: docs-cn
+                    key: tencent-ak
+              - name: TENCENTCLOUD_BUCKET_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: docs-cn
+                    key: tencent-bn
             resources:
               requests:
                 memory: 2Gi

--- a/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-tidb-operator/latest-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   pingcap/docs-tidb-operator:
     - name: update-pdfs
       agent: kubernetes
-      cluster: default
+      cluster: kce-pingcap-cicd
       decorate: true
       decoration_config:
         timeout: 60m
@@ -35,9 +35,7 @@ postsubmits:
                 python3 scripts/merge_by_toc.py zh/
                 scripts/generate_pdf.sh
 
-                export RCLONE_CONFIG_GCS_SERVICE_ACCOUNT_FILE="/secrets/gcs/service-account.json"
-                export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
-                gcs_dst="gcs:prow-tidb-logs/artifacts/pdf"
+                dst="${TENCENTCLOUD_RCLONE_CONN:?missing TENCENTCLOUD_RCLONE_CONN}:${TENCENTCLOUD_BUCKET_ID:?missing TENCENTCLOUD_BUCKET_ID}/pdf"
                 case "${branch}" in
                   main)
                     version="dev"
@@ -54,12 +52,19 @@ postsubmits:
                     ;;
                 esac
 
-                rclone copyto -P output_en.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-en-manual.pdf"
-                rclone copyto -P output_zh.pdf "${gcs_dst}/tidb-in-kubernetes-${version}-zh-manual.pdf"
-            volumeMounts:
-              - name: gcs-credentials
-                mountPath: /secrets/gcs
-                readOnly: true
+                rclone copyto -P output_en.pdf "${dst}/tidb-in-kubernetes-${version}-en-manual.pdf"
+                rclone copyto -P output_zh.pdf "${dst}/tidb-in-kubernetes-${version}-zh-manual.pdf"
+            env:
+              - name: TENCENTCLOUD_RCLONE_CONN
+                valueFrom:
+                  secretKeyRef:
+                    name: docs-cn
+                    key: tencent-ak
+              - name: TENCENTCLOUD_BUCKET_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: docs-cn
+                    key: tencent-bn
             resources:
               requests:
                 memory: 2Gi

--- a/prow-jobs/pingcap/docs/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/latest-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   pingcap/docs:
     - name: docs-merged-update-docs
       agent: kubernetes
-      cluster: default
+      cluster: kce-pingcap-cicd
       decorate: true
       decoration_config:
         timeout: 100m
@@ -41,9 +41,7 @@ postsubmits:
                   scripts/generate_cloud_pdf.sh
                 fi
 
-                export RCLONE_CONFIG_GCS_SERVICE_ACCOUNT_FILE="/secrets/gcs/service-account.json"
-                export RCLONE_CONFIG_GCS_TYPE="google cloud storage"
-                gcs_dst="gcs:prow-tidb-logs/artifacts/pdf"
+                dst="${TENCENTCLOUD_RCLONE_CONN:?missing TENCENTCLOUD_RCLONE_CONN}:${TENCENTCLOUD_BUCKET_ID:?missing TENCENTCLOUD_BUCKET_ID}/pdf"
                 case "${branch}" in
                   master)
                     version="dev"
@@ -60,14 +58,21 @@ postsubmits:
                     ;;
                 esac
 
-                rclone copyto --progress output.pdf "${gcs_dst}/tidb-${version}-en-manual.pdf"
+                rclone copyto --progress output.pdf "${dst}/tidb-${version}-en-manual.pdf"
                 if [ -f output_cloud.pdf ]; then
-                  rclone copyto --progress output_cloud.pdf "${gcs_dst}/tidbcloud-en-manual.pdf"
+                  rclone copyto --progress output_cloud.pdf "${dst}/tidbcloud-en-manual.pdf"
                 fi
-            volumeMounts:
-              - name: gcs-credentials
-                mountPath: /secrets/gcs
-                readOnly: true
+            env:
+              - name: TENCENTCLOUD_RCLONE_CONN
+                valueFrom:
+                  secretKeyRef:
+                    name: docs-cn
+                    key: tencent-ak
+              - name: TENCENTCLOUD_BUCKET_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: docs-cn
+                    key: tencent-bn
             resources:
               requests:
                 memory: 2Gi


### PR DESCRIPTION
## Summary

Revert GCS migration from PR #4701 and set cluster to  for all 3 docs postsubmit jobs to run near Chinese clouds for faster PDF document updates.

## Changes

- **docs/latest-postsubmits.yaml**: Restore TencentCloud COS upload, set cluster to 
- **docs-cn/latest-postsubmits.yaml**: Restore TencentCloud COS upload, set cluster to 
- **docs-tidb-operator/latest-postsubmits.yaml**: Restore TencentCloud COS upload, set cluster to 

## Motivation

Running these PDF generation jobs in  cluster (near Chinese clouds) will make PDF document updates faster.

Closes #4701