### PR TITLE
fix(tekton): add publisher-url param to tidbx-image-distributed trigger

### DIFF
--- a/tekton/v1/triggers/triggers/env-gcp/_/notify/update-ops-when-tidbx-image-distributed-to-clouds.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/notify/update-ops-when-tidbx-image-distributed-to-clouds.yaml
@@ -41,6 +41,7 @@ spec:
         - name: images
         - name: target_images
         - name: stage
+        - name: publisher-url
       resourceTemplates:
         - apiVersion: tekton.dev/v1
           kind: TaskRun


### PR DESCRIPTION
Add missing `publisher-url` parameter to the trigger spec in `update-ops-when-tidbx-image-distributed-to-clouds.yaml`.