### PR TITLE
fix(tekton): replace raw github URLs with jsdelivr CDN in v0 tasks

### DIFF
--- a/tekton/v0/tasks/build/pingcap-build-binaries-darwin.yaml
+++ b/tekton/v0/tasks/build/pingcap-build-binaries-darwin.yaml
@@ -124,7 +124,7 @@ spec:
         fi
 
         env_file="/workspace/remote.env"
-        deno run --allow-all https://github.com/PingCAP-QE/artifacts/raw/refs/heads/main/packages/scripts/build-in-darwin-boskos.ts \
+        deno run --allow-all https://cdn.jsdelivr.net/gh/PingCAP-QE/artifacts@main/packages/scripts/build-in-darwin-boskos.ts \
           --sshInfoDir ${WORKSPACE_SSH_DIRECTORY_PATH} \
           --sourcePath $(workspaces.source.path) \
           --envFile ${env_file} \

--- a/tekton/v0/tasks/hotfix/create-pr-to-sync-owners.yaml
+++ b/tekton/v0/tasks/hotfix/create-pr-to-sync-owners.yaml
@@ -39,7 +39,7 @@ spec:
         echo "repo=${repo}"
 
         if [ "$owner" == "pingcap" ]; then
-          deno run --allow-all https://github.com/PingCAP-QE/ci/raw/main/scripts/pingcap/community/update-prow-owners.ts \
+          deno run --allow-all https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/pingcap/community/update-prow-owners.ts \
             --force \
             --owner=${owner} \
             --github_private_token=$(cat /etc/github/token) \
@@ -55,7 +55,7 @@ spec:
             --inputs=teams/migration/membership.json \
             --inputs=teams/bigdata/membership.json
         elif [ "$owner" == "tikv" ]; then
-          deno run --allow-all https://github.com/PingCAP-QE/ci/raw/main/scripts/pingcap/community/update-prow-owners.ts \
+          deno run --allow-all https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/pingcap/community/update-prow-owners.ts \
             --force \
             --owner=${owner} \
             --github_private_token=$(cat /etc/github/token) \

--- a/tekton/v0/tasks/pingcap-deliver-image.yaml
+++ b/tekton/v0/tasks/pingcap-deliver-image.yaml
@@ -21,16 +21,16 @@ spec:
         - name: CACHE_READ_SERVER_BASE_URL
           value: "http://fileserver.pingcap.net/download"
       script: |
-        cfg_github_raw_path_url="PingCAP-QE/artifacts/main/packages/delivery.yaml"
-        gs_github_raw_path_url="PingCAP-QE/artifacts/main/packages/scripts/gen-delivery-image-commands.ts"
-        cfg_yaml_file="https://raw.githubusercontent.com/$cfg_github_raw_path_url"
-        gen_script_url="https://raw.githubusercontent.com/$gs_github_raw_path_url"
+        cfg_github_raw_path_url="PingCAP-QE/artifacts@main/packages/delivery.yaml"
+        gs_github_raw_path_url="PingCAP-QE/artifacts@main/packages/scripts/gen-delivery-image-commands.ts"
+        cfg_yaml_file="https://cdn.jsdelivr.net/gh/$cfg_github_raw_path_url"
+        gen_script_url="https://cdn.jsdelivr.net/gh/$gs_github_raw_path_url"
 
-        if wget -q --spider "$CACHE_READ_SERVER_BASE_URL/raw.githubusercontent.com/$cfg_github_raw_path_url"; then
-          cfg_yaml_file="$CACHE_READ_SERVER_BASE_URL/raw.githubusercontent.com/$cfg_github_raw_path_url"
+        if wget -q --spider "$CACHE_READ_SERVER_BASE_URL/cdn.jsdelivr.net/gh/$cfg_github_raw_path_url"; then
+          cfg_yaml_file="$CACHE_READ_SERVER_BASE_URL/cdn.jsdelivr.net/gh/$cfg_github_raw_path_url"
         fi
-        if wget -q --spider "$CACHE_READ_SERVER_BASE_URL/raw.githubusercontent.com/$gs_github_raw_path_url"; then
-          gen_script_url="$CACHE_READ_SERVER_BASE_URL/raw.githubusercontent.com/$gs_github_raw_path_url"
+        if wget -q --spider "$CACHE_READ_SERVER_BASE_URL/cdn.jsdelivr.net/gh/$gs_github_raw_path_url"; then
+          gen_script_url="$CACHE_READ_SERVER_BASE_URL/cdn.jsdelivr.net/gh/$gs_github_raw_path_url"
         fi
 
         wget -O delivery.yaml "$cfg_yaml_file"

--- a/tekton/v0/tasks/pingcap-get-set-release-version.yaml
+++ b/tekton/v0/tasks/pingcap-get-set-release-version.yaml
@@ -62,7 +62,7 @@ spec:
         - run
         - --allow-read
         - --allow-write
-        - https://github.com/PingCAP-QE/ci/raw/refs/heads/main/scripts/flow/build/versioning-strategy.ts
+        - https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/flow/build/versioning-strategy.ts
       args:
         - --git_version_file=/workspace/raw-version.txt
         - --contain_branches_file=/workspace/branches.txt

--- a/tekton/v0/tasks/release/create-pr-to-add-release-anchor-commit.yaml
+++ b/tekton/v0/tasks/release/create-pr-to-add-release-anchor-commit.yaml
@@ -88,7 +88,7 @@ spec:
         echo "pr dest branch: $(cat /workspace/inner-results-branch)"
         echo "pr placeholder version: $(cat /workspace/inner-results-version)"
 
-        deno run --allow-all https://github.com/PingCAP-QE/ci/raw/main/scripts/pingcap/add-placeholder-version-in-readme.ts \
+        deno run --allow-all https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/pingcap/add-placeholder-version-in-readme.ts \
           --owner=${owner} \
           --repo=${repo} \
           --branch=$(cat /workspace/inner-results-branch) \

--- a/tekton/v0/tasks/release/pingcap-create-github-alpha-tags.yaml
+++ b/tekton/v0/tasks/release/pingcap-create-github-alpha-tags.yaml
@@ -15,7 +15,7 @@ spec:
     - name: create-tags
       image: docker.io/denoland/deno:alpine-2.1.4
       script: |
-        deno run --allow-all https://github.com/PingCAP-QE/ci/raw/main/scripts/flow/sprint/create_github_alpha_tags.ts \
+        deno run --allow-all https://cdn.jsdelivr.net/gh/PingCAP-QE/ci@main/scripts/flow/sprint/create_github_alpha_tags.ts \
           --version="$(params.version)" \
           --token="$(cat $(workspaces.github.path)/token)" \
           --pushEventUrl=http://el-public:8080


### PR DESCRIPTION
## Summary

Replace all `raw.githubusercontent.com` and `github.com/.../raw/` URLs with `cdn.jsdelivr.net/gh` CDN equivalents in Tekton v0 task files, following the established pattern in `tekton/v1/tasks/`.

## Changes

- `tekton/v0/tasks/pingcap-deliver-image.yaml` — 6 URL replacements (primary + cache paths)
- `tekton/v0/tasks/pingcap-get-set-release-version.yaml` — 1 URL replacement
- `tekton/v0/tasks/build/pingcap-build-binaries-darwin.yaml` — 1 URL replacement
- `tekton/v0/tasks/hotfix/create-pr-to-sync-owners.yaml` — 2 URL replacements
- `tekton/v0/tasks/release/pingcap-create-github-alpha-tags.yaml` — 1 URL replacement
- `tekton/v0/tasks/release/create-pr-to-add-release-anchor-commit.yaml` — 1 URL replacement

## Testing

URL transport only, no logic changes. Targets `PingCAP-QE/ci@main` and `PingCAP-QE/artifacts@main`.

## Risk

Low. CDN fallback identical to already-converted `tekton/v1/tasks/`. Rollback: `git revert` of this PR.