### PR TITLE
chore(prow-jobs): remove triggers for release-6.1 branch for documentation repos as it is archived 

### DIFF
--- a/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs-cn/latest-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
       max_concurrency: 5
       branches:
         - ^master$
-        - ^release-6\.[15]$
+        - ^release-6\.5$
         - ^release-7\.[15]$
         - ^release-8\.[15]$
       spec:

--- a/prow-jobs/pingcap/docs/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/docs/latest-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
       max_concurrency: 5
       branches:
         - ^master$
-        - ^release-6\.[15]$
+        - ^release-6\.5$
         - ^release-7\.[15]$
         - ^release-8\.[15]$
       spec:


### PR DESCRIPTION
### What is changed?

- Stop generating TiDB docs PDF updates for `release-6.1`.
- Narrow the `release-6` postsubmit branch regex to keep only `release-6.5`.

### Related context

- Archive date: `2026-07-10`
