### PR TITLE
feat(pipelines/ticdc): update Jenkins image tag for Python 3.12 support

### DIFF
--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25
       command: [tini, --, bash]
       imagePullPolicy: Always
       name: golang

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25
       command: [tini, --, bash]
       imagePullPolicy: Always
       name: golang

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pod-build.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25
       command: [tini, --, bash]
       imagePullPolicy: Always
       name: golang

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-test.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25
       command: [tini, --, bash]
       imagePullPolicy: Always
       name: golang

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pod-test.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25
       command: [tini, --, bash]
       imagePullPolicy: Always
       name: golang

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25
       command: [tini, --, bash]
       imagePullPolicy: Always
       name: golang

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pod-test.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25
       command: [tini, --, bash]
       imagePullPolicy: Always
       name: golang

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pod-test.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25
       command: [tini, --, bash]
       imagePullPolicy: Always
       name: golang

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pod-build.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pod-build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pod-test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pod.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_integration_build.yaml
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_integration_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_kafka_integration_heavy.yaml
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_kafka_integration_heavy.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25
       command: [tini, --, bash]
       imagePullPolicy: Always
       name: golang

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_kafka_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_kafka_integration_light.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25
       command: [tini, --, bash]
       imagePullPolicy: Always
       name: golang

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_mysql_integration_heavy.yaml
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_mysql_integration_heavy.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_mysql_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_mysql_integration_light.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_pulsar_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_pulsar_integration_light.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_storage_integration_heavy.yaml
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_storage_integration_heavy.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_storage_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_storage_integration_light.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.28-2-g97bb688-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.6.28-3-g80620cc5-go1.25"
       tty: true
       resources:
         limits:


### PR DESCRIPTION
## Summary

Update all ticdc pod templates to use the new Jenkins image with Python 3.12 support (from PR #4760).

## Changes

Update image tag from `v2025.12.28-2-g97bb688-go1.25` to `v2026.6.28-3-g80620cc5-go1.25` in:
- `pipelines/pingcap/ticdc/` (52 files)
- `pipelines/pingcap-inc/ticdc/` (14 files)

Total: **66 files**

## Testing

- Verify CI pipelines use the new image tag
- Verify ticdc integration tests pass with Python 3.12
- Verify `tomllib` import works in CI environment

## Risk

Low. This is a tag-only update to use the already-built image from PR #4760. The new image includes Python 3.12 while maintaining backward compatibility with existing tools.

Ref: FLA-231
Depends on: #4760