### PR TITLE
fix(pipelines/pingcap/tiflash): resource limits in pod-pull_build.yaml

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
@@ -13,13 +13,9 @@ spec:
         - "cat"
       tty: true
       resources:
-        requests:
+        limits:
           memory: 24Gi
           cpu: "6"
-          ephemeral-storage: 20Gi
-        limits:
-          memory: 32Gi
-          cpu: "8"
           ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"


### PR DESCRIPTION
Removed resource requests and limits for memory and CPU.