### PR TITLE
fix(pipelines/tiflash): always skip fail-point-tests on release-6.5

### DIFF
--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -267,16 +267,15 @@ pipeline {
                                                         timeout 300 docker pull "${PD_IMAGE}"
                                                         timeout 300 docker pull "${TIKV_IMAGE}"
                                                         timeout 300 docker pull "${TIDB_IMAGE}"
-                                                        # release-6.5 failpoint images may no longer be published.
-                                                        # Fall back to the regular branch image so compose does not hard-fail on a missing tag,
-                                                        # and skip fail-point-tests that require a real failpoint TiDB binary.
-                                                        if ! timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}"; then
-                                                            echo "WARN: ${TIDB_FAILPOINT_IMAGE} not found; falling back to ${TIDB_IMAGE}"
-                                                            TIDB_FAILPOINT_IMAGE="${TIDB_IMAGE}"
-                                                            if [ -f ./run.sh ] && grep -q 'tidb-ci/fail-point-tests' ./run.sh; then
-                                                                echo "WARN: skipping tidb-ci/fail-point-tests because TiDB failpoint image is unavailable"
-                                                                sed -i -e 's#./run-test.sh tidb-ci/fail-point-tests && ##g' ./run.sh
-                                                            fi
+                                                        # release-6.5: OCI may still publish a :failpoint tag, but it does not expose
+                                                        # enableTestAPI (fail-point-tests fail on curl_tidb get fail/.../enableTestAPI).
+                                                        # Always use the regular TiDB image and skip suites that need real failpoints.
+                                                        timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
+                                                        echo "WARN: release-6.5 TiDB failpoint image is not usable for IT; falling back to ${TIDB_IMAGE}"
+                                                        TIDB_FAILPOINT_IMAGE="${TIDB_IMAGE}"
+                                                        if [ -f ./run.sh ] && grep -q 'tidb-ci/fail-point-tests' ./run.sh; then
+                                                            echo "WARN: skipping tidb-ci/fail-point-tests"
+                                                            sed -i -e 's#./run-test.sh tidb-ci/fail-point-tests && ##g' ./run.sh
                                                         fi
                                                         # Old hub.pingcap.net/tiflash/tiflash-ci-base included mysql client for run-test.sh.
                                                         # Builder images do not; rebuild the historical runtime locally (see tiflash_ci_base Dockerfile).


### PR DESCRIPTION
## Summary
Follow-up after #4849 / #4850.

`tidb-ci/cluster.yaml` on release-6.5 uses `qa/tidb:...-failpoint`. The previous logic only skipped `fail-point-tests` when the failpoint image **pull failed**. OCI still has `tidb-server:release-6.5-failpoint`, so pull succeeds, but the image does not expose `enableTestAPI`:

```text
Error: get fail/github.com/pingcap/tidb/server/enableTestAPI
```

## Change
- Always fall back `TIDB_FAILPOINT_IMAGE` → regular `release-6.5` TiDB image
- Always strip `./run-test.sh tidb-ci/fail-point-tests &&` from `run.sh`
- Other suites (`fullstack-test`, async_grpc, collation, …) still run

## Test plan
- [ ] Merge and `/test pull-integration-test` on pingcap/tiflash#10993
- [ ] Logs show WARN skip fail-point-tests
- [ ] `tidb-ci` proceeds to fullstack-test without enableTestAPI error