### PR TITLE
feat(pipelines): replace hub.pingcap.net image refs with ghcr.io equivalents in tikv/pd pod YAMLs

### DIFF
--- a/pipelines/tikv/pd/release-6.5-fips/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-6.5-fips/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-6.5/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.19:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-7.1/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-7.1/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-7.1/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/release-7.1/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.20:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-7.5/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-7.5/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-7.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/release-7.5/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-8.1/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-8.1/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-8.1/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/release-8.1/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-8.5/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-8.5/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/pd/release-9.0-beta/pod-ghpr_build.yaml
+++ b/pipelines/tikv/pd/release-9.0-beta/pod-ghpr_build.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/pd/release-9.0-beta/pod-pull_integration_copr_test.yaml
+++ b/pipelines/tikv/pd/release-9.0-beta/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "hub.pingcap.net/jenkins/centos7_golang-1.23:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         limits:

--- a/pipelines/tikv/tikv/release-6.5/pod-pull_integration_test.yaml
+++ b/pipelines/tikv/tikv/release-6.5/pod-pull_integration_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-6.5:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
       securityContext:
         privileged: true
     - name: golang
-      image: hub.pingcap.net/jenkins/centos7_golang-1.19:latest
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/tikv/release-6.5/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-6.5/pod-pull_unit_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-6.5:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
       tty: true
       command:
         - "/bin/sh"

--- a/pipelines/tikv/tikv/release-7.1/pod-pull_integration_test.yaml
+++ b/pipelines/tikv/tikv/release-7.1/pod-pull_integration_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-7.1:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
       securityContext:
         privileged: true
     - name: golang
-      image: hub.pingcap.net/jenkins/centos7_golang-1.20:latest
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/tikv/release-7.1/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-7.1/pod-pull_unit_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-7.1:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
       tty: true
       command:
         - "/bin/sh"

--- a/pipelines/tikv/tikv/release-7.5/pod-pull_integration_test.yaml
+++ b/pipelines/tikv/tikv/release-7.5/pod-pull_integration_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-7.5:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
       securityContext:
         privileged: true
     - name: golang
-      image: hub.pingcap.net/jenkins/centos7_golang-1.21:latest
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/tikv/release-8.1/pod-pull_integration_test.yaml
+++ b/pipelines/tikv/tikv/release-8.1/pod-pull_integration_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-8.1:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
       tty: true
       resources:
         requests:
@@ -15,7 +15,7 @@ spec:
       securityContext:
         privileged: true
     - name: golang
-      image: hub.pingcap.net/jenkins/centos7_golang-1.21:latest
+      image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25
       tty: true
       resources:
         requests:

--- a/pipelines/tikv/tikv/release-8.1/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-8.1/pod-pull_unit_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-8.1:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
       tty: true
       command:
         - "/bin/sh"

--- a/pipelines/tikv/tikv/release-8.2/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-8.2/pod-pull_unit_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-8.2:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
       tty: true
       command:
         - "/bin/sh"

--- a/pipelines/tikv/tikv/release-8.3/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-8.3/pod-pull_unit_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-cached-release-8.3:latest"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
       tty: true
       command:
         - "/bin/sh"

--- a/pipelines/tikv/tikv/release-8.4/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-8.4/pod-pull_unit_test.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: runner
-      image: "hub.pingcap.net/jenkins/tikv-ci:rocky8-base-cached-release-8.4"
+      image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
       imagePullPolicy: Always
       tty: true
       command:


### PR DESCRIPTION
## Summary

Replace all `hub.pingcap.net` image references in `pipelines/tikv/tikv/` and `pipelines/tikv/pd/` pod YAMLs with ghcr.io equivalents.

## Changes

- **D1**: Replace `hub.pingcap.net/jenkins/tikv-cached-release-*` and `hub.pingcap.net/jenkins/tikv-ci:*` with `ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135`
- **D2**: Replace `hub.pingcap.net/jenkins/centos7_golang-*` with `ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25`

Affected files (21 files, 25 occurrences):
- pipelines/tikv/tikv/ (release-6.5 through 8.4) - tikv runner and golang images
- pipelines/tikv/pd/ (release-6.5 through 9.0-beta) - golang build images

## Testing

- Verified `rg -l 'hub.pingcap.net' pipelines/tikv/tikv/ pipelines/tikv/pd/` returns zero matches
- All YAML files remain syntactically valid (image tag replacement only)
- No changes to groovy scripts, resource limits, affinity rules, or container structure

## Risk

Low. Image-only replacements with pinned digests/version tags. No structural changes.