### PR TITLE
feat(dockerfiles): add tidb-operator CI base images with skaffold and workflow support

### DIFF
--- a/.github/workflows/pull-ci-runtime-images.yaml
+++ b/.github/workflows/pull-ci-runtime-images.yaml
@@ -23,6 +23,7 @@ jobs:
       base-jenkins: ${{ steps.filter.outputs.base-jenkins }}
       jenkins-special: ${{ steps.filter.outputs.jenkins-special }}
       tici: ${{ steps.filter.outputs.tici }}
+      tidb-operator: ${{ steps.filter.outputs.tidb-operator }}
       skaffold: ${{ steps.filter.outputs.skaffold }}
     steps:
       - name: Checkout sources
@@ -42,6 +43,8 @@ jobs:
               - 'dockerfiles/ci/jenkins/tiflash/**'
             tici:
               - 'dockerfiles/ci/tici/**'
+            tidb-operator:
+              - 'dockerfiles/ci/tidb-operator/**'
             skaffold:
               - 'dockerfiles/ci/skaffold.yaml'
   skaffold-go:
@@ -194,6 +197,55 @@ jobs:
         uses: heypigeonhq/setup-skaffold@3b1a0687de1b580d3879bf6b9d423255c9954587
         with:
           version: 2.15.0
+
+      - name: Build images
+        working-directory: dockerfiles/ci
+        run: |
+          skaffold build \
+            --build-concurrency=1 \
+            --cache-artifacts \
+            --default-repo=ghcr.io/pingcap-qe/ci \
+            --module=${{ matrix.module }} \
+            --platform=${{ matrix.platform }} \
+            --push=false
+
+  skaffold-tidb-operator:
+    name: build tidb-operator images with skaffold
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.tidb-operator == 'true' || needs.detect-changes.outputs.skaffold == 'true' }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        module: [ci-tidb-operator]
+        platform: [linux/amd64, linux/arm64]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: "0"
+          fetch-tags: "true"
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup skaffold
+        uses: heypigeonhq/setup-skaffold@3b1a0687de1b580d3879bf6b9d423255c9954587
+        with:
+          version: 2.16.0
 
       - name: Build images
         working-directory: dockerfiles/ci

--- a/.github/workflows/release-ci-runtime-images.yaml
+++ b/.github/workflows/release-ci-runtime-images.yaml
@@ -21,6 +21,7 @@ jobs:
       base-jenkins: ${{ steps.filter.outputs.base-jenkins }}
       jenkins-special: ${{ steps.filter.outputs.jenkins-special }}
       tici: ${{ steps.filter.outputs.tici }}
+      tidb-operator: ${{ steps.filter.outputs.tidb-operator }}
       skaffold: ${{ steps.filter.outputs.skaffold }}
     steps:
       - name: Checkout sources
@@ -40,6 +41,8 @@ jobs:
               - 'dockerfiles/ci/jenkins/tiflash/**'
             tici:
               - 'dockerfiles/ci/tici/**'
+            tidb-operator:
+              - 'dockerfiles/ci/tidb-operator/**'
             skaffold:
               - 'dockerfiles/ci/skaffold.yaml'
   skaffold-go:
@@ -205,6 +208,57 @@ jobs:
         uses: heypigeonhq/setup-skaffold@3b1a0687de1b580d3879bf6b9d423255c9954587
         with:
           version: 2.15.0
+
+      - name: Publish images
+        working-directory: dockerfiles/ci
+        run: |
+          skaffold build \
+            --build-concurrency 1 \
+            --cache-artifacts \
+            --default-repo ghcr.io/pingcap-qe/ci \
+            --module ${{ matrix.module }}
+
+  skaffold-tidb-operator:
+    name: publish tidb-operator images with skaffold
+    runs-on: ubuntu-24.04
+    needs: [detect-changes]
+    if: |
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+       needs.detect-changes.outputs.tidb-operator == 'true' ||
+       needs.detect-changes.outputs.skaffold == 'true')
+
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        module: [ci-tidb-operator]
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+          fetch-depth: "0"
+          fetch-tags: "true"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup skaffold
+        uses: heypigeonhq/setup-skaffold@3b1a0687de1b580d3879bf6b9d423255c9954587
+        with:
+          version: 2.16.0
 
       - name: Publish images
         working-directory: dockerfiles/ci

--- a/dockerfiles/ci/skaffold.yaml
+++ b/dockerfiles/ci/skaffold.yaml
@@ -93,3 +93,26 @@ build:
     useBuildkit: true
     concurrency: 0
     tryImportMissing: true
+---
+apiVersion: skaffold/v4beta6
+kind: Config
+metadata:
+  name: ci-tidb-operator
+build:
+  artifacts:
+    - image: tidb-operator/e2e-base
+      platforms: [linux/amd64, linux/arm64]
+      docker:
+        dockerfile: tidb-operator/e2e-base/Dockerfile
+    - image: tidb-operator/backup-manager-base
+      platforms: [linux/amd64, linux/arm64]
+      docker:
+        dockerfile: tidb-operator/backup-manager-base/Dockerfile
+  tagPolicy:
+    customTemplate:
+      template: "{{ .GIT }}"
+  local:
+    useDockerCLI: true
+    useBuildkit: true
+    concurrency: 0
+    tryImportMissing: true

--- a/dockerfiles/ci/tidb-operator/backup-manager-base/Dockerfile
+++ b/dockerfiles/ci/tidb-operator/backup-manager-base/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+FROM ghcr.io/pingcap-qe/bases/pingcap-base:v1.11.3@sha256:d062f058122370102e55fab5dd25b89f67a8bd27ad18c70197fc348c1653e596
+
+ARG TARGETARCH
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    dnf install -y ca-certificates bind-utils wget nc unzip
+
+# install rclone tool
+# ARG RCLONE_VERSION=v1.71.2
+RUN curl -fsSL -o /tmp/rclone.zip \
+    "https://github.com/rclone/rclone/releases/download/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip"; \
+    && unzip -q /tmp/rclone.zip -d /tmp \
+    && install -m 0755 "/tmp/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}/rclone" /usr/local/bin/rclone \
+    && rm -rf /tmp/rclone.zip "/tmp/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}"
+
+# install shush tool
+ARG SHUSH_VERSION=v1.5.5
+RUN curl -fsSL -o /usr/local/bin/shush \
+    https://github.com/realestate-com-au/shush/releases/download/${SHUSH_VERSION}/shush_linux_${TARGETARCH} \
+    && chmod +x /usr/local/bin/shush

--- a/dockerfiles/ci/tidb-operator/backup-manager-base/Dockerfile
+++ b/dockerfiles/ci/tidb-operator/backup-manager-base/Dockerfile
@@ -6,9 +6,9 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     dnf install -y ca-certificates bind-utils wget nc unzip
 
 # install rclone tool
-# ARG RCLONE_VERSION=v1.71.2
+ARG RCLONE_VERSION=v1.71.2
 RUN curl -fsSL -o /tmp/rclone.zip \
-    "https://github.com/rclone/rclone/releases/download/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip"; \
+    "https://github.com/rclone/rclone/releases/download/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}.zip" \
     && unzip -q /tmp/rclone.zip -d /tmp \
     && install -m 0755 "/tmp/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}/rclone" /usr/local/bin/rclone \
     && rm -rf /tmp/rclone.zip "/tmp/rclone-${RCLONE_VERSION}-linux-${TARGETARCH}"

--- a/dockerfiles/ci/tidb-operator/e2e-base/Dockerfile
+++ b/dockerfiles/ci/tidb-operator/e2e-base/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux; \
     arm64) aws_arch=aarch64 ;; \
     *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip" -o awscliv2.zip; \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${aws_arch}.zip" -o awscliv2.zip; \
     unzip awscliv2.zip; \
     ./aws/install; \
     rm -rf aws awscliv2.zip

--- a/dockerfiles/ci/tidb-operator/e2e-base/Dockerfile
+++ b/dockerfiles/ci/tidb-operator/e2e-base/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    apt-get install -y ca-certificates curl git openssl default-mysql-client unzip python3
+
+# install kubectl, helm CLIs
+ARG KUBECTL_VERSION=v1.28.5
+ENV HELM_VERSION=v3.11.0
+RUN curl -fsSL "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl \
+    && curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz" | tar xz -C /usr/local/bin --strip-components=1 linux-${TARGETARCH}/helm
+
+# install AWS CLI
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+    amd64) aws_arch=x86_64 ;; \
+    arm64) aws_arch=aarch64 ;; \
+    *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip" -o awscliv2.zip; \
+    unzip awscliv2.zip; \
+    ./aws/install; \
+    rm -rf aws awscliv2.zip
+
+ARG CERT_MANAGER_VERSION=v1.15.1
+ADD https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml /cert-manager.yaml


### PR DESCRIPTION
## Changes

### New Dockerfiles
- `tidb-operator/e2e-base/Dockerfile` — e2e test base image (kubectl, helm, AWS CLI, cert-manager)
- `tidb-operator/backup-manager-base/Dockerfile` — backup manager base image (rclone, shush)

### Dockerfile Improvements
- Use `--mount=type=cache` instead of `rm -rf` for apt/dnf cache cleanup
- Pin `debian:bookworm-slim` to sha256 digest for reproducible builds
- Update cert-manager URL from `jetstack` to `cert-manager` (avoids 301 redirect)
- Update rclone URL from `ncw/rclone` to `rclone/rclone` (avoids 301 redirect)
- Simplify helm installation with `curl | tar` pipe
- Use `ADD` instruction for cert-manager.yaml download

### Skaffold
- Add `ci-tidb-operator` config with `tidb-operator/e2e-base` and `tidb-operator/backup-manager-base` artifacts

### GitHub Actions
- `pull-ci-runtime-images.yaml` — PR verification: add `skaffold-tidb-operator` job (dual-platform build, no push)
- `release-ci-runtime-images.yaml` — Release: add `skaffold-tidb-operator` job (QEMU multi-platform build and publish)