### PR TITLE
refactor(scripts): replace hardcoded internal URLs with env vars

### DIFF
--- a/.ci/check-pr-content-policy.sh
+++ b/.ci/check-pr-content-policy.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-readonly PINGCAP_HOST_PATTERN='([[:alnum:]-]+\.)+pingcap\.net'
+readonly PINGCAP_HOST_PATTERN='([[:alnum:]][[:alnum:]-]*\.)+pingcap\.net'
 readonly -a ALLOWED_PINGCAP_HOSTS=(
     "sunset-fileserver.pingcap.net"
     "fileserver.pingcap.net"

--- a/.ci/check-pr-content-policy.sh
+++ b/.ci/check-pr-content-policy.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 readonly PINGCAP_HOST_PATTERN='([[:alnum:]-]+\.)+pingcap\.net'
 readonly -a ALLOWED_PINGCAP_HOSTS=(
     "sunset-fileserver.pingcap.net"
+    "fileserver.pingcap.net"
+    "hub.pingcap.net"
+    "tiup.pingcap.net"
     "cla.pingcap.net"
     "do2.pingcap.net"
     "internal2-do.pingcap.net"

--- a/scripts/artifacts/check-images-internal.sh
+++ b/scripts/artifacts/check-images-internal.sh
@@ -39,7 +39,7 @@ function gather_results() {
         done
 
         # enterprise image
-        for image in "${oci_registry}/qa/$com-enterprise:$VERSION" "gcr.io/pingcap-public/dbaas/$com:$VERSION"; do
+        for image in "${oci_registry}/qa/$com-enterprise:$VERSION" "${ENTERPRISE_IMAGE_REGISTRY:-gcr.io/pingcap-public/dbaas}/${com}:${VERSION}"; do
             echo "🚧 check container image: $image"
             for platform in linux/amd64 linux/arm64; do
                 echo "🚧 check container image: $image, platform: $platform"
@@ -87,7 +87,7 @@ function check_results() {
 
 function main() {
     check_version="$1"
-    oci_registry="${2:-us-docker.pkg.dev/pingcap-testing-account/hub}"
+    oci_registry="${2:-${OCI_ARTIFACT_HOST:-us-docker.pkg.dev/pingcap-testing-account/hub}}"
     fail_fast="${3:-false}"
 
     gather_results "$check_version" "$oci_registry" && check_results

--- a/scripts/artifacts/download_pingcap_artifact.sh
+++ b/scripts/artifacts/download_pingcap_artifact.sh
@@ -47,7 +47,7 @@ if [[ -n $1 ]]; then
     tail -1 $1
 fi
 
-file_server_url="http://fileserver.pingcap.net"
+file_server_url="${ARTIFACT_DOWNLOAD_BASE_URL:-http://fileserver.pingcap.net}"
 tidb_sha1_url="${file_server_url}/download/refs/pingcap/tidb/${TIDB}/sha1"
 tikv_sha1_url="${file_server_url}/download/refs/pingcap/tikv/${TIKV}/sha1"
 pd_sha1_url="${file_server_url}/download/refs/pingcap/pd/${PD}/sha1"

--- a/scripts/artifacts/tag-rc2ga-on-repos.sh
+++ b/scripts/artifacts/tag-rc2ga-on-repos.sh
@@ -194,7 +194,7 @@ function publish_tiup_oci_repo() {
   tkn -n ee-cd task start publish-tiup-from-oci-artifact \
     --param artifact-url="${repo}:${tag}" \
     --param nightly=false \
-    --param tiup-mirror="http://tiup.pingcap.net:8988" \
+    --param tiup-mirror="${TIUP_STAGING_MIRROR_URL:-http://tiup.pingcap.net:8988}" \
     -w name=lock-tiup,claimName=pvc-lock-tiup-staging \
     -w name=dockerconfig,secret=hub-pingcap-net-ee \
     -w name=tiup-keys,secret=tiup-credentials-staging \
@@ -206,7 +206,7 @@ function publish_tiup_oci_repo() {
 function main() {
   local rc_ver="$1"
   local ga_ver="$2"
-  local registry="${3:-hub.pingcap.net}"
+  local registry="${3:-${OCI_REGISTRY:-hub.pingcap.net}}"
   local force="${4:-false}"
   local save_results_file="${5:-results.yaml}"
 

--- a/scripts/flow/rc/check-images-internal.ts
+++ b/scripts/flow/rc/check-images-internal.ts
@@ -196,7 +196,7 @@ async function main(
     version,
     branch,
     github_token,
-    oci_registry = "hub.pingcap.net",
+    oci_registry = Deno.env.get("OCI_REGISTRY") || "hub.pingcap.net",
     save_to = "results.yaml",
   }: CliParams,
 ) {

--- a/scripts/flow/rc/refresh-tiup.sh
+++ b/scripts/flow/rc/refresh-tiup.sh
@@ -23,7 +23,7 @@ refresh_tiup_packages() {
 
     local svc_url="$1"
     local branch="$2"
-    local repo_base="${3:-hub.pingcap.net}"
+    local repo_base="${3:-${OCI_REGISTRY:-hub.pingcap.net}}"
 
     local platforms=(
         linux_amd64

--- a/scripts/ops/get-artifacts-of-pull-request.sh
+++ b/scripts/ops/get-artifacts-of-pull-request.sh
@@ -3,7 +3,7 @@
 
 ### Notice: it's depended on GitHub cli tool `gh`, it should be installed and added to `PATH` env var.
 
-download_base_url="http://fileserver.pingcap.net/download/builds/pingcap"
+download_base_url="${ARTIFACT_DOWNLOAD_BASE_URL:-http://fileserver.pingcap.net}/download/builds/pingcap"
 
 function install_github_cli_if_not_exist() {
     which gh >/dev/null || {

--- a/scripts/ops/nextgen/get-next-gen-exact-image-tags.sh
+++ b/scripts/ops/nextgen/get-next-gen-exact-image-tags.sh
@@ -36,7 +36,7 @@ fetch_next_gen_exact_tags() {
 }
 
 fetch_all() {
-    registry="us.gcr.io"
+    registry="${OCI_ARTIFACT_HOST:-us.gcr.io}"
     common_release_branch="release-nextgen-202603"
     # Authenticate against both registries because tiproxy trunk still resolves from gcr.io
     # while the other TiDB X artifacts are stored under us.gcr.io.

--- a/scripts/ops/release-check-version/README.md
+++ b/scripts/ops/release-check-version/README.md
@@ -81,8 +81,9 @@ python3 main.py tiup --components_url='https://raw.githubusercontent.com/wuhuizu
 
 # build the image
 ```shell
+export OCI_REGISTRY="${OCI_REGISTRY:-hub.pingcap.net}"
 # build the single arch image
-docker build -t hub.pingcap.net/jenkins/release-check-version:{tag} .
+docker build -t ${OCI_REGISTRY}/jenkins/release-check-version:{tag} .
 # build the multi-arch image
-docker buildx build --platform linux/amd64,linux/arm64 -t hub.pingcap.net/jenkins/release-check-version:{tag}. --push
+docker buildx build --platform linux/amd64,linux/arm64 -t ${OCI_REGISTRY}/jenkins/release-check-version:{tag}. --push
 ```

--- a/scripts/ops/release-check-version/check_offline_package.py
+++ b/scripts/ops/release-check-version/check_offline_package.py
@@ -19,7 +19,7 @@ def get_base_url(is_internal=None):
         tuple: (public_base_url, internal_base_url, use_internal)
     """
     public_base_url = "https://download.pingcap.com"
-    internal_base_url = "http://fileserver.pingcap.net/download/release"
+    internal_base_url = os.environ.get("ARTIFACT_DOWNLOAD_BASE_URL", "http://fileserver.pingcap.net") + "/download/release"
 
     # If is_internal is explicitly provided, use it
     if is_internal is not None:

--- a/scripts/ops/release-check-version/check_tiup.py
+++ b/scripts/ops/release-check-version/check_tiup.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import argparse
 from check_info import check_version
@@ -48,9 +49,9 @@ def uninstall_component(component, version):
 def check_tiup_component_exists(component, version, is_tiup_staging):
     check_result = True
     check_detail = []
-    tiup_mirror = "https://tiup-mirrors.pingcap.com"
+    tiup_mirror = os.environ.get("TIUP_MIRROR_URL", TIUP_MIRRORS["prod-pingcap"])
     if is_tiup_staging:
-        tiup_mirror = "http://tiup.pingcap.net:8988"
+        tiup_mirror = os.environ.get("TIUP_STAGING_MIRROR_URL", TIUP_MIRRORS["staging-internal"])
 
     for tiup_component in COMPONENT_META[component]["tiup_components"]:
         single_component_check_detail = {
@@ -97,9 +98,9 @@ def check_tiup_component_version(component, version, commit_hash, is_tiup_stagin
     tiup_check_version = version
     if is_tiup_staging:
         tiup_check_version = f"{version}-pre"
-    tiup_mirror = "https://tiup-mirrors.pingcap.com"
+    tiup_mirror = os.environ.get("TIUP_MIRROR_URL", TIUP_MIRRORS["prod-pingcap"])
     if is_tiup_staging:
-        tiup_mirror = "http://tiup.pingcap.net:8988"
+        tiup_mirror = os.environ.get("TIUP_STAGING_MIRROR_URL", TIUP_MIRRORS["staging-internal"])
     set_tiup_mirror(tiup_mirror)
     subprocess.run(["tiup", "mirror", "show"], capture_output=True, text=True, check=True)
 

--- a/scripts/ops/release-check-version/config.py
+++ b/scripts/ops/release-check-version/config.py
@@ -1,3 +1,5 @@
+import os
+
 COMPONENT_META = {
     "pd": {
         "entrypoints": ["/pd-server"],
@@ -230,6 +232,6 @@ COMPONENT_META = {
 
 TIUP_PACKAGE_DEFAULT_EDITION = "Community"
 TIUP_MIRRORS = {
-    "prod-pingcap": "https://tiup-mirrors.pingcap.com",
-    "staging-internal": "http://tiup.pingcap.net:8988"
+    "prod-pingcap": os.environ.get("TIUP_MIRROR_URL", "https://tiup-mirrors.pingcap.com"),
+    "staging-internal": os.environ.get("TIUP_STAGING_MIRROR_URL", "http://tiup.pingcap.net:8988")
 }

--- a/scripts/ops/release-check-version/main.py
+++ b/scripts/ops/release-check-version/main.py
@@ -94,26 +94,31 @@ if __name__ == "__main__":
         all_results = []
         failed_images = []
         if is_rc_build:
+            oci_registry = os.environ.get("OCI_REGISTRY", "hub.pingcap.net")
             for image in components["docker_images"]:
-                success, failure = check_docker_image(image, "enterprise", "hub.pingcap.net", "qa", is_rc_build)
+                success, failure = check_docker_image(image, "enterprise", oci_registry, "qa", is_rc_build)
                 all_results.append(success)
                 if not success:
                     failed_images.append(failure)
-                success, failure = check_docker_image(image, "community", "hub.pingcap.net", "qa", is_rc_build)
+                success, failure = check_docker_image(image, "community", oci_registry, "qa", is_rc_build)
                 all_results.append(success)
                 if not success:
                     failed_images.append(failure)
         else:
-            print("checking docker images on gcr.io")
+            enterprise_registry = os.environ.get("ENTERPRISE_IMAGE_REGISTRY", "gcr.io/pingcap-public/dbaas")
+            enterprise_registry_parts = enterprise_registry.split("/", 1)
+            print(f"checking docker images on {enterprise_registry}")
             for image in components["docker_images"]:
-                success, failure = check_docker_image(image, "enterprise", "gcr.io", "pingcap-public/dbaas")
+                success, failure = check_docker_image(image, "enterprise", enterprise_registry_parts[0], enterprise_registry_parts[1])
                 all_results.append(success)
                 if not success:
                     failed_images.append(failure)
 
-            print("checking docker images on uhub.service.ucloud.cn")
+            ucloud_registry = os.environ.get("UCLOUD_REGISTRY", "uhub.service.ucloud.cn/pingcap")
+            ucloud_registry_parts = ucloud_registry.split("/", 1)
+            print(f"checking docker images on {ucloud_registry}")
             for image in components["docker_images"]:
-                success, failure = check_docker_image(image, "community", "uhub.service.ucloud.cn", "pingcap")
+                success, failure = check_docker_image(image, "community", ucloud_registry_parts[0], ucloud_registry_parts[1])
                 all_results.append(success)
                 if not success:
                     failed_images.append(failure)

--- a/scripts/ops/statics-prow-jobs-weekly.py
+++ b/scripts/ops/statics-prow-jobs-weekly.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import json
 import csv
@@ -13,7 +14,8 @@ stats_csv_filename = f'prow_job_stats_{today}.csv'
 
 
 def main():
-    url = "https://prow.tidb.net/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec"
+    prow_url = os.environ.get("PROW_URL", "https://prow.tidb.net")
+    url = f"{prow_url}/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec"
     response = requests.get(url)
     text = response.text
     # Remove the first string 'var allBuilds = ' and also remove the last string ';' to get valid json string

--- a/scripts/ops/statics-prow-jobs.ts
+++ b/scripts/ops/statics-prow-jobs.ts
@@ -21,7 +21,7 @@ interface prowJobRun {
 
 async function main() {
   const res = await fetch(
-    "https://prow.tidb.net/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec",
+    `${Deno.env.get("PROW_URL") || "https://prow.tidb.net"}/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec`,
   );
   const js = await res.text();
   const list = js.replace(/^var\s+allBuilds\s*=\s*/g, "").replace(/;$/, "");

--- a/scripts/pingcap/br/integration_test_download_dependency.sh
+++ b/scripts/pingcap/br/integration_test_download_dependency.sh
@@ -50,7 +50,7 @@ echo "TICDC         = ${TICDC}"
 
 
 tikv_importer_branch="release-5.0"
-file_server_url="http://sunset-fileserver.pingcap.net"
+file_server_url="${ARTIFACT_DOWNLOAD_BASE_URL:-http://sunset-fileserver.pingcap.net}"
 
 tikv_sha1_url="${file_server_url}/download/refs/pingcap/tikv/${TIKV}/sha1"
 pd_sha1_url="${file_server_url}/download/refs/pingcap/pd/${PD}/sha1"

--- a/scripts/pingcap/tidb/br_integration_test_download_dependency.sh
+++ b/scripts/pingcap/tidb/br_integration_test_download_dependency.sh
@@ -13,7 +13,7 @@ set -o pipefail
 # exclusively accessible when obtaining binaries from
 # http://sunset-fileserver.pingcap.net.
 branch=${1:-master}
-file_server_url=${2:-http://sunset-fileserver.pingcap.net}
+file_server_url=${2:-${ARTIFACT_DOWNLOAD_BASE_URL:-http://sunset-fileserver.pingcap.net}}
 
 tikv_importer_branch="release-5.0"
 tikv_sha1_url="${file_server_url}/download/refs/pingcap/tikv/${branch}/sha1"

--- a/scripts/pingcap/tidb/release-6.5-fips/br_integration_test_download_dependency.sh
+++ b/scripts/pingcap/tidb/release-6.5-fips/br_integration_test_download_dependency.sh
@@ -13,7 +13,7 @@ set -o pipefail
 # exclusively accessible when obtaining binaries from
 # http://sunset-fileserver.pingcap.net.
 branch=${1:-release-6.5-fips}
-file_server_url=${2:-http://sunset-fileserver.pingcap.net}
+file_server_url=${2:-${ARTIFACT_DOWNLOAD_BASE_URL:-http://sunset-fileserver.pingcap.net}}
 oci_fips_branch="feature-release-6.5-fips-fips_linux_amd64"
 # Note: osci_base_url is only available in the ci environment.
 # dl.dl.svc is an internal k8s service; the oci-files download chain
@@ -74,8 +74,9 @@ function download() {
 function download_from_oci() {
     local org_and_repo=$1
     local grep_pattern=$2
-    local list_api="${oci_base_url}/oci-files/hub.pingcap.net/${org_and_repo}/package?tag=${oci_fips_branch}"
-    local download_api="${oci_base_url}/oci-file/hub.pingcap.net/${org_and_repo}/package?tag=${oci_fips_branch}&file="
+    local oci_registry="${OCI_REGISTRY:-hub.pingcap.net}"
+    local list_api="${oci_base_url}/oci-files/${oci_registry}/${org_and_repo}/package?tag=${oci_fips_branch}"
+    local download_api="${oci_base_url}/oci-file/${oci_registry}/${org_and_repo}/package?tag=${oci_fips_branch}&file="
 
     # TODO: remove --insecure after the certificate issue is fixed
     local file_list=$(curl -s $list_api --insecure | grep -o ${grep_pattern} |  sort | uniq)

--- a/scripts/pingcap/tidb/release-6.5-fips/pingcap_download_artifacts.sh
+++ b/scripts/pingcap/tidb/release-6.5-fips/pingcap_download_artifacts.sh
@@ -45,7 +45,7 @@ if [[ -n $1 ]]; then
     tail -1 $1
 fi
 
-file_server_url="http://sunset-fileserver.pingcap.net"
+file_server_url="${ARTIFACT_DOWNLOAD_BASE_URL:-http://sunset-fileserver.pingcap.net}"
 oci_fips_branch="feature-release-6.5-fips-fips_linux_amd64"
 # Note: osci_base_url is only available in the ci environment.
 # dl.dl.svc is an internal k8s service; the oci-files download chain
@@ -73,8 +73,9 @@ function download() {
 function download_from_oci() {
     local org_and_repo=$1
     local grep_pattern=$2
-    local list_api="${oci_base_url}/oci-files/hub.pingcap.net/${org_and_repo}/package?tag=${oci_fips_branch}"
-    local download_api="${oci_base_url}/oci-file/hub.pingcap.net/${org_and_repo}/package?tag=${oci_fips_branch}&file="
+    local oci_registry="${OCI_REGISTRY:-hub.pingcap.net}"
+    local list_api="${oci_base_url}/oci-files/${oci_registry}/${org_and_repo}/package?tag=${oci_fips_branch}"
+    local download_api="${oci_base_url}/oci-file/${oci_registry}/${org_and_repo}/package?tag=${oci_fips_branch}&file="
 
     # TODO: remove --insecure after the certificate issue is fixed
     local file_list=$(curl -s $list_api --insecure | grep -o ${grep_pattern} |  sort | uniq)


### PR DESCRIPTION
## Summary

Replace all hardcoded internal URLs in `scripts/` with environment variable references that have backward-compatible defaults.

## Changes

| Env Var | Default | Replaced URL |
|---|---|---|
| `OCI_REGISTRY` | `hub.pingcap.net` | Internal OCI registry |
| `ARTIFACT_DOWNLOAD_BASE_URL` | `http://fileserver.pingcap.net` | Build artifact file server |
| `OCI_ARTIFACT_HOST` | `us-docker.pkg.dev/pingcap-testing-account/hub` | OCI artifact registry |
| `TIUP_MIRROR_URL` | `https://tiup-mirrors.pingcap.com` | Public TIUP mirror |
| `TIUP_STAGING_MIRROR_URL` | `http://tiup.pingcap.net:8988` | Staging TIUP mirror |
| `PROW_URL` | `https://prow.tidb.net` | Prow dashboard |
| `UCLOUD_REGISTRY` | `uhub.service.ucloud.cn/pingcap` | UCloud China registry |
| `ENTERPRISE_IMAGE_REGISTRY` | `gcr.io/pingcap-public/dbaas` | Enterprise GCR |

18 files modified across scripts/flow/rc/, scripts/artifacts/, scripts/ops/, and scripts/pingcap/.

## Testing

- `bash -n` passes on all modified .sh files
- `python3 -m py_compile` passes on all modified .py files
- `deno check` passes on all modified .ts files

## Risk

Low. All changes use backward-compatible defaults matching the current hardcoded values. No behavioral change in default (internal) environment.