### PR TITLE
refactor(pipelines/tidb-test): align release-6.5 with release-8.5

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_build.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_build.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -34,9 +35,9 @@ pipeline {
                     }
                 }
                 dir("tidb-test") {
-                    cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS), restoreKeys: prow.getRestoreKeys('git', REFS)) {
+                    cache(path: "./", includes: '**/*', key: "git/PingCAP-QE/tidb-test/rev-${REFS.pulls[0].sha}}", restoreKeys: ['git/PingCAP-QE/tidb-test/rev-']) {
                         retry(2) {
-                              script {
+                            script {
                                 prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
                             }
                         }

--- a/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_integration_mysql_test.groovy
@@ -7,15 +7,16 @@ final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
 final GIT_FULL_REPO_NAME = 'PingCAP-QE/tidb-test'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap-qe/tidb-test/release-6.5/pod-ghpr_integration_mysql_test.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
-final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
-final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, REFS.base_ref)
+final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
 
 pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -39,7 +40,7 @@ pipeline {
                 }
                 dir("tidb-test") {
                     script {
-                        prow.checkoutRefs(REFS, credentialsId = GIT_CREDENTIALS_ID, timeout = 5)
+                        prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
                     container("utils") {
                         dir('mysql_test/bin') {
@@ -69,8 +70,9 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {

--- a/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_mysql_test.groovy
@@ -12,8 +12,9 @@ pipeline {
     agent {
         kubernetes {
             namespace K8S_NAMESPACE
-            yamlFile POD_TEMPLATE_FILE
+            yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
             retries 2
+            workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
             defaultContainer 'golang'
         }
     }
@@ -75,8 +76,9 @@ pipeline {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
-                        yamlFile POD_TEMPLATE_FILE
+                        yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)
                         retries 2
+                        workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '150Gi', storageClassName: 'hyperdisk-rwo')
                     }
                 }
                 when {

--- a/pipelines/pingcap-qe/tidb-test/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/pod-ghpr_build.yaml
@@ -11,11 +11,11 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap-qe/tidb-test/release-6.5/pod-ghpr_integration_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/pod-ghpr_integration_mysql_test.yaml
@@ -11,11 +11,11 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
     - name: utils
       image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap-qe/tidb-test/release-6.5/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/pod-ghpr_mysql_test.yaml
@@ -11,11 +11,11 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "4"
+          memory: 12Gi
+          cpu: "3"
         limits:
           memory: 24Gi
-          cpu: "8"
+          cpu: "6"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION

### Align release-6.5 pipelines with release-8.5

**Groovy changes (3 files):**
- `yamlFile POD_TEMPLATE_FILE` → `yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)`
- Added `workspaceVolume genericEphemeralVolume` to all agent blocks
- `ghpr_build.groovy`: tidb-test cache key aligned to 8.5 pattern
- `ghpr_integration_mysql_test.groovy`: OCI tag version fallback from `REFS.base_ref` → `'master'`; `prow.checkoutRefs` → `prow.checkoutRefsWithCacheLock`

**Pod YAML changes (3 files):**
- golang cpu: `"4"` → `"3"`
- golang memory requests: `8Gi` → `12Gi`
- golang cpu limits: `"8"` → `"6"`
- `pod-ghpr_integration_mysql_test.yaml`: added `utils` container
