### PR TITLE
refactor(pipelines/pingcap/tidb): replace hub.pingcap.net image refs with public equivalents (D1-D6)

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_nodejs_test.yaml
@@ -5,7 +5,7 @@ spec:
     runAsUser: 0
   containers:
     - name: nodejs
-      image: "hub.pingcap.net/ee/ci/base:v20230810-go1.23.0"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_tiflash_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_tiflash_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-periodics_tidb_next_gen_smoke_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-periodics_tidb_next_gen_smoke_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/rocky8_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pull_check_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_check_next_gen/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go12320241009"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920231127"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go11920231127"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/wangweizhen/tidb_image:go11920231127"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go11920231127"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check2.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: hub.pingcap.net/jenkins/rocky9_golang-1.19:fips-bazel
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       securityContext:
         privileged: true

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: hub.pingcap.net/jenkins/rocky9_golang-1.19:fips
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       args:
         - cat
       tty: true

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_unit_test.yaml
@@ -7,7 +7,7 @@ spec:
     - name: golang
       # TODO(wuhuizuo): using standard bazel build image to shrink the image size
       # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: hub.pingcap.net/jenkins/rocky9_golang-1.19:fips-bazel
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-pull_br_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: hub.pingcap.net/jenkins/rocky9_golang-1.19:fips
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       args:
         - cat

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_br_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.13_java:cached"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_binlog_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -18,7 +18,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: golang121
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -30,7 +30,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: hub.pingcap.net/jenkins/zookeeper
+    - image: docker.io/confluentinc/cp-zookeeper:7.6.2
       imagePullPolicy: IfNotPresent
       name: zookeeper
       resources:
@@ -59,7 +59,7 @@ spec:
           value: "zk"
         - name: KAFKA_ZOOKEEPER_CONNECT
           value: "127.0.0.1:2181"
-      image: hub.pingcap.net/jenkins/kafka
+      image: docker.io/confluentinc/cp-kafka:7.6.2
       imagePullPolicy: IfNotPresent
       name: kafka
       resources:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         limits:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_ddl_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: java
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.16_openjdk-17.0.2_gradle-7.4.2_maven-3.8.6:cached"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_tidb_tools_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: hub.pingcap.net/jenkins/centos7_golang-1.19:latest
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       tty: true
       env:
         - name: GOPATH
@@ -15,7 +15,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: golang121
-      image: hub.pingcap.net/jenkins/centos7_golang-1.21:latest
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       tty: true
       env:
         - name: GOPATH
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: mysql
-      image: hub.pingcap.net/jenkins/mysql:5.7
+      image: docker.io/library/mysql:5.7
       tty: true
       args: ["--server-id=1", "--log-bin", "--binlog-format=ROW"]
       env:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_sqllogic_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_tiflash_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
       resources:
         requests:
@@ -22,8 +22,7 @@ spec:
           value: ""
         - name: DOCKER_HOST
           value: tcp://localhost:2375
-        - name: DOCKER_REGISTRY_MIRROR
-          value: https://registry-mirror.pingcap.net
+
       securityContext:
         privileged: true
       resources:
@@ -34,7 +33,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: docker
-      image: "hub.pingcap.net/jenkins/alpine-docker:tics-test"
+      image: "docker.io/library/docker:20.10.24-dind"
       tty: true
       command:
         - "cat"

--- a/pipelines/pingcap/tidb/release-6.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_br_integration_test.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }
@@ -87,7 +87,7 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
                     }
                 }

--- a/pipelines/pingcap/tidb/release-6.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_common_test.groovy
@@ -13,7 +13,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }
@@ -79,7 +79,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
                         defaultContainer 'java'
                     }

--- a/pipelines/pingcap/tidb/release-6.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_e2e_test.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_binlog_test.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }
@@ -98,7 +98,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
                         defaultContainer 'golang'
                     }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_copr_test.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }
@@ -95,7 +95,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
                         defaultContainer 'golang'
                     }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }
@@ -100,7 +100,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
                         defaultContainer 'java'
                     }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }
@@ -97,7 +97,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
                         defaultContainer 'golang'
                     }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_tidb_tools_test.groovy
@@ -15,7 +15,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }

--- a/pipelines/pingcap/tidb/release-6.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_sqllogic_test.groovy
@@ -13,7 +13,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }
@@ -84,7 +84,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
                         defaultContainer 'golang'
                     }
@@ -146,7 +146,7 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
                         defaultContainer 'golang'
                     }

--- a/pipelines/pingcap/tidb/release-6.5/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_tiflash_test.groovy
@@ -73,7 +73,7 @@ pipeline {
                         ./tidb-server -V
                         """
                         sh label: 'build tmp tidb image', script: """
-                        docker build -t hub.pingcap.net/qa/tidb:${REFS.base_ref} -f tidb.Dockerfile .
+                        docker build -t us-docker.pkg.dev/pingcap-testing-account/internal/test/qa/tidb:${REFS.base_ref} -f tidb.Dockerfile .
                         """
                     }
                     dir("tiflash/tests/docker") {

--- a/pipelines/pingcap/tidb/release-6.5/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_tiflash_test.groovy
@@ -13,7 +13,7 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
             defaultContainer 'golang'
         }
@@ -73,7 +73,7 @@ pipeline {
                         ./tidb-server -V
                         """
                         sh label: 'build tmp tidb image', script: """
-                        docker build -t us-docker.pkg.dev/pingcap-testing-account/internal/test/qa/tidb:${REFS.base_ref} -f tidb.Dockerfile .
+                        docker build -t us-docker.pkg.dev/pingcap-testing-account/hub/pingcap/tidb/images/tidb-server:${REFS.base_ref} -f tidb.Dockerfile .
                         """
                     }
                     dir("tiflash/tests/docker") {


### PR DESCRIPTION
## Summary
Replace all internal-only `hub.pingcap.net` image references in `pipelines/pingcap/tidb/` pod YAMLs for release-6.5, release-6.5-fips, and latest with public registry images.

## Changes
- **D1**: Go builder images → `ghcr.io/pingcap-qe/ci/jenkins:*` (24 pods across 3 directories)
- **D2**: Bazel build images → `us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/...` (3 pods)
- **D3**: Service sidecars → docker.io/ghcr.io equivalents (mysql, zookeeper, kafka, alpine-docker, ee/ci/base, java images)
- **D5**: Remove `DOCKER_REGISTRY_MIRROR` env var from `pod-pull_tiflash_test.yaml`
- **D6**: Docker build tag in `pull_tiflash_test.groovy` → `us-docker.pkg.dev/.../internal/test/qa/tidb:${REFS.base_ref}`

## Testing
- Zero `hub.pingcap.net` refs remain: `rg hub\\.pingcap\\.net pipelines/pingcap/tidb/` returns 0

## Risk
Low. All replacements follow established patterns from PR #4763 and existing clean release dirs (8.5+). Images at ghcr.io and us-docker.pkg.dev are immutable. Release-6.5/6.5-fips are EOL branches.