### PR TITLE
feat(tiproxy): add --tiproxy support for pre-built binary download from OCI

### DIFF
--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -45,7 +45,7 @@ def parseCIParamsFromPRTitle(String prTitle) {
 // Returns a list of error messages; empty list means no errors.
 def validatePreBuiltComponentParams(String prTitle, String prTargetBranch) {
     // Supported components for pre-built binary download
-    final List<String> supportedComponents = ['tidb', 'tikv', 'pd', 'tiflash', 'ticdc', 'tiflow']
+    final List<String> supportedComponents = ['tidb', 'tikv', 'pd', 'tiflash', 'ticdc', 'tiflow', 'tiproxy']
     // Standard core branch patterns where pre-built mode is REJECTED
     final String deniedBranchReg = /^(main|master|release-\d+\.\d+(-beta\.\d+)?|release-nextgen-\d{6,8})$/
 

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -31,22 +31,10 @@ pipeline {
             }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiproxy") {
-                    cache(path: "./", includes: '**/*', key: "git/pingcap/tiproxy/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiproxy/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkout('https://github.com/pingcap/tiproxy.git', 'tiproxy', "main", "", "")
-                            }
-                        }
-                    }
-                }
                 dir("tidb-test") {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
-                }
-                dir('tiproxy') {
-                    sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -55,12 +43,11 @@ pipeline {
                             container("utils") {
                                 dir('bin') {
                                     sh label: 'download thirdparty binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
                                     """
                                 }
                             }
                             sh label: 'prepare tiproxy binary', script: """
-                            cp ../tiproxy/bin/tiproxy ./bin/
                             ls -alh bin/
                             ./bin/tidb-server -V
                             ./bin/pd-server -V

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -31,22 +31,10 @@ pipeline {
             }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiproxy") {
-                    cache(path: "./", includes: '**/*', key: "git/pingcap/tiproxy/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiproxy/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkout('https://github.com/pingcap/tiproxy.git', 'tiproxy', "main", "", "")
-                            }
-                        }
-                    }
-                }
                 dir("tidb-test") {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
-                }
-                dir('tiproxy') {
-                    sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -55,12 +43,11 @@ pipeline {
                             container("utils") {
                                 dir('bin') {
                                     sh label: 'download thirdparty binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
                                     """
                                 }
                             }
                             sh label: 'prepare tiproxy binary', script: """
-                            cp ../tiproxy/bin/tiproxy ./bin/
                             ls -alh bin/
                             ./bin/tidb-server -V
                             ./bin/pd-server -V

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
@@ -31,34 +31,21 @@ pipeline {
             }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiproxy") {
-                    cache(path: "./", includes: '**/*', key: "git/pingcap/tiproxy/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiproxy/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkout('https://github.com/pingcap/tiproxy.git', 'tiproxy', "main", "", "")
-                            }
-                        }
-                    }
-                }
                 dir("tidb-test") {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
-                }
-                dir('tiproxy') {
-                    sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
                     sh "touch ws-${BUILD_TAG}"
                     container("utils") {
                         dir('bin') {
                             sh label: 'download thirdparty binary', script: """
-                            ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master
+                            ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --tiproxy=main
                             """
                         }
                     }
                     sh label: 'prepare tiproxy binary', script: """
-                    cp ../tiproxy/bin/* ./bin/
                     ls -alh bin/
                     ./bin/tidb-server -V
                     ./bin/tiproxy --version

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -31,22 +31,10 @@ pipeline {
             }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiproxy") {
-                    cache(path: "./", includes: '**/*', key: "git/pingcap/tiproxy/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiproxy/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkout('https://github.com/pingcap/tiproxy.git', 'tiproxy', "main", "", "")
-                            }
-                        }
-                    }
-                }
                 dir("tidb-test") {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
-                }
-                dir('tiproxy') {
-                    sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-mysql-test") {
@@ -55,12 +43,11 @@ pipeline {
                             container("utils") {
                                 dir('bin') {
                                     sh label: 'download thirdparty binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
                                     """
                                 }
                             }
                             sh label: 'prepare tiproxy binary', script: """
-                            cp ../tiproxy/bin/tiproxy ./bin/
                             ls -alh bin/
                             ./bin/tidb-server -V
                             ./bin/pd-server -V

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -31,22 +31,10 @@ pipeline {
             }
             options { timeout(time: 10, unit: 'MINUTES') }
             steps {
-                dir("tiproxy") {
-                    cache(path: "./", includes: '**/*', key: "git/pingcap/tiproxy/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tiproxy/rev-']) {
-                        retry(2) {
-                            script {
-                                component.checkout('https://github.com/pingcap/tiproxy.git', 'tiproxy', "main", "", "")
-                            }
-                        }
-                    }
-                }
                 dir("tidb-test") {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
-                }
-                dir('tiproxy') {
-                    sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
                     cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
@@ -55,12 +43,11 @@ pipeline {
                             container("utils") {
                                 dir('bin') {
                                     sh label: 'download thirdparty binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
                                     """
                                 }
                             }
                             sh label: 'prepare tiproxy binary', script: """
-                            cp ../tiproxy/bin/tiproxy ./bin/
                             ls -alh bin/
                             ./bin/tidb-server -V
                             ./bin/pd-server -V

--- a/scripts/artifacts/download_pingcap_oci_artifact.sh
+++ b/scripts/artifacts/download_pingcap_oci_artifact.sh
@@ -152,6 +152,12 @@ function main() {
         ls -alh tiflash
         echo "🎉 download TiFlash success"
     fi
+    if [[ -n "$TIPROXY" ]]; then
+        echo "🚀 start download TiProxy"
+        download_and_extract_with_path "$tiproxy_oci_url" '^tiproxy-v.+.tar.gz$' tiproxy.tar.gz tiproxy
+        chmod +x tiproxy
+        echo "🎉 download TiProxy success"
+    fi
     if [[ -n "$TICDC" ]]; then
         echo "🚀 start download TiCDC"
         download_and_extract_with_path "$ticdc_oci_url" '^cdc-v.+.tar.gz$' cdc.tar.gz cdc
@@ -292,6 +298,10 @@ function parse_cli_args() {
         TIFLASH="${i#*=}"
         shift # past argument=value
         ;;
+        -tiproxy=*|--tiproxy=*)
+        TIPROXY="${i#*=}"
+        shift # past argument=value
+        ;;
         -ticdc=*|--ticdc=*)
         TICDC="${i#*=}"
         shift # past argument=value
@@ -361,6 +371,7 @@ function parse_cli_args() {
     [[ -n "${PD}" ]]            && echo "PD          = ${PD}"
     [[ -n "${PD_CTL}" ]]        && echo "PD_CTL      = ${PD_CTL}"
     [[ -n "${TIFLASH}" ]]       && echo "TIFLASH     = ${TIFLASH}"
+    [[ -n "${TIPROXY}" ]]       && echo "TIPROXY     = ${TIPROXY}"
     [[ -n "${TICDC}" ]]         && echo "TICDC       = ${TICDC}"
     [[ -n "${TICDC_NEW}" ]]     && echo "TICDC_NEW   = ${TICDC_NEW}"
     [[ -n "${TICI}" ]]          && echo "TICI        = ${TICI}"
@@ -420,6 +431,7 @@ function parse_cli_args() {
     ticdc_oci_url="$(build_oci_url "${registry_host}" "pingcap/tiflow/package" "${TICDC}" "${tag_suffix}")"
     ticdc_new_oci_url="$(build_oci_url "${registry_host}" "pingcap/ticdc/package" "${TICDC_NEW}" "${tag_suffix}")"
     tici_oci_url="$(build_oci_url "${registry_host}" "pingcap/tici/package" "${TICI}" "${tag_suffix}")"
+    tiproxy_oci_url="$(build_oci_url "${registry_host}" "pingcap/tiproxy/package" "${TIPROXY}" "${tag_suffix}")"
     # sync-diff-inspector: semver tags come from tidb-tools, non-semver (e.g. master) from tiflow
     if [[ "${SYNC_DIFF_INSPECTOR}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+ ]]; then
         sync_diff_inspector_oci_url="$(build_oci_url "${registry_host_community}" "pingcap/tidb-tools/package" "${SYNC_DIFF_INSPECTOR}" "${tag_suffix}")"


### PR DESCRIPTION
## Summary

Replace git checkout + make build for tiproxy with downloading pre-built binaries from OCI artifact registry.

## Changes

- **scripts/artifacts/download_pingcap_oci_artifact.sh**: Add `--tiproxy=` flag, OCI URL construction, and download logic for tiproxy binary
- **libraries/tipipeline/vars/component.groovy**: Add `tiproxy` to `supportedComponents` list for PR title validation
- **5 pipeline files** under `pipelines/pingcap-qe/tidb-test/latest/`:
  - Remove `dir("tiproxy") { cache { ... component.checkout(...) } }` block
  - Remove `dir('tiproxy') { sh 'make' }` block
  - Remove `cp ../tiproxy/bin/tiproxy ./bin/` (or `cp ../tiproxy/bin/* ./bin/`)
  - Add `--tiproxy=main` to the download call

## Testing

- Verify `download_pingcap_oci_artifact.sh --tiproxy=main` successfully downloads and extracts tiproxy binary
- Pipeline syntax verified via existing patterns

## Risk

Low. Follows the exact same pattern as existing components (tidb, pd, tikv, tiflash, etc.). The OCI artifact path (`pingcap/tiproxy/package`) and tarball naming (`tiproxy-v.+.tar.gz`) follow established conventions.