### PR TITLE
refactor(pipelines/tiflow): align release-7.5 pipelines with release-8.5 refactoring

### DIFF
--- a/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/ghpr_verify.groovy
@@ -1,5 +1,6 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for release-7.5 branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
@@ -8,32 +9,12 @@ final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-ghpr_verify.
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
+    agent none
     options {
         timeout(time: 40, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 10, unit: 'MINUTES') }
-            steps {
-                dir(REFS.repo) {
-                    script {
-                        prow.checkoutRefsWithCacheLock(REFS)
-                    }
-                }
-            }
-        }
         stage('Tests') {
             matrix {
                 axes {
@@ -45,8 +26,9 @@ pipeline {
                 agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -62,18 +44,35 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {
-                                    sh label: "${TEST_CMD}", script: """
-                                        make ${TEST_CMD}
-                                    """
+                                script {
+                                    prow.checkoutRefsWithCacheLock(REFS)
                                 }
+                                sh label: "${TEST_CMD}", script: """
+                                    make ${TEST_CMD}
+                                """
                             }
                         }
                         post {
+                            success {
+                                dir(REFS.repo) {
+                                    script {
+
+                                        def testConfigs = [
+                                            dm_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/dm_test/cov.unit_test.out"],
+                                            unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/tidb_cdc_test/cov.unit.out"],
+                                            engine_unit_test_in_verify_ci: [flags: "unit", coverage_file: "/tmp/engine_test/cov.unit_test.out"]
+                                        ]
+                                        def config = testConfigs[TEST_CMD]
+                                        if (config && config.coverage_file) {
+                                            prow.uploadCoverageToCodecov(REFS, config.flags, config.coverage_file)
+                                        }
+                                    }
+                                }
+                                script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) }
+                            }
                             always {
                                 junit(testResults: "**/tiflow/*-junit-report.xml", allowEmptyResults : true)
                             }
-                            success { script { matrixCache.markDone(REFS, 'Test', [test_cmd: env.TEST_CMD]) } }
                         }
                     }
                 }

--- a/pipelines/pingcap/tiflow/release-7.5/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-ghpr_verify.yaml
@@ -9,23 +9,11 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 12Gi
-          cpu: "4"
+          memory: 16Gi
+          cpu: 4000m
         limits:
           memory: 16Gi
-          cpu: "6"
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
+          cpu: 6000m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_build.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_build.yaml
@@ -9,11 +9,21 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 24Gi
-          cpu: 6000m
+          memory: 12Gi
+          cpu: 3000m
         limits:
-          memory: 24Gi
+          memory: 16Gi
           cpu: 6000m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          memory: 4Gi
+          cpu: 1000m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -9,27 +9,25 @@ spec:
       name: zookeeper
       resources:
         requests:
-          cpu: 200m
-          memory: 4Gi
+          cpu: 500m
+          memory: 2Gi
         limits:
-          cpu: 2000m
+          cpu: 1000m
           memory: 4Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - args:
-        - cat
-      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:
         requests:
-          cpu: "2"
-          memory: 12Gi
-        limits:
-          cpu: "4"
+          cpu: 4000m
           memory: 16Gi
+        limits:
+          cpu: 8000m
+          memory: 24Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp
@@ -68,11 +66,11 @@ spec:
       name: kafka
       resources:
         requests:
-          cpu: 200m
-          memory: 4Gi
+          cpu: 1500m
+          memory: 6Gi
         limits:
-          cpu: 2000m
-          memory: 4Gi
+          cpu: 3000m
+          memory: 8Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp
@@ -99,11 +97,48 @@ spec:
       resources:
         requests:
           cpu: 200m
-          memory: 4Gi
+          memory: 2Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
+    - name: mysql
+      image: quay.io/debezium/example-mysql:2.4
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: ""
+        - name: MYSQL_USER
+          value: mysqluser
+        - name: MYSQL_PASSWORD
+          value: mysqlpw
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "yes"
+        - name: MYSQL_TCP_PORT
+          value: "3310"
+      resources:
+        requests:
+          cpu: 200m
+          memory: 1Gi
+    - name: connect
+      image: quay.io/debezium/connect:2.4
+      env:
+        - name: BOOTSTRAP_SERVERS
+          value: "127.0.0.1:9092"
+        - name: GROUP_ID
+          value: "1"
+        - name: CONFIG_STORAGE_TOPIC
+          value: "my_connect_configs"
+        - name: OFFSET_STORAGE_TOPIC
+          value: "my_connect_offsets"
+        - name: STATUS_STORAGE_TOPIC
+          value: "my_connect_statuses"
+        - name: LANG
+          value: "C.UTF-8"
+      resources:
+        requests:
+          cpu: 200m
+          memory: 1Gi
   volumes:
     - emptyDir: {}
       name: volume-0

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml
@@ -10,10 +10,10 @@ spec:
       resources:
         requests:
           memory: 12Gi
-          cpu: "4"
+          cpu: 3000m
         limits:
           memory: 16Gi
-          cpu: "6"
+          cpu: 6000m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml
@@ -9,23 +9,11 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 12Gi
-          cpu: "4"
+          memory: 24Gi
+          cpu: 6000m
         limits:
-          memory: 16Gi
-          cpu: "6"
-    - name: pulsar
-      image: "apachepulsar/pulsar:2.10.4"
-      imagePullPolicy: IfNotPresent
-      tty: true
-      resources:
-        requests:
-          memory: 4Gi
-          cpu: "4"
-        limits:
-          memory: 6Gi
-          cpu: "6"
-      command: ["bin/pulsar", "standalone"]
+          memory: 32Gi
+          cpu: 8000m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_compatibility_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_compatibility_test.yaml
@@ -9,18 +9,31 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 12Gi
-          cpu: "4"
+          memory: 10Gi
+          cpu: 2500m
         limits:
           memory: 16Gi
-          cpu: "6"
-    - name: mysql1
-      image: 'docker.io/library/mysql:5.7'
+          cpu: 6000m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
         limits:
           memory: 4Gi
-          cpu: 2
+          cpu: 1000m
+    - name: mysql1
+      image: "us-docker.pkg.dev/pingcap-testing-account/dockerhub-remote/mysql:5.7"
+      tty: true
+      resources:
+        requests:
+          memory: 2Gi
+          cpu: 500m
+        limits:
+          memory: 4Gi
+          cpu: 1000m
       env:
         - name: MYSQL_ROOT_PASSWORD
           value: '123456'
@@ -33,12 +46,15 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: 'docker.io/library/mysql:5.7'
+      image: "us-docker.pkg.dev/pingcap-testing-account/dockerhub-remote/mysql:5.7"
       tty: true
       resources:
+        requests:
+          memory: 2Gi
+          cpu: 500m
         limits:
           memory: 4Gi
-          cpu: 2
+          cpu: 1000m
       env:
         - name: MYSQL_ROOT_PASSWORD
           value: '123456'

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_build.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_build.yaml
@@ -9,11 +9,21 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 24Gi
-          cpu: 6000m
+          memory: 12Gi
+          cpu: 3000m
         limits:
-          memory: 24Gi
+          memory: 16Gi
           cpu: 6000m
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          memory: 4Gi
+          cpu: 1000m
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml
@@ -7,22 +7,23 @@ spec:
     - name: golang
       image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
       tty: true
-      args:
-        - cat
       resources:
         requests:
-          memory: 12Gi
-          cpu: "4"
+          memory: 10Gi
+          cpu: 2500m
         limits:
           memory: 16Gi
-          cpu: "6"
+          cpu: 6000m
     - name: mysql1
-      image: "docker.io/library/mysql:5.7"
+      image: "us-docker.pkg.dev/pingcap-testing-account/dockerhub-remote/mysql:5.7"
       tty: true
       resources:
+        requests:
+          memory: 2Gi
+          cpu: 500m
         limits:
           memory: 4Gi
-          cpu: 2
+          cpu: 1000m
       env:
         - name: MYSQL_ROOT_PASSWORD
           value: "123456"
@@ -35,12 +36,15 @@ spec:
         - "--server-id=1"
         - "--default-authentication-plugin=mysql_native_password"
     - name: mysql2
-      image: "docker.io/library/mysql:8.0.21"
+      image: "us-docker.pkg.dev/pingcap-testing-account/dockerhub-remote/mysql:8.0.21"
       tty: true
       resources:
+        requests:
+          memory: 2Gi
+          cpu: 500m
         limits:
           memory: 4Gi
-          cpu: 2
+          cpu: 1000m
       env:
         - name: MYSQL_ROOT_PASSWORD
           value: "123456"

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -1,110 +1,105 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for release-7.5 branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml'
+final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
+final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)
+final OCI_TAG_PD = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIDB = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
+final OCI_TAG_TIFLASH = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
+final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
+final OCI_TAG_ETCD = 'v3.5.15'
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_SCHEMA_REGISTRY = 'latest'
+final WORKSPACE_STASH_NAME = 'tiflow-cdc-workspace'
 
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
+    agent none
     options {
         timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 10, unit: 'MINUTES') }
-            steps {
-                dir(REFS.repo) {
-                    script {
-                        prow.checkoutRefsWithCacheLock(REFS)
-                    }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage("prepare") {
-            options { timeout(time: 20, unit: 'MINUTES') }
-            steps {
-                dir("third_party_download") {
-                    retry(2) {
-                        script {
-                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
-
-                            sh label: "download third_party", script: """
-                                mkdir -p bin
-                                cd ../tiflow
-
-                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
-                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
-                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
-
-                                    # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh release-7.5
-                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
-
-                                    # Then download and replace other components with exact versions
-                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
-                                    chmod +x download_test_binaries_by_tag.sh
-
-                                    # Save sync_diff_inspector and some other binaries
-                                    mv bin tmp_bin
-
-                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
-                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
-
-                                    # Restore some binaries
-                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
-                                else
-                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh release-7.5
-                                fi
-
+            stages {
+                stage('Checkout') {
+                    options { timeout(time: 10, unit: 'MINUTES') }
+                    steps {
+                        dir(REFS.repo) {
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS)
+                            }
+                        }
+                    }
+                }
+                stage("Prepare") {
+                    options { timeout(time: 20, unit: 'MINUTES') }
+                    steps {
+                        dir("third_party_download") {
+                            retry(2) {
+                                sh label: "prepare third_party dir", script: "mkdir -p bin"
+                                container("utils") {
+                                    dir("bin") {
+                                        sh label: "download third_party from OCI", script: """
+                                            script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                            \$script \
+                                                --tidb=${OCI_TAG_TIDB} \
+                                                --pd=${OCI_TAG_PD} \
+                                                --pd-ctl=${OCI_TAG_PD} \
+                                                --tikv=${OCI_TAG_TIKV} \
+                                                --tiflash=${OCI_TAG_TIFLASH} \
+                                                --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
+                                                --minio=${OCI_TAG_MINIO} \
+                                                --etcdctl=${OCI_TAG_ETCD} \
+                                                --ycsb=${OCI_TAG_YCSB} \
+                                                --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        dir(REFS.repo) {
+                            cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
+                                // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
+                                // only build binarys if not exist, use the cached binarys if exist
+                                sh label: "prepare", script: """
+                                    mkdir -p ./bin
+                                    ls -alh ./bin
+                                    [ -f ./bin/cdc ] || make cdc
+                                    [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
+                                    [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
+                                    [ -f ./bin/cdc.test ] || make integration_test_build
+                                    ls -alh ./bin
+                                    ./bin/cdc version
+                                """
+                            }
+                            sh label: "prepare workspace", script: """
+                                cp -r ../third_party_download/bin/* ./bin/
+                                ln -sf /usr/bin/jq ./bin/jq
                                 make check_third_party_binary
-                                cd - && mv ../tiflow/bin/* ./bin/
-
-                                # Verify all required binaries
-                                echo "Verifying downloaded binaries..."
                                 ls -alh ./bin
                                 ./bin/tidb-server -V
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
-                                ./bin/sync_diff_inspector --version
                             """
+                            stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                         }
-                    }
-                }
-                dir(REFS.repo) {
-                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
-                        // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
-                        // only build binarys if not exist, use the cached binarys if exist
-                        sh label: "prepare", script: """
-                            ls -alh ./bin
-                            [ -f ./bin/cdc ] || make cdc
-                            [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
-                            [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
-                            [ -f ./bin/cdc.test ] || make integration_test_build
-                            ls -alh ./bin
-                            ./bin/cdc version
-                        """
-                    }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
                     }
                 }
             }
@@ -124,6 +119,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -140,25 +136,24 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash name: WORKSPACE_STASH_NAME
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -1,110 +1,105 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for release-7.5 branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml'
+final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
+final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)
+final OCI_TAG_PD = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIDB = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
+final OCI_TAG_TIFLASH = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
+final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
+final OCI_TAG_ETCD = 'v3.5.15'
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_SCHEMA_REGISTRY = 'latest'
+final WORKSPACE_STASH_NAME = 'tiflow-cdc-workspace'
 
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
+    agent none
     options {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 10, unit: 'MINUTES') }
-            steps {
-                dir(REFS.repo) {
-                    script {
-                        prow.checkoutRefsWithCacheLock(REFS)
-                    }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage("prepare") {
-            options { timeout(time: 20, unit: 'MINUTES') }
-            steps {
-                dir("third_party_download") {
-                    retry(2) {
-                        script {
-                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
-
-                            sh label: "download third_party", script: """
-                                mkdir -p bin
-                                cd ../tiflow
-
-                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
-                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
-                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
-
-                                    # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh release-7.5
-                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
-
-                                    # Then download and replace other components with exact versions
-                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
-                                    chmod +x download_test_binaries_by_tag.sh
-
-                                    # Save sync_diff_inspector and some other binaries
-                                    mv bin tmp_bin
-
-                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
-                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
-
-                                    # Restore some binaries
-                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
-                                else
-                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh release-7.5
-                                fi
-
+            stages {
+                stage('Checkout') {
+                    options { timeout(time: 10, unit: 'MINUTES') }
+                    steps {
+                        dir(REFS.repo) {
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS)
+                            }
+                        }
+                    }
+                }
+                stage("Prepare") {
+                    options { timeout(time: 20, unit: 'MINUTES') }
+                    steps {
+                        dir("third_party_download") {
+                            retry(2) {
+                                sh label: "prepare third_party dir", script: "mkdir -p bin"
+                                container("utils") {
+                                    dir("bin") {
+                                        sh label: "download third_party from OCI", script: """
+                                            script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                            \$script \
+                                                --tidb=${OCI_TAG_TIDB} \
+                                                --pd=${OCI_TAG_PD} \
+                                                --pd-ctl=${OCI_TAG_PD} \
+                                                --tikv=${OCI_TAG_TIKV} \
+                                                --tiflash=${OCI_TAG_TIFLASH} \
+                                                --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
+                                                --minio=${OCI_TAG_MINIO} \
+                                                --etcdctl=${OCI_TAG_ETCD} \
+                                                --ycsb=${OCI_TAG_YCSB} \
+                                                --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        dir(REFS.repo) {
+                            cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
+                                // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
+                                // only build binarys if not exist, use the cached binarys if exist
+                                sh label: "prepare", script: """
+                                    mkdir -p ./bin
+                                    ls -alh ./bin
+                                    [ -f ./bin/cdc ] || make cdc
+                                    [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
+                                    [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
+                                    [ -f ./bin/cdc.test ] || make integration_test_build
+                                    ls -alh ./bin
+                                    ./bin/cdc version
+                                """
+                            }
+                            sh label: "prepare workspace", script: """
+                                cp -r ../third_party_download/bin/* ./bin/
+                                ln -sf /usr/bin/jq ./bin/jq
                                 make check_third_party_binary
-                                cd - && mv ../tiflow/bin/* ./bin/
-
-                                # Verify all required binaries
-                                echo "Verifying downloaded binaries..."
                                 ls -alh ./bin
                                 ./bin/tidb-server -V
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
-                                ./bin/sync_diff_inspector --version
                             """
+                            stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                         }
-                    }
-                }
-                dir(REFS.repo) {
-                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
-                        // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
-                        // only build binarys if not exist, use the cached binarys if exist
-                        sh label: "prepare", script: """
-                            ls -alh ./bin
-                            [ -f ./bin/cdc ] || make cdc
-                            [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
-                            [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
-                            [ -f ./bin/cdc.test ] || make integration_test_build
-                            ls -alh ./bin
-                            ./bin/cdc version
-                        """
-                    }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
                     }
                 }
             }
@@ -124,6 +119,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -140,13 +136,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -1,110 +1,104 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
-// should triggerd for master branches
+// should triggerd for release-7.5 branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml'
+final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
+final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)
+final OCI_TAG_PD = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIDB = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
+final OCI_TAG_TIFLASH = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
+final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
+final OCI_TAG_ETCD = 'v3.5.15'
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_SCHEMA_REGISTRY = 'latest'
+final WORKSPACE_STASH_NAME = 'tiflow-cdc-workspace'
 
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
+    agent none
     options {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 10, unit: 'MINUTES') }
-            steps {
-                dir(REFS.repo) {
-                    script {
-                        prow.checkoutRefsWithCacheLock(REFS)
-                    }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage("prepare") {
-            options { timeout(time: 20, unit: 'MINUTES') }
-            steps {
-                dir("third_party_download") {
-                    retry(2) {
-                        script {
-                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
-
-                            sh label: "download third_party", script: """
-                                mkdir -p bin
-                                cd ../tiflow
-
-                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
-                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
-                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
-
-                                    # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh release-7.5
-                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
-
-                                    # Then download and replace other components with exact versions
-                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
-                                    chmod +x download_test_binaries_by_tag.sh
-
-                                    # Save sync_diff_inspector and some other binaries
-                                    mv bin tmp_bin
-
-                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
-                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
-
-                                    # Restore some binaries
-                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
-                                else
-                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh release-7.5
-                                fi
-
+            stages {
+                stage('Checkout') {
+                    options { timeout(time: 10, unit: 'MINUTES') }
+                    steps {
+                        dir(REFS.repo) {
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS)
+                            }
+                        }
+                    }
+                }
+                stage("Prepare") {
+                    options { timeout(time: 20, unit: 'MINUTES') }
+                    steps {
+                        dir("third_party_download") {
+                            retry(2) {
+                                sh label: "prepare third_party dir", script: "mkdir -p bin"
+                                container("utils") {
+                                    dir("bin") {
+                                        sh label: "download third_party from OCI", script: """
+                                            script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                            \$script \
+                                                --tidb=${OCI_TAG_TIDB} \
+                                                --pd=${OCI_TAG_PD} \
+                                                --pd-ctl=${OCI_TAG_PD} \
+                                                --tikv=${OCI_TAG_TIKV} \
+                                                --tiflash=${OCI_TAG_TIFLASH} \
+                                                --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
+                                                --minio=${OCI_TAG_MINIO} \
+                                                --etcdctl=${OCI_TAG_ETCD} \
+                                                --ycsb=${OCI_TAG_YCSB} \
+                                                --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        dir(REFS.repo) {
+                            cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
+                                // build cdc, pulsar_consumer, cdc.test for integration test
+                                // only build binarys if not exist, use the cached binarys if exist
+                                sh label: "prepare", script: """
+                                    mkdir -p ./bin
+                                    ls -alh ./bin
+                                    [ -f ./bin/cdc ] || make cdc
+                                    [ -f ./bin/cdc_pulsar_consumer ] || make pulsar_consumer
+                                    [ -f ./bin/cdc.test ] || make integration_test_build
+                                    ls -alh ./bin
+                                    ./bin/cdc version
+                                """
+                            }
+                            sh label: "prepare workspace", script: """
+                                cp -r ../third_party_download/bin/* ./bin/
+                                ln -sf /usr/bin/jq ./bin/jq
                                 make check_third_party_binary
-                                cd - && mv ../tiflow/bin/* ./bin/
-
-                                # Verify all required binaries
-                                echo "Verifying downloaded binaries..."
                                 ls -alh ./bin
                                 ./bin/tidb-server -V
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
-                                ./bin/sync_diff_inspector --version
                             """
+                            stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                         }
-                    }
-                }
-                dir(REFS.repo) {
-                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
-                        // build cdc, pulsar_consumer, cdc.test for integration test
-                        // only build binarys if not exist, use the cached binarys if exist
-                        sh label: "prepare", script: """
-                            ls -alh ./bin
-                            [ -f ./bin/cdc ] || make cdc
-                            [ -f ./bin/cdc_pulsar_consumer ] || make pulsar_consumer
-                            [ -f ./bin/cdc.test ] || make integration_test_build
-                            ls -alh ./bin
-                            ./bin/cdc version
-                        """
-                    }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
                     }
                 }
             }
@@ -124,6 +118,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -136,23 +131,12 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    // TODO: currently we encounter some issue when using pulsar container to run shell script
-                                    // so we comment out this part now.
-                                    // container("pulsar") {
-                                    //     timeout(time: 6, unit: 'MINUTES') {
-                                    //         sh label: "Waiting for pulsar ready", script: """
-                                    //             echo "Waiting for pulsar to be ready..."
-                                    //             while ! nc -z localhost 6650; do sleep 10; done
-                                    //         """
-                                    //     }
-                                    // }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
-                                    """
-                                }
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -1,111 +1,105 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
-// should triggerd for master branches
+// should triggerd for release-7.5 branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_storage_test.yaml'
+final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
+final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)
+final OCI_TAG_PD = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIDB = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
+final OCI_TAG_TIFLASH = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
+final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
+final OCI_TAG_ETCD = 'v3.5.15'
+final OCI_TAG_YCSB = 'v1.0.3'
+final OCI_TAG_SCHEMA_REGISTRY = 'latest'
+final WORKSPACE_STASH_NAME = 'tiflow-cdc-workspace'
 
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
+    agent none
     options {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout') {
-            options { timeout(time: 10, unit: 'MINUTES') }
-            steps {
-                dir(REFS.repo) {
-                    script {
-                        prow.checkoutRefsWithCacheLock(REFS)
-                    }
+        stage('Checkout & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
                 }
             }
-        }
-        stage("prepare") {
-            options { timeout(time: 20, unit: 'MINUTES') }
-            steps {
-                dir("third_party_download") {
-                    retry(2) {
-                        script {
-                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
-
-                            sh label: "download third_party", script: """
-                                mkdir -p bin
-                                cd ../tiflow
-
-                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
-                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
-                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
-
-                                    # First download binary using the release branch script
-                                    ./scripts/download-integration-test-binaries.sh release-7.5
-                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
-
-                                    # Then download and replace other components with exact versions
-                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
-                                    chmod +x download_test_binaries_by_tag.sh
-
-                                    # Save sync_diff_inspector and some other binaries
-                                    mv bin tmp_bin
-
-                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
-                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
-
-                                    # Restore some binaries
-                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
-                                else
-                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    ./scripts/download-integration-test-binaries.sh release-7.5
-                                fi
-
+            stages {
+                stage('Checkout') {
+                    options { timeout(time: 10, unit: 'MINUTES') }
+                    steps {
+                        dir(REFS.repo) {
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS)
+                            }
+                        }
+                    }
+                }
+                stage("Prepare") {
+                    options { timeout(time: 20, unit: 'MINUTES') }
+                    steps {
+                        dir("third_party_download") {
+                            retry(2) {
+                                sh label: "prepare third_party dir", script: "mkdir -p bin"
+                                container("utils") {
+                                    dir("bin") {
+                                        sh label: "download third_party from OCI", script: """
+                                            script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                            \$script \
+                                                --tidb=${OCI_TAG_TIDB} \
+                                                --pd=${OCI_TAG_PD} \
+                                                --pd-ctl=${OCI_TAG_PD} \
+                                                --tikv=${OCI_TAG_TIKV} \
+                                                --tiflash=${OCI_TAG_TIFLASH} \
+                                                --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
+                                                --minio=${OCI_TAG_MINIO} \
+                                                --etcdctl=${OCI_TAG_ETCD} \
+                                                --ycsb=${OCI_TAG_YCSB} \
+                                                --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
+                                        """
+                                    }
+                                }
+                            }
+                        }
+                        dir(REFS.repo) {
+                            cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
+                                // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
+                                // only build binarys if not exist, use the cached binarys if exist
+                                sh label: "prepare", script: """
+                                    mkdir -p ./bin
+                                    ls -alh ./bin
+                                    [ -f ./bin/cdc ] || make cdc
+                                    [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
+                                    [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
+                                    [ -f ./bin/cdc.test ] || make integration_test_build
+                                    ls -alh ./bin
+                                    ./bin/cdc version
+                                """
+                            }
+                            sh label: "prepare workspace", script: """
+                                cp -r ../third_party_download/bin/* ./bin/
+                                ln -sf /usr/bin/jq ./bin/jq
                                 make check_third_party_binary
-                                cd - && mv ../tiflow/bin/* ./bin/
-
-                                # Verify all required binaries
-                                echo "Verifying downloaded binaries..."
                                 ls -alh ./bin
                                 ./bin/tidb-server -V
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
-                                ./bin/sync_diff_inspector --version
                             """
+                            stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                         }
-                    }
-                }
-                dir(REFS.repo) {
-                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
-                        // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
-                        // only build binarys if not exist, use the cached binarys if exist
-                        sh label: "prepare", script: """
-                            ls -alh ./bin
-                            [ -f ./bin/cdc ] || make cdc
-                            [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
-                            [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
-                            [ -f ./bin/cdc.test ] || make integration_test_build
-                            ls -alh ./bin
-                            ./bin/cdc version
-                        """
-                    }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
                     }
                 }
             }
@@ -125,6 +119,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -141,13 +136,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash name: WORKSPACE_STASH_NAME
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -1,6 +1,6 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
-// should triggerd for master branches
+// should triggerd for release-7.5 branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
@@ -8,6 +8,10 @@ final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_compatibility_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
+final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)
+final OCI_TAG_TIDB = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
+final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
+final OCI_TAG_MINIO = 'RELEASE.2020-02-27T00-23-05Z'
 def skipRemainingStages = false
 
 pipeline {
@@ -16,11 +20,9 @@ pipeline {
             namespace K8S_NAMESPACE
             yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
-    }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -33,11 +35,11 @@ pipeline {
                     script {
                         def pr_diff_files = component.getPrDiffFiles(GIT_FULL_REPO_NAME, REFS.pulls[0].number, GIT_CREDENTIALS_ID2)
                         def pattern = /(^dm\/|^pkg\/|^go\.mod).*$/
-                        println "pr_diff_files: ${pr_diff_files}"
+                        echo "pr_diff_files: ${pr_diff_files}"
                         // if any diff files start with dm/ or pkg/ or file go.mod, run the dm compatibility test
                         def matched = component.patternMatchAnyFile(pattern, pr_diff_files)
                         if (matched) {
-                            println "matched, some diff files full path start with dm/ or pkg/ or go.mod, run the dm compatibility test"
+                            echo "matched, some diff files full path start with dm/ or pkg/ or go.mod, run the dm compatibility test"
                         } else {
                             echo "not matched, all files full path not start with dm/ or pkg/ or go.mod, current pr not releate to dm, so skip the dm compatibility test"
                             currentBuild.result = 'SUCCESS'
@@ -82,36 +84,40 @@ pipeline {
                                 mv bin/dm-worker.test bin/dm-worker.test.current
                                 ls -alh ./bin/
                             """
-                            script {
-                                def branchInfo = component.extractHotfixInfo(REFS.base_ref)
-                                sh label: "download third_party", script: """
-                                    if [[ "${branchInfo.isHotfix}" == "true" ]]; then
-                                        echo "Hotfix version tag: ${branchInfo.versionTag}"
-                                        echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
-                                        cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh dm/tests/
-                                        chmod +x dm/tests/download_test_binaries_by_tag.sh
-                                        # First download binary using the release branch script
-                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-7.5
-                                        rm -rf bin/tidb-server
-                                        mv bin tmp_bin
-                                        # Then download and replace other components with exact versions
-                                        ./download_test_binaries_by_tag.sh ${branchInfo.versionTag} tidb
-                                        mv tmp_bin/* bin/ && rm -rf tmp_bin
-                                        cd -
-                                    else
-                                        echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                        cd dm/tests && ./download-compatibility-test-binaries.sh release-7.5
-                                        cd -
-                                    fi
-                                    # Verify all required binaries
-                                    cp -r dm/tests/bin/* ./bin/
-                                    pwd && ls -alh ./bin
-                                    ls -alh dm/tests/bin
-                                    ./bin/tidb-server -V
-                                    ./bin/sync_diff_inspector -V
-                                    ./bin/mydumper -V
-                                """
+                            sh label: "prepare third_party dir", script: "mkdir -p ./bin"
+                            container("utils") {
+                                dir("bin") {
+                                    sh label: "download third_party from OCI", script: """
+                                        script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                        \$script \
+                                            --tidb=${OCI_TAG_TIDB} \
+                                            --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
+                                            --minio=${OCI_TAG_MINIO}
+                                    """
+                                }
                             }
+                            sh label: "download extra non-OCI tools", script: """
+                                cd ./bin
+                                wget --no-verbose --retry-connrefused --waitretry=1 -t 3 \
+                                    -O tidb-enterprise-tools-latest-linux-amd64.tar.gz \
+                                    https://download.pingcap.com/tidb-enterprise-tools-latest-linux-amd64.tar.gz
+                                tar -xzf tidb-enterprise-tools-latest-linux-amd64.tar.gz \
+                                    tidb-enterprise-tools-latest-linux-amd64/bin/mydumper
+                                mv tidb-enterprise-tools-latest-linux-amd64/bin/mydumper ./
+                                rm -rf tidb-enterprise-tools-latest-linux-amd64 tidb-enterprise-tools-latest-linux-amd64.tar.gz
+
+                                wget --no-verbose --retry-connrefused --waitretry=1 -t 3 \
+                                    -O gh-ost.tar.gz \
+                                    https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz
+                                tar -xzf gh-ost.tar.gz
+                                rm -f gh-ost.tar.gz
+                                [ -f ./mydumper ] && chmod +x ./mydumper
+                                [ -f ./gh-ost ] && chmod +x ./gh-ost
+                                cd -
+                                ls -alh ./bin
+                                ./bin/tidb-server -V
+                                ./bin/mydumper -V
+                            """
                         }
                 }
             }

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
@@ -1,130 +1,139 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
+// should triggerd for release-7.5 branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
 final GIT_FULL_REPO_NAME = 'pingcap/tiflow'
 final GIT_CREDENTIALS_ID2 = 'github-pr-diff-token'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_test.yaml'
+final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_dm_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
+final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)
+final OCI_TAG_TIDB = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
+final OCI_TAG_TIKV = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_PD = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
+final OCI_TAG_MINIO = 'RELEASE.2020-02-27T00-23-05Z'
+final WORKSPACE_STASH_NAME = 'tiflow-dm-workspace'
 def skipRemainingStages = false
 
 pipeline {
-    agent {
-        kubernetes {
-            namespace K8S_NAMESPACE
-            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
-            retries 2
-            defaultContainer 'golang'
-        }
-    }
-    environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-    }
+    agent none
     options {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Check diff files') {
-            steps {
-                container("golang") {
-                    script {
-                        def pr_diff_files = component.getPrDiffFiles(GIT_FULL_REPO_NAME, REFS.pulls[0].number, GIT_CREDENTIALS_ID2)
-                        def pattern = /(^dm\/|^pkg\/|^go\.mod).*$/
-                        println "pr_diff_files: ${pr_diff_files}"
-                        // if any diff files start with dm/ or pkg/ or file go.mod, run the dm integration test
-                        def matched = component.patternMatchAnyFile(pattern, pr_diff_files)
-                        if (matched) {
-                            println "matched, some diff files full path start with dm/ or pkg/ or go.mod, run the dm integration test"
-                        } else {
-                            println "not matched, all files full path not start with dm/ or pkg/ or go.mod, current pr not releate to dm, so skip the dm integration test"
-                            currentBuild.result = 'SUCCESS'
-                            skipRemainingStages = true
-                            return 0
+        stage('Check Diff & Prepare') {
+            agent {
+                kubernetes {
+                    namespace K8S_NAMESPACE
+                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
+                    retries 2
+                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
+                    defaultContainer 'golang'
+                }
+            }
+            stages {
+                stage('Check diff files') {
+                    steps {
+                        container("golang") {
+                            script {
+                                def pr_diff_files = component.getPrDiffFiles(GIT_FULL_REPO_NAME, REFS.pulls[0].number, GIT_CREDENTIALS_ID2)
+                                def pattern = /(^dm\/|^pkg\/|^go\.mod).*$/
+                                echo "pr_diff_files: ${pr_diff_files}"
+                                // if any diff files start with dm/ or pkg/ or file go.mod, run the dm integration test
+                                def matched = component.patternMatchAnyFile(pattern, pr_diff_files)
+                                if (matched) {
+                                    echo "matched, some diff files full path start with dm/ or pkg/ or go.mod, run the dm integration test"
+                                } else {
+                                    echo "not matched, all files full path not start with dm/ or pkg/ or go.mod, current pr not related to dm, so skip the dm integration test"
+                                    currentBuild.result = 'SUCCESS'
+                                    skipRemainingStages = true
+                                    return 0 // exits script block; when guards on subsequent stages handle the skip
+                                }
+                            }
                         }
                     }
                 }
-            }
-        }
-        stage('Checkout') {
-            when { expression { !skipRemainingStages} }
-            options { timeout(time: 10, unit: 'MINUTES') }
-            steps {
-                dir(REFS.repo) {
-                    script {
-                        prow.checkoutRefsWithCacheLock(REFS)
+                stage('Checkout') {
+                    when { expression { !skipRemainingStages} }
+                    options { timeout(time: 10, unit: 'MINUTES') }
+                    steps {
+                        dir(REFS.repo) {
+                            script {
+                                prow.checkoutRefsWithCacheLock(REFS)
+                            }
+                        }
                     }
                 }
-            }
-        }
-        stage("prepare") {
-            when { expression { !skipRemainingStages} }
-            options { timeout(time: 20, unit: 'MINUTES') }
-            steps {
-                dir("third_party_download") {
-                    retry(2) {
-                        script {
-                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
-                            sh label: "download third_party", script: """
-                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
-                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
-                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
-
-                                    cp ${WORKSPACE}/scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ${WORKSPACE}/tiflow/dm/tests/
-                                    chmod +x ${WORKSPACE}/tiflow/dm/tests/download_test_binaries_by_tag.sh
-                                    # First download binary using the release branch script
-                                    cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-7.5
-                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server
-                                    mv bin tmp_bin
-                                    # Then download and replace other components with exact versions
-                                    ./dm/tests/download_test_binaries_by_tag.sh ${branchInfo.versionTag} tidb pd tikv ctl
-                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
-                                    cd -
-                                else
-                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
-                                    cd ../tiflow && ./dm/tests/download-integration-test-binaries.sh release-7.5
-                                    cd -
-                                fi
-                                # Verify all required binaries
-                                mkdir -p bin && mv ../tiflow/bin/* ./bin/
+                stage("Prepare") {
+                    when { expression { !skipRemainingStages} }
+                    options { timeout(time: 20, unit: 'MINUTES') }
+                    steps {
+                        dir("third_party_download") {
+                            retry(2) {
+                                sh label: "prepare third_party dir", script: "mkdir -p bin"
+                                container("utils") {
+                                    dir("bin") {
+                                        sh label: "download third_party from OCI", script: """
+                                            script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
+                                            \$script \
+                                                --tidb=${OCI_TAG_TIDB} \
+                                                --tikv=${OCI_TAG_TIKV} \
+                                                --pd=${OCI_TAG_PD} \
+                                                --pd-ctl=${OCI_TAG_PD} \
+                                                --minio=${OCI_TAG_MINIO} \
+                                                --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR}
+                                        """
+                                    }
+                                }
+                                sh label: "download gh-ost", script: """
+                                    cd bin
+                                    wget --no-verbose --retry-connrefused --waitretry=1 -t 3 \
+                                        -O gh-ost.tar.gz \
+                                        https://github.com/github/gh-ost/releases/download/v1.1.0/gh-ost-binary-linux-20200828140552.tar.gz
+                                    tar -xzf gh-ost.tar.gz
+                                    rm -f gh-ost.tar.gz
+                                    [ -f ./gh-ost ] && chmod +x ./gh-ost
+                                    ls -alh ./
+                                    ./tidb-server -V
+                                    ./pd-server -V
+                                    ./tikv-server -V
+                                """
+                            }
+                        }
+                        dir(REFS.repo) {
+                            cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
+                                // build dm-master.test for integration test
+                                // only build binarys if not exist, use the cached binarys if exist
+                                // TODO: how to update cached binarys if needed
+                                sh label: "prepare", script: """
+                                    if [[ ! -f "bin/sync_diff_inspector" || ! -f "bin/dm-master.test" || ! -f "bin/dm-test-tools/check_master_online" || ! -f "bin/dm-test-tools/check_worker_online" ]]; then
+                                        echo "Building binaries..."
+                                        make dm_integration_test_build
+                                        mkdir -p bin/dm-test-tools && cp -r ./dm/tests/bin/* ./bin/dm-test-tools
+                                    else
+                                        echo "Binaries already exist, skipping build..."
+                                    fi
+                                    ls -alh ./bin
+                                    ls -alh ./bin/dm-test-tools
+                                    which ./bin/dm-master.test
+                                    which ./bin/dm-syncer.test
+                                    which ./bin/dm-worker.test
+                                    which ./bin/dmctl.test
+                                    which ./bin/dm-test-tools/check_master_online
+                                    which ./bin/dm-test-tools/check_worker_online
+                                """
+                            }
+                            sh label: "prepare workspace", script: """
+                                cp -r ../third_party_download/bin/* ./bin/
                                 ls -alh ./bin
-                                ./bin/tidb-server -V
-                                ./bin/pd-server -V
-                                ./bin/tikv-server -V
+                                ls -alh ./bin/dm-test-tools
                             """
+                            stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                         }
-                    }
-                }
-                dir(REFS.repo) {
-                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'dm-integration-test')) {
-                        // build dm-master.test for integration test
-                        // only build binarys if not exist, use the cached binarys if exist
-                        // TODO: how to update cached binarys if needed
-                        sh label: "prepare", script: """
-                            if [[ ! -f "bin/dm-master.test" || ! -f "bin/dm-test-tools/check_master_online" || ! -f "bin/dm-test-tools/check_worker_online" ]]; then
-                                echo "Building binaries..."
-                                make dm_integration_test_build
-                                mkdir -p bin/dm-test-tools && cp -r ./dm/tests/bin/* ./bin/dm-test-tools
-                            else
-                                echo "Binaries already exist, skipping build..."
-                            fi
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                            which ./bin/dm-master.test
-                            which ./bin/dm-syncer.test
-                            which ./bin/dm-worker.test
-                            which ./bin/dmctl.test
-                            which ./bin/dm-test-tools/check_master_online
-                            which ./bin/dm-test-tools/check_worker_online
-                        """
-                    }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
                     }
                 }
             }
@@ -146,6 +155,7 @@ pipeline {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -170,33 +180,32 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                unstash name: WORKSPACE_STASH_NAME
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {


### PR DESCRIPTION
### Description

Align release-7.5 tiflow pipelines with the refactoring done in release-8.5, keeping Go 1.21 and ghpr_verify test matrix unchanged.

### Changes

**New files (infrastructure for existing tasks):**
- `pod-pull_cdc_integration_build.yaml` — lightweight build pod for CDC tests
- `pod-pull_dm_integration_build.yaml` — lightweight build pod for DM tests

**Modified pod YAMLs (7 files):**
- Resource specs switched to millicore format with explicit requests
- MySQL images migrated to dockerhub-remote registry
- `pod-pull_dm_compatibility_test.yaml`: added `utils` sidecar
- `pod-ghpr_verify.yaml`: removed gocache/gopathcache PVCs, increased memory
- Kafka pod: added debezium mysql + connect containers
- Pulsar pod: removed pulsar sidecar (only golang remains)
- CDC/DM pods: resource adjustments aligned with 8.5

**Modified groovy pipelines (7 files):**
- `ghpr_verify.groovy`: agent none, workspaceVolume, removed cache wrapper, **added codecov upload** (test matrix & coverage config preserved)
- CDC integration tests (4 files): agent none, build/test pod split, OCI artifact download, stash/unstash, workspaceVolume
- `pull_dm_integration_test.groovy`: same refactoring + gh-ost download, bin/sync_diff_inspector cache check
- `pull_dm_compatibility_test.groovy`: OCI artifact download, workspaceVolume, gh-ost + mydumper download

### Not changed
- Go version: kept `v2024.10.8-119-g4e56df7-go1.21` (not upgraded to go1.25)
- `ghpr_verify.groovy`: test matrix kept at 5 values (check, build, dm, unit, engine unit)
- Container args: removed `[cat]` (unnecessary with tty mode)
- `OCI_ARTIFACT_HOST` env var: removed