### PR TITLE
chore(scripts): replace fileserver.pingcap.net with download.pingcap.org in FIPS scripts

### DIFF
--- a/scripts/pingcap/tidb/release-6.5-fips/br_integration_test_download_dependency.sh
+++ b/scripts/pingcap/tidb/release-6.5-fips/br_integration_test_download_dependency.sh
@@ -11,11 +11,15 @@ set -o pipefail
 
 # Specify which branch to be utilized for executing the test, which is
 # exclusively accessible when obtaining binaries from
-# http://fileserver.pingcap.net.
+# https://download.pingcap.org.
 branch=${1:-release-6.5-fips}
-file_server_url=${2:-http://fileserver.pingcap.net}
+file_server_url=${2:-https://download.pingcap.org}
 oci_fips_branch="feature-release-6.5-fips-fips_linux_amd64"
 # Note: osci_base_url is only available in the ci environment.
+# dl.apps.svc is an internal k8s service; the oci-files download chain
+# (internal OCI registry) has no direct public equivalent. These scripts
+# will remain non-functional in public cloud until the artifact
+# infrastructure is migrated (release-6.5-fips is EOL; acceptable debt).
 oci_base_url="http://dl.apps.svc"
 
 tikv_importer_branch="release-5.0"

--- a/scripts/pingcap/tidb/release-6.5-fips/pingcap_download_artifacts.sh
+++ b/scripts/pingcap/tidb/release-6.5-fips/pingcap_download_artifacts.sh
@@ -45,9 +45,13 @@ if [[ -n $1 ]]; then
     tail -1 $1
 fi
 
-file_server_url="http://fileserver.pingcap.net"
+file_server_url="https://download.pingcap.org"
 oci_fips_branch="feature-release-6.5-fips-fips_linux_amd64"
 # Note: osci_base_url is only available in the ci environment.
+# dl.apps.svc is an internal k8s service; the oci-files download chain
+# (internal OCI registry) has no direct public equivalent. These scripts
+# will remain non-functional in public cloud until the artifact
+# infrastructure is migrated (release-6.5-fips is EOL; acceptable debt).
 oci_base_url="http://dl.apps.svc"
 
 tiflash_sha1_url="${file_server_url}/download/refs/pingcap/tiflash/${TIFLASH}/sha1"


### PR DESCRIPTION
## Summary
Replace `http://fileserver.pingcap.net` with `https://download.pingcap.org` in both FIPS scripts under `scripts/pingcap/tidb/release-6.5-fips/`. Document the `dl.apps.svc`/oci-files gap.

## Changes
- `br_integration_test_download_dependency.sh`: Updated `file_server_url` default and comment
- `pingcap_download_artifacts.sh`: Updated `file_server_url` default
- Both scripts: Added gap documentation for `dl.apps.svc`/oci-files/hub.pingcap.net (internal k8s services, no public equivalent)

## Testing
Changes are in shell scripts — syntax-verified by reading final output. No CI pipeline changes.

## Risk
Low. These scripts are for the EOL release-6.5-fips branch. The `dl.apps.svc` chain remains in place (non-functional in public cloud, documented as acceptable debt).