### PR TITLE
feat(prow-jobs/pingcap/ticdc): make next-gen jobs be required

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
@@ -21,7 +21,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light-next-gen|next-gen-mysql|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-light-next-gen"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint
@@ -31,7 +30,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light-next-gen-legacy-safepoint|next-gen-mysql-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-light-next-gen-legacy-safepoint"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy_next_gen
@@ -41,7 +39,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy-next-gen|next-gen-mysql|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-heavy-next-gen"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint
@@ -51,7 +48,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy-next-gen-legacy-safepoint|next-gen-mysql-legacy-safepoint|next-gen-heavy-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-heavy-next-gen-legacy-safepoint"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_light_next_gen
@@ -61,7 +57,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light-next-gen|next-gen-kafka|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-light-next-gen"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint
@@ -71,7 +66,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light-next-gen-legacy-safepoint|next-gen-kafka-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-light-next-gen-legacy-safepoint"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_heavy_next_gen
@@ -81,7 +75,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-heavy-next-gen|next-gen-kafka|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-heavy-next-gen"
       branches: *branches
-      optional: true
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint
@@ -91,7 +84,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-heavy-next-gen-legacy-safepoint|next-gen-kafka-legacy-safepoint|next-gen-heavy-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-heavy-next-gen-legacy-safepoint"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_light_next_gen
@@ -102,7 +94,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-light-next-gen|next-gen-pulsar|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-pulsar-integration-light-next-gen"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint
@@ -112,7 +103,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-light-next-gen-legacy-safepoint|next-gen-pulsar-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-pulsar-integration-light-next-gen-legacy-safepoint"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_heavy_next_gen
@@ -122,7 +112,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-heavy-next-gen|pulsar|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-pulsar-integration-heavy-next-gen"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint
@@ -132,7 +121,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-heavy-next-gen-legacy-safepoint|next-gen-pulsar-legacy-safepoint|next-gen-heavy-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-pulsar-integration-heavy-next-gen-legacy-safepoint"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_light_next_gen
@@ -142,7 +130,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light-next-gen|next-gen-storage|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-light-next-gen"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_light_next_gen_legacy_safepoint
@@ -152,7 +139,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light-next-gen-legacy-safepoint|next-gen-storage-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-light-next-gen-legacy-safepoint"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_heavy_next_gen
@@ -162,7 +148,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-heavy-next-gen|next-gen-storage|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-heavy-next-gen"
       branches: *branches
-      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint
@@ -172,7 +157,6 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-heavy-next-gen-legacy-safepoint|next-gen-storage-legacy-safepoint|next-gen-heavy-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-heavy-next-gen-legacy-safepoint"
       branches: *branches
-      optional: false
 
     - name: pull-unit-test-next-gen
       decorate: true # need add this.
@@ -196,13 +180,11 @@ presubmits:
               limits:
                 memory: 24Gi
                 cpu: "12"
-      optional: false
 
     - name: pull-build-next-gen
       decorate: true # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
-      optional: false
       branches:
         - ^master$
         - ^release-nextgen-\d+$

--- a/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits-next-gen.yaml
@@ -21,59 +21,62 @@ presubmits:
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light-next-gen|next-gen-mysql|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-light-next-gen"
       branches: *branches
-      optional: true
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint
       # skip_if_only_changed: *skip_if_only_changed
+      run_before_merge: true
       context: pull-cdc-mysql-integration-light-next-gen-legacy-safepoint
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-light-next-gen-legacy-safepoint|next-gen-mysql-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-light-next-gen-legacy-safepoint"
       branches: *branches
-      optional: true
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy_next_gen
       # skip_if_only_changed: *skip_if_only_changed
-      # run_before_merge: true
+      run_before_merge: true
       context: pull-cdc-mysql-integration-heavy-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy-next-gen|next-gen-mysql|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-heavy-next-gen"
       branches: *branches
-      optional: true
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint
       # skip_if_only_changed: *skip_if_only_changed
+      run_before_merge: true
       context: pull-cdc-mysql-integration-heavy-next-gen-legacy-safepoint
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-mysql-integration-heavy-next-gen-legacy-safepoint|next-gen-mysql-legacy-safepoint|next-gen-heavy-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-mysql-integration-heavy-next-gen-legacy-safepoint"
       branches: *branches
-      optional: true
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_light_next_gen
       # skip_if_only_changed: *skip_if_only_changed
-      # run_before_merge: true
+      run_before_merge: true
       context: pull-cdc-kafka-integration-light-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light-next-gen|next-gen-kafka|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-light-next-gen"
       branches: *branches
-      optional: true
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint
       # skip_if_only_changed: *skip_if_only_changed
+      run_before_merge: true
       context: pull-cdc-kafka-integration-light-next-gen-legacy-safepoint
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-light-next-gen-legacy-safepoint|next-gen-kafka-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-light-next-gen-legacy-safepoint"
       branches: *branches
-      optional: true
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_heavy_next_gen
       # skip_if_only_changed: *skip_if_only_changed
-      # run_before_merge: true
+      run_before_merge: true
       context: pull-cdc-kafka-integration-heavy-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-heavy-next-gen|next-gen-kafka|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-heavy-next-gen"
@@ -83,87 +86,93 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint
       # skip_if_only_changed: *skip_if_only_changed
+      run_before_merge: true
       context: pull-cdc-kafka-integration-heavy-next-gen-legacy-safepoint
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-kafka-integration-heavy-next-gen-legacy-safepoint|next-gen-kafka-legacy-safepoint|next-gen-heavy-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-kafka-integration-heavy-next-gen-legacy-safepoint"
       branches: *branches
-      optional: true
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_light_next_gen
       # skip_if_only_changed: *skip_if_only_changed
-      # run_before_merge: true
+      run_before_merge: true
       context: pull-cdc-pulsar-integration-light-next-gen
       optional: true # TODO: change this after the job is ready
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-light-next-gen|next-gen-pulsar|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-pulsar-integration-light-next-gen"
       branches: *branches
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint
       # skip_if_only_changed: *skip_if_only_changed
+      run_before_merge: true
       context: pull-cdc-pulsar-integration-light-next-gen-legacy-safepoint
-      optional: true
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-light-next-gen-legacy-safepoint|next-gen-pulsar-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-pulsar-integration-light-next-gen-legacy-safepoint"
       branches: *branches
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_heavy_next_gen
       # skip_if_only_changed: *skip_if_only_changed
-      # run_before_merge: true
+      run_before_merge: true
       context: pull-cdc-pulsar-integration-heavy-next-gen
-      optional: true
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-heavy-next-gen|pulsar|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-pulsar-integration-heavy-next-gen"
       branches: *branches
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint
       # skip_if_only_changed: *skip_if_only_changed
+      run_before_merge: true
       context: pull-cdc-pulsar-integration-heavy-next-gen-legacy-safepoint
-      optional: true
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-pulsar-integration-heavy-next-gen-legacy-safepoint|next-gen-pulsar-legacy-safepoint|next-gen-heavy-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-pulsar-integration-heavy-next-gen-legacy-safepoint"
       branches: *branches
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_light_next_gen
       # skip_if_only_changed: *skip_if_only_changed
-      # run_before_merge: true
+      run_before_merge: true
       context: pull-cdc-storage-integration-light-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light-next-gen|next-gen-storage|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-light-next-gen"
       branches: *branches
-      optional: true
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_light_next_gen_legacy_safepoint
       # skip_if_only_changed: *skip_if_only_changed
+      run_before_merge: true
       context: pull-cdc-storage-integration-light-next-gen-legacy-safepoint
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-light-next-gen-legacy-safepoint|next-gen-storage-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-light-next-gen-legacy-safepoint"
       branches: *branches
-      optional: true
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_heavy_next_gen
       # skip_if_only_changed: *skip_if_only_changed
-      # run_before_merge: true
+      run_before_merge: true
       context: pull-cdc-storage-integration-heavy-next-gen
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-heavy-next-gen|next-gen-storage|next-gen)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-heavy-next-gen"
       branches: *branches
-      optional: true
+      optional: false
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint
       # skip_if_only_changed: *skip_if_only_changed
+      run_before_merge: true
       context: pull-cdc-storage-integration-heavy-next-gen-legacy-safepoint
       trigger: "(?m)^/test (?:.*? )?(pull-cdc-storage-integration-heavy-next-gen-legacy-safepoint|next-gen-storage-legacy-safepoint|next-gen-heavy-legacy-safepoint|next-gen-legacy-safepoint|legacy-safepoint)(?: .*?)?$"
       rerun_command: "/test pull-cdc-storage-integration-heavy-next-gen-legacy-safepoint"
       branches: *branches
-      optional: true
+      optional: false
 
     - name: pull-unit-test-next-gen
       decorate: true # need add this.
@@ -187,13 +196,13 @@ presubmits:
               limits:
                 memory: 24Gi
                 cpu: "12"
-      optional: true
+      optional: false
 
     - name: pull-build-next-gen
       decorate: true # need add this.
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
-      optional: true
+      optional: false
       branches:
         - ^master$
         - ^release-nextgen-\d+$


### PR DESCRIPTION
Changed job configurations to set 'optional' to false for multiple jobs and added 'run_before_merge' where it was previously commented out.