### PR TITLE
chore(configs): update error-log-review approvers

### DIFF
--- a/configs/error-log-review/config.yaml
+++ b/configs/error-log-review/config.yaml
@@ -12,15 +12,13 @@ repositories:
         regex: '(?:^|\s)(?:(?:[^)]+\.)?(?:log|logutil|logger|brlog)(?:\.(?:L\(\)|CL\([^)]*\)|FromContext\([^)]*\)|Logger\([^)]*\)|[A-Za-z]+Logger\([^)]*\))\)?)?)\.(Error|Panic|Fatal|Fatalf|Fatalln)\(\s*([^,)]+?)(?:\s*,\s*[^)]+?)?\s*\)'
     approvers:
       - "zanmato1984"
-      - "fixdb"
       - "windtalker"
-      - "Benjamin2037"
       - "bb7133"
       - "terry1purcell"
       - "cfzjywxk"
       - "niubell"
       - "nongfushanquan"
-      - "BornChanger"
+      - "v01dstar"
       - "xuhuaiyu"
       - "YuJuncen"
 
@@ -44,7 +42,7 @@ repositories:
         description: "Pattern for variables and function calls"
         regex: '(?:^|\s)(?:(?:[^)]+\.)?(?:log|logutil|logger|brlog)(?:\.(?:L\(\)|CL\([^)]*\)|FromContext\([^)]*\)|Logger\([^)]*\)|[A-Za-z]+Logger\([^)]*\))\)?)?)\.(Error|Panic|Fatal|Fatalf|Fatalln)\(\s*([^,)]+?)(?:\s*,\s*[^)]+?)?\s*\)'
     approvers:
-      - "Benjamin2037"
+      - "bb7133"
       - "nongfushanquan"
 
   - name: "pingcap/ticdc"
@@ -73,7 +71,6 @@ repositories:
         regex: '(?:^|\s)error!\s*(\?%?\w+(?:\s*,\s*[^)]*)?)'
     approvers:
       - "zhangjinpeng87"
-      - "BornChanger"
       - "YuJuncen"
 
   - name: "pingcap/tiflash"
@@ -89,7 +86,8 @@ repositories:
         regex: '(?:^|\s)LOG_(ERROR|FATAL)\s*\(\s*[^,]+,\s*([^,)]+?)(?:\s*,\s*[^)]+)?\s*\)'
     approvers:
       - "windtalker"
-      - "kolafish"
+      - "JaySon-Huang"
+      - "zhangjinpeng87"
 
 # Global settings
 settings:


### PR DESCRIPTION
Update approvers in `configs/error-log-review/config.yaml`:

- **tidb**: Remove `fixdb`, replace `BornChanger` with `v01dstar`, deduplicate `bb7133` after replacing `Benjamin2037`
- **tikv/tikv**: Remove `BornChanger`
- **tiflow**: Replace `Benjamin2037` with `bb7133`
- **tiflash**: Replace `kolafish` with `JaySon-Huang`, add `zhangjinpeng87`

All approver lists are deduplicated per repo.