### PR TITLE
fix(prow-jobs): add step markers to ee-infra tofu commands

### DIFF
--- a/prow-jobs/pingcap-qe/ee-infra/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ee-infra/presubmits.yaml
@@ -20,9 +20,13 @@ presubmits:
             args:
               - |
                 cd terraform/gcp/pingcap-testing-account
+                echo "🔧 tofu fmt"
                 tofu fmt -check -recursive
+                echo "📦 tofu init"
                 tofu init -backend=false
+                echo "🔍 tofu validate"
                 tofu validate
+                echo "📋 tofu plan"
                 tofu plan -input=false
             resources:
               limits:
@@ -46,9 +50,13 @@ presubmits:
             args:
               - |
                 cd terraform/tencentcloud/tidb-cicd
+                echo "🔧 tofu fmt"
                 tofu fmt -check -recursive
+                echo "📦 tofu init"
                 tofu init -backend=false
+                echo "🔍 tofu validate"
                 tofu validate
+                echo "📋 tofu plan"
                 tofu plan -input=false
             env:
               - name: TENCENTCLOUD_SECRET_ID


### PR DESCRIPTION
Add `echo "::group::<step-name>"` before each tofu command in ee-infra presubmit jobs so that when a step fails, the log clearly shows which step was running.

Both gcp and tencentcloud jobs are updated.