### PR TITLE
refactor(prow-jobs/pingcap-qe/tidb-test): update master label for release-7.1 presubmits

### DIFF
--- a/prow-jobs/pingcap-qe/tidb-test/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/release-7.1-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build
@@ -20,7 +20,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|jdbc_test)/.*"
       context: ci/common-test
@@ -31,7 +31,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|mybatis_test|jooq_test|tidb_jdbc_test)/.*"
       context: ci/integration-jdbc-test
@@ -42,7 +42,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       run_if_changed: "randgen-test/.*"
       context: ci/integration-common-test
@@ -53,7 +53,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test
@@ -64,7 +64,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test


### PR DESCRIPTION
Enable master label (set to "1") for all presubmit jobs in tidb-test release-7.1, so they are triggered on PRs to the master branch.