### PR TITLE
fix(pipelines/tiflow): drop 'args: cat' from release-6.5 dm/cdc test pods

### DIFF
--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -18,9 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - args:
-        - cat
-      image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       imagePullPolicy: Always
       name: golang
       resources:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -18,9 +18,9 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
-      imagePullPolicy: Always
+    - image: ghcr.io/pingcap-qe/ci/jenkins:centos7-go1.21
       name: golang
+      command: [/tini, --, /bin/bash]
       resources:
         requests:
           cpu: "2"

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -18,7 +18,7 @@ spec:
       volumeMounts:
         - mountPath: /tmp
           name: volume-0
-    - image: ghcr.io/pingcap-qe/ci/jenkins:centos7-go1.21
+    - image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       name: golang
       command: [/tini, --, /bin/bash]
       resources:

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -20,7 +20,6 @@ spec:
           name: volume-0
     - image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       name: golang
-      command: [/tini, --, /bin/bash]
       resources:
         requests:
           cpu: "2"

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_integration_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_dm_integration_test.yaml
@@ -7,8 +7,6 @@ spec:
     - name: golang
       image: ghcr.io/pingcap-qe/ci/jenkins:v2024.10.8-119-g4e56df7-go1.21
       tty: true
-      args:
-        - cat
       resources:
         requests:
           memory: 10Gi


### PR DESCRIPTION
### Problem

After #4816, `pull_dm_integration_test` on release-6.5 failed on **every** matrix group:

```
process dm-master.test didn't exit after 120 seconds, current processlist:
jenkins 389 ... Z 14:19 0:00 [dm-master.test] <defunct>
curl: (7) Failed to connect to 127.0.0.1 port 8261: Connection refused
```

Failed build: https://prow.tidb.net/jenkins/job/pingcap/job/tiflow/job/release-6.5/job/pull_dm_integration_test/3/

### Root cause

The `golang` container in `pod-pull_dm_integration_test.yaml` (and `pod-pull_cdc_integration_kafka_test.yaml`) overrode the image CMD with `args: [cat]`. With the new `agent none` + stash/unstash flow the test steps run inside this container, where `cat` becomes PID 1 of the process tree. `cat` does not reap children, so killed `dm-master.test` / `dm-worker.test` / cdc processes turned into `<defunct>` zombies. The DM test cleanup loop then waited 120s per zombie and failed the group.

### Fix

Remove the `args: [cat]` override so the container uses the image's default entrypoint (which reaps child processes), matching the working release-7.1 DM/CDC pods that use the same image `v2024.10.8-119-g4e56df7-go1.21` without `args: [cat]`.

### Verification
- YAML validated
- Matches release-7.1 pod definitions (same image, no `cat` override)