### PR TITLE
feat(libraries): add bazel workspace preparation helpers with per-cloud cache config

### DIFF
--- a/libraries/tipipeline/tests/TestBazel.groovy
+++ b/libraries/tipipeline/tests/TestBazel.groovy
@@ -1,0 +1,248 @@
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.experimental.runners.Enclosed
+import static org.junit.Assert.*
+
+/**
+ * Table-driven unit tests for bazel.groovy utility functions.
+ *
+ * Usage:
+ *   groovy libraries/tipipeline/tests/TestBazel.groovy
+ */
+@RunWith(Enclosed.class)
+class TestBazel {
+    private static def loadScript() {
+        new GroovyShell().parse(
+            new File("libraries/tipipeline/vars/bazel.groovy"))
+    }
+
+    private static String captureException(Closure closure) {
+        try {
+            closure()
+        } catch (Exception e) {
+            return e.message
+        }
+        fail('expected an exception to be thrown')
+        return null
+    }
+
+    // ============================================================
+    // stripPattern
+    // ============================================================
+    static class StripPattern {
+        private def stripPattern
+
+        @Before
+        void setUp() {
+            def script = loadScript()
+            stripPattern = { List<String> urls ->
+                script.invokeMethod('stripPattern', [urls] as Object[])
+            }
+        }
+
+        @Test
+        void shouldEscapeDotsAndJoinWithAlternation() {
+            def cases = [
+                [urls: ['bazel-cache.pingcap.net:8080', 'ats.apps.svc', 'cache.hawkingrei.com', 'mirror.bazel.build'],
+                 expected: 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build'],
+                [urls: ['a.b.c'],
+                 expected: 'a[.]b[.]c'],
+            ]
+            cases.each { c ->
+                assert c.expected == stripPattern(c.urls) : "stripPattern(${c.urls}) should be '${c.expected}'"
+            }
+        }
+
+        @Test
+        void shouldReturnEmptyStringForEmptyList() {
+            assert stripPattern([]) == ''
+        }
+    }
+
+    // ============================================================
+    // envConfig
+    // ============================================================
+    static class EnvConfig {
+        private def envConfig
+
+        @Before
+        void setUp() {
+            def script = loadScript()
+            envConfig = { String cloud ->
+                script.invokeMethod('envConfig', [cloud])
+            }
+        }
+
+        @Test
+        void shouldReturnGcpConfigWithLegacyStripUrls() {
+            def cfg = envConfig('gcp')
+            assert cfg.stripUrls == ['bazel-cache.pingcap.net:8080', 'ats.apps.svc', 'cache.hawkingrei.com', 'mirror.bazel.build'] :
+                "gcp stripUrls should contain the 4 legacy URLs, got ${cfg.stripUrls}"
+            assert cfg.remoteCache == null : 'gcp remoteCache should be null by default'
+            assert cfg.repositoryCachePath == null : 'gcp repositoryCachePath should be null by default'
+        }
+
+        @Test
+        void shouldThrowOnUnknownCloud() {
+            def msg = captureException {
+                envConfig('azure')
+            }
+            assert msg.contains('unsupported bazel cloud env: azure') : "unexpected error message: ${msg}"
+        }
+    }
+
+    // ============================================================
+    // buildWorkspaceScript
+    // ============================================================
+    static class BuildWorkspaceScript {
+        private def buildWorkspaceScript
+
+        @Before
+        void setUp() {
+            def script = loadScript()
+            buildWorkspaceScript = { Map opts ->
+                script.invokeMethod('buildWorkspaceScript', [opts])
+            }
+        }
+
+        @Test
+        void shouldEmitDefaultGcpCleanup() {
+            def script = buildWorkspaceScript([cloud: 'gcp'])
+            assert script.startsWith('#!/usr/bin/env bash') : 'should start with bash shebang'
+            assert script.contains('set -euxo pipefail')
+            assert script.contains('bazel-cache[.]pingcap[.]net:8080') : 'should strip legacy bazel-cache URL'
+            assert script.contains('ats[.]apps[.]svc')
+            assert script.contains('cache[.]hawkingrei[.]com')
+            assert script.contains('mirror[.]bazel[.]build')
+            assert script.contains('for f in WORKSPACE DEPS.bzl; do')
+            assert script.contains("sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d'")
+            assert script.contains("sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true")
+            assert script.contains("grep -nE 'bazel-cache[.]pingcap[.]net:8080")
+            assert script.contains("grep -n '^check:' Makefile | head -n 3 || true")
+            assert !script.contains('noremote_accept_cached') : 'gcp default should not disable remote cache'
+            assert !script.contains('repository_cache=') : 'gcp default should not switch repository cache'
+            assert !script.contains('mkdir -p /home/jenkins/.tidb/tmp') : 'gcp default should not create tmp dir'
+        }
+
+        @Test
+        void shouldSkipMakefilePatchWhenDisabled() {
+            def script = buildWorkspaceScript([cloud: 'gcp', patchCheckTarget: false])
+            assert !script.contains('check-bazel-prepare') : 'should skip Makefile check target patch'
+        }
+
+        @Test
+        void shouldUseCustomStripUrls() {
+            def script = buildWorkspaceScript([cloud: 'gcp', stripUrls: ['cache.newcloud.example:8080']])
+            assert script.contains('cache[.]newcloud[.]example:8080') : 'should strip custom URL'
+            assert !script.contains('bazel-cache[.]pingcap[.]net') : 'should not contain default URLs when overridden'
+        }
+
+        @Test
+        void shouldSkipStripBlocksForEmptyUrls() {
+            def script = buildWorkspaceScript([cloud: 'gcp', stripUrls: []])
+            assert script.contains('No stale bazel cache URLs configured')
+            assert !script.contains('sed -i -E')
+        }
+
+        @Test
+        void shouldDisableRemoteCache() {
+            def script = buildWorkspaceScript([cloud: 'gcp', remoteCache: [mode: 'disable']])
+            assert script.contains("sed -i '/^try-import \u005C/data\u005C/bazel\$/d' .bazelrc")
+            ['build', 'test', 'run'].each { scope ->
+                assert script.contains("grep -q '^${scope} --noremote_accept_cached\$' .bazelrc || echo '${scope} --noremote_accept_cached' >> .bazelrc") :
+                    "should disable accept cached for ${scope}"
+                assert script.contains("grep -q '^${scope} --noremote_upload_local_results\$' .bazelrc || echo '${scope} --noremote_upload_local_results' >> .bazelrc") :
+                    "should disable upload local results for ${scope}"
+            }
+            assert script.contains('if [ -f .bazelrc ]; then') : 'should guard .bazelrc edits'
+        }
+
+        @Test
+        void shouldSetRemoteCacheUrl() {
+            def script = buildWorkspaceScript([cloud: 'gcp', remoteCache: [mode: 'set', url: 'https://cache.azure.example:8443']])
+            assert script.contains("sed -i '/^build --remote_cache=/d; /^test --remote_cache=/d; /^run --remote_cache=/d' .bazelrc")
+            ['build', 'test', 'run'].each { scope ->
+                assert script.contains("echo '${scope} --remote_cache=https://cache.azure.example:8443' >> .bazelrc") :
+                    "should set remote cache for ${scope}"
+            }
+        }
+
+        @Test
+        void shouldRequireUrlForSetMode() {
+            def msg = captureException {
+                buildWorkspaceScript([cloud: 'gcp', remoteCache: [mode: 'set']])
+            }
+            assert msg.contains('remoteCache mode "set" requires a url') : "unexpected error message: ${msg}"
+        }
+
+        @Test
+        void shouldRejectUnknownRemoteCacheMode() {
+            def msg = captureException {
+                buildWorkspaceScript([cloud: 'gcp', remoteCache: [mode: 'bogus']])
+            }
+            assert msg.contains('unsupported remoteCache mode: bogus') : "unexpected error message: ${msg}"
+        }
+
+        @Test
+        void shouldSwitchRepositoryCacheWithGuard() {
+            def script = buildWorkspaceScript([cloud: 'gcp', repositoryCache: [path: '/share/.cache/bazel-repository-cache', guard: true]])
+            assert script.contains('if [ -d /share/.cache/bazel-repository-cache ] && mkdir -p /share/.cache/bazel-repository-cache/content_addressable/sha256 2>/dev/null; then')
+            assert script.contains("sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common")
+            assert script.contains('else')
+            assert script.contains('fi')
+        }
+
+        @Test
+        void shouldSwitchRepositoryCacheWithoutGuard() {
+            def script = buildWorkspaceScript([cloud: 'gcp', repositoryCache: [path: '/share/.cache/bazel-repository-cache', guard: false]])
+            assert script.contains("sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common")
+            assert !script.contains('if [ -d /share/.cache/bazel-repository-cache ]') : 'should not guard when guard disabled'
+        }
+
+        @Test
+        void shouldAcceptRepositoryCacheAsString() {
+            def script = buildWorkspaceScript([cloud: 'gcp', repositoryCache: '/share/.cache/bazel-repository-cache'])
+            assert script.contains('if [ -d /share/.cache/bazel-repository-cache ]') : 'string path should default to guarded'
+        }
+
+        @Test
+        void shouldCreateTmpDirWhenRequested() {
+            def script = buildWorkspaceScript([cloud: 'gcp', ensureTmpDir: true])
+            assert script.contains('mkdir -p /home/jenkins/.tidb/tmp')
+        }
+    }
+
+    // ============================================================
+    // buildStaleUrlCleanupScript
+    // ============================================================
+    static class BuildStaleUrlCleanupScript {
+        private def buildStaleUrlCleanupScript
+
+        @Before
+        void setUp() {
+            def script = loadScript()
+            buildStaleUrlCleanupScript = { Map opts ->
+                script.invokeMethod('buildStaleUrlCleanupScript', [opts])
+            }
+        }
+
+        @Test
+        void shouldEmitGuardedReapply() {
+            def script = buildStaleUrlCleanupScript([cloud: 'gcp'])
+            assert script.contains("if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then")
+            assert script.contains('for f in WORKSPACE DEPS.bzl; do')
+            assert script.contains("sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d'")
+            assert script.contains("sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true")
+            assert script.contains('else')
+            assert script.contains('echo "No legacy bazel deps URL found in WORKSPACE/DEPS.bzl."')
+        }
+
+        @Test
+        void shouldSkipForEmptyUrls() {
+            def script = buildStaleUrlCleanupScript([cloud: 'gcp', stripUrls: []])
+            assert script.contains('No stale bazel cache URLs configured')
+            assert !script.contains('grep -qE')
+        }
+    }
+}

--- a/libraries/tipipeline/vars/bazel.groovy
+++ b/libraries/tipipeline/vars/bazel.groovy
@@ -1,0 +1,195 @@
+// bazel.groovy
+//
+// Shared helpers to prepare a checked-out bazel workspace for CI builds.
+//
+// Background: when jobs migrated from AWS to GCP, the legacy bazel
+// cache/mirror endpoints (bazel-cache.pingcap.net:8080, ats.apps.svc,
+// cache.hawkingrei.com, mirror.bazel.build) became unreachable/unstable.
+// Previously every pipeline carried its own "Hotfix bazel deps/cache
+// (temporary)" stage duplicating the same logic. These helpers centralize
+// that logic and make the cache endpoints configurable per cloud
+// environment, so the same job definition can run on any cloud.
+//
+// The cloud environment is selected through the CI_CLOUD_ENV env var
+// (injected globally by Jenkins), defaulting to 'gcp'. To onboard a new
+// cloud, add an entry to envConfig() and adjust the pod templates'
+// cache mounts; job definitions do not need to change.
+
+// Resolve the cloud environment name from the CI_CLOUD_ENV env var.
+def currentEnv() {
+    try {
+        return env.CI_CLOUD_ENV?.trim() ?: null
+    } catch (Exception e) {
+        return null
+    }
+}
+
+// Per-cloud bazel cache configuration.
+//
+// Fields:
+//   stripUrls:           legacy cache/mirror URLs to remove from WORKSPACE/DEPS.bzl
+//   remoteCache:         null, [mode: 'disable'] or [mode: 'set', url: '...']
+//   repositoryCachePath: shared local repository cache path or null
+def envConfig(String cloud = null) {
+    def resolved = cloud?.trim() ?: (currentEnv() ?: 'gcp')
+    switch (resolved) {
+        case 'gcp':
+            return [
+                stripUrls: [
+                    'bazel-cache.pingcap.net:8080',
+                    'ats.apps.svc',
+                    'cache.hawkingrei.com',
+                    'mirror.bazel.build',
+                ],
+                // Mainline gcp jobs do not override .bazelrc remote cache.
+                remoteCache: null,
+                // Shared repository cache is opt-in per job.
+                repositoryCachePath: null,
+            ]
+        default:
+            throw new Exception("unsupported bazel cloud env: ${resolved}, please add it to bazel.envConfig()")
+    }
+}
+
+// Build a sed -E alternation pattern from a list of cache/mirror URLs.
+def stripPattern(List<String> urls) {
+    return urls.collect { it.replaceAll(/\./, '[.]') }.join('|')
+}
+
+// Generate the script that cleans legacy bazel cache/mirror references
+// from the checked out workspace. Run it inside the repo dir.
+//
+// opts:
+//   cloud:            override cloud env name (default: CI_CLOUD_ENV or 'gcp')
+//   stripUrls:        override stale URLs to remove (default: envConfig)
+//   patchCheckTarget: patch Makefile "check:" target to drop check-bazel-prepare (default: true)
+//   remoteCache:      null, [mode: 'disable'] or [mode: 'set', url: '...'] (default: envConfig)
+//   repositoryCache:  null, '/path' or [path: '/path', guard: true|false] (default: envConfig)
+//   ensureTmpDir:     create /home/jenkins/.tidb/tmp (default: false)
+def buildWorkspaceScript(Map opts = [:]) {
+    def cfg = envConfig(opts.cloud)
+    def stripUrls = opts.containsKey('stripUrls') ? opts.stripUrls : cfg.stripUrls
+    def patchCheckTarget = opts.containsKey('patchCheckTarget') ? opts.patchCheckTarget : true
+    def remoteCache = opts.containsKey('remoteCache') ? opts.remoteCache : cfg.remoteCache
+    def repositoryCache = opts.containsKey('repositoryCache') ? opts.repositoryCache : (cfg.repositoryCachePath ? [path: cfg.repositoryCachePath, guard: true] : null)
+    def ensureTmpDir = opts.containsKey('ensureTmpDir') ? opts.ensureTmpDir : false
+
+    if (repositoryCache instanceof String) {
+        repositoryCache = [path: repositoryCache, guard: true]
+    }
+
+    def lines = []
+    lines << '#!/usr/bin/env bash'
+    lines << 'set -euxo pipefail'
+
+    if (stripUrls) {
+        def pattern = stripPattern(stripUrls)
+        lines << '# Clean legacy bazel cache/mirror URLs that are unstable outside the legacy environment.'
+        lines << 'for f in WORKSPACE DEPS.bzl; do'
+        lines << '  [ -f "$f" ] || continue'
+        lines << "  sed -i -E '/${pattern}/d' \"\$f\""
+        lines << 'done'
+
+        if (patchCheckTarget) {
+            lines << '# Avoid "check" targets re-writing legacy cache settings during replay validation.'
+            lines << "sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true"
+        }
+
+        if (ensureTmpDir) {
+            lines << '# Ensure expected bazel tmp dir exists after mount point change.'
+            lines << 'mkdir -p /home/jenkins/.tidb/tmp'
+        }
+
+        if (repositoryCache) {
+            if (repositoryCache.guard) {
+                lines << '# Prefer shared local repository cache when writable, fallback to default path.'
+                lines << "if [ -d ${repositoryCache.path} ] && mkdir -p ${repositoryCache.path}/content_addressable/sha256 2>/dev/null; then"
+                lines << "  sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=${repositoryCache.path}|g' Makefile.common"
+                lines << "  echo \"using shared bazel repository cache: ${repositoryCache.path}\""
+                lines << 'else'
+                lines << '  echo "shared bazel repository cache unavailable or not writable, keep repository_cache=/home/jenkins/.tidb/tmp"'
+                lines << 'fi'
+            } else {
+                lines << "sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=${repositoryCache.path}|g' Makefile.common"
+            }
+        }
+
+        if (remoteCache) {
+            switch (remoteCache.mode) {
+                case 'disable':
+                    lines << '# Disable remote cache usage for this migration replay path.'
+                    lines << 'if [ -f .bazelrc ]; then'
+                    lines << "  sed -i '/^try-import \u005C/data\u005C/bazel\$/d' .bazelrc"
+                    ['build', 'test', 'run'].each { scope ->
+                        lines << "  grep -q '^${scope} --noremote_accept_cached\$' .bazelrc || echo '${scope} --noremote_accept_cached' >> .bazelrc"
+                        lines << "  grep -q '^${scope} --noremote_upload_local_results\$' .bazelrc || echo '${scope} --noremote_upload_local_results' >> .bazelrc"
+                    }
+                    lines << 'fi'
+                    break
+                case 'set':
+                    def url = remoteCache.url?.trim()
+                    if (!url) {
+                        throw new Exception('remoteCache mode "set" requires a url')
+                    }
+                    lines << '# Point bazel remote cache at the cloud cache service.'
+                    lines << 'if [ -f .bazelrc ]; then'
+                    lines << "  sed -i '/^try-import \u005C/data\u005C/bazel\$/d' .bazelrc"
+                    lines << "  sed -i '/^build --remote_cache=/d; /^test --remote_cache=/d; /^run --remote_cache=/d' .bazelrc"
+                    ['build', 'test', 'run'].each { scope ->
+                        lines << "  echo '${scope} --remote_cache=${url}' >> .bazelrc"
+                    }
+                    lines << 'fi'
+                    break
+                default:
+                    throw new Exception("unsupported remoteCache mode: ${remoteCache.mode}")
+            }
+        }
+
+        lines << '# Verify no legacy bazel cache/mirror URLs remain.'
+        lines << "grep -nE '${pattern}' WORKSPACE DEPS.bzl || true"
+        lines << "grep -n '^check:' Makefile | head -n 3 || true"
+    } else {
+        lines << "echo 'No stale bazel cache URLs configured (stripUrls empty), skip cleanup'"
+    }
+
+    return lines.join('\n')
+}
+
+// Run the workspace preparation script. Must be called inside the repo dir.
+def prepareWorkspace(Map opts = [:]) {
+    sh script: buildWorkspaceScript(opts), label: 'prepare bazel workspace'
+}
+
+// Generate the lightweight cleanup script used inside matrix test stages,
+// where the workspace is restored from cache and may contain stale URLs
+// again. Run it inside the repo dir.
+//
+// opts:
+//   cloud:     override cloud env name (default: CI_CLOUD_ENV or 'gcp')
+//   stripUrls: override stale URLs to remove (default: envConfig)
+def buildStaleUrlCleanupScript(Map opts = [:]) {
+    def cfg = envConfig(opts.cloud)
+    def stripUrls = opts.containsKey('stripUrls') ? opts.stripUrls : cfg.stripUrls
+
+    if (!stripUrls) {
+        return '#!/usr/bin/env bash\nset -euxo pipefail\necho "No stale bazel cache URLs configured, skip cleanup"'
+    }
+    def pattern = stripPattern(stripUrls)
+    return """#!/usr/bin/env bash
+set -euxo pipefail
+if grep -qE '${pattern}' WORKSPACE DEPS.bzl 2>/dev/null; then
+  for f in WORKSPACE DEPS.bzl; do
+    [ -f "\$f" ] || continue
+    sed -i -E '/${pattern}/d' "\$f"
+  done
+  sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
+else
+  echo "No legacy bazel deps URL found in WORKSPACE/DEPS.bzl."
+fi
+"""
+}
+
+// Run the lightweight stale URL cleanup. Must be called inside the repo dir.
+def reapplyStaleUrlCleanup(Map opts = [:]) {
+    sh script: buildStaleUrlCleanupScript(opts), label: 're-apply bazel deps URL cleanup'
+}


### PR DESCRIPTION
## What changed

Add shared library helpers (`libraries/tipipeline/vars/bazel.groovy`) that centralize the scattered "Hotfix bazel deps/cache (temporary)" stages currently duplicated across 100+ Jenkins pipeline files.

### New functions

- `bazel.envConfig()` — per-cloud bazel cache configuration, selected via the globally injected `CI_CLOUD_ENV` env var (default `gcp`). Onboarding a new cloud only requires adding an entry here + adjusting pod cache mounts; job definitions stay unchanged.
- `bazel.stripPattern(urls)` — builds sed alternation patterns from cache URL lists (pure function).
- `bazel.prepareWorkspace()` / `buildWorkspaceScript()` — strips legacy cache/mirror URLs from `WORKSPACE`/`DEPS.bzl`, patches the Makefile `check:` target, and optionally disables or re-points `.bazelrc` remote cache / switches the repository cache path.
- `bazel.reapplyStaleUrlCleanup()` / `buildStaleUrlCleanupScript()` — lightweight cleanup for matrix stages that restore workspaces from cache.

### Tests

Table-driven unit tests in `libraries/tipipeline/tests/TestBazel.groovy` (18 cases), runnable via:

```bash
groovy libraries/tipipeline/tests/TestBazel.groovy
```

## Why

The existing hotfixes hardcode the same legacy URL list and cache handling in every pipeline, making multi-cloud rollout (different bazel cache service addresses) a shotgun-edit exercise. This PR is a pure addition — no pipeline call sites are changed yet; follow-up PRs will migrate jobs one batch at a time.