### PR TITLE
feat(tekton): migrate artifact URLs to jsDelivr CDN

### DIFF
--- a/tekton/v1/pipelines/pingcap-release-ga.yaml
+++ b/tekton/v1/pipelines/pingcap-release-ga.yaml
@@ -65,7 +65,7 @@ spec:
         - { name: version, value: $(params.version) }
         - { name: oci-registry, value: $(params.oci-registry) }
         - name: delivery-config
-          value: https://github.com/PingCAP-QE/artifacts/raw/main/packages/delivery.yaml
+          value: https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/packages/delivery.yaml
       taskRef:
         name: wait-delivery-images
     - name: compose-offline-pkgs-amd64-community

--- a/tekton/v1/tasks/delivery/pingcap-deliver-images.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-deliver-images.yaml
@@ -22,10 +22,10 @@ spec:
         - images-info # yaml/json content that stored images information return by image build task
     - name: delivery-config-url
       description: URL of the delivery configuration file
-      default: https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/packages/delivery.yaml
+      default: https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/packages/delivery.yaml
     - name: generator-script-url
       description: URL of the generator script
-      default: https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/packages/scripts/gen-delivery-image-commands.ts
+      default: https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/packages/scripts/gen-delivery-image-commands.ts
     - name: retries
       description: Number of retries for image delivery step
       default: "3"

--- a/tekton/v1/tasks/pingcap-build-binaries-darwin.yaml
+++ b/tekton/v1/tasks/pingcap-build-binaries-darwin.yaml
@@ -135,7 +135,7 @@ spec:
         fi
 
         env_file="/workspace/remote.env"
-        deno run --allow-all https://github.com/PingCAP-QE/artifacts/raw/refs/heads/main/packages/scripts/build-in-darwin-boskos.ts \
+        deno run --allow-all https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/packages/scripts/build-in-darwin-boskos.ts \
           --sshInfoDir ${WORKSPACE_SSH_DIRECTORY_PATH} \
           --sourcePath $(workspaces.source.path) \
           --envFile ${env_file} \

--- a/tekton/v1/tasks/pingcap-get-set-release-version.yaml
+++ b/tekton/v1/tasks/pingcap-get-set-release-version.yaml
@@ -64,7 +64,7 @@ spec:
         - run
         - --allow-read
         - --allow-write
-        - https://github.com/PingCAP-QE/ci/raw/refs/heads/main/scripts/flow/build/versioning-strategy.ts
+        - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/flow/build/versioning-strategy.ts
       args:
         - --git_version_file=/workspace/raw-version.txt
         - --contain_branches_file=/workspace/branches.txt

--- a/tekton/v1/tasks/release/create-pr-to-add-release-anchor-commit.yaml
+++ b/tekton/v1/tasks/release/create-pr-to-add-release-anchor-commit.yaml
@@ -89,7 +89,7 @@ spec:
         echo "pr dest branch: $(cat /workspace/inner-results-branch)"
         echo "pr placeholder version: $(cat /workspace/inner-results-version)"
 
-        deno run --allow-all https://github.com/PingCAP-QE/ci/raw/main/scripts/pingcap/add-placeholder-version-in-readme.ts \
+        deno run --allow-all https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/pingcap/add-placeholder-version-in-readme.ts \
           --owner=${owner} \
           --repo=${repo} \
           --branch=$(cat /workspace/inner-results-branch) \

--- a/tekton/v1/tasks/release/pingcap-create-github-releases.yaml
+++ b/tekton/v1/tasks/release/pingcap-create-github-releases.yaml
@@ -16,12 +16,12 @@ spec:
   steps:
     - name: create-releases
       script: |
-        deno run --allow-all https://github.com/PingCAP-QE/ci/raw/main/scripts/flow/ga/create_github_release.ts \
+        deno run --allow-all https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/flow/ga/create_github_release.ts \
           --version="$(params.version)" \
           --token="$(cat $(workspaces.github.path)/token)"
     - name: create-branches
       onError: continue # it's not so important.
       script: |
-        deno run --allow-net https://github.com/PingCAP-QE/ci/raw/main/scripts/flow/ga/create-patch-release-branches.ts \
+        deno run --allow-net https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/flow/ga/create-patch-release-branches.ts \
           --version="$(params.version)" \
           --token="$(cat $(workspaces.github.path)/token)"

--- a/tekton/v1/tasks/release/tag-and-deliver-rc2ga-on-oci-artifacts.yaml
+++ b/tekton/v1/tasks/release/tag-and-deliver-rc2ga-on-oci-artifacts.yaml
@@ -19,10 +19,10 @@ spec:
       description: force to create tag whether it existed or not.
     - name: delivery-config-url
       description: URL of the delivery configuration file
-      default: https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/packages/delivery.yaml
+      default: https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/packages/delivery.yaml
     - name: generator-script-url
       description: URL of the generator script
-      default: https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/packages/scripts/gen-delivery-image-commands.ts
+      default: https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/packages/scripts/gen-delivery-image-commands.ts
     - name: publisher-url
       description: URL of the publisher service
       default: http://publisher.publisher.svc
@@ -44,7 +44,7 @@ spec:
         registry="$3"
         force="$4"
 
-        wget -c --tries=3 https://github.com/PingCAP-QE/ci/raw/main/scripts/artifacts/tag-rc2ga-on-repos.sh
+        wget -c --tries=3 https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/artifacts/tag-rc2ga-on-repos.sh
         chmod +x tag-rc2ga-on-repos.sh
 
         ./tag-rc2ga-on-repos.sh "$rc_ver" "$ga_ver" "$registry" "$force" /workspace/results.yaml

--- a/tekton/v1/tasks/release/wait-delivery-images.yaml
+++ b/tekton/v1/tasks/release/wait-delivery-images.yaml
@@ -15,13 +15,13 @@ spec:
       default: us-docker.pkg.dev/pingcap-testing-account/hub
       description: The OCI registry stored the origin tarball files.
     - name: delivery-config
-      default: "https://github.com/PingCAP-QE/artifacts/raw/main/packages/delivery.yaml"
+      default: "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/packages/delivery.yaml"
       description: The delivery config yaml file, it contains delivery rules.
   steps:
     - name: compute
       image: docker.io/denoland/deno:alpine-2.1.4
       script: |
-        deno run --allow-all https://github.com/PingCAP-QE/artifacts/raw/main/packages/scripts/get-delivery-target-images.ts \
+        deno run --allow-all https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/packages/scripts/get-delivery-target-images.ts \
           --version="$(params.version)" \
           --registry="$(params.oci-registry)" \
           --config="$(params.delivery-config)" \

--- a/tekton/v1/tasks/release/wait-delivery-tiup.yaml
+++ b/tekton/v1/tasks/release/wait-delivery-tiup.yaml
@@ -33,7 +33,7 @@ spec:
         tiup mirror set $tiup_mirror
 
         # check the tiup pkgs
-        wget --tries 3 -c -O check-tiup.sh https://github.com/PingCAP-QE/ci/raw/main/scripts/artifacts/check-tiup.sh
+        wget --tries 3 -c -O check-tiup.sh https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/artifacts/check-tiup.sh
         chmod +x check-tiup.sh
 
         while true; do


### PR DESCRIPTION
Replace GitHub raw content URLs with jsDelivr CDN URLs for improved reliability and faster downloads across multiple Tekton tasks and pipelines.