### PR TITLE
chore(prow-jobs): replace raw GitHub URLs with jsdelivr CDN

### DIFF
--- a/prow-jobs/pingcap-inc/enterprise-extensions/postsubmits.yaml
+++ b/prow-jobs/pingcap-inc/enterprise-extensions/postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
               - deno
               - run
               - --allow-all
-              - https://github.com/PingCAP-QE/ci/raw/main/scripts/plugins/update-submodule.ts
+              - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/plugins/update-submodule.ts
             args:
               - --github_private_token=$(GITHUB_API_TOKEN)
               - --owner=pingcap
@@ -61,7 +61,7 @@ postsubmits:
                 deno,
                 run,
                 --allow-all,
-                https://github.com/PingCAP-QE/ci/raw/main/scripts/plugins/update-submodule.ts,
+                https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/plugins/update-submodule.ts,
               ]
             args:
               - --github_private_token=$(GITHUB_API_TOKEN)

--- a/prow-jobs/pingcap-inc/tici/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tici/presubmits.yaml
@@ -108,7 +108,7 @@ presubmits:
                 mkdir -p /cache
                 wget -qO - https://quickwit-datasets-public.s3.amazonaws.com/hdfs-logs-multitenants.json.gz | gzip -d - > /cache/hdfs-logs-multitenants.json
                 echo "Preparing TiFlash from OCI registry..."
-                oci_script=/tmp/download_pingcap_oci_artifact.sh; wget -qO "$oci_script" https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/artifacts/download_pingcap_oci_artifact.sh || { echo "Failed to download OCI script"; exit 1; }
+                oci_script=/tmp/download_pingcap_oci_artifact.sh; wget -qO "$oci_script" https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/artifacts/download_pingcap_oci_artifact.sh || { echo "Failed to download OCI script"; exit 1; }
                 mkdir -p "${TIUP_HOME}/components/tiflash/${TIFLASH_VERSION}"
                 ( cd "${TIUP_HOME}/components/tiflash/${TIFLASH_VERSION}" && bash "$oci_script" --tiflash="${TIFLASH_VERSION}" )
                 echo "TiFlash ready in ${TIUP_HOME}/components/tiflash/${TIFLASH_VERSION}"

--- a/prow-jobs/pingcap-inc/tiflash-scripts/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/tiflash-scripts/presubmits.yaml
@@ -143,7 +143,7 @@ presubmits:
                 fi
 
                 oci_script=/tmp/download_pingcap_oci_artifact.sh
-                curl -fsSL https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/artifacts/download_pingcap_oci_artifact.sh -o "${oci_script}"
+                curl -fsSL https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/artifacts/download_pingcap_oci_artifact.sh -o "${oci_script}"
 
                 artifact_dir=/tmp/oci-artifacts
                 rm -rf "${artifact_dir}"

--- a/prow-jobs/pingcap/community/postsubmits.yaml
+++ b/prow-jobs/pingcap/community/postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
               - deno
               - run
               - --allow-all
-              - https://github.com/PingCAP-QE/ci/raw/main/scripts/pingcap/community/update-prow-owners.ts
+              - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/pingcap/community/update-prow-owners.ts
             args:
               - --owner=pingcap
               - --github_private_token=$(GITHUB_API_TOKEN)
@@ -55,7 +55,7 @@ postsubmits:
               - deno
               - run
               - --allow-all
-              - https://github.com/PingCAP-QE/ci/raw/main/scripts/pingcap/community/update-prow-owners.ts
+              - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/pingcap/community/update-prow-owners.ts
             args:
               - --owner=pingcap
               - --only_repo.repo=tidb

--- a/prow-jobs/pingcap/ng-monitoring/postsubmits.yaml
+++ b/prow-jobs/pingcap/ng-monitoring/postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
               - deno
               - run
               - --allow-all
-              - https://github.com/PingCAP-QE/ci/raw/main/scripts/plugins/update-submodule.ts
+              - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/plugins/update-submodule.ts
             args:
               - --github_private_token=$(GITHUB_API_TOKEN)
               - --owner=pingcap
@@ -59,7 +59,7 @@ postsubmits:
               - deno
               - run
               - --allow-all
-              - https://github.com/PingCAP-QE/ci/raw/main/scripts/plugins/update-submodule.ts
+              - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/plugins/update-submodule.ts
             args:
               - --github_private_token=$(GITHUB_API_TOKEN)
               - --owner=pingcap

--- a/prow-jobs/pingcap/ticdc/common-postsubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/common-postsubmits.yaml
@@ -18,7 +18,7 @@ postsubmits:
               - deno
               - run
               - --allow-all
-              - https://github.com/PingCAP-QE/ci/raw/main/scripts/plugins/sync-owners-to-release.ts
+              - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/plugins/sync-owners-to-release.ts
             args:
               - --owner=$(REPO_OWNER)
               - --repository=$(REPO_NAME)

--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -224,7 +224,7 @@ presubmits:
                   echo "JOB_TYPE is batch, skipping error log review check"
                   exit 0
                 fi
-                wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
+                wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"

--- a/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-binlog/latest-presubmits.yaml
@@ -123,7 +123,7 @@ presubmits:
               - |
                 trap 'touch /tools/run.done' EXIT
                 curl -fsSL --retry 3 \
-                  https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/pingcap/tidb-binlog/pull_integration_test.sh \
+                  https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/pingcap/tidb-binlog/pull_integration_test.sh \
                   -o /tmp/pull_integration_test.sh
                 bash /tmp/pull_integration_test.sh
             resources:

--- a/prow-jobs/pingcap/tidb/common-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/common-postsubmits.yaml
@@ -20,7 +20,7 @@ postsubmits:
             command: [bash, -ce]
             args:
               - |
-                curl -L -O https://github.com/PingCAP-QE/ci/raw/main/scripts/pingcap/tidb/auto-handle-tidb-test-pr.py
+                curl -L -O https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/pingcap/tidb/auto-handle-tidb-test-pr.py
                 echo $PULL_BASE_SHA
                 echo $PULL_BASE_REF
                 python3 auto-handle-tidb-test-pr.py
@@ -134,7 +134,7 @@ postsubmits:
               - deno
               - run
               - --allow-all
-              - https://github.com/PingCAP-QE/ci/raw/main/scripts/plugins/sync-owners-to-release.ts
+              - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/plugins/sync-owners-to-release.ts
             args:
               - --owner=$(REPO_OWNER)
               - --repository=$(REPO_NAME)

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -285,7 +285,7 @@ presubmits:
                   echo "JOB_TYPE is batch, skipping error log review check"
                   exit 0
                 fi
-                wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
+                wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@eb8212b575c315a2d127ec71cc5a653bc4cba54f \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"

--- a/prow-jobs/pingcap/tiflash/common-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/common-postsubmits.yaml
@@ -18,7 +18,7 @@ postsubmits:
               - deno
               - run
               - --allow-all
-              - https://github.com/PingCAP-QE/ci/raw/main/scripts/plugins/sync-owners-to-release.ts
+              - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/plugins/sync-owners-to-release.ts
             args:
               - --owner=$(REPO_OWNER)
               - --repository=$(REPO_NAME)

--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -231,7 +231,7 @@ presubmits:
                   echo "JOB_TYPE is batch, skipping error log review check"
                   exit 0
                 fi
-                wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
+                wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"

--- a/prow-jobs/pingcap/tiflow/common-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/common-postsubmits.yaml
@@ -110,7 +110,7 @@ postsubmits:
               - deno
               - run
               - --allow-all
-              - https://github.com/PingCAP-QE/ci/raw/main/scripts/plugins/sync-owners-to-release.ts
+              - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/plugins/sync-owners-to-release.ts
             args:
               - --owner=$(REPO_OWNER)
               - --repository=$(REPO_NAME)

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -215,7 +215,7 @@ presubmits:
                   echo "JOB_TYPE is batch, skipping error log review check"
                   exit 0
                 fi
-                wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
+                wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"

--- a/prow-jobs/tikv/community/postsubmits.yaml
+++ b/prow-jobs/tikv/community/postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
               - deno
               - run
               - --allow-all
-              - https://github.com/PingCAP-QE/ci/raw/main/scripts/pingcap/community/update-prow-owners.ts
+              - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/pingcap/community/update-prow-owners.ts
             args:
               - --owner=tikv
               - --github_private_token=$(GITHUB_API_TOKEN)

--- a/prow-jobs/tikv/pd/latest-presubmits.yaml
+++ b/prow-jobs/tikv/pd/latest-presubmits.yaml
@@ -123,7 +123,7 @@ presubmits:
                   echo "JOB_TYPE is batch, skipping error log review check"
                   exit 0
                 fi
-                wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
+                wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"

--- a/prow-jobs/tikv/tikv/latest-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/latest-presubmits.yaml
@@ -96,7 +96,7 @@ presubmits:
                   echo "JOB_TYPE is batch, skipping error log review check"
                   exit 0
                 fi
-                wget -O /tmp/config.yaml https://raw.githubusercontent.com/pingcap-qe/ci/main/configs/error-log-review/config.yaml
+                wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
                 go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"


### PR DESCRIPTION
## Summary

Replace all raw.githubusercontent.com and github.com/.../raw/ URLs referencing PingCAP-QE/ci and pingcap-qe/ci in Prow presubmit/postsubmit configs with cdn.jsdelivr.net/gh equivalents.

## Changes

- **17 files** modified in `prow-jobs/`
- ~21 occurrences: `raw.githubusercontent.com` (9) and `github.com/.../raw/` (12) → `cdn.jsdelivr.net/gh`
- No logic changes — URL transport only

## Testing

- CI will run Prow job config validation after merge
- Error log review jobs and artifact download scripts use the same refs, no functional change

## Risk

Low. jsdelivr CDN is the established pattern (already used in tekton/v1/tasks/). Rollback is git revert.