### PR TITLE
fix(libraries): use codecov bundled in ci image for coverage upload

### DIFF
--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -208,36 +208,18 @@ def uploadCoverageToCodecov(refs, flags = "", file = "",  bazelLCov = false, baz
         fi
 
         if [ -f \$coverageFile ]; then
-            # Prefer GCS mirror with Workload Identity token; fallback to legacy fileserver.
-            codecov_url="https://storage.googleapis.com/pingcap-ci-bazel-mirror-static-us-central1/download/cicd/tools/codecov-v0.5.0"
-            codecov_legacy_url="http://fileserver.pingcap.net/download/cicd/tools/codecov-v0.5.0"
-            token_api="http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
-            token_json=\$(curl -fsS --retry 3 --retry-delay 2 --connect-timeout 5 --max-time 20 \
-                -H "Metadata-Flavor: Google" "\${token_api}" 2>/dev/null || true)
-            access_token=""
-            if [ -n "\${token_json}" ]; then
-                if command -v python3 >/dev/null 2>&1; then
-                    access_token=\$(printf '%s' "\${token_json}" | \
-                        python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null || true)
-                else
-                    echo "WARN: python3 not found; fallback to sed token parser."
-                fi
-                if [ -z "\${access_token}" ]; then
-                    access_token=\$(printf '%s' "\${token_json}" | \
-                        sed -n 's/.*"access_token":"\\([^"]*\\)".*/\\1/p' | head -n1 || true)
-                fi
-            fi
-            if [ -n "\${access_token}" ] && curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 5 --max-time 120 \
-                -H "Authorization: Bearer \${access_token}" \
-                -o codecov "\${codecov_url}"; then
-                echo "INFO: Downloaded codecov from GCS mirror."
+            # Prefer the codecov binary bundled in the CI base image; download from
+            # the public uploader.codecov.io only when it is not available.
+            if command -v codecov >/dev/null 2>&1; then
+                codecov_bin="codecov"
             else
-                echo "WARN: Could not download codecov from GCS mirror; fallback to legacy fileserver."
-                curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 5 --max-time 60 \
-                    -o codecov "\${codecov_legacy_url}"
+                echo "INFO: codecov not found in image; downloading from uploader.codecov.io."
+                curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 5 --max-time 120 \
+                    -o codecov "https://uploader.codecov.io/v0.8.0/linux/codecov"
+                chmod +x codecov
+                codecov_bin="./codecov"
             fi
-            chmod +x codecov
-            ./codecov --rootDir . --flags ${flags} --file \${coverageFile} ${codecovGitOptions}
+            \${codecov_bin} --rootDir . --flags ${flags} --file \${coverageFile} ${codecovGitOptions}
         fi
     """
 }


### PR DESCRIPTION
## Why

`prow.uploadCoverageToCodecov` downloads the codecov binary before every coverage upload, but both download paths are currently broken:

- **GCS mirror** (`storage.googleapis.com/pingcap-ci-bazel-mirror-static-us-central1/...`): the bucket is private (403 without auth), and CI pods have no Workload Identity, so this path is always skipped.
- **Legacy fileserver** (`http://fileserver.pingcap.net/download/cicd/tools/codecov-v0.5.0`): the file has been removed (404) as part of the fileserver sunset; on GCP runners the connection times out.

Result: the `codecov` binary is never downloaded, `chmod` fails, `./codecov` exits with 127, and the `upload coverage to codecov` step fails every run (not transient — retrying the job does not help).

## What changed

In `libraries/tipipeline/vars/prow.groovy` (`uploadCoverageToCodecov`):

1. Prefer the `codecov` binary already bundled in the CI base image (`/usr/local/bin/codecov`, installed from `uploader.codecov.io` in `dockerfiles/ci/base/Dockerfile`).
2. Only when it is missing, download from the public `https://uploader.codecov.io/v0.8.0/linux/codecov` (same source the base image uses, already verified reachable).
3. Remove the GCS mirror and legacy fileserver download paths entirely.

## Verification

- `bash -n` syntax check on the generated script: OK
- `prow.groovy` groovy parse: OK