### PR TITLE
feat(prow-jobs): update master trigger for release branch presubmits

### DIFF
--- a/prow-jobs/pingcap/tidb-tools/presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-tools/presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap/tidb-tools/pull_verify
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: true
       skip_report: false

--- a/prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml
@@ -245,7 +245,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_integration_binlog_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/tikv/pd/release-7.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-7.1-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
     - name: tikv/pd/release-7.1/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-copr-test

--- a/prow-jobs/tikv/pd/release-7.5-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-7.5-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
     - name: tikv/pd/release-7.5/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-copr-test

--- a/prow-jobs/tikv/pd/release-8.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-8.1-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
     - name: tikv/pd/release-8.1/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-copr-test

--- a/prow-jobs/tikv/pd/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-9.0-beta-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
     - name: tikv/pd/release-9.0-beta/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/tikv/tikv/release-6.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-6.5-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: tikv/tikv/release-6.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -21,7 +21,7 @@ presubmits:
     - name: tikv/tikv/release-6.5/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       always_run: false  # update here after test passed

--- a/prow-jobs/tikv/tikv/release-7.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-7.1-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - name: tikv/tikv/release-7.1/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -20,7 +20,7 @@ presubmits:
     - name: tikv/tikv/release-7.1/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       always_run: false # update here after test passed

--- a/prow-jobs/tikv/tikv/release-8.1-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.1-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: tikv/tikv/release-8.1/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -21,7 +21,7 @@ presubmits:
     - name: tikv/tikv/release-8.1/pull_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false  # update here after test passed
       optional: true # update here after test passed

--- a/prow-jobs/tikv/tikv/release-8.2-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.2-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: tikv/tikv/release-8.2/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test

--- a/prow-jobs/tikv/tikv/release-8.3-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.3-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: tikv/tikv/release-8.3/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test

--- a/prow-jobs/tikv/tikv/release-8.4-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-8.4-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - name: tikv/tikv/release-8.4/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test

--- a/prow-jobs/tikv/tikv/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-9.0-beta-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: tikv/tikv/release-9.0-beta/pull_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test


### PR DESCRIPTION
Set `master: "1"` for release branch presubmit jobs across tikv/pd, tikv/tikv, and pingcap/tidb, excluding tidb-test and tidb-tools.