### PR TITLE
fix(pipelines): cap golang memory to stop pull_unit_test_next_gen eviction

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
@@ -20,7 +20,7 @@ spec:
           cpu: "24"
           ephemeral-storage: 20Gi
         limits:
-          memory: 64Gi
+          memory: 52Gi
           cpu: "24"
           ephemeral-storage: 300Gi
       volumeMounts:
@@ -39,14 +39,6 @@ spec:
             command:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
-    - name: jnlp
-      image: "jenkins/inbound-agent:3355.v388858a_47b_33-3-jdk21"
-      resources:
-        requests:
-          memory: 1Gi
-          cpu: "100m"
-        limits:
-          memory: 2Gi
   volumes:
     - name: bazel-out-merged
       ephemeral:


### PR DESCRIPTION
## What & why

`pull_unit_test_next_gen` keeps aborting with jnlp eviction (e.g. [build #6868](https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_unit_test_next_gen/6868/console)). PR #4846 tried to fix it by raising jnlp memory — but that targeted the wrong container and never took effect.

Root cause, from the failed console:

```
node was low on resource: memory. available: 10904Ki.
Container golang was using 54170300Ki (~51.6Gi)
Container jnlp  was using 638188Ki, request is 256Mi, has larger consumption of memory.
```

bazel ran with `--local_ram_resources=58982` (~57.6Gi), derived from golang's `limits.memory=64Gi` via `/etc/containerinfo/mem_limit`. So golang legitimately consumed ~51.6Gi, drained the node to ~10MiB, and kubelet evicted jnlp (highest usage-over-request ratio) → JNLP4 channel closed → build ABORTED.

Raising jnlp memory cannot help: the node is still OOM from golang. And the Jenkins k8s plugin overrode #4846's jnlp `resources` with its default (rendered pod still showed `request 256Mi`), so #4846 was a no-op.

## Fix

- **golang `limits.memory` 64Gi → 52Gi** → bazel `local_ram_resources` drops ~57.6Gi → ~45.6Gi, actual usage ~51.6Gi → ~44Gi, giving the node ~7Gi headroom. 52Gi still exceeds the 51.6Gi historical peak (24-way parallel sum, not a single test), so no large test gets OOM-killed. `requests` stay at 48Gi → scheduling unchanged.
- **Revert the jnlp block added in #4846** — its resources are ignored by the plugin and the image is unnecessary.

| limits.memory | bazel budget | expected usage | node headroom |
|---|---|---|---|
| 64Gi (before) | ~57.6Gi | ~51.6Gi | ~0 ❌ |
| **52Gi (now)** | **~45.6Gi** | **~44Gi** | **~7Gi ✅** |

## Validation
- YAML parse OK
- `.ci/verify-k8s-pod-yaml.sh pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml` → passed
- `git diff --check` clean

## Follow-up
If replay shows node headroom still thin after this change, the node pool is likely undersized or co-located — next step would be a nodeSelector for a larger-memory pool (ops-level, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)