### PR TITLE
chore(prow-jobs): update client-go nextgen base image to go 1.25.12

### DIFF
--- a/prow-jobs/tikv/client-go/latest-presubmits-nextgen.yaml
+++ b/prow-jobs/tikv/client-go/latest-presubmits-nextgen.yaml
@@ -125,7 +125,7 @@ presubmits:
                 memory: 4Gi
         containers: &containers
           - name: test
-            image: ghcr.io/pingcap-qe/ci/base:v2026.4.12-27-g440b0c8-go1.25
+            image: ghcr.io/pingcap-qe/ci/base:v2026.7.12-6-gc8582dde-go1.25
             command: [bash, -ce]
             env:
               - name: GOTOOLCHAIN


### PR DESCRIPTION
## What

Update the base image of the `pull-integration-test-nextgen` job for `tikv/client-go` from `v2026.4.12-27-g440b0c8-go1.25` (Go 1.25.10) to `v2026.7.12-6-gc8582dde-go1.25` (Go 1.25.12).

## Why

`tikv/client-go` upgraded its Go toolchain requirement to 1.25.12 (tikv/client-go#2036, merged into master). The job sets `GOTOOLCHAIN=local`, so it fails at bootstrap with:

```
go: go.mod requires go >= 1.25.12 (running go 1.25.10; GOTOOLCHAIN=local)
```

## Related

- tikv/client-go PR: https://github.com/tikv/client-go/pull/2024