### PR TITLE
feat(tools): add zot image validate-repair script and tekton task

### DIFF
--- a/tekton/v1/tasks/kustomization.yaml
+++ b/tekton/v1/tasks/kustomization.yaml
@@ -33,3 +33,4 @@ resources:
   - release/tag-and-deliver-rc2ga-on-oci-artifacts.yaml
   - release/wait-delivery-images.yaml
   - release/wait-delivery-tiup.yaml
+  - zot-validate-repair-image.yaml

--- a/tekton/v1/tasks/zot-validate-repair-image.yaml
+++ b/tekton/v1/tasks/zot-validate-repair-image.yaml
@@ -1,0 +1,254 @@
+# yaml-language-server: $schema=https://github.com/redhat-developer/vscode-tekton/raw/refs/heads/main/scheme/tekton.dev/v1_Task.json
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: zot-validate-repair-image
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/categories: CLI
+    tekton.dev/tags: zot,registry,repair
+    tekton.dev/displayName: "zot validate repair image"
+    tekton.dev/platforms: "linux/amd64,linux/arm64"
+spec:
+  description: >-
+    Validate a zot registry image and repair broken layer blobs by
+    downloading them from a source image and uploading to KSY S3.
+
+    zot stores blobs in S3 at: s3://<bucket>/<repo-path>/blobs/sha256/<digest>
+    where <repo-path> is auto-derived from the target-image URL (e.g.
+    mirrors/hub/pingcap/tiflash/image for hub-zot.pingcap.net/mirrors/hub/pingcap/tiflash/image:tag).
+
+  params:
+    - name: target-image
+      description: The zot registry image URL to validate/repair.
+      type: string
+    - name: source-image
+      description: Source image URL to download healthy blobs from.
+      type: string
+    - name: bucket
+      description: S3 bucket name for blob storage.
+      type: string
+    - name: config-file-path
+      description: Path to ks3util config within the ks3util-config workspace.
+      type: string
+      default: ".ks3utilconfig"
+
+  workspaces:
+    - name: ks3util-config
+      description: Contains the ks3util config file for S3 authentication.
+
+  stepTemplate:
+    env:
+      - name: TARGET_IMAGE
+        value: $(params.target-image)
+      - name: SOURCE_IMAGE
+        value: $(params.source-image)
+      - name: S3_BUCKET
+        value: $(params.bucket)
+      - name: KS3_CONFIG_FILE
+        value: $(params.config-file-path)
+
+  steps:
+    - name: validate
+      image: gcr.io/go-containerregistry/crane/debug:latest
+      env:
+        - name: REPO_PATH
+          value: ""
+      results:
+        - name: broken-digests-file
+          type: string
+      script: |
+        #!/busybox/sh
+        set -e
+
+        BLOB_DIR="/workspace/blob-data"
+        mkdir -p "$BLOB_DIR"
+
+        DIGESTS_FILE="$BLOB_DIR/broken-digests.txt"
+        VALIDATE_LOG="$BLOB_DIR/validate.log"
+
+        echo "=== Validating: $TARGET_IMAGE ==="
+
+        if crane validate --remote "$TARGET_IMAGE" >"$VALIDATE_LOG" 2>&1; then
+          echo "Image is valid. No repair needed."
+          echo -n "" > "$DIGESTS_FILE"
+          echo -n "$DIGESTS_FILE" > "$(step.results.broken-digests-file.path)"
+          exit 0
+        fi
+
+        echo "Image validation FAILED."
+
+        grep -oE 'sha256:[a-f0-9]{64}' "$VALIDATE_LOG" | sort -u > "$DIGESTS_FILE"
+
+        BROKEN_COUNT=$(wc -l < "$DIGESTS_FILE" | tr -d ' ')
+        echo "Broken blob count: $BROKEN_COUNT"
+        echo "Broken digests:"
+        cat "$DIGESTS_FILE"
+
+        echo -n "$DIGESTS_FILE" > "$(step.results.broken-digests-file.path)"
+
+    - name: derive-repo-path
+      image: gcr.io/go-containerregistry/crane/debug:latest
+      results:
+        - name: repo-path
+          type: string
+      script: |
+        #!/busybox/sh
+        set -e
+
+        IMAGE="$TARGET_IMAGE"
+        IMAGE="${IMAGE%%@*}"
+        IMAGE="${IMAGE%%:*}"
+
+        REPO_PATH="${IMAGE#*://}"
+        REPO_PATH="${REPO_PATH#*/}"
+
+        if [ -z "$REPO_PATH" ] || [ "$REPO_PATH" = "$IMAGE" ]; then
+          echo "ERROR: Cannot extract repo path from: $TARGET_IMAGE"
+          exit 1
+        fi
+
+        echo "Repo path: $REPO_PATH"
+        echo -n "$REPO_PATH" > "$(step.results.repo-path.path)"
+
+    - name: download
+      image: gcr.io/go-containerregistry/crane/debug:latest
+      when:
+        - input: "$(steps.validate.results.broken-digests-file)"
+          operator: notin
+          values: [""]
+      results:
+        - name: downloaded
+          type: string
+      script: |
+        #!/busybox/sh
+        set -e
+
+        DIGESTS_FILE="$(steps.validate.results.broken-digests-file)"
+
+        BROKEN_COUNT=$(wc -l < "$DIGESTS_FILE" | tr -d ' ')
+        if [ "$BROKEN_COUNT" -eq 0 ]; then
+          echo "No broken blobs to download."
+          echo -n "false" > "$(step.results.downloaded.path)"
+          exit 0
+        fi
+
+        BLOB_DIR="/workspace/blob-data"
+        mkdir -p "$BLOB_DIR"
+
+        echo "Downloading $BROKEN_COUNT broken blob(s) from: $SOURCE_IMAGE"
+
+        FAILED=0
+        while IFS= read -r DIGEST; do
+          [ -z "$DIGEST" ] && continue
+
+          BLOB_NAME=$(echo "$DIGEST" | tr ':' '_' | tr '/' '_')
+          BLOB_FILE="$BLOB_DIR/$BLOB_NAME"
+
+          echo "--- Downloading $DIGEST ---"
+          if crane blob "${SOURCE_IMAGE}@${DIGEST}" > "$BLOB_FILE" 2>/dev/null; then
+            SIZE=$(wc -c < "$BLOB_FILE" | tr -d ' ')
+            echo "  OK: $SIZE bytes"
+          else
+            echo "  FAILED: could not download $DIGEST"
+            FAILED=$((FAILED + 1))
+          fi
+        done < "$DIGESTS_FILE"
+
+        if [ "$FAILED" -gt 0 ]; then
+          echo "ERROR: $FAILED blob(s) failed to download."
+          exit 1
+        fi
+
+        echo "All blobs downloaded successfully."
+        echo -n "true" > "$(step.results.downloaded.path)"
+
+    - name: upload
+      image: ghcr.io/pingcap-qe/cd/utils/ks3util:v2025.10.26-7-geb77a69
+      when:
+        - input: "$(steps.download.results.downloaded)"
+          operator: in
+          values: ["true"]
+      script: |
+        #!/bin/bash
+        set -e
+
+        REPO_PATH="$(steps.derive-repo-path.results.repo-path)"
+        BLOB_DIR="/workspace/blob-data"
+        DIGESTS_FILE="$(steps.validate.results.broken-digests-file)"
+        CONFIG_FILE="$(workspaces.ks3util-config.path)/${KS3_CONFIG_FILE}"
+
+        if [ ! -f "$CONFIG_FILE" ]; then
+          echo "ERROR: ks3util config file not found at: $CONFIG_FILE"
+          exit 1
+        fi
+
+        KS3UTIL="ks3util --config-file $CONFIG_FILE"
+
+        echo "Repo path: $REPO_PATH"
+        echo "S3 bucket: $S3_BUCKET"
+        echo "S3 prefix : s3://${S3_BUCKET}/${REPO_PATH}/blobs/"
+
+        FAILED=0
+        SUCCESS=0
+        while IFS= read -r DIGEST; do
+          [ -z "$DIGEST" ] && continue
+
+          BLOB_NAME=$(echo "$DIGEST" | tr ':' '_' | tr '/' '_')
+          BLOB_FILE="$BLOB_DIR/$BLOB_NAME"
+
+          ALG="${DIGEST%%:*}"
+          HASH="${DIGEST#*:}"
+          S3_PATH="s3://${S3_BUCKET}/${REPO_PATH}/blobs/${ALG}/${HASH}"
+
+          if [ ! -f "$BLOB_FILE" ]; then
+            echo "--- SKIP $DIGEST (file not found) ---"
+            FAILED=$((FAILED + 1))
+            continue
+          fi
+
+          echo "--- Uploading $DIGEST -> $S3_PATH ---"
+          if $KS3UTIL cp "$BLOB_FILE" "$S3_PATH"; then
+            echo "  OK"
+            SUCCESS=$((SUCCESS + 1))
+          else
+            echo "  FAILED"
+            FAILED=$((FAILED + 1))
+          fi
+        done < "$DIGESTS_FILE"
+
+        echo ""
+        echo "Upload complete: $SUCCESS succeeded, $FAILED failed"
+
+        if [ "$FAILED" -gt 0 ]; then
+          exit 1
+        fi
+
+    - name: re-validate
+      image: gcr.io/go-containerregistry/crane/debug:latest
+      when:
+        - input: "$(steps.download.results.downloaded)"
+          operator: in
+          values: ["true"]
+      script: |
+        #!/busybox/sh
+        set -e
+
+        echo "=== Re-validating: $TARGET_IMAGE ==="
+
+        if crane validate --remote "$TARGET_IMAGE"; then
+          echo ""
+          echo "=============================================="
+          echo "  Repair successful — image is now valid."
+          echo "=============================================="
+          exit 0
+        else
+          echo ""
+          echo "=============================================="
+          echo "  Image still has validation errors."
+          echo "  Manual investigation required."
+          echo "=============================================="
+          exit 1
+        fi

--- a/tekton/v1/tasks/zot-validate-repair-image.yaml
+++ b/tekton/v1/tasks/zot-validate-repair-image.yaml
@@ -18,7 +18,7 @@ spec:
 
     zot stores blobs in S3 at: s3://<bucket>/<repo-path>/blobs/sha256/<digest>
     where <repo-path> is auto-derived from the target-image URL (e.g.
-    mirrors/hub/pingcap/tiflash/image for hub-zot.pingcap.net/mirrors/hub/pingcap/tiflash/image:tag).
+    mirrors/example/image for registry.example.com/mirrors/example/image:tag).
 
   params:
     - name: target-image

--- a/tools/validate-repair-zot-image.sh
+++ b/tools/validate-repair-zot-image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 RED='\033[0;31m'

--- a/tools/validate-repair-zot-image.sh
+++ b/tools/validate-repair-zot-image.sh
@@ -245,14 +245,12 @@ upload_blob() {
     fi
 
     info "Uploading to ${CYAN}$s3_path${NC} ..."
-    ks3util cp "${config_opt[@]}" "$local_file" "$s3_path" 2>&1 | sed 's/^/  /'
-    local ret=${PIPESTATUS[0]}
-
-    if [[ $ret -ne 0 ]]; then
-        error "Upload failed for $digest (exit $ret)."
+    if ks3util cp "${config_opt[@]}" "$local_file" "$s3_path" 2>&1 | sed 's/^/  /'; then
+        info "  -> uploaded successfully."
+    else
+        error "Upload failed for $digest."
         return 1
     fi
-    info "  -> uploaded successfully."
 }
 
 repair_blobs() {

--- a/tools/validate-repair-zot-image.sh
+++ b/tools/validate-repair-zot-image.sh
@@ -1,0 +1,448 @@
+#!/bin/bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+TMPDIR="${TMPDIR:-/tmp}/validate-repair-$$"
+VALIDATE_LOG=""
+
+usage() {
+    cat <<EOF
+${BOLD}validate-repair-zot-image${NC} — Validate a zot registry image and repair broken layer blobs on KSY S3.
+
+${BOLD}Usage:${NC}
+  $0 [options] <remote-image-url>
+
+${BOLD}Arguments:${NC}
+  remote-image-url    Full remote image URL (e.g. registry.example.com/repo/image:tag)
+
+${BOLD}Options:${NC}
+  --source <url>      Source image URL (non-interactive mode)
+  --bucket <name>     S3 bucket name (non-interactive mode)
+  -c, --config-file <path>
+                      ks3util config file path for S3 authentication.
+                      When not set, ks3util uses its default config
+                      (~/.ks3utilconfig).
+  -y, --yes           Auto-confirm all prompts (non-interactive mode)
+
+${BOLD}Description:${NC}
+  1. Runs ${CYAN}crane validate${NC} against the remote image.
+  2. Reports validation result; on failure, lists all broken blob digests.
+  3. Prompts whether to attempt repair.
+  4. If confirmed, asks for a ${CYAN}source image URL${NC} (where healthy blobs live)
+      and target ${CYAN}KSY S3${NC} backend credentials.
+  5. Downloads each broken blob with ${CYAN}crane blob${NC} from the source image.
+  6. Uploads each blob to S3 with ${CYAN}ks3util cp${NC}.
+  7. Re-runs ${CYAN}crane validate${NC} to confirm the fix.
+
+${BOLD}Requirements:${NC}
+  - crane   (go-containerregistry)     https://github.com/google/go-containerregistry
+  - ks3util (Kingsoft Cloud S3 CLI)    https://www.ksyun.com
+
+${BOLD}Authentication:${NC}
+  ks3util reads credentials from a config file. Use --config-file to specify
+  one, otherwise ks3util falls back to its default path (~/.ks3utilconfig).
+  In interactive mode, the script will also prompt for AK/SK/region/endpoint
+  and pass them directly to ks3util.
+
+${BOLD}Non-interactive example:${NC}
+  $0 --source hub-os.pingcap.net/mirrors/hub/pingcap/tiflash/image:v8.5.0 \\
+     --bucket ee-zot \\
+     --config-file /path/to/ks3utilconfig \\
+     --yes \\
+     hub-zot.pingcap.net/mirrors/hub/pingcap/tiflash/image:v8.5.0
+EOF
+}
+
+info()    { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*"; }
+header()  { echo -e "\n${BOLD}${CYAN}=== $* ===${NC}\n"; }
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || { error "Required command '$1' not found in PATH."; exit 1; }
+}
+
+cleanup() {
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+run_validate() {
+    local image="$1"
+    local logfile="$TMPDIR/validate.log"
+
+    header "Validating image: $image"
+    info "Running: crane validate --remote $image"
+
+    set +e
+    crane validate --remote "$image" >"$logfile" 2>&1
+    local ret=$?
+    set -e
+
+    VALIDATE_LOG="$logfile"
+
+    if [[ $ret -eq 0 ]]; then
+        info "Validation ${GREEN}PASSED${NC} — image is intact."
+        return 0
+    fi
+
+    warn "Validation ${RED}FAILED${NC} (exit code $ret)."
+    return 1
+}
+
+extract_broken_digests() {
+    local logfile="$1"
+
+    grep -oE 'sha256:[a-f0-9]{64}' "$logfile" 2>/dev/null \
+        | sort -u \
+        || true
+}
+
+print_validate_errors() {
+    local logfile="$1"
+
+    echo ""
+    echo -e "${BOLD}--- Error details (last 20 lines) ---${NC}"
+    tail -20 "$logfile" | sed 's/^/  /'
+    echo -e "${BOLD}---------------------------------------${NC}"
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+extract_repo_path() {
+    local image="$1"
+
+    # Strip tag or digest
+    image="${image%%@*}"
+    image="${image%%:*}"
+
+    # Strip protocol if any
+    image="${image#*://}"
+
+    # Split host and path: everything after the first '/' is the repo path
+    local repo_path="${image#*/}"
+
+    if [[ -z "$repo_path" || "$repo_path" == "$image" ]]; then
+        error "Cannot extract repo path from image URL: $1"
+        error "Expected format: <registry>/<org>/<repo>[:<tag>|@<digest>]"
+        exit 1
+    fi
+
+    echo "$repo_path"
+}
+
+# ---------------------------------------------------------------------------
+# Repair
+# ---------------------------------------------------------------------------
+
+confirm() {
+    local prompt="$1"
+    local default="${2:-N}"
+    local answer
+
+    if [[ "$default" == "Y" ]]; then
+        read -r -p "$(echo -e "${YELLOW}$prompt [Y/n]: ${NC}")" answer
+        answer="${answer:-Y}"
+    else
+        read -r -p "$(echo -e "${YELLOW}$prompt [y/N]: ${NC}")" answer
+        answer="${answer:-N}"
+    fi
+
+    [[ "$answer" =~ ^[Yy]$ ]]
+}
+
+prompt_required() {
+    local prompt="$1"
+    local env_var="$2"
+    local val
+
+    val="${!env_var:-}"
+    if [[ -n "$val" ]]; then
+        info "Using $env_var from environment."
+        echo "$val"
+        return
+    fi
+
+    while true; do
+        read -r -p "$(echo -e "${CYAN}$prompt: ${NC}")" val
+        if [[ -n "$val" ]]; then
+            echo "$val"
+            return
+        fi
+        warn "This field is required."
+    done
+}
+
+download_blob() {
+    local source_image="$1"
+    local digest="$2"
+    local outfile="$TMPDIR/blobs/${digest//[:\/]/_}"
+
+    mkdir -p "$(dirname "$outfile")"
+
+    info "Downloading blob ${CYAN}$digest${NC} from ${CYAN}$source_image${NC} ..."
+    crane blob "${source_image}@${digest}" > "$outfile" 2>"$TMPDIR/blob-dl.log"
+
+    if [[ ! -s "$outfile" ]]; then
+        error "Downloaded blob is empty or failed for $digest."
+        cat "$TMPDIR/blob-dl.log" >&2
+        return 1
+    fi
+    info "  -> saved $(wc -c < "$outfile" | tr -d ' ') bytes"
+    echo "$outfile"
+}
+
+upload_blob() {
+    local local_file="$1"
+    local digest="$2"
+    local bucket="$3"
+    local repo_path="$4"
+    local config_file="$5"
+
+    local alg="${digest%%:*}"
+    local hash="${digest#*:}"
+
+    local s3_path="s3://${bucket}/${repo_path}/blobs/${alg}/${hash}"
+    local config_opt=()
+    if [[ -n "$config_file" ]]; then
+        config_opt=(--config-file "$config_file")
+    fi
+
+    info "Uploading to ${CYAN}$s3_path${NC} ..."
+    ks3util cp "${config_opt[@]}" "$local_file" "$s3_path" 2>&1 | sed 's/^/  /'
+    local ret=${PIPESTATUS[0]}
+
+    if [[ $ret -ne 0 ]]; then
+        error "Upload failed for $digest (exit $ret)."
+        return 1
+    fi
+    info "  -> uploaded successfully."
+}
+
+repair_blobs() {
+    local source_image="$1"
+    local -n digests_ref=$2
+    local bucket="$3"
+    local repo_path="$4"
+    local config_file="$5"
+
+    local failed=()
+    local repaired=()
+
+    header "Repairing ${#digests_ref[@]} broken blob(s)"
+
+    for digest in "${digests_ref[@]}"; do
+        echo ""
+        info "--- Processing $digest ---"
+
+        local local_file
+        if ! local_file=$(download_blob "$source_image" "$digest"); then
+            failed+=("$digest")
+            continue
+        fi
+
+        if ! upload_blob "$local_file" "$digest" "$bucket" "$repo_path" "$config_file"; then
+            failed+=("$digest")
+            continue
+        fi
+
+        repaired+=("$digest")
+    done
+
+    echo ""
+    if [[ ${#repaired[@]} -gt 0 ]]; then
+        info "${GREEN}Successfully repaired ${#repaired[@]} blob(s):${NC}"
+        for d in "${repaired[@]}"; do echo "    $d"; done
+    fi
+
+    if [[ ${#failed[@]} -gt 0 ]]; then
+        error "${RED}Failed to repair ${#failed[@]} blob(s):${NC}"
+        for d in "${failed[@]}"; do echo "    $d"; done
+        return 1
+    fi
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    require_command crane
+    require_command ks3util
+
+    local remote_image=""
+    local source_image=""
+    local bucket=""
+    local config_file=""
+    local auto_yes=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --source)
+                source_image="$2"
+                shift 2
+                ;;
+            --bucket)
+                bucket="$2"
+                shift 2
+                ;;
+            -c|--config-file)
+                config_file="$2"
+                shift 2
+                ;;
+            -y|--yes)
+                auto_yes=true
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -*)
+                error "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+            *)
+                if [[ -z "$remote_image" ]]; then
+                    remote_image="$1"
+                else
+                    error "Unexpected argument: $1"
+                    usage
+                    exit 1
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "$remote_image" ]]; then
+        usage
+        exit 1
+    fi
+
+    mkdir -p "$TMPDIR"
+
+    # ---- Step 1-3: Validate ----
+
+    if run_validate "$remote_image"; then
+        exit 0
+    fi
+
+    print_validate_errors "$VALIDATE_LOG"
+
+    local broken_digests
+    mapfile -t broken_digests < <(extract_broken_digests "$VALIDATE_LOG")
+
+    if [[ ${#broken_digests[@]} -eq 0 ]]; then
+        warn "No sha256 digests found in error output. Cannot determine broken blobs."
+        error "Raw error log saved at: $VALIDATE_LOG"
+        exit 1
+    fi
+
+    echo -e "\n${BOLD}Broken blob digests (${#broken_digests[@]} total):${NC}"
+    for d in "${broken_digests[@]}"; do
+        echo -e "  ${RED}$d${NC}"
+    done
+    echo ""
+
+    # ---- Step 4: Ask to repair ----
+
+    if ! $auto_yes; then
+        if ! confirm "Do you want to attempt repair?"; then
+            info "Repair skipped. Exiting."
+            exit 1
+        fi
+    fi
+
+    # ---- Step 5: Gather repair info ----
+
+    echo ""
+    if ! $auto_yes; then
+        header "Repair configuration"
+    fi
+
+    if [[ -z "$source_image" ]]; then
+        source_image=$(prompt_required "Source image URL (e.g. registry.example.com/repo/image:tag)" "")
+    else
+        info "Source image: ${CYAN}$source_image${NC}"
+    fi
+
+    local repo_path
+    repo_path=$(extract_repo_path "$remote_image")
+    info "Auto-derived S3 blob prefix from image URL: ${CYAN}${repo_path}/blobs/${NC}"
+
+    if [[ -z "$bucket" ]]; then
+        bucket=$(prompt_required "S3 bucket name" "")
+    else
+        info "S3 bucket: ${CYAN}$bucket${NC}"
+    fi
+
+    if [[ -n "$config_file" ]]; then
+        info "Using ks3util config file: ${CYAN}$config_file${NC}"
+        if [[ ! -f "$config_file" ]]; then
+            error "Config file not found: $config_file"
+            exit 1
+        fi
+    else
+        info "No --config-file specified, ks3util will use default config (~/.ks3utilconfig)."
+    fi
+
+    # ---- Show summary and confirm ----
+
+    echo ""
+    header "Summary"
+    echo -e "  ${BOLD}Target image:${NC}    $remote_image"
+    echo -e "  ${BOLD}Source image:${NC}    $source_image"
+    echo -e "  ${BOLD}S3 bucket:${NC}      $bucket"
+    echo -e "  ${BOLD}S3 blob path:${NC}    s3://${bucket}/${repo_path}/blobs/<alg>/<digest>"
+    if [[ -n "$config_file" ]]; then
+        echo -e "  ${BOLD}Config file:${NC}     $config_file"
+    else
+        echo -e "  ${BOLD}Config file:${NC}     (ks3util default)"
+    fi
+    echo -e "  ${BOLD}Blobs to repair:${NC} ${#broken_digests[@]}"
+    echo ""
+
+    if ! $auto_yes; then
+        if ! confirm "Proceed with repair?" "Y"; then
+            info "Repair cancelled. Exiting."
+            exit 1
+        fi
+    fi
+
+    # ---- Step 6-7: Download & Upload ----
+
+    repair_blobs "$source_image" broken_digests "$bucket" "$repo_path" "$config_file" || {
+        error "Some blobs could not be repaired. See above for details."
+    }
+
+    # ---- Step 8: Re-validate ----
+
+    if run_validate "$remote_image"; then
+        info "${GREEN}Repair successful — image is now valid.${NC}"
+        exit 0
+    else
+        print_validate_errors "$VALIDATE_LOG"
+        warn "Image still has validation errors after repair."
+        warn "You may need to repair additional blobs or check S3 connectivity."
+        exit 1
+    fi
+}
+
+main "$@"

--- a/tools/validate-repair-zot-image.sh
+++ b/tools/validate-repair-zot-image.sh
@@ -51,11 +51,11 @@ ${BOLD}Authentication:${NC}
   and pass them directly to ks3util.
 
 ${BOLD}Non-interactive example:${NC}
-  $0 --source hub-os.pingcap.net/mirrors/hub/pingcap/tiflash/image:v8.5.0 \\
-     --bucket ee-zot \\
+  $0 --source source-registry.example.com/mirrors/example/image:tag \\
+     --bucket my-bucket \\
      --config-file /path/to/ks3utilconfig \\
      --yes \\
-     hub-zot.pingcap.net/mirrors/hub/pingcap/tiflash/image:v8.5.0
+     target-registry.example.com/mirrors/example/image:tag
 EOF
 }
 

--- a/tools/validate-repair-zot-image.sh
+++ b/tools/validate-repair-zot-image.sh
@@ -29,6 +29,7 @@ ${BOLD}Options:${NC}
                       When not set, ks3util uses its default config
                       (~/.ks3utilconfig).
   -y, --yes           Auto-confirm all prompts (non-interactive mode)
+  --max-retries <n>   Max download/upload attempts per blob (default: 3)
 
 ${BOLD}Description:${NC}
   1. Runs ${CYAN}crane validate${NC} against the remote image.
@@ -201,7 +202,29 @@ download_blob() {
         cat "$TMPDIR/blob-dl.log" >&2
         return 1
     fi
-    info "  -> saved $(wc -c < "$outfile" | tr -d ' ') bytes"
+
+    local hash="${digest#*:}"
+    local downloaded_hash
+    if command -v sha256sum >/dev/null 2>&1; then
+        downloaded_hash=$(sha256sum "$outfile" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        downloaded_hash=$(shasum -a 256 "$outfile" | awk '{print $1}')
+    else
+        error "No sha256sum or shasum found, cannot verify blob integrity."
+        return 1
+    fi
+
+    if [[ "$downloaded_hash" != "$hash" ]]; then
+        error "Blob integrity check failed for $digest."
+        error "  expected: $hash"
+        error "  got:      $downloaded_hash"
+        rm -f "$outfile"
+        return 1
+    fi
+
+    local size
+    size=$(wc -c < "$outfile" | tr -d ' ')
+    info "  -> saved $size bytes (digest verified)"
     echo "$outfile"
 }
 
@@ -238,6 +261,7 @@ repair_blobs() {
     local bucket="$3"
     local repo_path="$4"
     local config_file="$5"
+    local max_retries="${6:-3}"
 
     local failed=()
     local repaired=()
@@ -248,18 +272,35 @@ repair_blobs() {
         echo ""
         info "--- Processing $digest ---"
 
-        local local_file
-        if ! local_file=$(download_blob "$source_image" "$digest"); then
-            failed+=("$digest")
-            continue
-        fi
+        local retry=0
+        local local_file=""
+        local ok=false
 
-        if ! upload_blob "$local_file" "$digest" "$bucket" "$repo_path" "$config_file"; then
-            failed+=("$digest")
-            continue
-        fi
+        while (( retry < max_retries )); do
+            if (( retry > 0 )); then
+                warn "  Retry $retry/$((max_retries - 1)) for $digest ..."
+            fi
 
-        repaired+=("$digest")
+            if ! local_file=$(download_blob "$source_image" "$digest"); then
+                retry=$((retry + 1))
+                continue
+            fi
+
+            if ! upload_blob "$local_file" "$digest" "$bucket" "$repo_path" "$config_file"; then
+                retry=$((retry + 1))
+                continue
+            fi
+
+            ok=true
+            break
+        done
+
+        if $ok; then
+            repaired+=("$digest")
+        else
+            error "Failed to repair $digest after $max_retries attempt(s)."
+            failed+=("$digest")
+        fi
     done
 
     echo ""
@@ -290,6 +331,7 @@ main() {
     local bucket=""
     local config_file=""
     local auto_yes=false
+    local max_retries=3
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -303,6 +345,10 @@ main() {
                 ;;
             -c|--config-file)
                 config_file="$2"
+                shift 2
+                ;;
+            --max-retries)
+                max_retries="$2"
                 shift 2
                 ;;
             -y|--yes)
@@ -428,7 +474,7 @@ main() {
 
     # ---- Step 6-7: Download & Upload ----
 
-    repair_blobs "$source_image" broken_digests "$bucket" "$repo_path" "$config_file" || {
+    repair_blobs "$source_image" broken_digests "$bucket" "$repo_path" "$config_file" "$max_retries" || {
         error "Some blobs could not be repaired. See above for details."
     }
 

--- a/tools/validate-repair-zot-image.sh
+++ b/tools/validate-repair-zot-image.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+CYAN=$'\033[0;36m'
+BOLD=$'\033[1m'
+NC=$'\033[0m'
 
 TMPDIR="${TMPDIR:-/tmp}/validate-repair-$$"
 VALIDATE_LOG=""
@@ -60,10 +60,10 @@ ${BOLD}Non-interactive example:${NC}
 EOF
 }
 
-info()    { echo -e "${GREEN}[INFO]${NC}  $*"; }
-warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
-error()   { echo -e "${RED}[ERROR]${NC} $*"; }
-header()  { echo -e "\n${BOLD}${CYAN}=== $* ===${NC}\n"; }
+info()    { echo "${GREEN}[INFO]${NC}  $*"; }
+warn()    { echo "${YELLOW}[WARN]${NC}  $*"; }
+error()   { echo "${RED}[ERROR]${NC} $*"; }
+header()  { echo; echo "${BOLD}${CYAN}=== $* ===${NC}"; echo; }
 
 require_command() {
     command -v "$1" >/dev/null 2>&1 || { error "Required command '$1' not found in PATH."; exit 1; }
@@ -113,9 +113,9 @@ print_validate_errors() {
     local logfile="$1"
 
     echo ""
-    echo -e "${BOLD}--- Error details (last 20 lines) ---${NC}"
+    echo "${BOLD}--- Error details (last 20 lines) ---${NC}"
     tail -20 "$logfile" | sed 's/^/  /'
-    echo -e "${BOLD}---------------------------------------${NC}"
+    echo "${BOLD}---------------------------------------${NC}"
     echo ""
 }
 
@@ -155,10 +155,10 @@ confirm() {
     local answer
 
     if [[ "$default" == "Y" ]]; then
-        read -r -p "$(echo -e "${YELLOW}$prompt [Y/n]: ${NC}")" answer
+        read -r -p "$(echo "${YELLOW}$prompt [Y/n]: ${NC}")" answer
         answer="${answer:-Y}"
     else
-        read -r -p "$(echo -e "${YELLOW}$prompt [y/N]: ${NC}")" answer
+        read -r -p "$(echo "${YELLOW}$prompt [y/N]: ${NC}")" answer
         answer="${answer:-N}"
     fi
 
@@ -178,7 +178,7 @@ prompt_required() {
     fi
 
     while true; do
-        read -r -p "$(echo -e "${CYAN}$prompt: ${NC}")" val
+        read -r -p "$(echo "${CYAN}$prompt: ${NC}")" val
         if [[ -n "$val" ]]; then
             echo "$val"
             return
@@ -399,9 +399,10 @@ main() {
         exit 1
     fi
 
-    echo -e "\n${BOLD}Broken blob digests (${#broken_digests[@]} total):${NC}"
+    echo
+    echo "${BOLD}Broken blob digests (${#broken_digests[@]} total):${NC}"
     for d in "${broken_digests[@]}"; do
-        echo -e "  ${RED}$d${NC}"
+        echo "  ${RED}$d${NC}"
     done
     echo ""
 
@@ -451,16 +452,16 @@ main() {
 
     echo ""
     header "Summary"
-    echo -e "  ${BOLD}Target image:${NC}    $remote_image"
-    echo -e "  ${BOLD}Source image:${NC}    $source_image"
-    echo -e "  ${BOLD}S3 bucket:${NC}      $bucket"
-    echo -e "  ${BOLD}S3 blob path:${NC}    s3://${bucket}/${repo_path}/blobs/<alg>/<digest>"
+    echo "  ${BOLD}Target image:${NC}    $remote_image"
+    echo "  ${BOLD}Source image:${NC}    $source_image"
+    echo "  ${BOLD}S3 bucket:${NC}      $bucket"
+    echo "  ${BOLD}S3 blob path:${NC}    s3://${bucket}/${repo_path}/blobs/<alg>/<digest>"
     if [[ -n "$config_file" ]]; then
-        echo -e "  ${BOLD}Config file:${NC}     $config_file"
+        echo "  ${BOLD}Config file:${NC}     $config_file"
     else
-        echo -e "  ${BOLD}Config file:${NC}     (ks3util default)"
+        echo "  ${BOLD}Config file:${NC}     (ks3util default)"
     fi
-    echo -e "  ${BOLD}Blobs to repair:${NC} ${#broken_digests[@]}"
+    echo "  ${BOLD}Blobs to repair:${NC} ${#broken_digests[@]}"
     echo ""
 
     if ! $auto_yes; then


### PR DESCRIPTION
## Summary

Add a shell script and Tekton task to validate and repair broken layer blobs for zot registry images on KSY S3 backend.

## Changes

### `tools/validate-repair-zot-image.sh`
- Shell script that validates remote images with `crane validate`
- Extracts broken blob digests from validation errors
- Downloads healthy blobs from a source image with `crane blob`
- Uploads blobs to S3 with `ks3util cp`
- Re-validates after repair
- Supports interactive and non-interactive (`--yes`) modes
- Uses `--config-file` for ks3util authentication

### `tekton/v1/tasks/zot-validate-repair-image.yaml`
- Tekton v1 Task wrapping the repair workflow
- Multi-step: validate → download → upload → re-validate
- Uses `crane/debug` and `ks3util` images per step
- Configurable via params: `target-image`, `source-image`, `bucket`
- ks3util auth via workspace-mounted config file
- Conditional step execution using step results

### `tekton/v1/tasks/kustomization.yaml`
- Register the new task in kustomization

## Testing

- Shell script: syntax-validated with `bash -n`
- Tekton task YAML: validated with `yq`