### PR TITLE
chore(dockerfiles): add codecov-cli to ci base image

### DIFF
--- a/dockerfiles/ci/base/Dockerfile
+++ b/dockerfiles/ci/base/Dockerfile
@@ -80,7 +80,7 @@ RUN wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VER}/binaries/apa
     rm apache-maven-${MAVEN_VER}-bin.tar.gz
 ENV PATH=$PATH:/opt/apache-maven-${MAVEN_VER}/bin
 
-#### install tools: bazelisk, codecov, oras
+#### install tools: bazelisk, codecov, codecovcli, oras
 # renovate: datasource=github-tags depName=bazelbuild/bazelisk
 ARG BAZELISK_VERSION=v1.29.0
 RUN OS=linux; ARCH=$([ "$(arch)" = "x86_64" ] && echo amd64 || echo arm64); \
@@ -92,6 +92,13 @@ ARG CODECOV_VERSION=v0.8.0
 RUN folder=$([ "$(arch)" = "x86_64" ] && echo linux || echo aarch64); \
     curl -fsSL https://uploader.codecov.io/${CODECOV_VERSION}/${folder}/codecov -o /usr/local/bin/codecov && \
     chmod +x /usr/local/bin/codecov
+
+# codecov-cli tool
+# renovate: datasource=github-tags depName=codecov/codecov-cli
+ARG CODECOVCLI_VERSION=v11.3.1
+RUN ARCH=$([ "$(arch)" = "x86_64" ] && echo linux || echo linux_arm64); \
+    curl -fsSL "https://github.com/codecov/codecov-cli/releases/download/${CODECOVCLI_VERSION}/codecovcli_${ARCH}" -o /usr/local/bin/codecovcli && \
+    chmod +x /usr/local/bin/codecovcli
 
 # oras tool
 COPY --from=ghcr.io/oras-project/oras:v1.3.3 /bin/oras /usr/local/bin/oras


### PR DESCRIPTION
## What changed

Add `codecovcli` (Codecov CLI) to the CI base image in `dockerfiles/ci/base/Dockerfile`, installed at `/usr/local/bin/codecovcli`:

- Pinned to `v11.3.1`, downloaded from GitHub releases (`codecovcli_linux` / `codecovcli_linux_arm64` for amd64/arm64)
- Renovate-tracked via `# renovate: datasource=github-tags depName=codecov/codecov-cli`, same convention as `bazelbuild/bazelisk` and `codecov/uploader` in this file

Both asset URLs verified reachable (200).

## Why

`codecovcli` is currently downloaded at runtime as an unpinned `latest` in the tiflow `ghpr_verify`/merged unit test jobs (e.g. `wget https://cli.codecov.io/latest/linux/codecov` in a sidecar container). Baking a pinned version into the base image makes the toolchain reproducible and removes the runtime download, mirroring how the legacy `codecov` uploader is already bundled. A follow-up PR will switch the pipelines to use the bundled `codecovcli` and drop the sidecar.