### PR TITLE
refactor(pipelines): use shared bazel.prepareWorkspace in tidb latest ghpr_check

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check.groovy
@@ -34,22 +34,10 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps URL (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-
-                    # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
-                    '''
+                    script { bazel.prepareWorkspace() }
                 }
             }
         }


### PR DESCRIPTION
## What changed

Migrate the first pipeline to the shared bazel workspace helpers added in #4874:

- `pipelines/pingcap/tidb/latest/ghpr_check.groovy`: replace the inline `Hotfix bazel deps URL (temporary)` stage with `bazel.prepareWorkspace()`.

The generated script is byte-identical to the previous inline logic (strip legacy URLs from `WORKSPACE`/`DEPS.bzl` + patch Makefile `check:` target), verified locally against a simulated workspace.

## Why this one first

ghpr_check is a small standalone job — a safe canary to validate the shared helper on a real job before migrating the remaining ~100 pipelines in follow-up PRs.