### PR TITLE
feat(pipelines): replace raw GitHub URLs with jsDelivr CDN

### DIFF
--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -61,7 +61,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pod-test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pod-test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pod-test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pod-test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pod-test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pod-test.yaml
@@ -58,7 +58,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_kafka_integration_heavy.yaml
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_kafka_integration_heavy.yaml
@@ -58,7 +58,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_kafka_integration_light.yaml
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pod-pull_cdc_kafka_integration_light.yaml
@@ -58,7 +58,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tidb/release-6.5/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_tiflash_test.groovy
@@ -67,7 +67,7 @@ pipeline {
                     }
                     dir("build-docker-image") {
                         sh label: 'generate dockerfile', script: """
-                        curl -o tidb.Dockerfile https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/tidb.Dockerfile
+                        curl -o tidb.Dockerfile https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/tidb.Dockerfile
                         cat tidb.Dockerfile
                         cp ../tidb/bin/tidb-server tidb-server
                         ./tidb-server -V

--- a/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/latest/pod-pull_cdc_integration_kafka_test.yaml
@@ -61,7 +61,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pod-pull_cdc_integration_kafka_test.yaml
@@ -62,7 +62,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-6.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -59,7 +59,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.1/pod-pull_cdc_integration_kafka_test.yaml
@@ -61,7 +61,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.2/pod-pull_cdc_integration_kafka_test.yaml
@@ -62,7 +62,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.3/pod-pull_cdc_integration_kafka_test.yaml
@@ -62,7 +62,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.4/pod-pull_cdc_integration_kafka_test.yaml
@@ -62,7 +62,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -61,7 +61,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-7.6/pod-pull_cdc_integration_kafka_test.yaml
@@ -62,7 +62,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.0/pod-pull_cdc_integration_kafka_test.yaml
@@ -62,7 +62,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.1/pod-pull_cdc_integration_kafka_test.yaml
@@ -61,7 +61,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.2/pod-pull_cdc_integration_kafka_test.yaml
@@ -62,7 +62,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.3/pod-pull_cdc_integration_kafka_test.yaml
@@ -62,7 +62,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.4/pod-pull_cdc_integration_kafka_test.yaml
@@ -62,7 +62,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-8.5/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-8.5/pod-pull_cdc_integration_kafka_test.yaml
@@ -61,7 +61,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pod-pull_cdc_integration_kafka_test.yaml
@@ -59,7 +59,7 @@ spec:
         - name: KAFKA_SSL_TRUSTSTORE_LOCATION
           value: /tmp/kafka.server.truststore.jks
         - name: RACK_COMMAND
-          value: curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
+          value: curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.keystore.jks -o /tmp/kafka.server.keystore.jks && curl -sfL https://cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/tests/_certificates/kafka.server.truststore.jks -o /tmp/kafka.server.truststore.jks
       image: wurstmeister/kafka:2.12-2.4.1
       imagePullPolicy: IfNotPresent
       name: kafka

--- a/pipelines/tikv/tikv/latest/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/latest/pull_unit_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                         CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
                         # Cargo metadata
                         cargo metadata --format-version 1 > test-metadata.json
-                        wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                        wget https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/tikv/tikv/gen_test_binary_json.py
                         export TIKV_SRC_DIR=${WORKSPACE}/${SRC_DIR}
                         python gen_test_binary_json.py
                         cat test-binaries.json

--- a/pipelines/tikv/tikv/release-6.5/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-6.5/pull_unit_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                             # Cargo metadata
                             cargo metadata --format-version 1 > test-metadata.json
                             # cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
-                            wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                            wget https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/tikv/tikv/gen_test_binary_json.py
                             python gen_test_binary_json.py
                             cat test-binaries.json
 

--- a/pipelines/tikv/tikv/release-7.1/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-7.1/pull_unit_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                             # Cargo metadata
                             cargo metadata --format-version 1 > test-metadata.json
                             # cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
-                            wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                            wget https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/tikv/tikv/gen_test_binary_json.py
                             python gen_test_binary_json.py
                             cat test-binaries.json
 

--- a/pipelines/tikv/tikv/release-7.5/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-7.5/pull_unit_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                         CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
                         # Cargo metadata
                         cargo metadata --format-version 1 > test-metadata.json
-                        wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                        wget https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/tikv/tikv/gen_test_binary_json.py
                         export TIKV_SRC_DIR=${WORKSPACE}/${SRC_DIR}
                         python gen_test_binary_json.py
                         cat test-binaries.json

--- a/pipelines/tikv/tikv/release-8.1/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-8.1/pull_unit_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                             # Cargo metadata
                             cargo metadata --format-version 1 > test-metadata.json
                             # cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
-                            wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                            wget https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/tikv/tikv/gen_test_binary_json.py
                             python gen_test_binary_json.py
                             cat test-binaries.json
 

--- a/pipelines/tikv/tikv/release-8.2/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-8.2/pull_unit_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                             # Cargo metadata
                             cargo metadata --format-version 1 > test-metadata.json
                             # cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
-                            wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                            wget https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/tikv/tikv/gen_test_binary_json.py
                             python gen_test_binary_json.py
                             cat test-binaries.json
 

--- a/pipelines/tikv/tikv/release-8.3/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-8.3/pull_unit_test.groovy
@@ -100,7 +100,7 @@ pipeline {
                             # Cargo metadata
                             cargo metadata --format-version 1 > test-metadata.json
                             # cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
-                            wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                            wget https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/tikv/tikv/gen_test_binary_json.py
                             python gen_test_binary_json.py
                             cat test-binaries.json
 

--- a/pipelines/tikv/tikv/release-8.4/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-8.4/pull_unit_test.groovy
@@ -96,7 +96,7 @@ pipeline {
                             # Cargo metadata
                             cargo metadata --format-version 1 > test-metadata.json
                             # cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
-                            wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                            wget https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/tikv/tikv/gen_test_binary_json.py
                             python gen_test_binary_json.py
                             cat test-binaries.json
 

--- a/pipelines/tikv/tikv/release-8.5/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-8.5/pull_unit_test.groovy
@@ -103,7 +103,7 @@ pipeline {
                         CUSTOM_TEST_COMMAND="nextest list" EXTRA_CARGO_ARGS="--message-format json --list-type binaries-only" make test_with_nextest | grep -E '^{.+}\$' > test.json
                         # Cargo metadata
                         cargo metadata --format-version 1 > test-metadata.json
-                        wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                        wget https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/tikv/tikv/gen_test_binary_json.py
                         export TIKV_SRC_DIR=${WORKSPACE}/${SRC_DIR}
                         python gen_test_binary_json.py
                         cat test-binaries.json

--- a/pipelines/tikv/tikv/release-9.0-beta/pull_unit_test.groovy
+++ b/pipelines/tikv/tikv/release-9.0-beta/pull_unit_test.groovy
@@ -101,7 +101,7 @@ pipeline {
                             # Cargo metadata
                             cargo metadata --format-version 1 > test-metadata.json
                             # cp ${WORKSPACE}/scripts/tikv/tikv/gen_test_binary_json.py ./gen_test_binary_json.py
-                            wget https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/tikv/tikv/gen_test_binary_json.py
+                            wget https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/tikv/tikv/gen_test_binary_json.py
                             python gen_test_binary_json.py
                             cat test-binaries.json
 


### PR DESCRIPTION
## Summary

Replace all raw.githubusercontent.com and github.com/.../raw/ download URLs in pipeline groovy scripts and pod YAMLs with cdn.jsdelivr.net/gh equivalents.

## Changes

- 10 tikv pull_unit_test groovy scripts: raw.githubusercontent.com/PingCAP-QE/ci/main/ → cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/
- 1 tidb pull_tiflash_test groovy script: raw.githubusercontent.com/PingCAP-QE/artifacts/main/ → cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/
- 27 tiflow/ticdc pod YAMLs: github.com/pingcap/tiflow/raw/6e62afcfecc4e3965d8818784327d4bf2600d9fa/ → cdn.jsdelivr.net/gh/pingcap/tiflow@6e62afcfecc4e3965d8818784327d4bf2600d9fa/

## Testing

URL transport only, no logic changes. CI will verify correctness.

## Risk

Low. Identical URL substitution pattern already established in tekton/v1/tasks/. jsDelivr resolves commit SHA refs identically to raw.githubusercontent.com.