### PR TITLE
fix(pipelines/tiflash): release-6.5 IT image rewrite + failpoint fallback

### DIFF
--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -267,7 +267,17 @@ pipeline {
                                                         timeout 300 docker pull "${PD_IMAGE}"
                                                         timeout 300 docker pull "${TIKV_IMAGE}"
                                                         timeout 300 docker pull "${TIDB_IMAGE}"
-                                                        timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
+                                                        # release-6.5 failpoint images may no longer be published.
+                                                        # Fall back to the regular branch image so compose does not hard-fail on a missing tag,
+                                                        # and skip fail-point-tests that require a real failpoint TiDB binary.
+                                                        if ! timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}"; then
+                                                            echo "WARN: ${TIDB_FAILPOINT_IMAGE} not found; falling back to ${TIDB_IMAGE}"
+                                                            TIDB_FAILPOINT_IMAGE="${TIDB_IMAGE}"
+                                                            if [ -f ./run.sh ] && grep -q 'tidb-ci/fail-point-tests' ./run.sh; then
+                                                                echo "WARN: skipping tidb-ci/fail-point-tests because TiDB failpoint image is unavailable"
+                                                                sed -i -e 's#./run-test.sh tidb-ci/fail-point-tests && ##g' ./run.sh
+                                                            fi
+                                                        fi
                                                         timeout 600 docker pull "${TIFLASH_IMAGE}"
 
                                                         find ../docker . -name '*.yaml' -type f -exec sed -i \

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -278,6 +278,7 @@ pipeline {
                                                             -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
                                                             -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
                                                             -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base$#'"${TIFLASH_IMAGE}"'#g' \
                                                             -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
                                                             -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
                                                             -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \


### PR DESCRIPTION
## Summary
Unblock `release-6.5` TiFlash `pull_integration_test` (e.g. pingcap/tiflash#10993):

1. **Untagged `tiflash-ci-base` rewrite**  
   `release-6.5` yamls still use `hub.pingcap.net/tiflash/tiflash-ci-base` without a tag. Existing rocky8/rocky9 sed rules miss it, so compose hits the retired registry. Add a sed rule mapping the untagged form to `TIFLASH_TEST_IMAGE` (`ghcr.io/pingcap-qe/cd/builders/tiflash:v20231106`).

2. **TiDB failpoint image fallback** (from closed #4845)  
   If `tidb-server:release-6.5-failpoint` cannot be pulled, fall back to the regular `release-6.5` TiDB image for compose rewrites, and skip `tidb-ci/fail-point-tests` (requires a real failpoint binary).

## Test plan
- [ ] Merge this PR
- [ ] On pingcap/tiflash#10993, run `/test pull-integration-test`
- [ ] Confirm no `hub.pingcap.net` pull for `tics0` / `tiflash-ci-base`
- [ ] If failpoint tag is missing: logs show WARN fallback + skip fail-point-tests; other suites still run
- [ ] If failpoint tag exists: pull succeeds and fail-point-tests still run