### PR TITLE
refactor(pipelines/pingcap/tiflow): replace internal registry refs with public equivalents (PR1)

### DIFF
--- a/pipelines/pingcap/tiflow/release-6.2/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.2/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_kafka_test.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: hub.pingcap.net/jenkins/rocky9_golang-1.19:fips
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       args:
         - cat

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: hub.pingcap.net/jenkins/rocky9_golang-1.19:fips
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       args:
         - cat

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: hub.pingcap.net/jenkins/rocky9_golang-1.19:fips
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       args:
         - cat
@@ -18,7 +18,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -36,7 +36,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.19
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: hub.pingcap.net/jenkins/golang-tini:1.19
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       tty: true
       args:
         - cat
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1.0/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/wulifu/golang-tini:1.20.2
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-tini:1.20"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       args:
         - cat
       tty: true
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.20
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.20
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.21
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.21
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       args:
         - cat
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.6/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.21
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       args:
         - cat
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.0/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.21
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:pulsar-test"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       args:
         - cat
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.1/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.21
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:pulsar-test"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       args:
         - cat
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.2/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.21
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:pulsar-test"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       args:
         - cat
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.3/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.21
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:pulsar-test"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-tini:1.21"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       args:
         - cat
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-ghpr_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-merged_unit_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/golang-tini:1.23
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:pulsar-test"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/golang-tini:1.23"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       args:
         - cat
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.5/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-merged_unit_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/rocky8_golang-1.23:tini
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       command:
         - sh
         - -c
@@ -17,7 +17,7 @@ spec:
           name: "mysql-config-volume"
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         limits:
@@ -28,7 +28,7 @@ spec:
           name: "mysql-config-volume"
           subPath: ".my.cnf"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -46,7 +46,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       command:
         - sh
         - -c
@@ -17,7 +17,7 @@ spec:
           name: "mysql-config-volume"
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:tini"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       args:
         - cat
@@ -30,7 +30,7 @@ spec:
           name: "mysql-config-volume"
           subPath: ".my.cnf"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -48,7 +48,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_syncdiff_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_syncdiff_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: hub.pingcap.net/jenkins/centos7_golang-1.23:latest
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25
       tty: true
       env:
         - name: GOPATH
@@ -25,7 +25,7 @@ spec:
           cpu: "1"
           memory: 4Gi
     - name: mysql
-      image: hub.pingcap.net/jenkins/mysql:5.7
+      image: docker.io/library/mysql:5.7
       tty: true
       args: ["--server-id=1", "--log-bin", "--binlog-format=ROW"]
       env:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
## Summary
Replace all `hub.pingcap.net` and `registry-mirror.pingcap.net` image references in YAML files across 16 release branches under `pipelines/pingcap/tiflow/`.

## Changes
- 96 YAML files modified, 155 replacements total
- `hub.pingcap.net/jenkins/*` → `ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25`
- `hub.pingcap.net/jenkins/mysql:5.7` → `docker.io/library/mysql:5.7`
- `hub.pingcap.net/wulifu/golang-tini:1.20.2` → `ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25`
- `registry-mirror.pingcap.net/library/mysql:8.0.21` → `docker.io/library/mysql:8.0.21`

## Branches affected
release-6.2, release-6.5, release-6.5-fips, release-7.1, release-7.1.0, release-7.2, release-7.3, release-7.4, release-7.5, release-7.6, release-8.0, release-8.1, release-8.2, release-8.3, release-8.4, release-8.5, release-9.0-beta

## Testing
`rg 'hub\.pingcap\.net|registry-mirror\.pingcap\.net' pipelines/pingcap/tiflow/` returns 0 matches after changes.

## Risk
Low — configuration-only YAML changes replacing internal registry refs with public equivalents. Revert via single PR rollback.

Ref: FLA-233