### PR TITLE
fix(pipelines): raise jnlp memory for pull_unit_test_next_gen

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
@@ -39,6 +39,14 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
+    - name: jnlp
+      image: "jenkins/inbound-agent:3355.v388858a_47b_33-3-jdk21"
+      resources:
+        requests:
+          memory: 1Gi
+          cpu: "100m"
+        limits:
+          memory: 2Gi
   volumes:
     - name: bazel-out-merged
       ephemeral:


### PR DESCRIPTION
Raise the Jenkins jnlp container memory request/limit so the agent is less likely to be evicted under node memory pressure.\n\nValidation:\n- YAML parse OK\n- .ci/verify-k8s-pod-yaml.sh pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml\n- git diff --check\n\nRelated failure evidence: Jenkins build #6864 was aborted after kubelet evicted jnlp with "The node was low on resource: memory".