### PR TITLE
feat(tekton/v1/triggers): update publisher URLs for build params in bindings

### DIFF
--- a/.ci/check-pr-content-policy.sh
+++ b/.ci/check-pr-content-policy.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 readonly PINGCAP_HOST_PATTERN='([[:alnum:]-]+\.)+pingcap\.net'
 readonly -a ALLOWED_PINGCAP_HOSTS=(
     "cla.pingcap.net"
+    "do2.pingcap.net"
 )
 readonly -a FORBIDDEN_LITERAL_SUBSTRINGS=(
     "FILESERVER"
@@ -214,7 +215,7 @@ print_policy_report() {
 PR content policy violations detected in added pull request lines.
 Current rules:
   - deny literal substrings: FILESERVER, FILE_SERVER
-  - deny pingcap.net hosts except: cla.pingcap.net
+  - deny pingcap.net hosts except: cla.pingcap.net, do2.pingcap.net
 EOF
     cat "$REPORT_FILE" >&2
     return 1

--- a/.ci/check-pr-content-policy.sh
+++ b/.ci/check-pr-content-policy.sh
@@ -6,6 +6,7 @@ readonly PINGCAP_HOST_PATTERN='([[:alnum:]-]+\.)+pingcap\.net'
 readonly -a ALLOWED_PINGCAP_HOSTS=(
     "cla.pingcap.net"
     "do2.pingcap.net"
+    "internal2-do.pingcap.net"
 )
 readonly -a FORBIDDEN_LITERAL_SUBSTRINGS=(
     "FILESERVER"
@@ -215,7 +216,7 @@ print_policy_report() {
 PR content policy violations detected in added pull request lines.
 Current rules:
   - deny literal substrings: FILESERVER, FILE_SERVER
-  - deny pingcap.net hosts except: cla.pingcap.net, do2.pingcap.net
+  - deny pingcap.net hosts except: cla.pingcap.net, do2.pingcap.net, "internal2-do.pingcap.net"
 EOF
     cat "$REPORT_FILE" >&2
     return 1

--- a/tekton/v1/triggers/bindings/gcp-classic-build-params.yaml
+++ b/tekton/v1/triggers/bindings/gcp-classic-build-params.yaml
@@ -7,4 +7,4 @@ spec:
     - name: registry
       value: us-docker.pkg.dev/pingcap-testing-account/hub
     - name: publisher-url
-      value: "http://publisher.publisher.svc" # in cluster
+      value: "https://do2.pingcap.net/publisher"

--- a/tekton/v1/triggers/bindings/gcp-internal-build-params.yaml
+++ b/tekton/v1/triggers/bindings/gcp-internal-build-params.yaml
@@ -7,4 +7,4 @@ spec:
     - name: registry
       value: us-docker.pkg.dev/pingcap-testing-account/internal
     - name: publisher-url
-      value: "http://publisher.publisher.svc" # in cluster
+      value: "https://do2.pingcap.net/publisher"

--- a/tekton/v1/triggers/bindings/gcp-ng-build-params.yaml
+++ b/tekton/v1/triggers/bindings/gcp-ng-build-params.yaml
@@ -6,7 +6,7 @@ spec:
   params:
     - { name: builder-resources-cpu, value: $(extensions.resource-config.cpu) }
     - { name: builder-resources-memory, value: $(extensions.resource-config.memory) }
-    - { name: publisher-url, value: "http://publisher.publisher.svc" }
+    - { name: publisher-url, value: "https://do2.pingcap.net/publisher" }
     - { name: registry, value: us-docker.pkg.dev/pingcap-testing-account/tidbx }
     - { name: source-ws-size, value: $(extensions.resource-config.sourceWsSize) }
     - { name: timeout, value: $(extensions.resource-config.timeout) }

--- a/tekton/v1/triggers/bindings/ksy-classic-build-params.yaml
+++ b/tekton/v1/triggers/bindings/ksy-classic-build-params.yaml
@@ -9,7 +9,7 @@ spec:
     - name: boskos-server-url
       value: http://boskos.ee-cd.svc
     - name: publisher-url
-      value: https://publisher.pingcap.net
+      value: "https://internal2-do.pingcap.net/publisher"
     - name: git-instead-of
       value: >-
         https://github.com/ => http://git-cdn.cache.svc:8000/,


### PR DESCRIPTION

Replace in-cluster publisher service URLs with external do2.pingcap.net and internal2-do.pingcap.net endpoints in GCP and KSY build bindings