### PR TITLE
fix(pipelines/tiflow): revert 4 CDC integration tests to a80d7d9c state

### DIFF
--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -9,25 +9,27 @@ spec:
       name: zookeeper
       resources:
         requests:
-          cpu: 500m
-          memory: 2Gi
+          cpu: 200m
+          memory: 4Gi
         limits:
-          cpu: 1000m
+          cpu: 2000m
           memory: 4Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
+    - args:
+        - cat
+      image: hub.pingcap.net/jenkins/golang-tini:1.21
       imagePullPolicy: Always
       name: golang
       resources:
         requests:
-          cpu: 4000m
-          memory: 16Gi
+          cpu: "2"
+          memory: 12Gi
         limits:
-          cpu: 8000m
-          memory: 24Gi
+          cpu: "4"
+          memory: 16Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp
@@ -66,11 +68,11 @@ spec:
       name: kafka
       resources:
         requests:
-          cpu: 1500m
-          memory: 6Gi
+          cpu: 200m
+          memory: 4Gi
         limits:
-          cpu: 3000m
-          memory: 8Gi
+          cpu: 2000m
+          memory: 4Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp
@@ -97,48 +99,11 @@ spec:
       resources:
         requests:
           cpu: 200m
-          memory: 2Gi
+          memory: 4Gi
       tty: true
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - name: mysql
-      image: quay.io/debezium/example-mysql:2.4
-      imagePullPolicy: IfNotPresent
-      env:
-        - name: MYSQL_ROOT_PASSWORD
-          value: ""
-        - name: MYSQL_USER
-          value: mysqluser
-        - name: MYSQL_PASSWORD
-          value: mysqlpw
-        - name: MYSQL_ALLOW_EMPTY_PASSWORD
-          value: "yes"
-        - name: MYSQL_TCP_PORT
-          value: "3310"
-      resources:
-        requests:
-          cpu: 200m
-          memory: 1Gi
-    - name: connect
-      image: quay.io/debezium/connect:2.4
-      env:
-        - name: BOOTSTRAP_SERVERS
-          value: "127.0.0.1:9092"
-        - name: GROUP_ID
-          value: "1"
-        - name: CONFIG_STORAGE_TOPIC
-          value: "my_connect_configs"
-        - name: OFFSET_STORAGE_TOPIC
-          value: "my_connect_offsets"
-        - name: STATUS_STORAGE_TOPIC
-          value: "my_connect_statuses"
-        - name: LANG
-          value: "C.UTF-8"
-      resources:
-        requests:
-          cpu: 200m
-          memory: 1Gi
   volumes:
     - emptyDir: {}
       name: volume-0

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml
@@ -5,15 +5,15 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       tty: true
       resources:
         requests:
           memory: 12Gi
-          cpu: 3000m
+          cpu: "4"
         limits:
           memory: 16Gi
-          cpu: 6000m
+          cpu: "6"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml
@@ -5,15 +5,27 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       tty: true
       resources:
         requests:
-          memory: 24Gi
-          cpu: 6000m
+          memory: 12Gi
+          cpu: "4"
         limits:
-          memory: 32Gi
-          cpu: 8000m
+          memory: 16Gi
+          cpu: "6"
+    - name: pulsar
+      image: "apachepulsar/pulsar:2.10.4"
+      imagePullPolicy: IfNotPresent
+      tty: true
+      resources:
+        requests:
+          memory: 4Gi
+          cpu: "4"
+        limits:
+          memory: 6Gi
+          cpu: "6"
+      command: ["bin/pulsar", "standalone"]
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_storage_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_storage_test.yaml
@@ -5,15 +5,15 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21"
+      image: "hub.pingcap.net/jenkins/centos7_golang-1.21:latest"
       tty: true
       resources:
         requests:
-          memory: 24Gi
-          cpu: 6000m
+          memory: 12Gi
+          cpu: "4"
         limits:
-          memory: 24Gi
-          cpu: 6000m
+          memory: 16Gi
+          cpu: "6"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -1,105 +1,115 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
-// should triggerd for release-7.5 branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml'
-final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)
-final OCI_TAG_PD = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_TIDB = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
-final OCI_TAG_TIFLASH = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_TIKV = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
-final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
-final OCI_TAG_ETCD = 'v3.5.15'
-final OCI_TAG_YCSB = 'v1.0.3'
-final OCI_TAG_SCHEMA_REGISTRY = 'latest'
-final WORKSPACE_STASH_NAME = 'tiflow-cdc-workspace'
 
 pipeline {
-    agent none
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            retries 2
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+    }
     options {
         timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout & Prepare') {
-            agent {
-                kubernetes {
-                    namespace K8S_NAMESPACE
-                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
-                    retries 2
-                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
-                    defaultContainer 'golang'
-                }
-            }
-            stages {
-                stage('Checkout') {
-                    options { timeout(time: 10, unit: 'MINUTES') }
-                    steps {
-                        dir(REFS.repo) {
+        stage('Checkout') {
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir("tiflow") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
                             script {
-                                prow.checkoutRefsWithCacheLock(REFS)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }
                 }
-                stage("Prepare") {
-                    options { timeout(time: 20, unit: 'MINUTES') }
-                    steps {
-                        dir("third_party_download") {
-                            retry(2) {
-                                sh label: "prepare third_party dir", script: "mkdir -p bin"
-                                container("utils") {
-                                    dir("bin") {
-                                        sh label: "download third_party from OCI", script: """
-                                            script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
-                                            \$script \
-                                                --tidb=${OCI_TAG_TIDB} \
-                                                --pd=${OCI_TAG_PD} \
-                                                --pd-ctl=${OCI_TAG_PD} \
-                                                --tikv=${OCI_TAG_TIKV} \
-                                                --tiflash=${OCI_TAG_TIFLASH} \
-                                                --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
-                                                --minio=${OCI_TAG_MINIO} \
-                                                --etcdctl=${OCI_TAG_ETCD} \
-                                                --ycsb=${OCI_TAG_YCSB} \
-                                                --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-                                        """
-                                    }
-                                }
-                            }
-                        }
-                        dir(REFS.repo) {
-                            cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
-                                // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
-                                // only build binarys if not exist, use the cached binarys if exist
-                                sh label: "prepare", script: """
-                                    mkdir -p ./bin
-                                    ls -alh ./bin
-                                    [ -f ./bin/cdc ] || make cdc
-                                    [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
-                                    [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
-                                    [ -f ./bin/cdc.test ] || make integration_test_build
-                                    ls -alh ./bin
-                                    ./bin/cdc version
-                                """
-                            }
-                            sh label: "prepare workspace", script: """
-                                cp -r ../third_party_download/bin/* ./bin/
-                                ln -sf /usr/bin/jq ./bin/jq
+            }
+        }
+        stage("prepare") {
+            options { timeout(time: 20, unit: 'MINUTES') }
+            steps {
+                dir("third_party_download") {
+                    retry(2) {
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh release-7.5
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
+
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh release-7.5
+                                fi
+
                                 make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
                                 ls -alh ./bin
                                 ./bin/tidb-server -V
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
                             """
-                            stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                         }
+                    }
+                }
+                dir("tiflow") {
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
+                        // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
+                        // only build binarys if not exist, use the cached binarys if exist
+                        sh label: "prepare", script: """
+                            ls -alh ./bin
+                            [ -f ./bin/cdc ] || make cdc
+                            [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
+                            [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
+                            [ -f ./bin/cdc.test ] || make integration_test_build
+                            ls -alh ./bin
+                            ./bin/cdc version
+                        """
+                    }
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
+                        sh label: "prepare", script: """
+                            cp -r ../third_party_download/bin/* ./bin/
+                            ls -alh ./bin
+                        """
                     }
                 }
             }
@@ -119,7 +129,6 @@ pipeline {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
-                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -135,25 +144,26 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir(REFS.repo) {
-                                unstash name: WORKSPACE_STASH_NAME
-                                container("kafka") {
-                                    timeout(time: 6, unit: 'MINUTES') {
-                                        sh label: "Waiting for kafka ready", script: """
-                                            echo "Waiting for zookeeper to be ready..."
-                                            while ! nc -z localhost 2181; do sleep 10; done
-                                            echo "Waiting for kafka to be ready..."
-                                            while ! nc -z localhost 9092; do sleep 10; done
-                                            echo "Waiting for kafka-broker to be ready..."
-                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                        """
+                            dir('tiflow') {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
+                                    container("kafka") {
+                                        timeout(time: 6, unit: 'MINUTES') {
+                                            sh label: "Waiting for kafka ready", script: """
+                                                echo "Waiting for zookeeper to be ready..."
+                                                while ! nc -z localhost 2181; do sleep 10; done
+                                                echo "Waiting for kafka to be ready..."
+                                                while ! nc -z localhost 9092; do sleep 10; done
+                                                echo "Waiting for kafka-broker to be ready..."
+                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                            """
+                                        }
                                     }
+                                    sh label: "${TEST_GROUP}", script: """
+                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                        chmod +x ./tests/integration_tests/run_group.sh
+                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                    """
                                 }
-                                sh label: "${TEST_GROUP}", script: """
-                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                    chmod +x ./tests/integration_tests/run_group.sh
-                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -1,105 +1,115 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
-// should triggerd for release-7.5 branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_mysql_test.yaml'
-final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)
-final OCI_TAG_PD = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_TIDB = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
-final OCI_TAG_TIFLASH = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_TIKV = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
-final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
-final OCI_TAG_ETCD = 'v3.5.15'
-final OCI_TAG_YCSB = 'v1.0.3'
-final OCI_TAG_SCHEMA_REGISTRY = 'latest'
-final WORKSPACE_STASH_NAME = 'tiflow-cdc-workspace'
 
 pipeline {
-    agent none
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            retries 2
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+    }
     options {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout & Prepare') {
-            agent {
-                kubernetes {
-                    namespace K8S_NAMESPACE
-                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
-                    retries 2
-                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
-                    defaultContainer 'golang'
-                }
-            }
-            stages {
-                stage('Checkout') {
-                    options { timeout(time: 10, unit: 'MINUTES') }
-                    steps {
-                        dir(REFS.repo) {
+        stage('Checkout') {
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir("tiflow") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
                             script {
-                                prow.checkoutRefsWithCacheLock(REFS)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }
                 }
-                stage("Prepare") {
-                    options { timeout(time: 20, unit: 'MINUTES') }
-                    steps {
-                        dir("third_party_download") {
-                            retry(2) {
-                                sh label: "prepare third_party dir", script: "mkdir -p bin"
-                                container("utils") {
-                                    dir("bin") {
-                                        sh label: "download third_party from OCI", script: """
-                                            script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
-                                            \$script \
-                                                --tidb=${OCI_TAG_TIDB} \
-                                                --pd=${OCI_TAG_PD} \
-                                                --pd-ctl=${OCI_TAG_PD} \
-                                                --tikv=${OCI_TAG_TIKV} \
-                                                --tiflash=${OCI_TAG_TIFLASH} \
-                                                --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
-                                                --minio=${OCI_TAG_MINIO} \
-                                                --etcdctl=${OCI_TAG_ETCD} \
-                                                --ycsb=${OCI_TAG_YCSB} \
-                                                --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-                                        """
-                                    }
-                                }
-                            }
-                        }
-                        dir(REFS.repo) {
-                            cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
-                                // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
-                                // only build binarys if not exist, use the cached binarys if exist
-                                sh label: "prepare", script: """
-                                    mkdir -p ./bin
-                                    ls -alh ./bin
-                                    [ -f ./bin/cdc ] || make cdc
-                                    [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
-                                    [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
-                                    [ -f ./bin/cdc.test ] || make integration_test_build
-                                    ls -alh ./bin
-                                    ./bin/cdc version
-                                """
-                            }
-                            sh label: "prepare workspace", script: """
-                                cp -r ../third_party_download/bin/* ./bin/
-                                ln -sf /usr/bin/jq ./bin/jq
+            }
+        }
+        stage("prepare") {
+            options { timeout(time: 20, unit: 'MINUTES') }
+            steps {
+                dir("third_party_download") {
+                    retry(2) {
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh release-7.5
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
+
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh release-7.5
+                                fi
+
                                 make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
                                 ls -alh ./bin
                                 ./bin/tidb-server -V
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
                             """
-                            stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                         }
+                    }
+                }
+                dir("tiflow") {
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
+                        // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
+                        // only build binarys if not exist, use the cached binarys if exist
+                        sh label: "prepare", script: """
+                            ls -alh ./bin
+                            [ -f ./bin/cdc ] || make cdc
+                            [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
+                            [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
+                            [ -f ./bin/cdc.test ] || make integration_test_build
+                            ls -alh ./bin
+                            ./bin/cdc version
+                        """
+                    }
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
+                        sh label: "prepare", script: """
+                            cp -r ../third_party_download/bin/* ./bin/
+                            ls -alh ./bin
+                        """
                     }
                 }
             }
@@ -119,7 +129,6 @@ pipeline {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
-                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -135,13 +144,14 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir(REFS.repo) {
-                                unstash name: WORKSPACE_STASH_NAME
-                                sh label: "${TEST_GROUP}", script: """
-                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                    chmod +x ./tests/integration_tests/run_group.sh
-                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                """
+                            dir('tiflow') {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
+                                    sh label: "${TEST_GROUP}", script: """
+                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                        chmod +x ./tests/integration_tests/run_group.sh
+                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                    """
+                                }
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -1,104 +1,115 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
-// should triggerd for release-7.5 branches
+// should triggerd for master branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_pulsar_test.yaml'
-final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)
-final OCI_TAG_PD = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_TIDB = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
-final OCI_TAG_TIFLASH = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_TIKV = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
-final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
-final OCI_TAG_ETCD = 'v3.5.15'
-final OCI_TAG_YCSB = 'v1.0.3'
-final OCI_TAG_SCHEMA_REGISTRY = 'latest'
-final WORKSPACE_STASH_NAME = 'tiflow-cdc-workspace'
 
 pipeline {
-    agent none
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            retries 2
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+    }
     options {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout & Prepare') {
-            agent {
-                kubernetes {
-                    namespace K8S_NAMESPACE
-                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
-                    retries 2
-                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
-                    defaultContainer 'golang'
-                }
-            }
-            stages {
-                stage('Checkout') {
-                    options { timeout(time: 10, unit: 'MINUTES') }
-                    steps {
-                        dir(REFS.repo) {
+        stage('Checkout') {
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir("tiflow") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
                             script {
-                                prow.checkoutRefsWithCacheLock(REFS)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }
                 }
-                stage("Prepare") {
-                    options { timeout(time: 20, unit: 'MINUTES') }
-                    steps {
-                        dir("third_party_download") {
-                            retry(2) {
-                                sh label: "prepare third_party dir", script: "mkdir -p bin"
-                                container("utils") {
-                                    dir("bin") {
-                                        sh label: "download third_party from OCI", script: """
-                                            script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
-                                            \$script \
-                                                --tidb=${OCI_TAG_TIDB} \
-                                                --pd=${OCI_TAG_PD} \
-                                                --pd-ctl=${OCI_TAG_PD} \
-                                                --tikv=${OCI_TAG_TIKV} \
-                                                --tiflash=${OCI_TAG_TIFLASH} \
-                                                --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
-                                                --minio=${OCI_TAG_MINIO} \
-                                                --etcdctl=${OCI_TAG_ETCD} \
-                                                --ycsb=${OCI_TAG_YCSB} \
-                                                --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-                                        """
-                                    }
-                                }
-                            }
-                        }
-                        dir(REFS.repo) {
-                            cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
-                                // build cdc, pulsar_consumer, cdc.test for integration test
-                                // only build binarys if not exist, use the cached binarys if exist
-                                sh label: "prepare", script: """
-                                    mkdir -p ./bin
-                                    ls -alh ./bin
-                                    [ -f ./bin/cdc ] || make cdc
-                                    [ -f ./bin/cdc_pulsar_consumer ] || make pulsar_consumer
-                                    [ -f ./bin/cdc.test ] || make integration_test_build
-                                    ls -alh ./bin
-                                    ./bin/cdc version
-                                """
-                            }
-                            sh label: "prepare workspace", script: """
-                                cp -r ../third_party_download/bin/* ./bin/
-                                ln -sf /usr/bin/jq ./bin/jq
+            }
+        }
+        stage("prepare") {
+            options { timeout(time: 20, unit: 'MINUTES') }
+            steps {
+                dir("third_party_download") {
+                    retry(2) {
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh release-7.5
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
+
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh release-7.5
+                                fi
+
                                 make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
                                 ls -alh ./bin
                                 ./bin/tidb-server -V
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
                             """
-                            stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                         }
+                    }
+                }
+                dir("tiflow") {
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-pulsar-test')) {
+                        // build cdc, pulsar_consumer, cdc.test for integration test
+                        // only build binarys if not exist, use the cached binarys if exist
+                        sh label: "prepare", script: """
+                            ls -alh ./bin
+                            [ -f ./bin/cdc ] || make cdc
+                            [ -f ./bin/cdc_pulsar_consumer ] || make pulsar_consumer
+                            [ -f ./bin/cdc.test ] || make integration_test_build
+                            ls -alh ./bin
+                            ./bin/cdc version
+                        """
+                    }
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
+                        sh label: "prepare", script: """
+                            cp -r ../third_party_download/bin/* ./bin/
+                            ls -alh ./bin
+                        """
                     }
                 }
             }
@@ -118,7 +129,6 @@ pipeline {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
-                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -130,13 +140,24 @@ pipeline {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
-                            dir(REFS.repo) {
-                                unstash name: WORKSPACE_STASH_NAME
-                                sh label: "${TEST_GROUP}", script: """
-                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                    chmod +x ./tests/integration_tests/run_group.sh
-                                    ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
-                                """
+                            dir('tiflow') {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
+                                    // TODO: currently we encounter some issue when using pulsar container to run shell script
+                                    // so we comment out this part now.
+                                    // container("pulsar") {
+                                    //     timeout(time: 6, unit: 'MINUTES') {
+                                    //         sh label: "Waiting for pulsar ready", script: """
+                                    //             echo "Waiting for pulsar to be ready..."
+                                    //             while ! nc -z localhost 6650; do sleep 10; done
+                                    //         """
+                                    //     }
+                                    // }
+                                    sh label: "${TEST_GROUP}", script: """
+                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                        chmod +x ./tests/integration_tests/run_group.sh
+                                        ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
+                                    """
+                                }
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -1,105 +1,116 @@
 // REF: https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
 // Keep small than 400 lines: https://issues.jenkins.io/browse/JENKINS-37984
-// should triggerd for release-7.5 branches
+// should triggerd for master branches
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_storage_test.yaml'
-final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_build.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final HOTFIX_INFO = component.extractHotfixInfo(REFS.base_ref)
-final OCI_TAG_PD = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_TIDB = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
-final OCI_TAG_TIFLASH = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tiflash', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_TIKV = HOTFIX_INFO.isHotfix ? HOTFIX_INFO.versionTag : component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
-final OCI_TAG_SYNC_DIFF_INSPECTOR = 'master'
-final OCI_TAG_MINIO = 'RELEASE.2025-07-23T15-54-02Z'
-final OCI_TAG_ETCD = 'v3.5.15'
-final OCI_TAG_YCSB = 'v1.0.3'
-final OCI_TAG_SCHEMA_REGISTRY = 'latest'
-final WORKSPACE_STASH_NAME = 'tiflow-cdc-workspace'
 
 pipeline {
-    agent none
+    agent {
+        kubernetes {
+            namespace K8S_NAMESPACE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
+            retries 2
+            defaultContainer 'golang'
+        }
+    }
+    environment {
+        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+    }
     options {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
     stages {
-        stage('Checkout & Prepare') {
-            agent {
-                kubernetes {
-                    namespace K8S_NAMESPACE
-                    yaml pod_label.withCiLabels(POD_TEMPLATE_FILE_BUILD, REFS)
-                    retries 2
-                    workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
-                    defaultContainer 'golang'
-                }
-            }
-            stages {
-                stage('Checkout') {
-                    options { timeout(time: 10, unit: 'MINUTES') }
-                    steps {
-                        dir(REFS.repo) {
+        stage('Checkout') {
+            options { timeout(time: 10, unit: 'MINUTES') }
+            steps {
+                dir("tiflow") {
+                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                        retry(2) {
                             script {
-                                prow.checkoutRefsWithCacheLock(REFS)
+                                prow.checkoutRefs(REFS)
                             }
                         }
                     }
                 }
-                stage("Prepare") {
-                    options { timeout(time: 20, unit: 'MINUTES') }
-                    steps {
-                        dir("third_party_download") {
-                            retry(2) {
-                                sh label: "prepare third_party dir", script: "mkdir -p bin"
-                                container("utils") {
-                                    dir("bin") {
-                                        sh label: "download third_party from OCI", script: """
-                                            script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
-                                            \$script \
-                                                --tidb=${OCI_TAG_TIDB} \
-                                                --pd=${OCI_TAG_PD} \
-                                                --pd-ctl=${OCI_TAG_PD} \
-                                                --tikv=${OCI_TAG_TIKV} \
-                                                --tiflash=${OCI_TAG_TIFLASH} \
-                                                --sync-diff-inspector=${OCI_TAG_SYNC_DIFF_INSPECTOR} \
-                                                --minio=${OCI_TAG_MINIO} \
-                                                --etcdctl=${OCI_TAG_ETCD} \
-                                                --ycsb=${OCI_TAG_YCSB} \
-                                                --schema-registry=${OCI_TAG_SCHEMA_REGISTRY}
-                                        """
-                                    }
-                                }
-                            }
-                        }
-                        dir(REFS.repo) {
-                            cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
-                                // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
-                                // only build binarys if not exist, use the cached binarys if exist
-                                sh label: "prepare", script: """
-                                    mkdir -p ./bin
-                                    ls -alh ./bin
-                                    [ -f ./bin/cdc ] || make cdc
-                                    [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
-                                    [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
-                                    [ -f ./bin/cdc.test ] || make integration_test_build
-                                    ls -alh ./bin
-                                    ./bin/cdc version
-                                """
-                            }
-                            sh label: "prepare workspace", script: """
-                                cp -r ../third_party_download/bin/* ./bin/
-                                ln -sf /usr/bin/jq ./bin/jq
+            }
+        }
+        stage("prepare") {
+            options { timeout(time: 20, unit: 'MINUTES') }
+            steps {
+                dir("third_party_download") {
+                    retry(2) {
+                        script {
+                            def branchInfo = component.extractHotfixInfo(REFS.base_ref)
+
+                            sh label: "download third_party", script: """
+                                mkdir -p bin
+                                cd ../tiflow
+
+                                if [[ "${branchInfo.isHotfix}" == "true" ]]; then
+                                    echo "Hotfix version tag: ${branchInfo.versionTag}"
+                                    echo "This is a hotfix branch, downloading exact version ${branchInfo.versionTag} binaries"
+
+                                    # First download binary using the release branch script
+                                    ./scripts/download-integration-test-binaries.sh release-7.5
+                                    # remove binarys of tidb-server, pd-server, tikv-server, tiflash
+                                    rm -rf bin/tidb-server bin/pd-* bin/tikv-server bin/tiflash bin/tiflash_dir bin/lib*
+
+                                    # Then download and replace other components with exact versions
+                                    cp ../scripts/pingcap/tiflow/download_test_binaries_by_tag.sh ./
+                                    chmod +x download_test_binaries_by_tag.sh
+
+                                    # Save sync_diff_inspector and some other binaries
+                                    mv bin tmp_bin
+
+                                    # Download exact versions of tidb-server, pd-server, tikv-server, tiflash
+                                    ./download_test_binaries_by_tag.sh ${branchInfo.versionTag}
+
+                                    # Restore some binaries
+                                    mv tmp_bin/* bin/ && rm -rf tmp_bin
+                                else
+                                    echo "Release branch, downloading binaries from ${REFS.base_ref}"
+                                    ./scripts/download-integration-test-binaries.sh release-7.5
+                                fi
+
                                 make check_third_party_binary
+                                cd - && mv ../tiflow/bin/* ./bin/
+
+                                # Verify all required binaries
+                                echo "Verifying downloaded binaries..."
                                 ls -alh ./bin
                                 ./bin/tidb-server -V
                                 ./bin/pd-server -V
                                 ./bin/tikv-server -V
                                 ./bin/tiflash --version
+                                ./bin/sync_diff_inspector --version
                             """
-                            stash includes: '**/*', name: WORKSPACE_STASH_NAME, useDefaultExcludes: false
                         }
+                    }
+                }
+                dir("tiflow") {
+                    cache(path: "./bin", includes: '**/*', key: prow.getCacheKey('binary', REFS, 'cdc-integration-test')) {
+                        // build cdc, kafka_consumer, storage_consumer, cdc.test for integration test
+                        // only build binarys if not exist, use the cached binarys if exist
+                        sh label: "prepare", script: """
+                            ls -alh ./bin
+                            [ -f ./bin/cdc ] || make cdc
+                            [ -f ./bin/cdc_kafka_consumer ] || make kafka_consumer
+                            [ -f ./bin/cdc_storage_consumer ] || make storage_consumer
+                            [ -f ./bin/cdc.test ] || make integration_test_build
+                            ls -alh ./bin
+                            ./bin/cdc version
+                        """
+                    }
+                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
+                        sh label: "prepare", script: """
+                            cp -r ../third_party_download/bin/* ./bin/
+                            ls -alh ./bin
+                        """
                     }
                 }
             }
@@ -119,7 +130,6 @@ pipeline {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
-                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                         defaultContainer 'golang'
                     }
                 }
@@ -135,13 +145,14 @@ pipeline {
                             TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
-                            dir(REFS.repo) {
-                                unstash name: WORKSPACE_STASH_NAME
-                                sh label: "${TEST_GROUP}", script: """
-                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                    chmod +x ./tests/integration_tests/run_group.sh
-                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                """
+                            dir('tiflow') {
+                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
+                                    sh label: "${TEST_GROUP}", script: """
+                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                        chmod +x ./tests/integration_tests/run_group.sh
+                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                    """
+                                }
                             }
                         }
                         post {

--- a/prow-jobs/pingcap/tiflow/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.5-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -23,7 +23,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -36,7 +36,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -49,7 +49,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -62,7 +62,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/pull_dm_compatibility_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -75,7 +75,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/pull_dm_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -88,7 +88,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/ghpr_verify
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify


### PR DESCRIPTION
Temporarily revert 4 CDD integration test files for release-7.5 and their Prow job master label to the pre-refactoring state (commit a80d7d9c).

**Reverted files:**
- `pull_cdc_integration_kafka_test.groovy` + `pod-pull_cdc_integration_kafka_test.yaml`
- `pull_cdc_integration_mysql_test.groovy` + `pod-pull_cdc_integration_mysql_test.yaml`
- `pull_cdc_integration_storage_test.groovy` + `pod-pull_cdc_integration_storage_test.yaml`
- `pull_cdc_integration_pulsar_test.groovy` + `pod-pull_cdc_integration_pulsar_test.yaml`

**Prow job labels:** `master: "1"` → `master: "0"` for all 4 CDC jobs

**Note:** `ghpr_verify`, DM integration, DM compatibility, and build pod infrastructure remain unchanged.