### PR TITLE
fix(pipelines): use PVC for realcluster bazel cache

### DIFF
--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml
@@ -37,7 +37,15 @@ spec:
               - /data/bazel-prepare-in-container.sh
   volumes:
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: hyperdisk-rwo
     - name: bazel-rc
       configMap:
         name: bazel


### PR DESCRIPTION
## Summary
- Move `bazel-out-merged` from `emptyDir` to a 200Gi `hyperdisk-rwo` ephemeral PVC for the dedicated realcluster next-gen test pod.
- Keep `/home/jenkins/.tidb` on PVC-backed storage, matching the existing pingcap/tidb realcluster next-gen pattern.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "YAML OK"' pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml`\n- Replay from build `#6379`: https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_integration_realcluster_test_next_gen/6397/ (running at PR creation)