### PR TITLE
fix(pipelines): revert tidb release-7.5/8.1 unit test go image to go121

### DIFF
--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml
@@ -7,7 +7,7 @@ spec:
     - name: golang
       # TODO(wuhuizuo): using standard bazel build image to shrink the image size
       # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_unit_test.yaml
@@ -7,7 +7,7 @@ spec:
     - name: golang
       # TODO(wuhuizuo): using standard bazel build image to shrink the image size
       # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true


### PR DESCRIPTION
The cloud migration (#4684, #4685) accidentally bumped the Go image from `go12120230809` to `go12520260122` for `release-7.5` and `release-8.1` unit test pods. These release branches are built with Go 1.21, and the `go12120230809` image is being copied to `us-docker.pkg.dev`.

## Changes
- `pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml`: `go12520260122` → `go12120230809`
- `pipelines/pingcap/tidb/release-8.1/pod-ghpr_unit_test.yaml`: `go12520260122` → `go12120230809`