### PR TITLE
fix(pipelines): revert tidb release-7.5/8.1 check2 go image to go121

### DIFF
--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12120230809"
       securityContext:
         privileged: true
       tty: true


### PR DESCRIPTION
The cloud migration (#4684, #4685) accidentally bumped the Go image from `go12120230809` to `go12320241009` for `release-7.5` and `release-8.1` check2 pods. These release branches are built with Go 1.21.

## Changes
- `pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml`: `go12320241009` → `go12120230809`
- `pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml`: `go12320241009` → `go12120230809`