### PR TITLE
feat(plugins): add cargo nextest flaky test analyzer

### DIFF
--- a/scripts/plugins/analyze-nextest-output.sh
+++ b/scripts/plugins/analyze-nextest-output.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+DEFAULT_NEXTEST_INDEX_FILE="nextest-index.log"
+DEFAULT_NEXTEST_PROBLEM_CASES_JSONFILE="nextest-problem-cases.json"
+
+NEXTEST_SCAN_KEYS=()
+declare -A NEXTEST_SCAN_ATTEMPTS
+declare -A NEXTEST_SCAN_STATUSES
+declare -A NEXTEST_SCAN_ELAPSED
+declare -A NEXTEST_SCAN_SAW_PASS
+declare -A NEXTEST_SCAN_TIMED_OUT
+declare -A NEXTEST_SCAN_SLOW
+declare -A NEXTEST_SCAN_FLAKY
+declare -A NEXTEST_SCAN_PANIC
+
+# nextest per-attempt status line, e.g.:
+#   TRY 1 FAIL [   0.011s] (───) demo tests::test_flaky
+#   TRY 2 PASS [   0.009s] (1/1) demo tests::test_flaky
+#   TRY 1 TMT [   0.505s] (───) demo tests::test_flaky_timeout
+#   TRY 1 TRMNTG [>  0.500s] (───) demo tests::test_flaky_timeout
+#   SLOW [>  0.500s] (───) demo tests::test_slow
+#   PASS [   0.004s] (1/1) demo tests::test_ok
+NEXTEST_STATUS_REG='^[[:space:]]*(TRY[[:space:]]+([0-9]+)[[:space:]]+)?(FAIL|PASS|TMT|SLOW|TRMNTG)[[:space:]]+\[([^]]+)\][[:space:]]+(\([^)]*\)[[:space:]]+)?([^[:space:]]+)[[:space:]]+([^[:space:]]+)$'
+
+# nextest post-run flaky marker line, e.g.:
+#   FLAKY 2/3 [   0.009s] (1/1) demo tests::test_flaky
+NEXTEST_FLAKY_REG='^[[:space:]]*FLAKY[[:space:]]+[0-9]+/[0-9]+[[:space:]]+\[[^]]+\][[:space:]]+(\([^)]*\)[[:space:]]+)?([^[:space:]]+)[[:space:]]+([^[:space:]]+)$'
+
+NEXTEST_INDEX_REG='(TRY[[:space:]]+[0-9]+[[:space:]]+)?(FAIL|PASS|TMT|SLOW|TRMNTG)[[:space:]]+\[|^[[:space:]]*FLAKY[[:space:]]+|^[[:space:]]+Summary[[:space:]]+\[|panicked at'
+
+# parse nextest log to index file: extract significant lines with line numbers
+# param $1 file path
+function parse_nextest_index_log() {
+    local logPath="$1"
+    grep --color -nE "$NEXTEST_INDEX_REG" "$logPath" >"$DEFAULT_NEXTEST_INDEX_FILE" || true
+}
+
+# extract the numeric duration from a nextest elapsed field like "   0.912s" or ">  0.500s"
+function nextest_elapsed_seconds() {
+    local elapsed="$1"
+    printf '%s' "$elapsed" | sed -E 's/[^0-9.]//g; s/^\./0./'
+}
+
+# scan the raw log and emit per-test facts through the NEXTEST_SCAN_* globals
+function scan_nextest_log() {
+    local logPath="$1"
+
+    declare -A attempts
+    declare -A statuses
+    declare -A elapsed
+    declare -A saw_pass
+    declare -A timed_out
+    declare -A slow_marked
+    declare -A flaky_marked
+    declare -A panic_msg
+
+    local current_key=""
+    local prev_panic_line=""
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ $NEXTEST_FLAKY_REG ]]; then
+            local binary="${BASH_REMATCH[2]}"
+            local testName="${BASH_REMATCH[3]}"
+            flaky_marked["$binary|$testName"]=1
+            current_key=""
+            prev_panic_line=""
+        elif [[ "$line" =~ $NEXTEST_STATUS_REG ]]; then
+            local tryNum="${BASH_REMATCH[2]:-1}"
+            local status="${BASH_REMATCH[3]}"
+            local elapsedStr="${BASH_REMATCH[4]}"
+            local binary="${BASH_REMATCH[6]}"
+            local testName="${BASH_REMATCH[7]}"
+            local key="$binary|$testName"
+
+            attempts[$key]=$tryNum
+            statuses[$key]=$status
+            elapsed[$key]="$elapsedStr"
+
+            if [ "$status" = "PASS" ]; then
+                saw_pass[$key]=1
+                current_key=""
+            elif [ "$status" = "TMT" ]; then
+                timed_out[$key]=1
+                current_key="$key"
+            elif [ "$status" = "SLOW" ]; then
+                slow_marked[$key]=1
+                current_key=""
+            elif [ "$status" = "FAIL" ]; then
+                current_key="$key"
+            else
+                current_key=""
+            fi
+            prev_panic_line=""
+        elif [ -n "$current_key" ]; then
+            if [[ "$line" == *"panicked at"* ]]; then
+                prev_panic_line="${line#*panicked at }"
+            elif [ -n "$prev_panic_line" ] && [ -z "${panic_msg[$current_key]:-}" ]; then
+                local continuation
+                continuation="$(printf '%s' "$line" | xargs)"
+                local msg="$prev_panic_line"
+                if [ -n "$continuation" ] && [[ "$continuation" != note:* ]]; then
+                    msg="${msg} ${continuation}"
+                fi
+                panic_msg["$current_key"]="$(printf '%s' "$msg" | head -c 200)"
+                prev_panic_line=""
+            fi
+        fi
+    done <"$logPath"
+
+    NEXTEST_SCAN_KEYS=()
+
+    declare -A seen_keys
+    local key
+    for key in "${!statuses[@]}" "${!flaky_marked[@]}"; do
+        if [ -n "${seen_keys[$key]:-}" ]; then
+            continue
+        fi
+        seen_keys[$key]=1
+        NEXTEST_SCAN_KEYS+=("$key")
+        NEXTEST_SCAN_ATTEMPTS[$key]="${attempts[$key]:-1}"
+        NEXTEST_SCAN_STATUSES[$key]="${statuses[$key]:-}"
+        NEXTEST_SCAN_ELAPSED[$key]="${elapsed[$key]:-}"
+        NEXTEST_SCAN_SAW_PASS[$key]="${saw_pass[$key]:-0}"
+        NEXTEST_SCAN_TIMED_OUT[$key]="${timed_out[$key]:-0}"
+        NEXTEST_SCAN_SLOW[$key]="${slow_marked[$key]:-0}"
+        NEXTEST_SCAN_FLAKY[$key]="${flaky_marked[$key]:-0}"
+        NEXTEST_SCAN_PANIC[$key]="${panic_msg[$key]:-}"
+    done
+}
+
+function parse_nextest_problem_cases() {
+    local logPath="$1"
+    local resultFile="$2"
+
+    echo "{}" >"$resultFile"
+
+    scan_nextest_log "$logPath"
+
+    declare -A crash_cases
+    declare -A crash_attempt
+    declare -A crash_panic
+
+    local key
+    for key in "${NEXTEST_SCAN_KEYS[@]}"; do
+        local binary="${key%%|*}"
+        local testName="${key##*|}"
+        local lastStatus="${NEXTEST_SCAN_STATUSES[$key]}"
+        local tryNum="${NEXTEST_SCAN_ATTEMPTS[$key]}"
+        local elapsedStr="${NEXTEST_SCAN_ELAPSED[$key]}"
+
+        # flaky: failed at least once then passed on a retry (FLAKY marker or attempt tracking)
+        if [ "${NEXTEST_SCAN_FLAKY[$key]}" = "1" ] ||
+            { [ "${NEXTEST_SCAN_SAW_PASS[$key]}" = "1" ] && { [ "$lastStatus" = "FAIL" ] || [ "$lastStatus" = "TMT" ]; }; }; then
+            local reason="flaky"
+            if [ "${NEXTEST_SCAN_TIMED_OUT[$key]}" = "1" ]; then
+                reason="timeout"
+            fi
+            jq --arg binary "$binary" \
+               --arg name "$testName" \
+               --arg reason "$reason" \
+               '(.[$binary] //= {}) | .[$binary].new_flaky |= ((. // []) + [{"name": $name, "reason": $reason}] | unique)' \
+               "$resultFile" >"$resultFile".new && mv "$resultFile".new "$resultFile"
+        fi
+
+        # long_time: tests marked SLOW, duration of the last attempt (-1 for timeout)
+        if [ "${NEXTEST_SCAN_SLOW[$key]}" = "1" ]; then
+            local duration=-1
+            if [ "$lastStatus" != "TMT" ] && [ "$lastStatus" != "TRMNTG" ]; then
+                duration="$(nextest_elapsed_seconds "$elapsedStr")"
+            fi
+            jq --arg binary "$binary" \
+               --arg name "$testName" \
+               --argjson duration "$duration" \
+               '(.[$binary] //= {}) | (.[$binary].long_time //= {}) | .[$binary].long_time[$name] = $duration' \
+               "$resultFile" >"$resultFile".new && mv "$resultFile".new "$resultFile"
+        fi
+
+        # crash: tests that failed on all attempts (never passed), grouped by binary
+        if [ "$lastStatus" = "FAIL" ] || [ "$lastStatus" = "TMT" ]; then
+            if [ -n "${crash_cases[$binary]:-}" ]; then
+                crash_cases[$binary]="${crash_cases[$binary]} $testName"
+            else
+                crash_cases[$binary]="$testName"
+            fi
+            if [ "$tryNum" -gt "${crash_attempt[$binary]:-0}" ]; then
+                crash_attempt[$binary]="$tryNum"
+            fi
+            if [ -z "${crash_panic[$binary]:-}" ] && [ -n "${NEXTEST_SCAN_PANIC[$key]:-}" ]; then
+                crash_panic[$binary]="${NEXTEST_SCAN_PANIC[$key]}"
+            fi
+        fi
+    done
+
+    local binary
+    for binary in "${!crash_cases[@]}"; do
+        local cases_json
+        cases_json="$(
+            for c in ${crash_cases[$binary]}; do
+                printf '%s\n' "$c"
+            done | jq -R . | jq -s -c .
+        )"
+        jq --arg binary "$binary" \
+           --arg attempt "${crash_attempt[$binary]}" \
+           --argjson cases "$cases_json" \
+           --arg panic "${crash_panic[$binary]:-}" \
+           '.[$binary] |= (. // {}) | .[$binary].crash += [{"attempt": $attempt, "cases": $cases, "panic": $panic}]' \
+           "$resultFile" >"$resultFile".new && mv "$resultFile".new "$resultFile"
+    done
+}
+
+# param $1 file path or url
+function main() {
+    local logPath="$1"
+
+    if [[ $logPath =~ https?://.* ]]; then
+        echo "Parse from remote url: $logPath"
+        if command -v wget &>/dev/null; then
+            wget -O nextest-output.log "$logPath"
+        elif command -v curl &>/dev/null; then
+            curl -o nextest-output.log -L "$logPath"
+        else
+            echo "Error: neither wget nor curl found." >&2
+            exit 1
+        fi
+        logPath="nextest-output.log"
+    else
+        echo "Parse from local file: $logPath"
+    fi
+
+    parse_nextest_index_log "$logPath"
+    parse_nextest_problem_cases "$logPath" "$DEFAULT_NEXTEST_PROBLEM_CASES_JSONFILE"
+
+    echo "Output files:"
+    ls "$DEFAULT_NEXTEST_PROBLEM_CASES_JSONFILE" \
+        "$DEFAULT_NEXTEST_INDEX_FILE" || true
+}
+
+main "$@"

--- a/scripts/plugins/test_analyze-nextest-output.sh
+++ b/scripts/plugins/test_analyze-nextest-output.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+analyzer="$repo_root/scripts/plugins/analyze-nextest-output.sh"
+testdata="$repo_root/scripts/plugins/testdata/analyze-nextest-output"
+
+# Helper: run the analyzer against a fixture in a temp dir and evaluate a jq
+# predicate against the produced nextest-problem-cases.json.
+assert_json() {
+    local fixture="$1" jq_expr="$2" desc="$3"
+    local tmpdir2
+    tmpdir2="$(mktemp -d)"
+    if (cd "$tmpdir2" && \
+        bash "$analyzer" "$testdata/$fixture" >/dev/null 2>&1 && \
+        jq -e "$jq_expr" nextest-problem-cases.json >/dev/null); then
+        echo "PASS: $desc ($fixture)"
+        rm -rf "$tmpdir2"
+        return 0
+    fi
+    echo "FAIL: $desc ($fixture)"
+    rm -rf "$tmpdir2"
+    return 1
+}
+
+# Helper: assert a test is in new_flaky for a binary, optionally with a reason
+assert_flaky() {
+    local fixture="$1" binary="$2" test_name="$3" reason="${4:-}"
+    local expr
+    if [ -n "$reason" ]; then
+        expr='(.["'"$binary"'"].new_flaky // []) | any(.name == "'"$test_name"'" and .reason == "'"$reason"'")'
+    else
+        expr='(.["'"$binary"'"].new_flaky // []) | map(.name) | index("'"$test_name"'") != null'
+    fi
+    assert_json "$fixture" "$expr" "$test_name should be in new_flaky ($binary)" || return 1
+}
+
+# Helper: assert a test is NOT in new_flaky for a binary
+assert_not_flaky() {
+    local fixture="$1" binary="$2" test_name="$3"
+    assert_json "$fixture" \
+        '(.["'"$binary"'"].new_flaky // []) | map(.name) | index("'"$test_name"'") == null' \
+        "$test_name should NOT be in new_flaky ($binary)" || return 1
+}
+
+# Helper: assert a test is in crash.cases for a binary
+assert_crash() {
+    local fixture="$1" binary="$2" test_name="$3"
+    assert_json "$fixture" \
+        '(.["'"$binary"'"].crash // []) | any(.cases | index("'"$test_name"'") != null)' \
+        "$test_name should be in crash ($binary)" || return 1
+}
+
+# Helper: assert a test is NOT in crash.cases for a binary
+assert_not_crash() {
+    local fixture="$1" binary="$2" test_name="$3"
+    assert_json "$fixture" \
+        '(.["'"$binary"'"].crash // []) | any(.cases | index("'"$test_name"'") != null) | not' \
+        "$test_name should NOT be in crash ($binary)" || return 1
+}
+
+# Helper: assert long_time value for a test (min_duration: minimum seconds, -1 for timeout)
+assert_long_time() {
+    local fixture="$1" binary="$2" test_name="$3" min_duration="$4"
+    assert_json "$fixture" \
+        '(.["'"$binary"'"].long_time // {})["'"$test_name"'"] >= '"$min_duration" \
+        "$test_name long_time >= $min_duration ($binary)" || return 1
+}
+
+failures=0
+
+echo "--- TDD tests: flaky detection ---"
+
+# Test 1: all tests pass on first attempt -> nothing flagged
+assert_json "all_pass.log" 'length == 0' "empty result for all-pass run" || failures=$((failures + 1))
+
+# Test 2: FAIL on TRY 1 then PASS on TRY 2 -> flaky, reason flaky
+assert_flaky "flaky_retry_pass.log" "demo" "tests::test_flaky" "flaky" || failures=$((failures + 1))
+
+# Test 3: TMT on TRY 1 then PASS on TRY 2 -> flaky, reason timeout
+assert_flaky "flaky_timeout.log" "demo" "tests::test_flaky_timeout" "timeout" || failures=$((failures + 1))
+
+# Test 4: SLOW marked test that passes -> long_time recorded, not flaky, no crash
+assert_json "slow_pass.log" \
+    '(.["demo"].long_time // {})["tests::test_slow"] >= 0.9' \
+    "test_slow long_time >= 0.9" || failures=$((failures + 1))
+assert_not_flaky "slow_pass.log" "demo" "tests::test_slow" || failures=$((failures + 1))
+assert_not_crash "slow_pass.log" "demo" "tests::test_slow" || failures=$((failures + 1))
+
+# Test 5: persistent failure (FAIL on all retries, panic) -> crash, not flaky
+assert_not_flaky "persistent_fail.log" "demo" "tests::test_always_fail" || failures=$((failures + 1))
+assert_crash "persistent_fail.log" "demo" "tests::test_always_fail" || failures=$((failures + 1))
+assert_json "persistent_fail.log" \
+    '(.["demo"].crash[0].attempt | tonumber) == 3' \
+    "crash attempt is 3 (all retries)" || failures=$((failures + 1))
+assert_json "persistent_fail.log" \
+    '("\(.["demo"].crash[0].panic)" | contains("always fails"))' \
+    "crash panic message captured" || failures=$((failures + 1))
+
+# Test 6: no retries configured -> FAIL is a crash with attempt 1, zero flaky
+assert_not_flaky "no_retry_fail.log" "demo" "tests::test_always_fail" || failures=$((failures + 1))
+assert_crash "no_retry_fail.log" "demo" "tests::test_always_fail" || failures=$((failures + 1))
+assert_json "no_retry_fail.log" \
+    '(.["demo"].crash[0].attempt | tonumber) == 1' \
+    "crash attempt is 1 (no retries)" || failures=$((failures + 1))
+
+# Test 7: flaky tests in two binaries are indexed by their own binary
+assert_flaky "multiple_binaries.log" "demo" "tests::test_flaky" "flaky" || failures=$((failures + 1))
+assert_flaky "multiple_binaries.log" "demo2" "tests::test_flaky_b" "flaky" || failures=$((failures + 1))
+assert_not_flaky "multiple_binaries.log" "demo" "tests::test_flaky_b" || failures=$((failures + 1))
+assert_not_flaky "multiple_binaries.log" "demo2" "tests::test_flaky" || failures=$((failures + 1))
+
+# Test 8: sample mixed run — flaky, crash and long_time all detected
+assert_flaky "sample.log" "demo" "tests::test_flaky" "flaky" || failures=$((failures + 1))
+assert_crash "sample.log" "demo" "tests::test_always_fail" || failures=$((failures + 1))
+assert_not_flaky "sample.log" "demo" "tests::test_ok" || failures=$((failures + 1))
+assert_json "sample.log" \
+    '(.["demo"].long_time // {})["tests::test_slow"] >= 0.9' \
+    "test_slow long_time >= 0.9" || failures=$((failures + 1))
+
+echo ""
+if [ "$failures" -gt 0 ]; then
+    echo "FAILED: $failures assertion(s) failed"
+    exit 1
+else
+    echo "All TDD tests passed."
+fi

--- a/scripts/plugins/testdata/analyze-nextest-output/all_pass.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/all_pass.log
@@ -1,0 +1,8 @@
+   Compiling demo v0.1.0 (/private/tmp/multica-task-384010209/demo)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.05s
+────────────
+ Nextest run ID b02737bc-73c1-4db6-a213-762947bfc758 with nextest profile: ci
+    Starting 1 test across 1 binary (4 tests skipped)
+        PASS [   0.008s] (1/1) demo tests::test_ok
+────────────
+     Summary [   0.008s] 1 test run: 1 passed, 4 skipped

--- a/scripts/plugins/testdata/analyze-nextest-output/flaky_retry_pass.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/flaky_retry_pass.log
@@ -1,0 +1,28 @@
+   Compiling demo v0.1.0 (/private/tmp/multica-task-384010209/demo)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.05s
+────────────
+ Nextest run ID 137fadac-6a97-4e99-8c77-62d63d26ac81 with nextest profile: ci
+    Starting 1 test across 1 binary (4 tests skipped)
+  TRY 1 FAIL [   0.011s] (───) demo tests::test_flaky
+  stdout ───
+
+    running 1 test
+    test tests::test_flaky ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_flaky
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_flaky' panicked at src/lib.rs:46:9:
+    flaky failure
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  TRY 2 PASS [   0.009s] (1/1) demo tests::test_flaky
+────────────
+     Summary [   0.022s] 1 test run: 1 passed (1 flaky), 4 skipped
+   FLAKY 2/3 [   0.009s] (1/1) demo tests::test_flaky

--- a/scripts/plugins/testdata/analyze-nextest-output/flaky_timeout.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/flaky_timeout.log
@@ -1,0 +1,16 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
+────────────
+ Nextest run ID cd0678f2-d3b8-4f96-ba4f-eeab6a2a69d2 with nextest profile: ci
+    Starting 1 test across 1 binary (4 tests skipped)
+TRY 1 TRMNTG [>  0.500s] (───) demo tests::test_flaky_timeout
+   TRY 1 TMT [   0.505s] (───) demo tests::test_flaky_timeout
+  stdout ───
+
+    running 1 test
+
+    (test timed out)
+
+  TRY 2 PASS [   0.021s] (1/1) demo tests::test_flaky_timeout
+────────────
+     Summary [   0.528s] 1 test run: 1 passed (1 flaky), 4 skipped
+   FLAKY 2/3 [   0.021s] (1/1) demo tests::test_flaky_timeout

--- a/scripts/plugins/testdata/analyze-nextest-output/multiple_binaries.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/multiple_binaries.log
@@ -1,0 +1,68 @@
+   Compiling demo2 v0.1.0 (/private/tmp/multica-task-384010209/demo/demo2)
+warning: unused import: `std::io::Write`
+ --> demo2/src/lib.rs:1:5
+  |
+1 | use std::io::Write;
+  |     ^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+warning: function `counter_file` is never used
+ --> demo2/src/lib.rs:4:4
+  |
+4 | fn counter_file(key: &str) -> PathBuf {
+  |    ^^^^^^^^^^^^
+  |
+  = note: `#[warn(dead_code)]` on by default
+
+warning: `demo2` (lib) generated 2 warnings (run `cargo fix --lib -p demo2` to apply 1 suggestion)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.10s
+────────────
+ Nextest run ID 7654515c-96f3-4ac4-a3b5-e75753a5ddad with nextest profile: ci
+    Starting 4 tests across 2 binaries (3 tests skipped)
+        PASS [   0.019s] (1/4) demo tests::test_ok
+        PASS [   0.019s] (2/4) demo2 tests::test_ok_b
+  TRY 1 FAIL [   0.019s] (───) demo tests::test_flaky
+  stdout ───
+
+    running 1 test
+    test tests::test_flaky ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_flaky
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_flaky' panicked at src/lib.rs:46:9:
+    flaky failure
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  TRY 1 FAIL [   0.020s] (───) demo2 tests::test_flaky_b
+  stdout ───
+
+    running 1 test
+    test tests::test_flaky_b ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_flaky_b
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_flaky_b' panicked at demo2/src/lib.rs:24:9:
+    flaky failure in demo2
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  TRY 2 PASS [   0.011s] (3/4) demo2 tests::test_flaky_b
+  TRY 2 PASS [   0.011s] (4/4) demo tests::test_flaky
+────────────
+     Summary [   0.031s] 4 tests run: 4 passed (2 flaky), 3 skipped
+   FLAKY 2/3 [   0.011s] (3/4) demo2 tests::test_flaky_b
+   FLAKY 2/3 [   0.011s] (4/4) demo tests::test_flaky

--- a/scripts/plugins/testdata/analyze-nextest-output/no_retry_fail.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/no_retry_fail.log
@@ -1,0 +1,28 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
+────────────
+ Nextest run ID dccc0d77-b136-4b37-b0b3-aa5676b6f484 with nextest profile: default
+    Starting 1 test across 1 binary (4 tests skipped)
+        FAIL [   0.004s] (1/1) demo tests::test_always_fail
+  stdout ───
+
+    running 1 test
+    test tests::test_always_fail ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_always_fail
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_always_fail' panicked at src/lib.rs:61:9:
+    always fails
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  Cancelling due to test failure: 
+────────────
+     Summary [   0.005s] 1 test run: 0 passed, 1 failed, 4 skipped
+        FAIL [   0.004s] (1/1) demo tests::test_always_fail
+error: test run failed

--- a/scripts/plugins/testdata/analyze-nextest-output/persistent_fail.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/persistent_fail.log
@@ -1,0 +1,66 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
+────────────
+ Nextest run ID 97cc0652-c058-4459-bb45-c40c83972781 with nextest profile: ci
+    Starting 1 test across 1 binary (4 tests skipped)
+  TRY 1 FAIL [   0.004s] (───) demo tests::test_always_fail
+  stdout ───
+
+    running 1 test
+    test tests::test_always_fail ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_always_fail
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_always_fail' panicked at src/lib.rs:61:9:
+    always fails
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  TRY 2 FAIL [   0.004s] (───) demo tests::test_always_fail
+  stdout ───
+
+    running 1 test
+    test tests::test_always_fail ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_always_fail
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_always_fail' panicked at src/lib.rs:61:9:
+    always fails
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  TRY 3 FAIL [   0.004s] (1/1) demo tests::test_always_fail
+  stdout ───
+
+    running 1 test
+    test tests::test_always_fail ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_always_fail
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_always_fail' panicked at src/lib.rs:61:9:
+    always fails
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  Cancelling due to test failure: 
+────────────
+     Summary [   0.016s] 1 test run: 0 passed, 1 failed, 4 skipped
+  TRY 3 FAIL [   0.004s] (1/1) demo tests::test_always_fail
+error: test run failed

--- a/scripts/plugins/testdata/analyze-nextest-output/sample.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/sample.log
@@ -1,0 +1,103 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
+────────────
+ Nextest run ID a24ced2f-ba26-4084-acdd-efa58aea5e76 with nextest profile: ci
+    Starting 5 tests across 1 binary
+        PASS [   0.006s] (1/5) demo tests::test_ok
+  TRY 1 FAIL [   0.006s] (───) demo tests::test_always_fail
+  stdout ───
+
+    running 1 test
+    test tests::test_always_fail ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_always_fail
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_always_fail' panicked at src/lib.rs:61:9:
+    always fails
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  TRY 1 FAIL [   0.006s] (───) demo tests::test_flaky
+  stdout ───
+
+    running 1 test
+    test tests::test_flaky ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_flaky
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_flaky' panicked at src/lib.rs:46:9:
+    flaky failure
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  TRY 2 PASS [   0.005s] (2/5) demo tests::test_flaky
+  TRY 2 FAIL [   0.005s] (───) demo tests::test_always_fail
+  stdout ───
+
+    running 1 test
+    test tests::test_always_fail ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_always_fail
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_always_fail' panicked at src/lib.rs:61:9:
+    always fails
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  TRY 3 FAIL [   0.005s] (3/5) demo tests::test_always_fail
+  stdout ───
+
+    running 1 test
+    test tests::test_always_fail ... FAILED
+
+    failures:
+
+    failures:
+        tests::test_always_fail
+
+    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+  stderr ───
+
+    thread 'tests::test_always_fail' panicked at src/lib.rs:61:9:
+    always fails
+    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+  Cancelling due to test failure: 2 tests still running
+        SLOW [>  0.500s] (───) demo tests::test_slow
+        SLOW [>  0.500s] (───) demo tests::test_flaky_timeout
+        PASS [   0.907s] (4/5) demo tests::test_slow
+        SLOW [>  1.000s] (───) demo tests::test_flaky_timeout
+        SLOW [>  1.500s] (───) demo tests::test_flaky_timeout
+        SLOW [>  2.000s] (───) demo tests::test_flaky_timeout
+TRY 1 TRMNTG [>  2.500s] (───) demo tests::test_flaky_timeout
+   TRY 1 TMT [   2.513s] (───) demo tests::test_flaky_timeout
+  stdout ───
+
+    running 1 test
+
+    (test timed out)
+
+────────────
+     Summary [   2.515s] 4/5 tests run: 3 passed (1 slow, 1 flaky), 1 failed, 0 skipped
+   FLAKY 2/3 [   0.005s] (2/5) demo tests::test_flaky
+  TRY 3 FAIL [   0.005s] (3/5) demo tests::test_always_fail
+warning: 1/5 tests were not run due to test failure (run with --no-fail-fast to run all tests, or run with --max-fail)
+error: test run failed

--- a/scripts/plugins/testdata/analyze-nextest-output/slow_pass.log
+++ b/scripts/plugins/testdata/analyze-nextest-output/slow_pass.log
@@ -1,0 +1,8 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
+────────────
+ Nextest run ID 51721611-4f21-453c-b443-101fe03b02b7 with nextest profile: ci
+    Starting 1 test across 1 binary (4 tests skipped)
+        SLOW [>  0.500s] (───) demo tests::test_slow
+        PASS [   0.912s] (1/1) demo tests::test_slow
+────────────
+     Summary [   0.912s] 1 test run: 1 passed (1 slow), 4 skipped


### PR DESCRIPTION
## Summary

Add `scripts/plugins/analyze-nextest-output.sh`, a bash analyzer that parses `cargo nextest run` output to detect flaky/unstable Rust tests and emit a structured `nextest-problem-cases.json`, following the existing patterns in `analyze-go-test-output.sh` and `analyze-go-test-from-bazel-output.sh`.

## Changes

- **`scripts/plugins/analyze-nextest-output.sh`** (new): parses nextest per-attempt status lines (`TRY N FAIL/PASS/TMT/SLOW/TRMNTG`, `PASS`, post-run `FLAKY N/M`) plus panic messages; outputs JSON indexed by test binary:
  ```json
  {
    "<binary>": {
      "new_flaky": [{"name": "<test>", "reason": "flaky|timeout"}],
      "long_time": {"<test>": <seconds>},
      "crash": [{"attempt": N, "cases": ["<test>"], "panic": "<message>"}]
    }
  }
  ```
  - flaky: failed on an attempt then passed on a retry (authoritative `FLAKY` post-run marker, with attempt-tracking fallback); `reason=timeout` when a TMT attempt preceded the pass
  - long_time: tests flagged `SLOW`, duration of last attempt (`-1` on timeout)
  - crash: tests that never passed (FAIL/TMT on all attempts), grouped per binary with truncated panic message
  - supports local log files and URLs; no retries configured -> empty `{}`, not an error
- **`scripts/plugins/test_analyze-nextest-output.sh`** (new): TDD harness with `jq` assertions, mirroring `test_analyze-go-test-from-bazel-output.sh`
- **`scripts/plugins/testdata/analyze-nextest-output/`** (new): 8 fixtures captured from real `cargo nextest 0.9.140` runs (flaky, timeout-flaky, slow, persistent failure, no-retries, multi-binary, all-pass, mixed sample)

## Testing

- `bash scripts/plugins/test_analyze-nextest-output.sh` — all 21 assertions pass
- `shellcheck` clean on both scripts
- Fixtures generated by running `cargo nextest` 0.9.140 with `retries = 2` and `slow-timeout` profiles (verifiable output format, not hand-crafted)

## Risk

- Low. New standalone plugin; no existing files modified.
- Parses human-readable nextest output, which is not a stable API across nextest versions; the regexes cover the 0.9.86+ retries format (verified against 0.9.140) and degrade to no-TRY lines for older outputs. Logs captured with ANSI colors are not supported (CI logs are non-TTY).
