### PR TITLE
fix(prow-jobs): restore prow jobs crawler script URL

### DIFF
--- a/prow-jobs/pingcap-qe/ci/periodics.yaml
+++ b/prow-jobs/pingcap-qe/ci/periodics.yaml
@@ -19,7 +19,7 @@ periodics:
             - deno
             - run
             - --allow-net
-            - insight/crawlers/ci/prow-jobs.ts
+            - https://github.com/PingCAP-QE/ee-apps/raw/main/insight/crawlers/ci/prow-jobs.ts
           args: [--dsn=$(DSN)]
           env:
             - name: DSN


### PR DESCRIPTION
Summary:
- Restore periodic-crawl-ci-run-data to run the prow_jobs crawler from the ee-apps raw URL.
- The previous relative path points at PingCAP-QE/ci, where the insight crawler does not exist.

Tests:
- .ci/update-prow-job-kustomization.sh
- python3 text assertion for the periodic config
- curl the ee-apps raw crawler URL

Notes:
- deno cache was not run locally because deno is not installed in this workspace.