### PR TITLE
feat(scripts): add analyze-nextest-output.sh for cargo nextest flaky test analysis

### DIFF
--- a/scripts/plugins/analyze-nextest-output.sh
+++ b/scripts/plugins/analyze-nextest-output.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEFAULT_NEXTEST_INDEX_FILE="nextest-index.log"
+DEFAULT_NEXTEST_PROBLEM_CASES_JSONFILE="nextest-problem-cases.json"
+NEXTEST_SLOW_TIME_THRESHOLD="${NEXTEST_SLOW_TIME_THRESHOLD:-60}"
+MAX_PANIC_LENGTH="${MAX_PANIC_LENGTH:-200}"
+
+# Extract significant lines (status, summary, panic markers) with line numbers
+# param $1 file path
+function parse_nextest_index_log() {
+    local logPath="$1"
+    local indexReg='^[[:space:]]+(TRY [0-9]+ (FAIL|PASS|TIMEOUT)|FAIL|PASS|SKIP|SLOW|TIMEOUT|FLAKY [0-9]+/[0-9]+)([[:space:]]+\[|$)|^[[:space:]]+Summary \[|panicked at|race detected during execution'
+
+    grep -nE "$indexReg" "$logPath" >"$DEFAULT_NEXTEST_INDEX_FILE" || true
+}
+
+# Identify flaky tests from FLAKY summary lines and attempt-tracked retry success
+# param $1 file path
+# param $2 result json file
+function parse_nextest_flaky_cases() {
+    local logPath="$1"
+    local resultFile="$2"
+    local recordsFile="${resultFile}.flaky.records"
+
+    [ -f "$DEFAULT_NEXTEST_INDEX_FILE" ] || parse_nextest_index_log "$logPath"
+
+    awk '
+        function emit(binary, test, reason) {
+            print binary "\t" test "\t" reason
+        }
+        {
+            sub(/^[0-9]+:/, "")
+            if (match($0, /^[[:space:]]+(TRY [0-9]+ (FAIL|PASS|TIMEOUT)|FAIL|PASS|SKIP|SLOW|TIMEOUT|FLAKY [0-9]+\/[0-9]+)([[:space:]]+\[|$)/)) {
+                line = $0
+                sub(/^[[:space:]]+/, "", line)
+                split(line, f, /[[:space:]]+/)
+                if (f[1] == "TRY") {
+                    attempt = f[2] + 0
+                    status = f[3]
+                    has_try = 1
+                } else {
+                    status = f[1]
+                    attempt = 1
+                    has_try = 0
+                }
+                binary = $(NF-1)
+                test = $NF
+                key = binary SUBSEP test
+                if (has_try) try_keys[key] = 1
+                if (status == "TIMEOUT") timeout_keys[key] = 1
+                if (status == "FAIL" || status == "TIMEOUT") {
+                    if (has_try || !try_keys[key]) {
+                        if (first_fail[key] == 0 || attempt < first_fail[key]) first_fail[key] = attempt
+                    }
+                }
+                if (status == "PASS") {
+                    if (has_try || !try_keys[key]) {
+                        if (min_pass[key] == 0 || attempt < min_pass[key]) min_pass[key] = attempt
+                    }
+                }
+                if (f[1] == "FLAKY") {
+                    reason = (timeout_keys[key] ? "timeout" : (race_keys[key] ? "race" : "flaky"))
+                    emit(binary, test, reason)
+                }
+                current_key = key
+                next
+            }
+            if (/race detected/) {
+                if (current_key != "") race_keys[current_key] = 1
+            }
+        }
+        END {
+            for (key in try_keys) {
+                split(key, parts, SUBSEP)
+                if (first_fail[key] > 0 && min_pass[key] > 0 && min_pass[key] > first_fail[key]) {
+                    reason = (timeout_keys[key] ? "timeout" : (race_keys[key] ? "race" : "flaky"))
+                    emit(parts[1], parts[2], reason)
+                }
+            }
+        }
+    ' "$logPath" >"$recordsFile"
+
+    sort -u "$recordsFile" |
+        while IFS=$'\t' read -r binary test_name reason; do
+            [ -n "$binary" ] || continue
+            jq --arg binary "$binary" \
+               --arg test_name "$test_name" \
+               --arg reason "$reason" \
+               '(.[$binary] //= {}) |
+                .[$binary].new_flaky |= ((. // []) + [{"name": $test_name, "reason": $reason}] | unique)' \
+               "$resultFile" >"$resultFile".new && mv "$resultFile".new "$resultFile"
+        done
+
+    rm -f "$recordsFile"
+}
+
+# Extract test durations; flag tests marked SLOW, timed out, or exceeding threshold
+# param $1 file path
+# param $2 result json file
+function parse_nextest_long_cases() {
+    local logPath="$1"
+    local resultFile="$2"
+    local recordsFile="${resultFile}.long.records"
+
+    [ -f "$DEFAULT_NEXTEST_INDEX_FILE" ] || parse_nextest_index_log "$logPath"
+
+    awk -v threshold="$NEXTEST_SLOW_TIME_THRESHOLD" '
+        {
+            sub(/^[0-9]+:/, "")
+            if (match($0, /^[[:space:]]+(TRY [0-9]+ (FAIL|PASS|TIMEOUT)|FAIL|PASS|SKIP|SLOW|TIMEOUT)([[:space:]]+\[|$)/)) {
+                line = $0
+                sub(/^[[:space:]]+/, "", line)
+                split(line, f, /[[:space:]]+/)
+                if (f[1] == "TRY") {
+                    status = f[3]
+                } else {
+                    status = f[1]
+                }
+                binary = $(NF-1)
+                test = $NF
+                key = binary SUBSEP test
+                duration = -1
+                if (match(line, /\[[[:space:]]*[0-9.]+s\]/)) {
+                    dur_str = substr(line, RSTART + 1, RLENGTH - 2)
+                    gsub(/[[:space:]]s/, "", dur_str)
+                    duration = dur_str + 0
+                }
+                if (duration >= 0 && duration > max_duration[key]) max_duration[key] = duration
+                if (status == "TIMEOUT") timeout_keys[key] = 1
+                if (status == "SLOW") slow_keys[key] = 1
+                if (status == "SKIP") skip_keys[key] = 1
+            }
+        }
+        END {
+            for (key in max_duration) {
+                split(key, parts, SUBSEP)
+                if (skip_keys[key]) continue
+                if (timeout_keys[key]) {
+                    print parts[1] "\t" parts[2] "\t-1"
+                } else if (slow_keys[key] || max_duration[key] >= threshold) {
+                    print parts[1] "\t" parts[2] "\t" max_duration[key]
+                }
+            }
+        }
+    ' "$logPath" >"$recordsFile"
+
+    sort -u "$recordsFile" |
+        while IFS=$'\t' read -r binary test_name duration; do
+            [ -n "$binary" ] || continue
+            jq --arg binary "$binary" \
+               --arg test_name "$test_name" \
+               --argjson duration "$duration" \
+               '(.[$binary] //= {}) |
+                (.[$binary].long_time //= {}) |
+                .[$binary].long_time[$test_name] = (if .[$binary].long_time[$test_name] != null and .[$binary].long_time[$test_name] >= 0 then .[$binary].long_time[$test_name] else $duration end)' \
+               "$resultFile" >"$resultFile".new && mv "$resultFile".new "$resultFile"
+        done
+
+    rm -f "$recordsFile"
+}
+
+# Identify binaries with panics: tests that failed on all retries with `panicked at`
+# param $1 file path
+# param $2 result json file
+function parse_nextest_crash_cases() {
+    local logPath="$1"
+    local resultFile="$2"
+    local recordsFile="${resultFile}.crash.records"
+
+    [ -f "$DEFAULT_NEXTEST_INDEX_FILE" ] || parse_nextest_index_log "$logPath"
+
+    awk -v max_panic_len="$MAX_PANIC_LENGTH" '
+        {
+            sub(/^[0-9]+:/, "")
+            if (match($0, /^[[:space:]]+(TRY [0-9]+ (FAIL|PASS|TIMEOUT)|FAIL|PASS|SKIP|SLOW|TIMEOUT)([[:space:]]+\[|$)/)) {
+                line = $0
+                sub(/^[[:space:]]+/, "", line)
+                split(line, f, /[[:space:]]+/)
+                if (f[1] == "TRY") {
+                    attempt = f[2] + 0
+                    status = f[3]
+                    has_try = 1
+                } else {
+                    status = f[1]
+                    attempt = 1
+                    has_try = 0
+                }
+                binary = $(NF-1)
+                test = $NF
+                key = binary SUBSEP test
+                if (has_try) try_keys[key] = 1
+                if (status == "PASS" && (has_try || !try_keys[key])) passed_keys[key] = 1
+                if ((status == "FAIL" || status == "TIMEOUT") && (has_try || !try_keys[key])) {
+                    failed_keys[key] = 1
+                    if (attempt > max_attempt[key]) max_attempt[key] = attempt
+                }
+                if (!(key in seen_keys)) {
+                    seen_keys[key] = 1
+                    key_order[++key_count] = key
+                }
+                current_key = key
+                next
+            }
+            if (/panicked at/) {
+                if (current_key != "" && !(current_key in panic_seen)) {
+                    line = $0
+                    sub(/^[0-9]+:/, "")
+                    sub(/^[[:space:]]+/, "", line)
+                    panic_msg[current_key] = substr(line, 1, max_panic_len)
+                    panic_seen[current_key] = 1
+                }
+            }
+        }
+        END {
+            for (i = 1; i <= key_count; i++) {
+                key = key_order[i]
+                if (!(key in failed_keys)) continue
+                if (key in passed_keys) continue
+                if (!(key in panic_seen)) continue
+                split(key, parts, SUBSEP)
+                print parts[1] "\t" parts[2] "\t" max_attempt[key] "\t" panic_msg[key]
+            }
+        }
+    ' "$logPath" >"$recordsFile"
+
+    declare -A crash_attempt
+    declare -A crash_panic
+    declare -A crash_cases
+    local -a crash_order=()
+
+    while IFS=$'\t' read -r binary test_name attempt panic; do
+        [ -n "$binary" ] || continue
+        if [ -z "${crash_attempt[$binary]+x}" ]; then
+            crash_order+=("$binary")
+            crash_attempt[$binary]=$attempt
+            crash_panic[$binary]="$panic"
+            crash_cases[$binary]="$test_name"
+        else
+            if [ "$attempt" -gt "${crash_attempt[$binary]}" ]; then
+                crash_attempt[$binary]=$attempt
+            fi
+            crash_cases[$binary]="${crash_cases[$binary]}\n$test_name"
+        fi
+    done <"$recordsFile"
+
+    local binary
+    for binary in "${crash_order[@]}"; do
+        local casesJson="[]"
+        if [ -n "${crash_cases[$binary]}" ]; then
+            casesJson=$(printf '%b\n' "${crash_cases[$binary]}" | jq -R . | jq -s -c .)
+        fi
+        jq --arg binary "$binary" \
+           --argjson attempt "${crash_attempt[$binary]}" \
+           --argjson cases "$casesJson" \
+           --arg panic "${crash_panic[$binary]}" \
+           '(.[$binary] //= {}) |
+            .[$binary].crash += [{"attempt": $attempt, "cases": $cases, "panic": $panic}]' \
+           "$resultFile" >"$resultFile".new && mv "$resultFile".new "$resultFile"
+    done
+
+    rm -f "$recordsFile"
+}
+
+# param $1 file path or url
+function main() {
+    local logPath="$1"
+
+    if [[ $logPath =~ https?://.* ]]; then
+        echo "Parse from remote url: $logPath"
+        wget -O nextest-output.log "$logPath"
+        logPath="nextest-output.log"
+    else
+        echo "Parse from local file: $logPath"
+    fi
+
+    parse_nextest_index_log "$logPath"
+
+    echo "{}" >"$DEFAULT_NEXTEST_PROBLEM_CASES_JSONFILE"
+    parse_nextest_flaky_cases "$logPath" "$DEFAULT_NEXTEST_PROBLEM_CASES_JSONFILE"
+    parse_nextest_long_cases "$logPath" "$DEFAULT_NEXTEST_PROBLEM_CASES_JSONFILE"
+    parse_nextest_crash_cases "$logPath" "$DEFAULT_NEXTEST_PROBLEM_CASES_JSONFILE"
+
+    echo "Output files:"
+    ls "$DEFAULT_NEXTEST_PROBLEM_CASES_JSONFILE" \
+        "$DEFAULT_NEXTEST_INDEX_FILE" || true
+}
+
+main "$@"

--- a/scripts/plugins/test_analyze-nextest-output.sh
+++ b/scripts/plugins/test_analyze-nextest-output.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cd "$tmpdir"
+
+FIXTURE_DIR="$repo_root/scripts/plugins/testdata/analyze-nextest-output"
+ANALYZER="$repo_root/scripts/plugins/analyze-nextest-output.sh"
+
+# Helper: assert a test name is in new_flaky for a given binary
+assert_flaky() {
+    local fixture="$1" binary="$2" test_name="$3"
+    local tmpdir2="$(mktemp -d)"
+    (cd "$tmpdir2" && \
+     bash "$ANALYZER" "$FIXTURE_DIR/$fixture" >/dev/null 2>&1 && \
+     jq -e --arg b "$binary" --arg t "$test_name" \
+        '(.[$b].new_flaky // []) | map(.name) | index($t)' \
+        nextest-problem-cases.json >/dev/null) || \
+        { echo "FAIL: $test_name should be in new_flaky for $fixture ($binary)"; rm -rf "$tmpdir2"; return 1; }
+    echo "PASS: $test_name in new_flaky ($fixture / $binary)"
+    rm -rf "$tmpdir2"
+}
+
+# Helper: assert a test name is NOT in new_flaky for a given binary
+assert_not_flaky() {
+    local fixture="$1" binary="$2" test_name="$3"
+    local tmpdir2="$(mktemp -d)"
+    (cd "$tmpdir2" && \
+     bash "$ANALYZER" "$FIXTURE_DIR/$fixture" >/dev/null 2>&1 && \
+     jq -e --arg b "$binary" --arg t "$test_name" \
+        '(.[$b].new_flaky // []) | map(.name) | index($t) | not' \
+        nextest-problem-cases.json >/dev/null) || \
+        { echo "FAIL: $test_name should NOT be in new_flaky for $fixture ($binary)"; rm -rf "$tmpdir2"; return 1; }
+    echo "PASS: $test_name not in new_flaky ($fixture / $binary)"
+    rm -rf "$tmpdir2"
+}
+
+# Helper: assert the reason of a flaky test entry
+assert_flaky_reason() {
+    local fixture="$1" binary="$2" test_name="$3" reason="$4"
+    local tmpdir2="$(mktemp -d)"
+    (cd "$tmpdir2" && \
+     bash "$ANALYZER" "$FIXTURE_DIR/$fixture" >/dev/null 2>&1 && \
+     jq -e --arg b "$binary" --arg t "$test_name" --arg r "$reason" \
+        '(.[$b].new_flaky // []) | any(.name == $t and .reason == $r)' \
+        nextest-problem-cases.json >/dev/null) || \
+        { echo "FAIL: $test_name should have reason '$reason' in $fixture ($binary)"; rm -rf "$tmpdir2"; return 1; }
+    echo "PASS: $test_name reason is '$reason' ($fixture / $binary)"
+    rm -rf "$tmpdir2"
+}
+
+# Helper: assert a test name is in crash cases for a given binary
+assert_crash() {
+    local fixture="$1" binary="$2" test_name="$3"
+    local tmpdir2="$(mktemp -d)"
+    (cd "$tmpdir2" && \
+     bash "$ANALYZER" "$FIXTURE_DIR/$fixture" >/dev/null 2>&1 && \
+     jq -e --arg b "$binary" --arg t "$test_name" \
+        '(.[$b].crash // []) | any(.cases | index($t))' \
+        nextest-problem-cases.json >/dev/null) || \
+        { echo "FAIL: $test_name should be in crash for $fixture ($binary)"; rm -rf "$tmpdir2"; return 1; }
+    echo "PASS: $test_name in crash ($fixture / $binary)"
+    rm -rf "$tmpdir2"
+}
+
+# Helper: assert a test name is NOT in crash cases for a given binary
+assert_no_crash() {
+    local fixture="$1" binary="$2" test_name="$3"
+    local tmpdir2="$(mktemp -d)"
+    (cd "$tmpdir2" && \
+     bash "$ANALYZER" "$FIXTURE_DIR/$fixture" >/dev/null 2>&1 && \
+     jq -e --arg b "$binary" --arg t "$test_name" \
+        '(.[$b].crash // []) | any(.cases | index($t)) | not' \
+        nextest-problem-cases.json >/dev/null) || \
+        { echo "FAIL: $test_name should NOT be in crash for $fixture ($binary)"; rm -rf "$tmpdir2"; return 1; }
+    echo "PASS: $test_name not in crash ($fixture / $binary)"
+    rm -rf "$tmpdir2"
+}
+
+# Helper: assert the crash attempt count of a test in a given binary
+assert_crash_attempt() {
+    local fixture="$1" binary="$2" test_name="$3" attempt="$4"
+    local tmpdir2="$(mktemp -d)"
+    (cd "$tmpdir2" && \
+     bash "$ANALYZER" "$FIXTURE_DIR/$fixture" >/dev/null 2>&1 && \
+     jq -e --arg b "$binary" --arg t "$test_name" --argjson a "$attempt" \
+        'any((.[$b].crash // [])[] | select(.cases | index($t)); .attempt == $a)' \
+        nextest-problem-cases.json >/dev/null) || \
+        { echo "FAIL: crash attempt for $test_name should be $attempt in $fixture ($binary)"; rm -rf "$tmpdir2"; return 1; }
+    echo "PASS: crash attempt for $test_name is $attempt ($fixture / $binary)"
+    rm -rf "$tmpdir2"
+}
+
+# Helper: assert a test has a long_time entry with duration >= min (or == -1 when min < 0)
+assert_long_time() {
+    local fixture="$1" binary="$2" test_name="$3" min_duration="$4"
+    local tmpdir2="$(mktemp -d)"
+    (cd "$tmpdir2" && \
+     bash "$ANALYZER" "$FIXTURE_DIR/$fixture" >/dev/null 2>&1 && \
+     jq -e --arg b "$binary" --arg t "$test_name" --argjson min "$min_duration" \
+        '(.[$b].long_time[$t]? != null) and (if $min < 0 then .[$b].long_time[$t] == -1 else .[$b].long_time[$t] >= $min end)' \
+        nextest-problem-cases.json >/dev/null) || \
+        { echo "FAIL: $test_name should have long_time >= $min_duration in $fixture ($binary)"; rm -rf "$tmpdir2"; return 1; }
+    echo "PASS: $test_name long_time is $min_duration ($fixture / $binary)"
+    rm -rf "$tmpdir2"
+}
+
+# Helper: assert a test has no long_time entry
+assert_no_long_time() {
+    local fixture="$1" binary="$2" test_name="$3"
+    local tmpdir2="$(mktemp -d)"
+    (cd "$tmpdir2" && \
+     bash "$ANALYZER" "$FIXTURE_DIR/$fixture" >/dev/null 2>&1 && \
+     jq -e --arg b "$binary" --arg t "$test_name" \
+        '(.[$b].long_time[$t]? == null)' \
+        nextest-problem-cases.json >/dev/null) || \
+        { echo "FAIL: $test_name should NOT have a long_time entry in $fixture ($binary)"; rm -rf "$tmpdir2"; return 1; }
+    echo "PASS: $test_name no long_time ($fixture / $binary)"
+    rm -rf "$tmpdir2"
+}
+
+failures=0
+
+echo "--- TDD tests: output artifacts ---"
+smoke_dir="$(mktemp -d)"
+if (cd "$smoke_dir" && \
+     bash "$ANALYZER" "$FIXTURE_DIR/sample.log" >/dev/null 2>&1 && \
+     test -f nextest-index.log && \
+     test -f nextest-problem-cases.json && \
+     jq -e 'length > 0' nextest-problem-cases.json >/dev/null); then
+    echo "PASS: output artifacts (nextest-index.log, nextest-problem-cases.json) produced"
+else
+    echo "FAIL: output artifacts missing or empty"
+    failures=$((failures + 1))
+fi
+rm -rf "$smoke_dir"
+
+echo "--- TDD tests: flaky detection ---"
+
+# Smoke test: mixed pass/fail/flaky/crash
+assert_flaky "sample.log" "fixture::basic" "test_flaky_mod_2" || failures=$((failures + 1))
+assert_flaky_reason "sample.log" "fixture::basic" "test_flaky_mod_2" "flaky" || failures=$((failures + 1))
+assert_not_flaky "sample.log" "fixture::panic" "test_flaky_mod_2" || failures=$((failures + 1))
+
+# Flaky detection from FLAKY summary + retry success
+assert_flaky "flaky_retry_pass.log" "fixture::basic" "test_flaky_mod_2" || failures=$((failures + 1))
+assert_flaky_reason "flaky_retry_pass.log" "fixture::basic" "test_flaky_mod_2" "flaky" || failures=$((failures + 1))
+assert_not_flaky "flaky_retry_pass.log" "fixture::basic" "test_pass" || failures=$((failures + 1))
+
+# Timeout-then-pass is flaky with reason=timeout
+assert_flaky "flaky_timeout.log" "fixture::basic" "test_flaky_timeout" || failures=$((failures + 1))
+assert_flaky_reason "flaky_timeout.log" "fixture::basic" "test_flaky_timeout" "timeout" || failures=$((failures + 1))
+
+# No false positive on all-pass
+assert_not_flaky "all_pass.log" "fixture::basic" "test_pass_1" || failures=$((failures + 1))
+assert_not_flaky "all_pass.log" "fixture::basic" "test_pass_2" || failures=$((failures + 1))
+
+# No false positive on always-fail
+assert_not_flaky "persistent_fail.log" "fixture::basic" "test_always_fail" || failures=$((failures + 1))
+
+# No flaky when no retries configured
+assert_not_flaky "no_flaky_no_crash.log" "fixture::basic" "test_fail_no_panic" || failures=$((failures + 1))
+
+# Multi-binary isolation
+assert_flaky "multiple_binaries.log" "crate_a::tests" "test_flaky_a" || failures=$((failures + 1))
+assert_flaky "multiple_binaries.log" "crate_b::tests" "test_flaky_b" || failures=$((failures + 1))
+assert_not_flaky "multiple_binaries.log" "crate_b::tests" "test_flaky_a" || failures=$((failures + 1))
+assert_not_flaky "multiple_binaries.log" "crate_a::tests" "test_flaky_b" || failures=$((failures + 1))
+
+echo "--- TDD tests: crash detection ---"
+
+assert_crash "sample.log" "fixture::panic" "test_crash" || failures=$((failures + 1))
+assert_crash_attempt "sample.log" "fixture::panic" "test_crash" 2 || failures=$((failures + 1))
+assert_crash "persistent_fail.log" "fixture::basic" "test_always_fail" || failures=$((failures + 1))
+assert_crash_attempt "persistent_fail.log" "fixture::basic" "test_always_fail" 3 || failures=$((failures + 1))
+
+# Flaky test that eventually passed is NOT a crash
+assert_no_crash "flaky_retry_pass.log" "fixture::basic" "test_flaky_mod_2" || failures=$((failures + 1))
+assert_no_crash "flaky_timeout.log" "fixture::basic" "test_flaky_timeout" || failures=$((failures + 1))
+# All-pass and no-retries plain failures without panic are NOT crashes
+assert_no_crash "all_pass.log" "fixture::basic" "test_pass_1" || failures=$((failures + 1))
+assert_no_crash "no_flaky_no_crash.log" "fixture::basic" "test_fail_no_panic" || failures=$((failures + 1))
+
+echo "--- TDD tests: long time detection ---"
+
+assert_long_time "slow_pass.log" "fixture::tests" "test_slow" 60 || failures=$((failures + 1))
+assert_no_long_time "slow_pass.log" "fixture::tests" "test_fast" || failures=$((failures + 1))
+assert_long_time "flaky_timeout.log" "fixture::basic" "test_flaky_timeout" -1 || failures=$((failures + 1))
+assert_no_long_time "all_pass.log" "fixture::basic" "test_pass_1" || failures=$((failures + 1))
+assert_no_long_time "no_flaky_no_crash.log" "fixture::basic" "test_fail_no_panic" || failures=$((failures + 1))
+
+echo ""
+if [ "$failures" -gt 0 ]; then
+    echo "FAILED: $failures assertion(s) failed"
+    exit 1
+else
+    echo "All TDD tests passed."
+fi

--- a/scripts/plugins/testdata/analyze-nextest-output/all_pass.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/all_pass.log
@@ -1,0 +1,7 @@
+────────────  Nextest run ID 00000000-0000-0000-0000-000000000001 with nextest profile: default
+    Starting 3 tests across 1 binary (0 skipped)
+       PASS [   0.001s] fixture::basic test_pass_1
+       PASS [   0.002s] fixture::basic test_pass_2
+       PASS [   0.003s] fixture::basic test_pass_3
+────────────
+  Summary [   0.006s] 3 tests run: 3 passed (0 flaky), 0 skipped, 0 failed

--- a/scripts/plugins/testdata/analyze-nextest-output/flaky_retry_pass.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/flaky_retry_pass.log
@@ -1,0 +1,14 @@
+────────────  Nextest run ID 00000000-0000-0000-0000-000000000002 with nextest profile: default
+    Starting 3 tests across 1 binary (0 skipped)
+       PASS [   0.001s] fixture::basic test_pass
+       TRY 1 FAIL [   0.003s] fixture::basic test_flaky_mod_2
+     stdout ---
+        captured stdout line
+     stderr ---
+        thread 'test_flaky_mod_2' panicked at src/basic.rs:42:9:
+        assertion failed
+       TRY 2 PASS [   0.002s] fixture::basic test_flaky_mod_2
+       PASS [   0.001s] fixture::basic test_pass_2
+────────────
+  Summary [   0.008s] 3 tests run: 3 passed (1 flaky), 0 skipped, 0 failed
+     FLAKY 2/3 [   0.002s] fixture::basic test_flaky_mod_2

--- a/scripts/plugins/testdata/analyze-nextest-output/flaky_timeout.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/flaky_timeout.log
@@ -1,0 +1,10 @@
+────────────  Nextest run ID 00000000-0000-0000-0000-000000000004 with nextest profile: default
+    Starting 1 test across 1 binary (0 skipped)
+       TRY 1 TIMEOUT [   5.000s] fixture::basic test_flaky_timeout
+     stderr ---
+        thread 'test_flaky_timeout' panicked at src/basic.rs:200:5:
+        timed out waiting for lock
+       TRY 2 PASS [   0.002s] fixture::basic test_flaky_timeout
+────────────
+  Summary [   5.010s] 1 test run: 1 passed (1 flaky), 0 skipped, 0 failed
+     FLAKY 2/2 [   0.002s] fixture::basic test_flaky_timeout

--- a/scripts/plugins/testdata/analyze-nextest-output/multiple_binaries.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/multiple_binaries.log
@@ -1,0 +1,18 @@
+────────────  Nextest run ID 00000000-0000-0000-0000-000000000006 with nextest profile: default
+    Starting 4 tests across 2 binaries (0 skipped)
+       TRY 1 FAIL [   0.003s] crate_a::tests test_flaky_a
+     stderr ---
+        thread 'test_flaky_a' panicked at src/lib_a.rs:10:5:
+        flaky failure
+       TRY 2 PASS [   0.002s] crate_a::tests test_flaky_a
+       TRY 1 FAIL [   0.003s] crate_b::tests test_flaky_b
+     stderr ---
+        thread 'test_flaky_b' panicked at src/lib_b.rs:10:5:
+        flaky failure
+       TRY 2 PASS [   0.002s] crate_b::tests test_flaky_b
+       PASS [   0.001s] crate_a::tests test_pass_a
+       PASS [   0.001s] crate_b::tests test_pass_b
+────────────
+  Summary [   0.012s] 4 tests run: 4 passed (2 flaky), 0 skipped, 0 failed
+     FLAKY 2/2 [   0.002s] crate_a::tests test_flaky_a
+     FLAKY 2/2 [   0.002s] crate_b::tests test_flaky_b

--- a/scripts/plugins/testdata/analyze-nextest-output/no_flaky_no_crash.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/no_flaky_no_crash.log
@@ -1,0 +1,7 @@
+────────────  Nextest run ID 00000000-0000-0000-0000-000000000008 with nextest profile: default
+    Starting 3 tests across 1 binary (0 skipped)
+       PASS [   0.001s] fixture::basic test_pass
+       FAIL [   0.003s] fixture::basic test_fail_no_panic
+       PASS [   0.002s] fixture::basic test_pass_2
+────────────
+  Summary [   0.006s] 3 tests run: 2 passed, 0 skipped, 1 failed

--- a/scripts/plugins/testdata/analyze-nextest-output/persistent_fail.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/persistent_fail.log
@@ -1,0 +1,17 @@
+────────────  Nextest run ID 00000000-0000-0000-0000-000000000003 with nextest profile: default
+    Starting 1 test across 1 binary (0 skipped)
+       TRY 1 FAIL [   0.003s] fixture::basic test_always_fail
+     stdout ---
+     stderr ---
+        thread 'test_always_fail' panicked at src/basic.rs:100:9:
+        assertion `left == right` failed
+          left: 1
+         right: 2
+       TRY 2 FAIL [   0.003s] fixture::basic test_always_fail
+     stderr ---
+        thread 'test_always_fail' panicked at src/basic.rs:100:9:
+        assertion `left == right` failed
+       TRY 3 FAIL [   0.002s] fixture::basic test_always_fail
+────────────
+  Summary [   0.010s] 1 test run: 0 passed, 0 skipped, 1 failed (1 persistent failure)
+       FAIL [   0.002s] fixture::basic test_always_fail

--- a/scripts/plugins/testdata/analyze-nextest-output/sample.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/sample.log
@@ -1,0 +1,17 @@
+────────────  Nextest run ID 00000000-0000-0000-0000-000000000007 with nextest profile: default
+    Starting 4 tests across 2 binaries (0 skipped)
+       PASS [   0.001s] fixture::basic test_pass
+       TRY 1 FAIL [   0.003s] fixture::basic test_flaky_mod_2
+     stderr ---
+        thread 'test_flaky_mod_2' panicked at src/basic.rs:42:9:
+        assertion failed
+       TRY 2 PASS [   0.002s] fixture::basic test_flaky_mod_2
+       TRY 1 FAIL [   0.003s] fixture::panic test_crash
+     stderr ---
+        thread 'test_crash' panicked at src/panic.rs:5:5:
+        index out of bounds
+       TRY 2 FAIL [   0.003s] fixture::panic test_crash
+────────────
+  Summary [   0.012s] 4 tests run: 3 passed (1 flaky), 0 skipped, 1 failed (1 persistent failure)
+     FLAKY 2/3 [   0.002s] fixture::basic test_flaky_mod_2
+       FAIL [   0.003s] fixture::panic test_crash

--- a/scripts/plugins/testdata/analyze-nextest-output/slow_pass.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/slow_pass.log
@@ -1,0 +1,6 @@
+────────────  Nextest run ID 00000000-0000-0000-0000-000000000005 with nextest profile: default
+    Starting 2 tests across 1 binary (0 skipped)
+       PASS [   0.001s] fixture::tests test_fast
+       SLOW [  61.000s] fixture::tests test_slow
+────────────
+  Summary [  61.005s] 2 tests run: 2 passed (0 flaky), 0 skipped, 0 failed


### PR DESCRIPTION
## Summary

Add `scripts/plugins/analyze-nextest-output.sh`, a bash plugin that parses `cargo nextest run` terminal output (log file or URL) and produces a structured JSON report (`nextest-problem-cases.json`) of flaky, long-running, and crashing tests — following the existing `analyze-go-test-output.sh` / `analyze-go-test-from-bazel-output.sh` patterns.

## Changes

- `scripts/plugins/analyze-nextest-output.sh` — pipeline: index log → flaky cases → long-time cases → crash cases
  - Flaky detection: authoritative `FLAKY n/m` summary lines + attempt tracking fallback (`TRY N FAIL` → `TRY M PASS`), reasons: `flaky` / `timeout` / `race`
  - Long time: tests marked `SLOW`, exceeding `NEXTEST_SLOW_TIME_THRESHOLD` (default 60s), or timed out (`long_time = -1`)
  - Crash: tests that failed on all retries with `panicked at`, grouped per binary with attempt count and panic message (truncated to 200 chars)
  - Output JSON schema: indexed by binary ID with `new_flaky` / `long_time` / `crash` sections
- `scripts/plugins/test_analyze-nextest-output.sh` — TDD test script (33 assertions)
- `scripts/plugins/testdata/analyze-nextest-output/` — 8 log fixtures covering pass/fail/flaky/timeout/slow/multi-binary scenarios

## Testing

`bash scripts/plugins/test_analyze-nextest-output.sh` — All TDD tests passed (flaky, crash, long_time assertions incl. multi-binary isolation and no-false-positive cases).

## Risk

Low. Standalone plugin script; no existing files modified. Parses human-readable nextest output (not a stable API), so regex-based markers may need updates on nextest format changes — mitigated by parsing both attempt lines and FLAKY summary lines.
