### PR TITLE
feat(tekton): add trigger to auto-remove do-not-merge/hold on cherry-pick PRs

### DIFF
--- a/tekton/v1/triggers/triggers/env-gcp/_/github-pr-synchronized-remove-hold.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/github-pr-synchronized-remove-hold.yaml
@@ -1,0 +1,111 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: github-pr-synchronized-remove-hold-for-cherry-pick
+  labels:
+    type: github-pr
+spec:
+  interceptors:
+    - name: filter on repo, branch, and labels
+      ref: { name: cel }
+      params:
+        - name: filter
+          value: >-
+            body.action == 'synchronize'
+            &&
+            body.repository.full_name in [
+              'pingcap/tidb',
+              'pingcap/tiflash',
+              'pingcap/tiflow',
+              'pingcap/ticdc',
+              'tikv/tikv',
+              'tikv/pd',
+            ]
+            &&
+            body.pull_request.base.ref.startsWith('release-')
+            &&
+            body.pull_request.labels.exists(l, l.name == 'do-not-merge/hold')
+            &&
+            body.pull_request.labels.exists(l, l.name.startsWith('type/cherry-pick-for-release'))
+  bindings:
+    - ref: github-pr
+  template:
+    spec:
+      params:
+        - name: pr-owner
+        - name: pr-repo
+        - name: pr-number
+      resourcetemplates:
+        - apiVersion: tekton.dev/v1
+          kind: TaskRun
+          metadata:
+            generateName: auto-remove-hold-from-cherry-pick-
+          spec:
+            params:
+              - name: owner
+                value: $(tt.params.pr-owner)
+              - name: repo
+                value: $(tt.params.pr-repo)
+              - name: number
+                value: $(tt.params.pr-number)
+            taskSpec:
+              description: Auto-remove do-not-merge/hold from cherry-pick PRs when conflicts are resolved
+              params:
+                - name: owner
+                  description: repo owner
+                - name: repo
+                  description: repo short name
+                - name: number
+                  description: pull request number
+              steps:
+                - name: wait-for-mergeable-and-remove-hold
+                  image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.26-7-geb77a69
+                  script: |
+                    #!/usr/bin/env bash
+                    set -eo pipefail
+
+                    export GH_TOKEN="$(cat $(workspaces.github.path)/token)"
+                    pr_url="https://github.com/$(params.owner)/$(params.repo)/pull/$(params.number)"
+
+                    # Wait for mergeability (GitHub computes it async after push)
+                    mergeable=""
+                    for i in $(seq 1 10); do
+                      mergeable=$(gh pr view "$pr_url" --json mergeable --jq '.mergeable' 2>/dev/null || echo "UNKNOWN")
+                      if [ "$mergeable" = "MERGEABLE" ]; then
+                        break
+                      fi
+                      if [ "$i" -lt 10 ]; then
+                        sleep 5
+                      fi
+                    done
+
+                    if [ "$mergeable" != "MERGEABLE" ]; then
+                      echo "PR is not mergeable (state: $mergeable), keeping hold."
+                      exit 0
+                    fi
+
+                    # Check bot origin: only proceed if do-not-merge/hold was added by ti-chi-bot
+                    owner="$(params.owner)"
+                    repo="$(params.repo)"
+                    number="$(params.number)"
+
+                    last_labeler=$(gh api --paginate "repos/$owner/$repo/issues/$number/timeline?per_page=100" --jq '[.[] | select(.event == "labeled" and .label.name == "do-not-merge/hold")][-1].actor.login' 2>/dev/null | tail -1)
+
+                    if [ "$last_labeler" != "ti-chi-bot" ] && [ "$last_labeler" != "ti-chi-bot[bot]" ]; then
+                      echo "do-not-merge/hold was not added by bot (labeler: $last_labeler), skipping."
+                      exit 0
+                    fi
+
+                    # Post tip comment
+                    gh pr comment "$pr_url" --body "Cherry-pick conflicts appear resolved; removing the \`do-not-merge/hold\` label."
+
+                    # Remove the hold label
+                    gh pr edit --remove-label "do-not-merge/hold" "$pr_url"
+
+              workspaces:
+                - name: github
+                  description: Must includes a key `token`
+            workspaces:
+              - name: github
+                secret:
+                  secretName: github

--- a/tekton/v1/triggers/triggers/env-gcp/_/github-pr-synchronized-remove-hold.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/github-pr-synchronized-remove-hold.yaml
@@ -89,7 +89,7 @@ spec:
                     repo="$(params.repo)"
                     number="$(params.number)"
 
-                    last_labeler=$(gh api --paginate "repos/$owner/$repo/issues/$number/timeline?per_page=100" --jq '[.[] | select(.event == "labeled" and .label.name == "do-not-merge/hold")][-1].actor.login' 2>/dev/null | tail -1)
+                    last_labeler=$(gh api --paginate "repos/$owner/$repo/issues/$number/timeline?per_page=100" --jq '.[] | select(.event == "labeled" and .label.name == "do-not-merge/hold") | .actor.login' 2>/dev/null | tail -1 || echo "")
 
                     if [ "$last_labeler" != "ti-chi-bot" ] && [ "$last_labeler" != "ti-chi-bot[bot]" ]; then
                       echo "do-not-merge/hold was not added by bot (labeler: $last_labeler), skipping."

--- a/tekton/v1/triggers/triggers/env-gcp/kustomization.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - _/git-push-on-fips-branches.yaml
   - _/github-pr-labeled-with-lgtm.yaml
   - _/github-pr-labeled-with-needs-ok-to-test.yaml
+  - _/github-pr-synchronized-remove-hold.yaml
   - _/github-tag-build-community-linux-fts.yaml
   - _/notify/notified-successful-image-delivery-tidbx.yaml
   - _/notify/update-ops-when-tidbx-image-distributed-to-clouds.yaml


### PR DESCRIPTION
## Summary

Add a new Tekton Trigger that auto-removes `do-not-merge/hold` from cherry-pick PRs when conflicts are resolved (synchronize event).

## Changes

1. **NEW** `tekton/v1/triggers/triggers/env-gcp/_/github-pr-synchronized-remove-hold.yaml` — Trigger with CEL filter and inline TaskSpec that:
   - Filters on `synchronize` action for 6 cherry-pick repos with `release-*` base ref and `do-not-merge/hold` + `type/cherry-pick-for-release-*` labels
   - Polls `mergeable` state (up to 10 × 5s) — exits silently if still CONFLICTING/UNKNOWN
   - Checks `do-not-merge/hold` was added by `ti-chi-bot` or `ti-chi-bot[bot]` via timeline API — human `/hold` is respected
   - Posts a tip comment then removes the label

2. **MODIFIED** `tekton/v1/triggers/triggers/env-gcp/kustomization.yaml` — registered the new trigger

## Testing

- `kustomize build tekton/v1/triggers/triggers/env-gcp` succeeds (verified via docker)
- `gh pr view` with `--json mergeable` polling handles GitHubs async mergeable computation
- Cherry-pick repo set verified against `ti-community-cherrypicker` config in `ti-community-infra/configs`

## Risk

Low. Purely additive — no changes to existing triggers. Removes label only when all gates pass. Fails closed (keeps hold) on CONFLICTING/UNKNOWN or non-bot labeler.

## Open Items

- Requirement #2 "tip before adding" — the add path is in prow config (`ti-community-infra/configs`), not this repo. Out of scope for this PR; separate ticket needed if still wanted.