### PR TITLE
fix(tasks): move step result substitutions to env for Tekton v1 compliance + add presubmit to validate Tekton YAML with server dry-run

### DIFF
--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -117,6 +117,42 @@ presubmits:
                 memory: 256Mi
                 cpu: 200m
 
+    - name: pull-verify-tekton-yaml
+      labels: *labels
+      decorate: true
+      max_concurrency: 1
+      run_if_changed: "^tekton/v1/.*\\.yaml$"
+      branches:
+        - ^main$
+      spec:
+        containers:
+          - name: main
+            image: alpine:3.24
+            command: [sh, -ce]
+            args:
+              - |
+                apk add --no-cache kubectl yq-go git
+                changed_files=$(git diff --name-only --diff-filter=d "${PULL_BASE_SHA:?}" -- 'tekton/v1/**/*.yaml' | LC_ALL=C sort)
+                if [ -z "$changed_files" ]; then
+                  echo "No changed Tekton YAML files to verify."
+                  exit 0
+                fi
+                failed=0
+                for f in $changed_files; do
+                  echo "Validating: $f"
+                  if ! kubectl apply --dry-run=server -f "$f" 2>&1 | sed 's/^/  /'; then
+                    failed=1
+                  fi
+                done
+                if [ "$failed" -eq 0 ]; then
+                  echo "All Tekton YAML files passed server dry-run validation."
+                fi
+                exit $failed
+            resources:
+              limits:
+                memory: 256Mi
+                cpu: 200m
+
     - name: pull-test-jenkins-libraries
       labels: *labels
       decorate: true

--- a/tekton/v1/tasks/zot-validate-repair-image.yaml
+++ b/tekton/v1/tasks/zot-validate-repair-image.yaml
@@ -119,14 +119,15 @@ spec:
         - input: "$(steps.validate.results.broken-digests-file)"
           operator: notin
           values: [""]
+      env:
+        - name: DIGESTS_FILE
+          value: $(steps.validate.results.broken-digests-file)
       results:
         - name: downloaded
           type: string
       script: |
         #!/busybox/sh
         set -e
-
-        DIGESTS_FILE="$(steps.validate.results.broken-digests-file)"
 
         BROKEN_COUNT=$(wc -l < "$DIGESTS_FILE" | tr -d ' ')
         if [ "$BROKEN_COUNT" -eq 0 ]; then
@@ -171,13 +172,16 @@ spec:
         - input: "$(steps.download.results.downloaded)"
           operator: in
           values: ["true"]
+      env:
+        - name: REPO_PATH
+          value: $(steps.derive-repo-path.results.repo-path)
+        - name: DIGESTS_FILE
+          value: $(steps.validate.results.broken-digests-file)
       script: |
         #!/bin/bash
         set -e
 
-        REPO_PATH="$(steps.derive-repo-path.results.repo-path)"
         BLOB_DIR="/workspace/blob-data"
-        DIGESTS_FILE="$(steps.validate.results.broken-digests-file)"
         CONFIG_FILE="$(workspaces.ks3util-config.path)/${KS3_CONFIG_FILE}"
 
         if [ ! -f "$CONFIG_FILE" ]; then


### PR DESCRIPTION
## Changes

1. **fix(tasks/zot-validate-repair-image)**: Move cross-step result references (`$(steps.<name>.results.<name>)`) from `script` to `env` — the Tekton v1 admission webhook rejects these in `script` fields.

2. **ci(prow)**: Add `pull-verify-tekton-yaml` presubmit that runs `kubectl apply --dry-run=server` on changed `tekton/v1/**/*.yaml` files, preventing similar admission webhook rejections from reaching main.

## Verification

- Server dry-run of the fixed task YAML passes: ✅
- Original task YAML (before fix) fails with the same admission webhook error: ❌

Closes the issue where `tekton-config-tasks` kustomization was in `Ready=False` state due to webhook rejection.