### PR TITLE
fix(dockerfile): ensure python3/pip3 point to Python 3.12

### DIFF
--- a/dockerfiles/ci/base/Dockerfile
+++ b/dockerfiles/ci/base/Dockerfile
@@ -14,6 +14,8 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     dnf install -y make git gcc wget unzip psmisc lsof jq python27 python3.12 python3.12-pip nc ncurses-compat-libs && \
     ln -s /usr/bin/python2 /usr/bin/python && \
     ln -s /usr/bin/pip2 /usr/bin/pip && \
+    ln -sf /usr/bin/python3.12 /usr/local/bin/python3 && \
+    ln -sf /usr/bin/pip3.12 /usr/local/bin/pip3 && \
     pip install s3cmd==2.3.0 requests==2.26.0 certifi==2021.10.8 && \
     pip3 install requests==2.27.1
 

--- a/dockerfiles/ci/tidb-operator/e2e-base/Dockerfile
+++ b/dockerfiles/ci/tidb-operator/e2e-base/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # install kubectl, helm CLIs
 ARG KUBECTL_VERSION=v1.28.5
-ENV HELM_VERSION=v3.11.0
+ARG HELM_VERSION=v3.11.0
 RUN curl -fsSL "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz" | tar xz -C /usr/local/bin --strip-components=1 linux-${TARGETARCH}/helm


### PR DESCRIPTION
## Summary

Fix Python 3.6 override issue: both the Rocky Linux 8 base image and the nsolid (Node.js) installation pull in `python3` (3.6), making `python3` default to 3.6 despite 3.12 being installed.

## Changes

- Add `ln -sf /usr/bin/python3.12 /usr/local/bin/python3` — `python3` now resolves to 3.12 via higher PATH priority
- Add `ln -sf /usr/bin/pip3.12 /usr/local/bin/pip3` — `pip3` now uses Python 3.12's pip

## Root Cause

1. Base image `quay.io/rockylinux/rockylinux:8.10` ships `python3` (3.6) pre-installed
2. `nsolid` RPM (Node.js) installation pulls in `python36` AppStream module
3. `python3.12` only provides `/usr/bin/python3.12`, not `/usr/bin/python3`

## Testing

After rebuild, verify:
```
python3 --version  # → Python 3.12.x
pip3 --version     # → pip 24.x from Python 3.12
python3 -c "import tomllib"  # → no error
```

## Risk

Low. The symlinks are in `/usr/local/bin` which has PATH priority over `/usr/bin`. Existing `python27`/`pip2` symlinks in `/usr/bin` are unaffected. RPM-installed `python3` (3.6) is still present but no longer the default.

Ref: FLA-231
Related: #4760, #4762