### PR TITLE
fix(pipelines): normalize TiFlash image tags

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -238,9 +238,9 @@ pipeline {
                                     docker ps -a && docker version
                                     """
                                     script {
-                                        def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
-                                        def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
-                                        def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
+                                        def pdBranch = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+                                        def tikvBranch = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+                                        def tidbBranch = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
                                         def tidbImage = "${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}"
                                         def tidbFailpointImage = "${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint"
                                         def tidbRuntimeImage = env.TEST_PATH == 'tidb-ci' ? tidbFailpointImage : tidbImage

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -342,9 +342,9 @@ pipeline {
                                         // TODO: check the env TAG, currently the tiflash_commmit_hash is not the pr latest commit hash
                                         // because we checkout tiflash pr code in pre-merge method.
                                         script {
-                                            def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-6.5')
-                                            def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-6.5')
-                                            def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-6.5')
+                                            def pdBranch = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-6.5')
+                                            def tikvBranch = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-6.5')
+                                            def tidbBranch = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-6.5')
                                             sh label: "run integration tests", script: """
                                             PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
                                             """

--- a/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
@@ -342,9 +342,9 @@ pipeline {
                                         // TODO: check the env TAG, currently the tiflash_commmit_hash is not the pr latest commit hash
                                         // because we checkout tiflash pr code in pre-merge method.
                                         script {
-                                            def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-7.1')
-                                            def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-7.1')
-                                            def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-7.1')
+                                            def pdBranch = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-7.1')
+                                            def tikvBranch = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-7.1')
+                                            def tidbBranch = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-7.1')
                                             sh label: "run integration tests", script: """
                                             PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
                                             """

--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -388,9 +388,9 @@ pipeline {
                                         // TODO: check the env TAG, currently the tiflash_commmit_hash is not the pr latest commit hash
                                         // because we checkout tiflash pr code in pre-merge method.
                                         script {
-                                            def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-7.5')
-                                            def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-7.5')
-                                            def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-7.5')
+                                            def pdBranch = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-7.5')
+                                            def tikvBranch = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-7.5')
+                                            def tidbBranch = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-7.5')
                                             sh label: "run integration tests", script: """
                                             PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
                                             """

--- a/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
@@ -344,9 +344,9 @@ pipeline {
                                         echo "path: ${pwd()}"
                                         sh "docker ps -a && docker version"
                                         script {
-                                            def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
-                                            def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
-                                            def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
+                                            def pdBranch = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
+                                            def tikvBranch = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
+                                            def tidbBranch = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'release-8.1')
                                             sh label: "run integration tests", script: """
                                             PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
                                             """

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
@@ -376,9 +376,9 @@ pipeline {
                                         """
                                         script {
                                             def default_match_branch = REFS.base_ref
-                                            def pdBranch = component.computeBranchFromPR('pd', REFS.base_ref, REFS.pulls[0].title, default_match_branch)
-                                            def tikvBranch = component.computeBranchFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, default_match_branch)
-                                            def tidbBranch = component.computeBranchFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, default_match_branch)
+                                            def pdBranch = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, default_match_branch)
+                                            def tikvBranch = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, default_match_branch)
+                                            def tidbBranch = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, default_match_branch)
                                             sh label: "run integration tests", script: """
                                             PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh
                                             """


### PR DESCRIPTION
## Summary
- follow up #4820 by using OCI-safe artifact tags in the remaining TiFlash integration pipelines
- update latest, release-6.5, release-7.1, release-7.5, release-8.1, and release-9.0-beta
- keep the change scoped to TiFlash pipeline groovy files

## Notes
- release-8.5 was already handled in #4820
- remaining computeBranchFromPR usages are in TiCDC binary-download preparation and are left unchanged because they keep branch-selection semantics rather than directly constructing TiFlash dependency image tags

## Verification
- validated all changed Jenkinsfiles with .ci/verify-jenkins-pipeline-file.sh against https://prow.tidb.net/jenkins