### PR TITLE
refactor(pipelines/pingcap/tiflash): replace internal endpoint refs with public equivalents (PR1)

### DIFF
--- a/pipelines/pingcap/tiflash/release-6.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-6.5/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-13.0.0"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v20231106"
       command:
         - "/bin/bash"
         - "-c"
@@ -40,16 +40,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-6.5/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-6.5/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-13.0.0"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v20231106"
       command:
         - "cat"
       tty: true
@@ -39,16 +39,6 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
       nfs:

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -39,20 +39,6 @@ pipeline {
                 dir("tiflash") {
                     retry(2) {
                         script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
                             sh """
                             git config --global --add safe.directory "*"
                             git version

--- a/pipelines/pingcap/tiflash/release-6.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_unit_test.groovy
@@ -38,20 +38,6 @@ pipeline {
                 dir("tiflash") {
                     retry(2) {
                         script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
                             sh """
                             git config --global --add safe.directory "*"
                             git version

--- a/pipelines/pingcap/tiflash/release-7.1/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-7.1/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-13.0.0"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v20231106"
       command:
         - "/bin/bash"
         - "-c"
@@ -40,16 +40,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-7.1/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-7.1/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-13.0.0"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v20231106"
       command:
         - "cat"
       tty: true
@@ -39,16 +39,6 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
       nfs:

--- a/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
@@ -39,20 +39,6 @@ pipeline {
                 dir("tiflash") {
                     retry(2) {
                         script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
                             sh """
                             git config --global --add safe.directory "*"
                             git version

--- a/pipelines/pingcap/tiflash/release-7.1/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_unit_test.groovy
@@ -38,20 +38,6 @@ pipeline {
                 dir("tiflash") {
                     retry(2) {
                         script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
                             sh """
                             git config --global --add safe.directory "*"
                             git version

--- a/pipelines/pingcap/tiflash/release-7.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-7.5/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-13.0.0"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v20231106"
       command:
         - "/bin/bash"
         - "-c"
@@ -40,47 +40,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: jnlp
-      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
-          readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-7.5/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-7.5/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-13.0.0"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v20231106"
       command:
         - "cat"
       tty: true
@@ -39,50 +39,6 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-8"
           readOnly: false
-    - name: jnlp
-      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
-          readOnly: false
-        - mountPath: "/home/jenkins"
-          name: "volume-8"
-          readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
       nfs:

--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -43,20 +43,6 @@ pipeline {
                 dir("tiflash") {
                     retry(2) {
                         script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
                             sh """
                             git config --global --add safe.directory "*"
                             git version

--- a/pipelines/pingcap/tiflash/release-7.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_unit_test.groovy
@@ -41,20 +41,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                             git version
                             git config --global --add safe.directory "*"

--- a/pipelines/pingcap/tiflash/release-8.1/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.1/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-13.0.0"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v20231106"
       command:
         - "/bin/bash"
         - "-c"
@@ -40,47 +40,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: jnlp
-      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
-          readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-8.1/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.1/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-13.0.0"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v20231106"
       command:
         - "cat"
       tty: true
@@ -36,50 +36,6 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-8"
           readOnly: false
-    - name: jnlp # TODO: remove this default container
-      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
-          readOnly: false
-        - mountPath: "/home/jenkins"
-          name: "volume-8"
-          readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
       nfs:

--- a/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
@@ -37,20 +37,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version

--- a/pipelines/pingcap/tiflash/release-8.1/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_unit_test.groovy
@@ -37,20 +37,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version

--- a/pipelines/pingcap/tiflash/release-8.2/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.2/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-17.0.6"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2"
       command:
         - "/bin/bash"
         - "-c"
@@ -40,47 +40,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: jnlp
-      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
-          readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-8.2/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.2/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-17.0.6"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2"
       command:
         - "cat"
       tty: true
@@ -36,50 +36,6 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-8"
           readOnly: false
-    - name: jnlp # TODO: remove this default container
-      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
-          readOnly: false
-        - mountPath: "/home/jenkins"
-          name: "volume-8"
-          readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
       nfs:

--- a/pipelines/pingcap/tiflash/release-8.2/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.2/pull_integration_test.groovy
@@ -37,20 +37,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version

--- a/pipelines/pingcap/tiflash/release-8.2/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.2/pull_unit_test.groovy
@@ -37,20 +37,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version

--- a/pipelines/pingcap/tiflash/release-8.3/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.3/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-17.0.6"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2"
       command:
         - "/bin/bash"
         - "-c"
@@ -40,47 +40,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: jnlp
-      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
-          readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-8.3/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.3/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-17.0.6"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2"
       command:
         - "cat"
       tty: true
@@ -36,50 +36,6 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-8"
           readOnly: false
-    - name: jnlp # TODO: remove this default container
-      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
-          readOnly: false
-        - mountPath: "/home/jenkins"
-          name: "volume-8"
-          readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
       nfs:

--- a/pipelines/pingcap/tiflash/release-8.3/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.3/pull_integration_test.groovy
@@ -37,20 +37,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version

--- a/pipelines/pingcap/tiflash/release-8.3/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.3/pull_unit_test.groovy
@@ -37,20 +37,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version

--- a/pipelines/pingcap/tiflash/release-8.4/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.4/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-17.0.6"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2"
       command:
         - "/bin/bash"
         - "-c"
@@ -40,47 +40,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: jnlp
-      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
-          readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-8.4/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.4/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:amd64-llvm-17.0.6"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2"
       command:
         - "cat"
       tty: true
@@ -36,50 +36,6 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-8"
           readOnly: false
-    - name: jnlp # TODO: remove this default container
-      image: "jenkins/inbound-agent:3345.v03dee9b_f88fc-1"
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
-      volumeMounts:
-        - mountPath: "/home/jenkins/agent/rust"
-          name: "volume-0"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ccache"
-          name: "volume-1"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/dependency"
-          name: "volume-2"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/ci-cached-code-daily"
-          name: "volume-4"
-          readOnly: false
-        - mountPath: "/home/jenkins/agent/proxy-cache"
-          name: "volume-5"
-          readOnly: false
-        - mountPath: "/tmp"
-          name: "volume-6"
-          readOnly: false
-        - mountPath: "/tmp-memfs"
-          name: "volume-7"
-          readOnly: false
-        - mountPath: "/home/jenkins"
-          name: "volume-8"
-          readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
       nfs:

--- a/pipelines/pingcap/tiflash/release-8.4/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.4/pull_integration_test.groovy
@@ -37,20 +37,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version

--- a/pipelines/pingcap/tiflash/release-8.4/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.4/pull_unit_test.groovy
@@ -37,20 +37,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version

--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
@@ -40,20 +40,6 @@ pipeline {
                 dir("tiflash") {
                     retry(2) {
                         script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
                             sh """
                             git config --global --add safe.directory "*"
                             git version

--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_unit_test.groovy
@@ -40,20 +40,6 @@ pipeline {
                 dir("tiflash") {
                     retry(2) {
                         script {
-                            container("util") {
-                                withCredentials(
-                                    [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                                ) {
-                                    sh "rm -rf ./*"
-                                    sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                    sh """
-                                    ls -alh
-                                    chown 1000:1000 src-tiflash.tar.gz
-                                    tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                    ls -alh
-                                    """
-                                }
-                            }
                             sh """
                             git config --global --add safe.directory "*"
                             git version

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pod-merged_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2"
       command:
         - "/bin/bash"
         - "-c"
@@ -40,16 +40,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pod-merged_unit_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2"
       command:
         - "cat"
       tty: true
@@ -33,16 +33,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
       nfs:

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pod-pull_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2"
       command:
         - "/bin/bash"
         - "-c"
@@ -40,16 +40,6 @@ spec:
         - mountPath: "/tmp-memfs"
           name: "volume-7"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       args: ["sleep", "infinity"]

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pod-pull_unit-test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/tiflash/tiflash-llvm-base:llvm-17.0.6-rocky8"
+      image: "ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2"
       command:
         - "cat"
       tty: true
@@ -37,16 +37,6 @@ spec:
         - mountPath: "/home/jenkins"
           name: "volume-8"
           readOnly: false
-    - name: util
-      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2026.3.29-14-g90ae7ef
-      tty: true
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "500Mi"
-        limits:
-          cpu: "500m"
-          memory: "500Mi"
   volumes:
     - name: "volume-0"
       nfs:

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
@@ -41,20 +41,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_unit_test.groovy
@@ -40,20 +40,6 @@ pipeline {
             steps {
                 dir("tiflash") {
                     script {
-                        container("util") {
-                            withCredentials(
-                                [file(credentialsId: 'ks3util-config', variable: 'KS3UTIL_CONF')]
-                            ) {
-                                sh "rm -rf ./*"
-                                sh "ks3util -c \$KS3UTIL_CONF cp -f ks3://ee-fileserver/download/cicd/daily-cache-code/src-tiflash.tar.gz src-tiflash.tar.gz"
-                                sh """
-                                ls -alh
-                                chown 1000:1000 src-tiflash.tar.gz
-                                tar -xf src-tiflash.tar.gz --strip-components=1 && rm -rf src-tiflash.tar.gz
-                                ls -alh
-                                """
-                            }
-                        }
                         sh """
                         git config --global --add safe.directory "*"
                         git version

--- a/prow-jobs/pingcap/tiflash/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-6.5-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - name: pingcap/tiflash/release-6.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -22,7 +22,7 @@ presubmits:
     - name: pingcap/tiflash/release-6.5/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-7.1-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tiflash/release-7.1/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -23,7 +23,7 @@ presubmits:
     - name: pingcap/tiflash/release-7.1/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-7.5-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tiflash/release-7.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -23,7 +23,7 @@ presubmits:
     - name: pingcap/tiflash/release-7.5/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.1-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.1/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -23,7 +23,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.1/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-8.2-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.2-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.2/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-unit-test
@@ -17,7 +17,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.2/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-8.3-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.3-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.3/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-unit-test
@@ -17,7 +17,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.3/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-8.4-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.4-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.4/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-unit-test
@@ -17,7 +17,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.4/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-integration-test

--- a/prow-jobs/pingcap/tiflash/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-9.0-beta-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - name: pingcap/tiflash/release-9.0-beta/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -24,7 +24,7 @@ presubmits:
     - name: pingcap/tiflash/release-9.0-beta/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test


### PR DESCRIPTION
## Summary

Replace internal-only service references (`hub.pingcap.net`, `ee-fileserver`) under `pipelines/pingcap/tiflash/` with public equivalents, enabling tiflash pipelines to run from a public cloud environment.

## Changes

- **Pod YAMLs**: Replace `hub.pingcap.net/tiflash/tiflash-llvm-base:<tag>` with `ghcr.io/pingcap-qe/cd/builders/tiflash:<tag>` across 19 pod YAML files
  - `amd64-llvm-13.0.0` → `v20231106` (releases 6.5/7.1/7.5/8.1)
  - `amd64-llvm-17.0.6` → `v2025.4.15-rocky8-llvm-17.0.6-v2` (releases 8.2/8.3/8.4)
  - `llvm-17.0.6-rocky8` → `v2025.4.15-rocky8-llvm-17.0.6-v2` (release 9.0-beta)
- **Groovy pipelines**: Remove `ks3util` + `ee-fileserver` pre-cached source tarball downloads from Checkout stages (18 groovy files)
- **Pod templates**: Remove the `util` (ks3util) and `jnlp` containers from pod YAMLs (no longer needed)
- Direct git checkout via `prow.checkoutRefs()` is now the primary checkout mechanism

## Testing

- Matches the clean pattern already established in `release-8.5/` and `latest/`
- No prow-job or job DSL changes needed
- Canary releases: 8.4 and 9.0-beta

## Risk

Low. Each release directory is independent; rollback by reverting individual directory changes. Image tags are immutable in ghcr. Removing the cached tarball may increase checkout time but mirrors the working release-8.5 approach.