### PR TITLE
chore(pipelines): remove unused gocache and gopathcache PVCs and GOPATH/GOCACHE env vars

### DIFF
--- a/pipelines/pingcap-inc/enterprise-extensions/latest/pod-pr-verify.yaml
+++ b/pipelines/pingcap-inc/enterprise-extensions/latest/pod-pr-verify.yaml
@@ -13,11 +13,6 @@ spec:
         limits:
           memory: 64Gi
           cpu: "16"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
       volumeMounts:
         - mountPath: /home/jenkins/.tidb/tmp
           name: bazel-out-merged
@@ -26,10 +21,6 @@ spec:
           mountPath: /bazel-out-lower
         - name: bazel-out-overlay
           mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -42,12 +33,6 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
     - name: bazel-out-lower
       persistentVolumeClaim:
         claimName: bazel-out-data

--- a/pipelines/pingcap-inc/enterprise-extensions/le-release-7.4/pod-pr-verify.yaml
+++ b/pipelines/pingcap-inc/enterprise-extensions/le-release-7.4/pod-pr-verify.yaml
@@ -21,10 +21,6 @@ spec:
           mountPath: /bazel-out-lower
         - name: bazel-out-overlay
           mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - mountPath: /share/.cache/bazel-repository-cache
           name: bazel-repository-cache
         - name: bazel-rc
@@ -39,12 +35,6 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
     - name: bazel-out-lower
       persistentVolumeClaim:
         claimName: bazel-out-data

--- a/pipelines/pingcap/tidb-tools/latest/pod-pull_verify.yaml
+++ b/pipelines/pingcap/tidb-tools/latest/pod-pull_verify.yaml
@@ -7,9 +7,6 @@ spec:
     - name: runner
       image: ghcr.io/pingcap-qe/ci/jenkins:v2025.12.7-3-g1c0b8cf-go1.23
       tty: true
-      env:
-        - name: GOPATH
-          value: /go
       resources:
         limits:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/latest/pull_check_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_check_next_gen/pod.yaml
@@ -16,11 +16,6 @@ spec:
         limits:
           memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
       volumeMounts:
         - mountPath: /home/jenkins/.tidb/tmp
           name: bazel-out-merged
@@ -29,10 +24,6 @@ spec:
           mountPath: /bazel-out-lower
         - name: bazel-out-overlay
           mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,12 +36,6 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
     - name: bazel-out-lower
       persistentVolumeClaim:
         claimName: bazel-out-data

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_build.yaml
@@ -21,10 +21,6 @@ spec:
           mountPath: /bazel-out-lower
         - name: bazel-out-overlay
           mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - mountPath: /share/.cache/bazel-repository-cache
           name: bazel-repository-cache
         - name: bazel-rc
@@ -39,12 +35,6 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
     - name: bazel-out-lower
       persistentVolumeClaim:
         claimName: bazel-out-data

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check.yaml
@@ -16,11 +16,6 @@ spec:
         limits:
           memory: 32Gi
           cpu: "8"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
       volumeMounts:
         - mountPath: /home/jenkins/.tidb/tmp
           name: bazel-out-merged
@@ -29,10 +24,6 @@ spec:
           mountPath: /bazel-out-lower
         - name: bazel-out-overlay
           mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -45,12 +36,6 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
     - name: bazel-out-lower
       persistentVolumeClaim:
         claimName: bazel-out-data

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_check2.yaml
@@ -22,10 +22,6 @@ spec:
           mountPath: /bazel-out-lower
         - name: bazel-out-overlay
           mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - mountPath: /share/.cache/bazel-repository-cache
           name: bazel-repository-cache
         - name: bazel-rc
@@ -40,12 +36,6 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
     - name: bazel-out-lower
       persistentVolumeClaim:
         claimName: bazel-out-data

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_mysql_test.yaml
@@ -16,18 +16,6 @@ spec:
         limits:
           memory: 6Gi
           cpu: "3"
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pod-ghpr_unit_test.yaml
@@ -25,10 +25,6 @@ spec:
           mountPath: /bazel-out-lower
         - name: bazel-out-overlay
           mountPath: /bazel-out-overlay
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -44,12 +40,6 @@ spec:
     - name: bazel-repository-cache
       persistentVolumeClaim:
         claimName: bazel-repository-cache
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
     - name: bazel-out-lower
       persistentVolumeClaim:
         claimName: bazel-out-data

--- a/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-pull_integration_tidb_tools_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       tty: true
-      env:
-        - name: GOPATH
-          value: /go
       resources:
         limits:
           memory: 8Gi
@@ -17,9 +14,6 @@ spec:
     - name: golang121
       image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       tty: true
-      env:
-        - name: GOPATH
-          value: /go
       resources:
         limits:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_tidb_tools_test.yaml
@@ -8,8 +8,6 @@ spec:
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
-        - name: GOPATH
-          value: /go
         - name: GOPROXY
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_tidb_tools_test.yaml
@@ -8,8 +8,6 @@ spec:
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
-        - name: GOPATH
-          value: /go
         - name: GOPROXY
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_tidb_tools_test.yaml
@@ -8,8 +8,6 @@ spec:
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
-        - name: GOPATH
-          value: /go
         - name: GOPROXY
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_tidb_tools_test.yaml
@@ -8,8 +8,6 @@ spec:
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
-        - name: GOPATH
-          value: /go
         - name: GOPROXY
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_tidb_tools_test.yaml
@@ -8,8 +8,6 @@ spec:
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
-        - name: GOPATH
-          value: /go
         - name: GOPROXY
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:

--- a/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_syncdiff_integration_test.yaml
@@ -8,9 +8,6 @@ spec:
       image: ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25
       command: [tini, --, bash]
       tty: true
-      env:
-        - name: GOPATH
-          value: /go
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tiflow/release-6.2/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.2/pod-ghpr_verify.yaml
@@ -14,23 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-ghpr_verify.yaml
@@ -14,18 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-ghpr_verify.yaml
@@ -14,18 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.2/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-ghpr_verify.yaml
@@ -14,18 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.3/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-ghpr_verify.yaml
@@ -14,18 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.4/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-ghpr_verify.yaml
@@ -14,23 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-7.6/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-ghpr_verify.yaml
@@ -14,18 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-8.0/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-ghpr_verify.yaml
@@ -14,18 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-8.2/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-ghpr_verify.yaml
@@ -14,18 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-8.3/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-ghpr_verify.yaml
@@ -14,23 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-8.4/pod-ghpr_verify.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-ghpr_verify.yaml
@@ -14,23 +14,6 @@ spec:
         limits:
           memory: 16Gi
           cpu: "6"
-      # env:
-      #   - name: GOPATH
-      #     value: /share/.go
-      #   - name: GOCACHE
-      #     value: /share/.cache/go-build
-      volumeMounts:
-        - name: gocache
-          mountPath: /share/.cache/go-build
-        - name: gopathcache
-          mountPath: /share/.go
-  volumes:
-    - name: gopathcache
-      persistentVolumeClaim:
-        claimName: gopathcache
-    - name: gocache
-      persistentVolumeClaim:
-        claimName: gocache
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_syncdiff_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_syncdiff_integration_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: runner
       image: ghcr.io/pingcap-qe/ci/jenkins:v2026.3.15-1-g5625431-go1.25
       tty: true
-      env:
-        - name: GOPATH
-          value: /go
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_syncdiff_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_syncdiff_integration_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: runner
       image: ghcr.io/pingcap-qe/ci/jenkins:v2026.4.12-10-gc29110c-go1.25
       tty: true
-      env:
-        - name: GOPATH
-          value: /go
       resources:
         limits:
           memory: 8Gi


### PR DESCRIPTION
Clean up unused PVC references and env vars across pipeline pod YAMLs:

- Remove `gocache` volume mount and PVC definition
- Remove `gopathcache` volume mount and PVC definition
- Remove commented `GOPATH`/`GOCACHE` env blocks
- Remove uncommented `GOPATH` env entries in non-PVC-related pod YAMLs

29 files affected.