### PR TITLE
fix(prow-jobs): use Go 1.25.12 base for client-go

### DIFF
--- a/prow-jobs/tikv/client-go/latest-presubmits-nextgen.yaml
+++ b/prow-jobs/tikv/client-go/latest-presubmits-nextgen.yaml
@@ -125,7 +125,7 @@ presubmits:
                 memory: 4Gi
         containers: &containers
           - name: test
-            image: ghcr.io/pingcap-qe/ci/base:v2026.4.12-27-g440b0c8-go1.25
+            image: ghcr.io/pingcap-qe/ci/base:v2026.7.12-6-gc8582dde-go1.25
             command: [bash, -ce]
             env:
               - name: GOTOOLCHAIN


### PR DESCRIPTION
## Summary

- Update the `tikv/client-go` nextgen test container to `ghcr.io/pingcap-qe/ci/base:v2026.7.12-6-gc8582dde-go1.25`.
- The shared container anchor also applies the update to the release-nextgen variant.

## Motivation

[pull-integration-test-nextgen build 2084622432705974272](https://prow.tidb.net/view/gs/prow-tidb-logs/pr-logs/pull/tikv_client-go/2041/pull-integration-test-nextgen/2084622432705974272) used Go 1.25.10, while the PR's `go.mod` requires Go 1.25.12. `GOTOOLCHAIN=local` prevents automatic toolchain download.

## Validation

- Ran `.ci/update-prow-job-kustomization.sh`.
- Parsed the updated YAML with `yq`.
- Verified the selected image's `go-version` label is `1.25.12` with `crane config`.