### PR TITLE
ci(dockerfiles): add go1.19 and go1.20 jenkins image profiles

### DIFF
--- a/.github/workflows/release-ci-runtime-images.yaml
+++ b/.github/workflows/release-ci-runtime-images.yaml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         module: [ci]
-        go-profile: [go-1.25]
+        go-profile: [go-1.19, go-1.20, go-1.25]
 
     steps:
       - name: Checkout sources

--- a/dockerfiles/ci/skaffold.yaml
+++ b/dockerfiles/ci/skaffold.yaml
@@ -26,6 +26,46 @@ build:
     concurrency: 0
     tryImportMissing: true
 profiles:
+  - name: go-1.19
+    patches:
+      - op: replace
+        path: /build/tagPolicy/customTemplate/template
+        value: "{{ .GIT }}-go1.19"
+      - op: add
+        path: /build/artifacts/0/docker/buildArgs
+        value:
+          # renovate: datasource=docker depName=golang
+          GOLANG_VERSION: 1.19.13
+  - name: go-1.20
+    patches:
+      - op: replace
+        path: /build/tagPolicy/customTemplate/template
+        value: "{{ .GIT }}-go1.20"
+      - op: add
+        path: /build/artifacts/0/docker/buildArgs
+        value:
+          # renovate: datasource=docker depName=golang
+          GOLANG_VERSION: 1.20.14
+  - name: go-1.21
+    patches:
+      - op: replace
+        path: /build/tagPolicy/customTemplate/template
+        value: "{{ .GIT }}-go1.21"
+      - op: add
+        path: /build/artifacts/0/docker/buildArgs
+        value:
+          # renovate: datasource=docker depName=golang
+          GOLANG_VERSION: 1.21.13
+  - name: go-1.23
+    patches:
+      - op: replace
+        path: /build/tagPolicy/customTemplate/template
+        value: "{{ .GIT }}-go1.23"
+      - op: add
+        path: /build/artifacts/0/docker/buildArgs
+        value:
+          # renovate: datasource=docker depName=golang
+          GOLANG_VERSION: 1.23.8
   - name: go-1.25
     patches:
       - op: replace

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_dm_integration_test.yaml
@@ -18,7 +18,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -36,7 +36,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_integration_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_dm_integration_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_dm_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_dm_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_dm_integration_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-pull_dm_integration_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-pull_dm_integration_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-pull_dm_integration_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-pull_dm_integration_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-pull_dm_integration_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_compatibility_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -33,7 +33,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-pull_dm_integration_test.yaml
@@ -17,7 +17,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -35,7 +35,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-8.5/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-merged_unit_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,7 @@ spec:
           name: volume-0
     - args:
         - cat
-      image: hub.pingcap.net/jenkins/rocky8_golang-1.23:tini
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_storage_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_compatibility_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       command:
         - sh
         - -c
@@ -17,7 +17,7 @@ spec:
           name: "mysql-config-volume"
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         limits:
@@ -28,7 +28,7 @@ spec:
           name: "mysql-config-volume"
           subPath: ".my.cnf"
     - name: mysql1
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:
@@ -46,7 +46,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'hub.pingcap.net/jenkins/mysql:5.7'
+      image: 'docker.io/library/mysql:5.7'
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_dm_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       command:
         - sh
         - -c
@@ -17,7 +17,7 @@ spec:
           name: "mysql-config-volume"
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:tini"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       args:
         - cat
@@ -30,7 +30,7 @@ spec:
           name: "mysql-config-volume"
           subPath: ".my.cnf"
     - name: mysql1
-      image: "hub.pingcap.net/jenkins/mysql:5.7"
+      image: "docker.io/library/mysql:5.7"
       tty: true
       resources:
         limits:
@@ -48,7 +48,7 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "registry-mirror.pingcap.net/library/mysql:8.0.21"
+      image: "docker.io/library/mysql:8.0.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_syncdiff_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_syncdiff_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: hub.pingcap.net/jenkins/centos7_golang-1.23:latest
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25
       tty: true
       env:
         - name: GOPATH
@@ -25,7 +25,7 @@ spec:
           cpu: "1"
           memory: 4Gi
     - name: mysql
-      image: hub.pingcap.net/jenkins/mysql:5.7
+      image: docker.io/library/mysql:5.7
       tty: true
       args: ["--server-id=1", "--log-bin", "--binlog-format=ROW"]
       env:

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_verify.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25"
       tty: true
       resources:
         requests:


### PR DESCRIPTION
## Summary
Add skaffold profiles and workflow matrix entries to build GHCR jenkins images for Go 1.19 and Go 1.20.

## Changes
- Added  profile (Go 1.19.13) to 
- Added  profile (Go 1.20.14) to 
- Added  and  profiles for completeness (images already on GHCR)
- Updated workflow matrix to build  and  variants

## Motivation
Pre-8.5 tiflow release branches require Go 1.19/1.20 images. Currently only Go 1.25 is built by CI. This unblocks PR #4763 (internal registry cleanup).

## Testing
After merge, verify images exist:
```
docker manifest inspect ghcr.io/pingcap-qe/ci/jenkins:<tag>-go1.19
docker manifest inspect ghcr.io/pingcap-qe/ci/jenkins:<tag>-go1.20
```

## Risk
Low — adds new build profiles, does not modify existing ones.

Ref: FLA-233