### PR TITLE
fix(pipelines): normalize TiFlash release-8.5 image tags

### DIFF
--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -249,9 +249,9 @@ pipeline {
                                     docker ps -a && docker version
                                     """
                                     script {
-                                        def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
-                                        def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
-                                        def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
+                                        def pdBranch = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
+                                        def tikvBranch = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
+                                        def tidbBranch = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.5')
                                         withEnv([
                                             "PD_IMAGE=${OCI_ARTIFACT_HOST}/tikv/pd/image:${pdBranch}",
                                             "TIKV_IMAGE=${OCI_ARTIFACT_HOST}/tikv/tikv/image:${tikvBranch}",


### PR DESCRIPTION
## Summary
- use OCI-safe artifact tags for TiFlash release-8.5 integration test dependency images
- keep the change scoped to the TiFlash release-8.5 pipeline groovy file

## Verification
- JENKINS_URL=https://prow.tidb.net/jenkins JENKINS_CRUMB=<crumb> .ci/verify-jenkins-pipeline-file.sh pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
- confirmed manifests exist for normalized feature-release-8.5-materialized-view PD, TiKV, TiDB, and TiDB failpoint images