### PR TITLE
refactor(pipelines/tidb-test): replace hub.pingcap.net refs with public equivalents

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/release-6.0/pod-ghpr_build.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.18:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/pod-ghpr_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.18:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-6.0/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.0/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.18:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/pod-ghpr_build.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/pod-ghpr_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-6.2/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.2/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_common_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_integration_common_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_integration_jdbc_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       securityContext:
         privileged: true
       tty: true


### PR DESCRIPTION
## Summary

Replace all `hub.pingcap.net` image references in `pipelines/pingcap-qe/tidb-test/` pod YAML files across release-6.0, release-6.2, and release-7.1 with cloud-accessible equivalents.

## Changes

- **release-6.0/**, **release-6.2/**, **release-7.1/**: 12 pod YAML files, 14 image references updated
- Golang images (centos7_golang-1.18/1.19/1.23) → `ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25`
- Java combo image → `us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/...`
- Quote normalization: double-quoted → unquoted (per release-8.5/latest convention)

## Testing

- `grep -rn 'hub.pingcap.net' pipelines/pingcap-qe/tidb-test/` returns zero
- Diff verified: all 14 replacements match the expected mapping

## Risk

Low. Pure string replacements in pod YAML files (zero logic changes). Images already in active use by release-8.5 jobs on the same cluster.