### PR TITLE
chore(pipelines): replace raw GitHub URLs with jsDelivr CDN in CD pipeline files

### DIFF
--- a/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
+++ b/jenkins/pipelines/cd/atom-jobs/products/tiflash/master.groovy
@@ -180,7 +180,7 @@ def buildBin={
 def buildDocker={
     sh 'printenv HUB_PSW | docker login -u $HUB_USR --password-stdin hub.pingcap.net'
     sh """
-        curl --fail --retry 3 -o Dockerfile https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflash/Dockerfile
+        curl --fail --retry 3 -o Dockerfile https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tiflash/Dockerfile
         curl --fail --retry 3 -o tiflash.tar.gz ${getBinDownloadURL()}
         tar -xzvf tiflash.tar.gz
         rm -f tiflash.tar.gz

--- a/jenkins/pipelines/cd/build-arm-image.groovy
+++ b/jenkins/pipelines/cd/build-arm-image.groovy
@@ -1,4 +1,4 @@
-def baseUrl = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-arm64/"
+def baseUrl = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-arm64/"
 node("arm_image") {
    dir("go/src/github.com/pingcap/monitoring") {
        stage("prepare monitor") {

--- a/jenkins/pipelines/cd/build-operator-arm-image.groovy
+++ b/jenkins/pipelines/cd/build-operator-arm-image.groovy
@@ -1,4 +1,4 @@
-def baseUrl = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-arm64/"
+def baseUrl = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-arm64/"
 
 node("arm_image") {
     stage("Prepare & build binary") {

--- a/jenkins/pipelines/cd/dev-build.groovy
+++ b/jenkins/pipelines/cd/dev-build.groovy
@@ -94,67 +94,67 @@ def get_dockerfile_url={arch ->
     // Use semverCompare to check if Version >= v6.6.0
     if (semverCompare(Version, 'v6.6.0-0') >= 0){
         if (Product == "tidb" && Edition == "enterprise") {
-            return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/tidb.enterprise.Dockerfile"
+            return "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/tidb.enterprise.Dockerfile"
         }
         // note new ticdc only supports from v9.0.0
         return [
-            "tidb":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/tidb.Dockerfile",
-            "tidb-lightning":   "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/tidb-lightning.Dockerfile",
-            "br":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/br.Dockerfile",
-            "dumpling":         "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/dumpling.Dockerfile",
-            "tiflash":          "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflash/Dockerfile",
-            "dm":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflow/dm.Dockerfile",
-            "ticdc":            "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflow/ticdc.Dockerfile",
-            "ticdc-newarch":    "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/ticdc/Dockerfile",
-            "drainer":          "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-binlog/Dockerfile",
-            "pump":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-binlog/Dockerfile",
-            "tidb-tools":       "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-tools/Dockerfile",
-            "tidb-dashboard":   "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-dashboard/Dockerfile",
-            "tikv":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tikv/Dockerfile",
-            "pd":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/pd/Dockerfile",
-            "ng-monitoring":    "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/ng-monitoring/Dockerfile",
+            "tidb":             "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/tidb.Dockerfile",
+            "tidb-lightning":   "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/tidb-lightning.Dockerfile",
+            "br":               "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/br.Dockerfile",
+            "dumpling":         "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/dumpling.Dockerfile",
+            "tiflash":          "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tiflash/Dockerfile",
+            "dm":               "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tiflow/dm.Dockerfile",
+            "ticdc":            "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tiflow/ticdc.Dockerfile",
+            "ticdc-newarch":    "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/ticdc/Dockerfile",
+            "drainer":          "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-binlog/Dockerfile",
+            "pump":             "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-binlog/Dockerfile",
+            "tidb-tools":       "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-tools/Dockerfile",
+            "tidb-dashboard":   "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-dashboard/Dockerfile",
+            "tikv":             "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tikv/Dockerfile",
+            "pd":               "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/pd/Dockerfile",
+            "ng-monitoring":    "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/ng-monitoring/Dockerfile",
         ][Product]
     } else if (semverCompare(Version, 'v6.5.12-0') >= 0) {
         if (Product == "tidb" && Edition == "enterprise") {
-            return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/~6.5.12/tidb.enterprise.Dockerfile"
+            return "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/~6.5.12/tidb.enterprise.Dockerfile"
         }
 
         return [
-            "tidb":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/~6.5.12/tidb.Dockerfile",
-            "tidb-lightning":   "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/~6.5.12/tidb-lightning.Dockerfile",
-            "br":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/~6.5.12/br.Dockerfile",
-            "dumpling":         "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/~6.5.12/dumpling.Dockerfile",
-            "tiflash":          "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflash/~6.5.12/Dockerfile",
-            "dm":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflow/~6.5.12/dm.Dockerfile",
-            "ticdc":            "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflow/~6.5.12/ticdc.Dockerfile",
-            "drainer":          "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-binlog/~6.5.12/Dockerfile",
-            "pump":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-binlog/~6.5.12/Dockerfile",
-            "tidb-tools":       "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-tools/~6.5.12/Dockerfile",
-            "tidb-dashboard":   "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-dashboard/~6.5.12/Dockerfile",
-            "tikv":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tikv/~6.5.12/Dockerfile",
-            "pd":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/pd/~6.5.12/Dockerfile",
-            "ng-monitoring":    "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/ng-monitoring/~6.5.12/Dockerfile",
+            "tidb":             "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/~6.5.12/tidb.Dockerfile",
+            "tidb-lightning":   "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/~6.5.12/tidb-lightning.Dockerfile",
+            "br":               "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/~6.5.12/br.Dockerfile",
+            "dumpling":         "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/~6.5.12/dumpling.Dockerfile",
+            "tiflash":          "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tiflash/~6.5.12/Dockerfile",
+            "dm":               "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tiflow/~6.5.12/dm.Dockerfile",
+            "ticdc":            "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tiflow/~6.5.12/ticdc.Dockerfile",
+            "drainer":          "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-binlog/~6.5.12/Dockerfile",
+            "pump":             "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-binlog/~6.5.12/Dockerfile",
+            "tidb-tools":       "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-tools/~6.5.12/Dockerfile",
+            "tidb-dashboard":   "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-dashboard/~6.5.12/Dockerfile",
+            "tikv":             "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tikv/~6.5.12/Dockerfile",
+            "pd":               "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/pd/~6.5.12/Dockerfile",
+            "ng-monitoring":    "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/ng-monitoring/~6.5.12/Dockerfile",
         ][Product]
     } else {
         if (Product == "tidb" && Edition == "enterprise") {
-            return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/lt6.5.12/tidb.enterprise.Dockerfile"
+            return "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/lt6.5.12/tidb.enterprise.Dockerfile"
         }
 
         return [
-            "tidb":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/lt6.5.12/tidb.Dockerfile",
-            "tidb-lightning":   "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/lt6.5.12/tidb-lightning.Dockerfile",
-            "br":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/lt6.5.12/br.Dockerfile",
-            "dumpling":         "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb/lt6.5.12/dumpling.Dockerfile",
-            "tiflash":          "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflash/lt6.5.12/Dockerfile",
-            "dm":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflow/lt6.5.12/dm.Dockerfile",
-            "ticdc":            "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tiflow/lt6.5.12/ticdc.Dockerfile",
-            "drainer":          "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-binlog/lt6.5.12/Dockerfile",
-            "pump":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-binlog/lt6.5.12/Dockerfile",
-            "tidb-tools":       "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-tools/lt6.5.12/Dockerfile",
-            "tidb-dashboard":   "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tidb-dashboard/lt6.5.12/Dockerfile",
-            "tikv":             "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/tikv/lt6.5.12/Dockerfile",
-            "pd":               "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/pd/lt6.5.12/Dockerfile",
-            "ng-monitoring":    "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/ng-monitoring/lt6.5.12/Dockerfile",
+            "tidb":             "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/lt6.5.12/tidb.Dockerfile",
+            "tidb-lightning":   "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/lt6.5.12/tidb-lightning.Dockerfile",
+            "br":               "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/lt6.5.12/br.Dockerfile",
+            "dumpling":         "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb/lt6.5.12/dumpling.Dockerfile",
+            "tiflash":          "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tiflash/lt6.5.12/Dockerfile",
+            "dm":               "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tiflow/lt6.5.12/dm.Dockerfile",
+            "ticdc":            "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tiflow/lt6.5.12/ticdc.Dockerfile",
+            "drainer":          "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-binlog/lt6.5.12/Dockerfile",
+            "pump":             "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-binlog/lt6.5.12/Dockerfile",
+            "tidb-tools":       "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-tools/lt6.5.12/Dockerfile",
+            "tidb-dashboard":   "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tidb-dashboard/lt6.5.12/Dockerfile",
+            "tikv":             "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/tikv/lt6.5.12/Dockerfile",
+            "pd":               "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/pd/lt6.5.12/Dockerfile",
+            "ng-monitoring":    "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/ng-monitoring/lt6.5.12/Dockerfile",
         ][Product]
     }
 }

--- a/jenkins/pipelines/cd/multibranch/build_cdc_multi_branch.groovy
+++ b/jenkins/pipelines/cd/multibranch/build_cdc_multi_branch.groovy
@@ -72,7 +72,7 @@ def release_docker_image(product, filepath, tag) {
     def image = "pingcap/${product}:$tag"
     echo "docker image ${image}"
 
-    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-amd64/${product}"
+    def dockerfile = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-amd64/${product}"
     def paramsDocker = [
         string(name: "ARCH", value: "amd64"),
         string(name: "OS", value: "linux"),

--- a/jenkins/pipelines/cd/multibranch/build_tiflash_multi_branch.groovy
+++ b/jenkins/pipelines/cd/multibranch/build_tiflash_multi_branch.groovy
@@ -113,7 +113,7 @@ def docker_amd64(repo, hash) {
         string(name: "REPO", value: repo),
         string(name: "PRODUCT", value: repo),
         string(name: "RELEASE_TAG", value: release_tag),
-        string(name: "DOCKERFILE", value: "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-amd64/tiflash_ci"),
+        string(name: "DOCKERFILE", value: "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-amd64/tiflash_ci"),
         string(name: "RELEASE_DOCKER_IMAGES", value: "hub.pingcap.net/tiflash/tiflash:${image_tag},hub.pingcap.net/tiflash/tics:${image_tag}")
     ]
 

--- a/jenkins/pipelines/cd/nightly/release-all-images-by-branch.groovy
+++ b/jenkins/pipelines/cd/nightly/release-all-images-by-branch.groovy
@@ -200,7 +200,7 @@ def parseBuildInfo(repo) {
             "dockerfileAmd64"                 : dockerfileAmd64,
             "dockerfileArm64"                 : dockerfileArm64,
             "dockerfileForDebugAmd64"         : get_dockerfile_url('amd64',repo,true),
-            // "dockerfileForDebugArm64": "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-arm64/${repo}",  // TODO: arm64 have not unique debug image Dockerfile
+            // "dockerfileForDebugArm64": "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-arm64/${repo}",  // TODO: arm64 have not unique debug image Dockerfile
             "imageName"                       : "${HARBOR_PROJECT_PREFIX}/${repo}:${GIT_BRANCH}",
             "imageNameEnableFailpoint"        : "${HARBOR_PROJECT_PREFIX}/${repo}:${GIT_BRANCH}-failpoint",
             "imageNameForDebug"               : "${HARBOR_PROJECT_PREFIX}/${repo}:${GIT_BRANCH}-debug",
@@ -218,14 +218,14 @@ def get_dockerfile_url(arch, repo, isDebug){
     def fileName = Product
     if (RELEASE_TAG >='v6.6.0'){
         if (Product == 'tiflash'){
-            "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-${arch}/${fileName}_nightly"
+            "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-${arch}/${fileName}_nightly"
         }
-        return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${fileName}.Dockerfile"
+        return "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/${fileName}.Dockerfile"
     }else{
         if (isDebug){
-            return "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/${fileName}"
+            return "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/debug-image/${fileName}"
         }
-        return "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-${arch}/${fileName}"
+        return "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-${arch}/${fileName}"
     }
 }
 

--- a/jenkins/pipelines/cd/optimization-libs.groovy
+++ b/jenkins/pipelines/cd/optimization-libs.groovy
@@ -178,12 +178,12 @@ def build_tidb_enterprise_image(product, sha1, plugin_hash, arch, if_release, if
     plugin_binary = "builds/pingcap/enterprise-plugin/optimization/${RELEASE_TAG}/${plugin_hash}/centos7/enterprise-plugin-linux-${arch}-enterprise.tar.gz"
 
 
-    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-${arch}/${product}"
+    def dockerfile = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-${arch}/${product}"
     if (product == "tidb" && arch == "amd64") {
-        dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-amd64/enterprise/tidb"
+        dockerfile = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-amd64/enterprise/tidb"
     }
     if (product == "tidb" && arch == "arm64") {
-        dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-arm64/enterprise/tidb"
+        dockerfile = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-arm64/enterprise/tidb"
     }
     def image = get_image_str_for_enterprise("tidb", arch, RELEASE_TAG, if_release, if_multi_arch)
 
@@ -335,7 +335,7 @@ def build_enterprise_image(product, sha1, arch, if_release, if_multi_arch) {
     if (product == "tidb-lightning") {
         binary = "builds/pingcap/br/optimization/${RELEASE_TAG}/${sha1}/centos7/br-linux-${arch}-enterprise.tar.gz"
     }
-    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-${arch}/${product}"
+    def dockerfile = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-${arch}/${product}"
     def repo = product
     def image = get_image_str_for_enterprise(product, arch, RELEASE_TAG, if_release, if_multi_arch)
 
@@ -545,9 +545,9 @@ def release_online_image(product, sha1, arch, os, platform, tag, enterprise, pre
         binary = "builds/pingcap/${product}/optimization/${tag}/${sha1}/${platform}/${product}-${os}-${arch}-enterprise.tar.gz"
     }
 
-    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-${arch}/${product}"
+    def dockerfile = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-${arch}/${product}"
     if (enterprise && product == "tidb" && os == "linux" && arch == "amd64") {
-        dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-amd64/enterprise/tidb"
+        dockerfile = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-amd64/enterprise/tidb"
     }
     def imageName = product
     def repo = product

--- a/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
+++ b/jenkins/pipelines/cd/pre-release-community-docker-rocky.groovy
@@ -12,7 +12,7 @@ def get_dockerfile_url(product, is_enterprise, is_debug){
     if (is_debug) {
         fileName = fileName + "-debug"
     }
-    return "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${fileName}.Dockerfile"
+    return "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/${fileName}.Dockerfile"
 }
 
 def get_image_str_for_community(product, arch, is_failpoint, is_debug) {

--- a/jenkins/pipelines/cd/pre-release-community-docker.groovy
+++ b/jenkins/pipelines/cd/pre-release-community-docker.groovy
@@ -253,7 +253,7 @@ def release_one(repo, arch, failpoint) {
     }
 
 
-    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-${arch}/${repo}"
+    def dockerfile = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-${arch}/${repo}"
     // if current version not need multi-arch image, then use image image to distingush amd64 and arm64.
     // otherwise, use imageTag to distingush different version.
     // example1:
@@ -282,7 +282,7 @@ def release_one(repo, arch, failpoint) {
 
 
     if (NEED_DEBUG_IMAGE && arch == "amd64") {
-        def dockerfileForDebug = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/${repo}"
+        def dockerfileForDebug = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/debug-image/${repo}"
         def imageForDebug = "${HARBOR_REGISTRY_PROJECT_PREFIX}/${repo}:${IMAGE_TAG}-debug"
         if (failpoint) {
             imageForDebug = "${HARBOR_REGISTRY_PROJECT_PREFIX}/${repo}:${IMAGE_TAG}-failpoint-debug"
@@ -310,7 +310,7 @@ def release_one(repo, arch, failpoint) {
 
     // dm version >= v5.3.0 && < v6.0.0 need build image pingcap/dm-monitor-initializer
     if (repo == "dm" && RELEASE_TAG < "v6.0.0") {
-        def dockerfileForDmMonitorInitializer = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-${arch}/dm-monitor-initializer"
+        def dockerfileForDmMonitorInitializer = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-${arch}/dm-monitor-initializer"
         def imageNameForDmMonitorInitializer = "dm-monitor-initializer"
         if (arch == "arm64") {
             imageNameForDmMonitorInitializer = imageNameForDmMonitorInitializer + "-arm64"
@@ -338,7 +338,7 @@ def release_one(repo, arch, failpoint) {
 
     if (repo == "br") {
         println("start push tidb-lightning")
-        def dockerfileLightning = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-${arch}/tidb-lightning"
+        def dockerfileLightning = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/linux-${arch}/tidb-lightning"
         imageName = "tidb-lightning"
         if (arch == "arm64" && !NEED_MULTIARCH) {
             imageName = imageName + "-arm64"
@@ -366,7 +366,7 @@ def release_one(repo, arch, failpoint) {
                 parameters: paramsDockerLightning
 
         if (NEED_DEBUG_IMAGE && arch == "amd64") {
-            def dockerfileLightningForDebug = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/tidb-lightning"
+            def dockerfileLightningForDebug = "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/Dockerfile/release/debug-image/tidb-lightning"
             def imageLightlingForDebug = "${HARBOR_REGISTRY_PROJECT_PREFIX}/tidb-lightning:${IMAGE_TAG}-debug"
             def paramsDockerLightningForDebug = [
                     string(name: "ARCH", value: "amd64"),

--- a/jenkins/pipelines/cd/pre-release-enterprise-docker-rocky.groovy
+++ b/jenkins/pipelines/cd/pre-release-enterprise-docker-rocky.groovy
@@ -77,7 +77,7 @@ def get_image_str_for_enterprise(product, arch, tag) {
 def build_tidb_enterprise_image(product, sha1, plugin_hash, arch) {
     def binary = "builds/pingcap/${product}/optimization/${RELEASE_TAG}/${sha1}/centos7/${product}-linux-${arch}-enterprise.tar.gz"
     def plugin_binary = "builds/pingcap/enterprise-plugin/optimization/${RELEASE_TAG}/${plugin_hash}/centos7/enterprise-plugin-linux-${arch}-enterprise.tar.gz"
-    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${product}-enterprise.Dockerfile"
+    def dockerfile = "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/${product}-enterprise.Dockerfile"
     def image = get_image_str_for_enterprise("tidb", arch, RELEASE_TAG)
     def paramsDocker = [
             string(name: "ARCH", value: arch),
@@ -101,7 +101,7 @@ def build_enterprise_image(product, sha1, arch) {
     if (product == "tidb-lightning") {
         binary = "builds/pingcap/br/optimization/${RELEASE_TAG}/${sha1}/centos7/br-linux-${arch}-enterprise.tar.gz"
     }
-    def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/artifacts/main/dockerfiles/products/${product}.Dockerfile"
+    def dockerfile = "https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/dockerfiles/products/${product}.Dockerfile"
     def repo = product
     def image = get_image_str_for_enterprise(product, arch, RELEASE_TAG)
 

--- a/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update-test.groovy
+++ b/jenkins/pipelines/cd/tiup/grafana-tiup-mirror-update-test.groovy
@@ -120,7 +120,7 @@ run_with_pod {
         }
         retry(5) {
             sh """
-            wget -qnc https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/pipelines/cd/tiup/tiup_utils.groovy
+            wget -qnc https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/jenkins/pipelines/cd/tiup/tiup_utils.groovy
             """
         }
 

--- a/pipelines/pingcap-inc/tiflash-scripts/latest/common/prepare_runtime_and_artifacts.sh
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/common/prepare_runtime_and_artifacts.sh
@@ -86,7 +86,7 @@ if [[ -z "${oci_script}" && -n "${WORKSPACE:-}" && -f "${WORKSPACE}/scripts/arti
 fi
 if [[ -z "${oci_script}" || ! -f "${oci_script}" ]]; then
   oci_script="/tmp/download_pingcap_oci_artifact.sh"
-  curl -fsSL "https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/artifacts/download_pingcap_oci_artifact.sh" -o "${oci_script}"
+  curl -fsSL "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/artifacts/download_pingcap_oci_artifact.sh" -o "${oci_script}"
 fi
 
 branch="${TEST_BRANCH:-master}"

--- a/scripts/pingcap/tidb-binlog/pull_integration_test.sh
+++ b/scripts/pingcap/tidb-binlog/pull_integration_test.sh
@@ -101,7 +101,7 @@ prepare_download_tools() {
   else
     log "Fetching OCI download helper"
     curl -fsSL --retry 3 \
-      "https://raw.githubusercontent.com/PingCAP-QE/ci/main/scripts/artifacts/download_pingcap_oci_artifact.sh" \
+      "https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/artifacts/download_pingcap_oci_artifact.sh" \
       -o "${OCI_SCRIPT}"
   fi
   chmod +x "${OCI_SCRIPT}"


### PR DESCRIPTION
## Summary

Replace raw.githubusercontent.com and github.com/.../raw/ URLs with cdn.jsdelivr.net/gh CDN equivalents in Jenkins CD pipeline Dockerfile/script downloads.

## Changes

- **jenkins/pipelines/cd/** (12 files): Replace Dockerfile download URLs referencing PingCAP-QE/ci and PingCAP-QE/artifacts
- **scripts/** (1 file): Replace OCI download helper URL
- **pipelines/** (1 file): Replace OCI download script URL

## Testing

URL transport only change - no logic changes. CI should pass and Docker image builds should succeed using CDN-backed downloads.

## Risk

Low. jsDelivr CDN fallback for raw GitHub downloads. Same content, different transport.