### PR TITLE
fix(tools): guard indirect variable expansion against empty env_var

### DIFF
--- a/tools/validate-repair-zot-image.sh
+++ b/tools/validate-repair-zot-image.sh
@@ -170,11 +170,13 @@ prompt_required() {
     local env_var="$2"
     local val
 
-    val="${!env_var:-}"
-    if [[ -n "$val" ]]; then
-        info "Using $env_var from environment."
-        echo "$val"
-        return
+    if [[ -n "${env_var:-}" ]]; then
+        val="${!env_var:-}"
+        if [[ -n "$val" ]]; then
+            info "Using $env_var from environment."
+            echo "$val"
+            return
+        fi
     fi
 
     while true; do


### PR DESCRIPTION
## Problem

`tools/validate-repair-zot-image.sh` crashes with:

```
./validate-repair-zot-image.sh: line 173: : invalid variable name
```

## Root cause

In `prompt_required()`, the line `val="${!env_var:-}"` performs indirect variable expansion. When callers pass an empty string as `env_var` (e.g. `prompt_required "some prompt" ""`), this expands to `${!:-}` — trying to dereference a variable with an empty name, which is invalid in bash.

## Fix

Guard the indirect expansion with a check for non-empty `env_var` before attempting expansion.