### PR TITLE
fix(tekton): revert image-push-on-harbor-for-pingkai trigger filter

### DIFF
--- a/tekton/v1/triggers/triggers/env-prod2/_/harbor/image-push-on-harbor-for-pingkai.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/harbor/image-push-on-harbor-for-pingkai.yaml
@@ -20,7 +20,7 @@ spec:
             &&
             body.event_data.resources[0].tag.matches('[-_](amd64|arm64)$')
             &&
-            body.event_data.resources[0].resource_url.startsWith('us-docker.pkg.dev/pingcap-testing-account/')
+            body.event_data.resources[0].resource_url.startsWith('hub.pingcap.net/')
   bindings:
     - ref: harbor-image-push
   template:


### PR DESCRIPTION
## Summary

Revert the filter change in `triggers/triggers/env-prod2/_/harbor/image-push-on-harbor-for-pingkai.yaml` that was included in PR #4785. This file should not have been modified — restore the original `hub.pingcap.net/` filter.

## Changes

- `tekton/v1/triggers/triggers/env-prod2/_/harbor/image-push-on-harbor-for-pingkai.yaml`: revert trigger filter from `us-docker.pkg.dev/pingcap-testing-account/` back to `hub.pingcap.net/`

## Risk

Low. Single-line revert of a filter string. No other changes.