### PR TITLE
feat(prow-jobs): only verify changed k8s pod yaml files in pull-verify-k8s-pod-yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,8 @@ Follow the **Conventional Commits** specification for commit messages:
   - `scope`: optional but recommended for this repo (e.g. `prow-jobs`, `pipelines`, `jobs`, `tekton`, `tools`, `libraries`)
   - `subject`: imperative, present tense (e.g. "add", "fix", "update")
 
+- **Language**: All commit messages and PR titles/descriptions must be written in English.
+
 Examples:
 - `ci(prow): add presubmit for tiflow lint`
 - `pipelines(tiflow): increase pipeline timeout`

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -185,11 +185,16 @@ presubmits:
             command: [sh, -ce]
             args:
               - |
-                apk add --no-cache kubectl yq-go wget tar
+                apk add --no-cache kubectl yq-go wget tar git
                 wget -qO /tmp/crane.tar.gz "https://github.com/google/go-containerregistry/releases/download/v0.21.5/go-containerregistry_Linux_x86_64.tar.gz"
                 tar xzf /tmp/crane.tar.gz -C /usr/local/bin/ crane
                 rm /tmp/crane.tar.gz
-                sh .ci/verify-k8s-pod-yaml.sh
+                changed_files=$(git diff --name-only --diff-filter=d "${PULL_BASE_SHA:?}" -- 'pipelines/**/*.yaml' 'pipelines/**/*.yml' | LC_ALL=C sort)
+                if [ -z "$changed_files" ]; then
+                  echo "No changed pipeline Pod YAML files to verify."
+                  exit 0
+                fi
+                sh .ci/verify-k8s-pod-yaml.sh $changed_files
             resources:
               limits:
                 memory: 128Mi


### PR DESCRIPTION
### Summary

Improve the `pull-verify-k8s-pod-yaml` CI job to only validate Pod YAML files that have changed relative to the PR base branch, instead of scanning all files under `pipelines/`.

### Changes

- Add `git` to the container toolchain
- Use `git diff --name-only` against `PULL_BASE_SHA` to find changed `pipelines/**/*.yaml|yml` files
- Exit early when no files changed, avoiding unnecessary work
- Pass only the changed file list to `verify-k8s-pod-yaml.sh`