### PR TITLE
refactor(libraries): run bazel workspace prep from shell script

### DIFF
--- a/libraries/tipipeline/tests/TestBazel.groovy
+++ b/libraries/tipipeline/tests/TestBazel.groovy
@@ -1,3 +1,4 @@
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -5,7 +6,8 @@ import org.junit.experimental.runners.Enclosed
 import static org.junit.Assert.*
 
 /**
- * Table-driven unit tests for bazel.groovy utility functions.
+ * Table-driven unit tests for bazel.groovy utility functions and the
+ * resources/bazel/prepare-workspace.sh script.
  *
  * Usage:
  *   groovy libraries/tipipeline/tests/TestBazel.groovy
@@ -93,85 +95,68 @@ class TestBazel {
     }
 
     // ============================================================
-    // buildWorkspaceScript
+    // workspaceEnv
     // ============================================================
-    static class BuildWorkspaceScript {
-        private def buildWorkspaceScript
+    static class WorkspaceEnv {
+        private def workspaceEnv
 
         @Before
         void setUp() {
             def script = loadScript()
-            buildWorkspaceScript = { Map opts ->
-                script.invokeMethod('buildWorkspaceScript', [opts])
+            workspaceEnv = { Map opts ->
+                script.invokeMethod('workspaceEnv', [opts])
             }
         }
 
         @Test
-        void shouldEmitDefaultGcpCleanup() {
-            def script = buildWorkspaceScript([cloud: 'gcp'])
-            assert script.startsWith('#!/usr/bin/env bash') : 'should start with bash shebang'
-            assert script.contains('set -euxo pipefail')
-            assert script.contains('bazel-cache[.]pingcap[.]net:8080') : 'should strip legacy bazel-cache URL'
-            assert script.contains('ats[.]apps[.]svc')
-            assert script.contains('cache[.]hawkingrei[.]com')
-            assert script.contains('mirror[.]bazel[.]build')
-            assert script.contains('for f in WORKSPACE DEPS.bzl; do')
-            assert script.contains("sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d'")
-            assert script.contains("sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true")
-            assert script.contains("grep -nE 'bazel-cache[.]pingcap[.]net:8080")
-            assert script.contains("grep -n '^check:' Makefile | head -n 3 || true")
-            assert !script.contains('noremote_accept_cached') : 'gcp default should not disable remote cache'
-            assert !script.contains('repository_cache=') : 'gcp default should not switch repository cache'
-            assert !script.contains('mkdir -p /home/jenkins/.tidb/tmp') : 'gcp default should not create tmp dir'
+        void shouldEmitDefaultGcpEnv() {
+            def env = workspaceEnv([cloud: 'gcp'])
+            assert env.BAZEL_STRIP_URLS == 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' :
+                "unexpected strip urls: ${env.BAZEL_STRIP_URLS}"
+            assert env.BAZEL_PATCH_CHECK_TARGET == 'true' : 'should patch check target by default'
+            assert env.BAZEL_ENSURE_TMP_DIR == 'false' : 'should not create tmp dir by default'
+            assert env.BAZEL_REPOSITORY_CACHE_PATH == '' : 'should not switch repository cache by default'
+            assert env.BAZEL_REPOSITORY_CACHE_GUARD == '' : 'guard should be empty without a path'
+            assert env.BAZEL_REMOTE_CACHE_MODE == '' : 'should not touch remote cache by default'
+            assert env.BAZEL_REMOTE_CACHE_URL == '' : 'remote cache url should be empty by default'
         }
 
         @Test
         void shouldSkipMakefilePatchWhenDisabled() {
-            def script = buildWorkspaceScript([cloud: 'gcp', patchCheckTarget: false])
-            assert !script.contains('check-bazel-prepare') : 'should skip Makefile check target patch'
+            def env = workspaceEnv([cloud: 'gcp', patchCheckTarget: false])
+            assert env.BAZEL_PATCH_CHECK_TARGET == 'false'
         }
 
         @Test
         void shouldUseCustomStripUrls() {
-            def script = buildWorkspaceScript([cloud: 'gcp', stripUrls: ['cache.newcloud.example:8080']])
-            assert script.contains('cache[.]newcloud[.]example:8080') : 'should strip custom URL'
-            assert !script.contains('bazel-cache[.]pingcap[.]net') : 'should not contain default URLs when overridden'
+            def env = workspaceEnv([cloud: 'gcp', stripUrls: ['cache.newcloud.example:8080']])
+            assert env.BAZEL_STRIP_URLS == 'cache[.]newcloud[.]example:8080'
         }
 
         @Test
-        void shouldSkipStripBlocksForEmptyUrls() {
-            def script = buildWorkspaceScript([cloud: 'gcp', stripUrls: []])
-            assert script.contains('No stale bazel cache URLs configured')
-            assert !script.contains('sed -i -E')
+        void shouldEmptyStripUrlsForEmptyList() {
+            def env = workspaceEnv([cloud: 'gcp', stripUrls: []])
+            assert env.BAZEL_STRIP_URLS == ''
         }
 
         @Test
         void shouldDisableRemoteCache() {
-            def script = buildWorkspaceScript([cloud: 'gcp', remoteCache: [mode: 'disable']])
-            assert script.contains("sed -i '/^try-import \u005C/data\u005C/bazel\$/d' .bazelrc")
-            ['build', 'test', 'run'].each { scope ->
-                assert script.contains("grep -q '^${scope} --noremote_accept_cached\$' .bazelrc || echo '${scope} --noremote_accept_cached' >> .bazelrc") :
-                    "should disable accept cached for ${scope}"
-                assert script.contains("grep -q '^${scope} --noremote_upload_local_results\$' .bazelrc || echo '${scope} --noremote_upload_local_results' >> .bazelrc") :
-                    "should disable upload local results for ${scope}"
-            }
-            assert script.contains('if [ -f .bazelrc ]; then') : 'should guard .bazelrc edits'
+            def env = workspaceEnv([cloud: 'gcp', remoteCache: [mode: 'disable']])
+            assert env.BAZEL_REMOTE_CACHE_MODE == 'disable'
+            assert env.BAZEL_REMOTE_CACHE_URL == ''
         }
 
         @Test
         void shouldSetRemoteCacheUrl() {
-            def script = buildWorkspaceScript([cloud: 'gcp', remoteCache: [mode: 'set', url: 'https://cache.azure.example:8443']])
-            assert script.contains("sed -i '/^build --remote_cache=/d; /^test --remote_cache=/d; /^run --remote_cache=/d' .bazelrc")
-            ['build', 'test', 'run'].each { scope ->
-                assert script.contains("echo '${scope} --remote_cache=https://cache.azure.example:8443' >> .bazelrc") :
-                    "should set remote cache for ${scope}"
-            }
+            def env = workspaceEnv([cloud: 'gcp', remoteCache: [mode: 'set', url: 'https://cache.azure.example:8443']])
+            assert env.BAZEL_REMOTE_CACHE_MODE == 'set'
+            assert env.BAZEL_REMOTE_CACHE_URL == 'https://cache.azure.example:8443'
         }
 
         @Test
         void shouldRequireUrlForSetMode() {
             def msg = captureException {
-                buildWorkspaceScript([cloud: 'gcp', remoteCache: [mode: 'set']])
+                workspaceEnv([cloud: 'gcp', remoteCache: [mode: 'set']])
             }
             assert msg.contains('remoteCache mode "set" requires a url') : "unexpected error message: ${msg}"
         }
@@ -179,70 +164,213 @@ class TestBazel {
         @Test
         void shouldRejectUnknownRemoteCacheMode() {
             def msg = captureException {
-                buildWorkspaceScript([cloud: 'gcp', remoteCache: [mode: 'bogus']])
+                workspaceEnv([cloud: 'gcp', remoteCache: [mode: 'bogus']])
             }
             assert msg.contains('unsupported remoteCache mode: bogus') : "unexpected error message: ${msg}"
         }
 
         @Test
-        void shouldSwitchRepositoryCacheWithGuard() {
-            def script = buildWorkspaceScript([cloud: 'gcp', repositoryCache: [path: '/share/.cache/bazel-repository-cache', guard: true]])
-            assert script.contains('if [ -d /share/.cache/bazel-repository-cache ] && mkdir -p /share/.cache/bazel-repository-cache/content_addressable/sha256 2>/dev/null; then')
-            assert script.contains("sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common")
-            assert script.contains('else')
-            assert script.contains('fi')
-        }
-
-        @Test
-        void shouldSwitchRepositoryCacheWithoutGuard() {
-            def script = buildWorkspaceScript([cloud: 'gcp', repositoryCache: [path: '/share/.cache/bazel-repository-cache', guard: false]])
-            assert script.contains("sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common")
-            assert !script.contains('if [ -d /share/.cache/bazel-repository-cache ]') : 'should not guard when guard disabled'
-        }
-
-        @Test
         void shouldAcceptRepositoryCacheAsString() {
-            def script = buildWorkspaceScript([cloud: 'gcp', repositoryCache: '/share/.cache/bazel-repository-cache'])
-            assert script.contains('if [ -d /share/.cache/bazel-repository-cache ]') : 'string path should default to guarded'
+            def env = workspaceEnv([cloud: 'gcp', repositoryCache: '/share/.cache/bazel-repository-cache'])
+            assert env.BAZEL_REPOSITORY_CACHE_PATH == '/share/.cache/bazel-repository-cache'
+            assert env.BAZEL_REPOSITORY_CACHE_GUARD == 'true' : 'string path should default to guarded'
+        }
+
+        @Test
+        void shouldDisableRepositoryCacheGuard() {
+            def env = workspaceEnv([cloud: 'gcp', repositoryCache: [path: '/share/.cache/bazel-repository-cache', guard: false]])
+            assert env.BAZEL_REPOSITORY_CACHE_PATH == '/share/.cache/bazel-repository-cache'
+            assert env.BAZEL_REPOSITORY_CACHE_GUARD == 'false'
         }
 
         @Test
         void shouldCreateTmpDirWhenRequested() {
-            def script = buildWorkspaceScript([cloud: 'gcp', ensureTmpDir: true])
-            assert script.contains('mkdir -p /home/jenkins/.tidb/tmp')
+            def env = workspaceEnv([cloud: 'gcp', ensureTmpDir: true])
+            assert env.BAZEL_ENSURE_TMP_DIR == 'true'
         }
     }
 
     // ============================================================
-    // buildStaleUrlCleanupScript
+    // scripts/pingcap/tidb/prepare-bazel-workspace.sh (functional)
     // ============================================================
-    static class BuildStaleUrlCleanupScript {
-        private def buildStaleUrlCleanupScript
+    static class PrepareWorkspaceScript {
+        private static final File RESOURCE = new File('scripts/pingcap/tidb/prepare-bazel-workspace.sh')
+
+        private File workDir
+        private File makefile
+        private File workspaceFile
+        private File depsFile
+
+        private static File createWorkDir() {
+            def dir = new File(System.getProperty('java.io.tmpdir'),
+                "bazel-prepare-test-${System.nanoTime()}")
+            dir.mkdirs()
+            return dir
+        }
 
         @Before
         void setUp() {
-            def script = loadScript()
-            buildStaleUrlCleanupScript = { Map opts ->
-                script.invokeMethod('buildStaleUrlCleanupScript', [opts])
+            workDir = createWorkDir()
+            workspaceFile = new File(workDir, 'WORKSPACE')
+            workspaceFile.text = 'urls = ["https://bazel-cache.pingcap.net:8080/a", "https://mirror.bazel.build/b"]\n'
+            depsFile = new File(workDir, 'DEPS.bzl')
+            depsFile.text = 'DEPS = "https://cache.hawkingrei.com/x"\n'
+            makefile = new File(workDir, 'Makefile')
+            makefile.text = 'check: check-bazel-prepare all\n'
+        }
+
+        @After
+        void tearDown() {
+            workDir.deleteDir()
+        }
+
+        private String runScript(Map<String, String> env) {
+            def builder = new ProcessBuilder('bash', RESOURCE.absolutePath)
+            builder.directory(workDir)
+            builder.environment().putAll(env)
+            builder.environment().remove('BAZEL_GUARDED')
+            def proc = builder.start()
+            def out = proc.inputStream.text
+            def err = proc.errorStream.text
+            def exit = proc.waitFor()
+            if (exit != 0) {
+                fail("script failed (exit ${exit})\nstdout:\n${out}\nstderr:\n${err}")
+            }
+            return out
+        }
+
+        private String stripPattern() {
+            return 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build'
+        }
+
+        @Test
+        void shouldStripLegacyUrlsAndPatchCheckTarget() {
+            runScript([BAZEL_STRIP_URLS: stripPattern()])
+            assert !workspaceFile.text.contains('bazel-cache.pingcap.net') : 'WORKSPACE should not contain legacy URL'
+            assert !depsFile.text.contains('cache.hawkingrei.com') : 'DEPS.bzl should not contain legacy URL'
+            assert makefile.text == 'check: all\n' : "Makefile check target should drop check-bazel-prepare, got: ${makefile.text}"
+        }
+
+        @Test
+        void shouldSkipMakefilePatchWhenDisabled() {
+            runScript([BAZEL_STRIP_URLS: stripPattern(), BAZEL_PATCH_CHECK_TARGET: 'false'])
+            assert makefile.text == 'check: check-bazel-prepare all\n' : 'Makefile should be untouched'
+        }
+
+        @Test
+        void shouldSkipWhenEmptyStripUrls() {
+            runScript([BAZEL_STRIP_URLS: ''])
+            assert workspaceFile.text.contains('bazel-cache.pingcap.net') : 'nothing should be stripped'
+            assert makefile.text.contains('check-bazel-prepare') : 'Makefile should be untouched'
+        }
+
+        @Test
+        void shouldSkipCleanupInGuardedModeWhenNoStaleUrls() {
+            def dir = createWorkDir()
+            try {
+                def wf = new File(dir, 'WORKSPACE')
+                wf.text = 'urls = ["https://example.com/clean"]\n'
+                def mf = new File(dir, 'Makefile')
+                mf.text = 'check: check-bazel-prepare all\n'
+                def builder = new ProcessBuilder('bash', RESOURCE.absolutePath)
+                builder.directory(dir)
+                builder.environment().putAll([BAZEL_STRIP_URLS: stripPattern(), BAZEL_GUARDED: 'true'])
+                def proc = builder.start()
+                def exit = proc.waitFor()
+                assert exit == 0 : "script failed: ${proc.errorStream.text}"
+                assert wf.text.contains('example.com/clean') : 'clean workspace should be untouched'
+                assert mf.text.contains('check-bazel-prepare') : 'Makefile should be untouched in guarded skip'
+            } finally {
+                dir.deleteDir()
             }
         }
 
         @Test
-        void shouldEmitGuardedReapply() {
-            def script = buildStaleUrlCleanupScript([cloud: 'gcp'])
-            assert script.contains("if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then")
-            assert script.contains('for f in WORKSPACE DEPS.bzl; do')
-            assert script.contains("sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d'")
-            assert script.contains("sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true")
-            assert script.contains('else')
-            assert script.contains('echo "No legacy bazel deps URL found in WORKSPACE/DEPS.bzl."')
+        void shouldCleanupInGuardedModeWhenStaleUrlsPresent() {
+            runScript([BAZEL_STRIP_URLS: stripPattern(), BAZEL_GUARDED: 'true'])
+            def dir = createWorkDir()
+            try {
+                def wf = new File(dir, 'WORKSPACE')
+                wf.text = 'urls = ["https://bazel-cache.pingcap.net:8080/a"]\n'
+                new File(dir, 'Makefile').text = 'check: check-bazel-prepare all\n'
+                def builder = new ProcessBuilder('bash', RESOURCE.absolutePath)
+                builder.directory(dir)
+                builder.environment().putAll([BAZEL_STRIP_URLS: stripPattern(), BAZEL_GUARDED: 'true'])
+                def proc = builder.start()
+                def exit = proc.waitFor()
+                assert exit == 0 : "script failed: ${proc.errorStream.text}"
+                assert !wf.text.contains('bazel-cache.pingcap.net') : 'stale URL should be removed'
+                assert new File(dir, 'Makefile').text == 'check: all\n' : 'Makefile should be patched'
+            } finally {
+                dir.deleteDir()
+            }
         }
 
         @Test
-        void shouldSkipForEmptyUrls() {
-            def script = buildStaleUrlCleanupScript([cloud: 'gcp', stripUrls: []])
-            assert script.contains('No stale bazel cache URLs configured')
-            assert !script.contains('grep -qE')
+        void shouldDisableRemoteCacheInBazelrc() {
+            def bazelrc = new File(workDir, '.bazelrc')
+            bazelrc.text = 'try-import /data/bazel\n'
+            runScript([BAZEL_STRIP_URLS: stripPattern(), BAZEL_REMOTE_CACHE_MODE: 'disable'])
+            def content = bazelrc.text
+            assert !content.contains('try-import /data/bazel') : 'try-import should be removed'
+            ['build', 'test', 'run'].each { scope ->
+                assert content.contains("${scope} --noremote_accept_cached") : "missing ${scope} --noremote_accept_cached"
+                assert content.contains("${scope} --noremote_upload_local_results") : "missing ${scope} --noremote_upload_local_results"
+            }
+        }
+
+        @Test
+        void shouldSetRemoteCacheUrlInBazelrc() {
+            def bazelrc = new File(workDir, '.bazelrc')
+            bazelrc.text = 'build --remote_cache=old://cache\n'
+            runScript([BAZEL_STRIP_URLS: stripPattern(), BAZEL_REMOTE_CACHE_MODE: 'set',
+                       BAZEL_REMOTE_CACHE_URL: 'https://cache.azure.example:8443'])
+            def content = bazelrc.text
+            assert !content.contains('old://cache') : 'old remote cache url should be removed'
+            ['build', 'test', 'run'].each { scope ->
+                assert content.contains("${scope} --remote_cache=https://cache.azure.example:8443") :
+                    "missing ${scope} --remote_cache url"
+            }
+        }
+
+        @Test
+        void shouldUseSharedRepositoryCacheWhenWritable() {
+            def shared = new File(workDir, 'share-cache')
+            shared.mkdirs()
+            def makefileCommon = new File(workDir, 'Makefile.common')
+            makefileCommon.text = 'repository_cache=/home/jenkins/.tidb/tmp\n'
+            runScript([BAZEL_STRIP_URLS: stripPattern(),
+                       BAZEL_REPOSITORY_CACHE_PATH: shared.absolutePath])
+            assert makefileCommon.text.contains("repository_cache=${shared.absolutePath}") :
+                "Makefile.common should point at shared cache, got: ${makefileCommon.text}"
+        }
+
+        @Test
+        void shouldKeepDefaultRepositoryCacheWhenSharedUnavailable() {
+            def makefileCommon = new File(workDir, 'Makefile.common')
+            makefileCommon.text = 'repository_cache=/home/jenkins/.tidb/tmp\n'
+            runScript([BAZEL_STRIP_URLS: stripPattern(),
+                       BAZEL_REPOSITORY_CACHE_PATH: '/nonexistent-share-cache'])
+            assert makefileCommon.text.contains('repository_cache=/home/jenkins/.tidb/tmp') :
+                'Makefile.common should keep the default path'
+        }
+
+        @Test
+        void shouldSwitchRepositoryCacheWithoutGuard() {
+            def makefileCommon = new File(workDir, 'Makefile.common')
+            makefileCommon.text = 'repository_cache=/home/jenkins/.tidb/tmp\n'
+            runScript([BAZEL_STRIP_URLS: stripPattern(),
+                       BAZEL_REPOSITORY_CACHE_PATH: '/nonexistent-share-cache',
+                       BAZEL_REPOSITORY_CACHE_GUARD: 'false'])
+            assert makefileCommon.text.contains('repository_cache=/nonexistent-share-cache') :
+                'unguarded mode should switch unconditionally'
+        }
+
+        @Test
+        void shouldCreateTmpDirWhenRequested() {
+            def tmpDir = new File(workDir, 'tmp-dir')
+            runScript([BAZEL_STRIP_URLS: stripPattern(), BAZEL_ENSURE_TMP_DIR: 'true', BAZEL_TMP_DIR: tmpDir.absolutePath])
+            assert tmpDir.isDirectory() : 'tmp dir should be created'
         }
     }
 }

--- a/libraries/tipipeline/vars/bazel.groovy
+++ b/libraries/tipipeline/vars/bazel.groovy
@@ -10,6 +10,12 @@
 // that logic and make the cache endpoints configurable per cloud
 // environment, so the same job definition can run on any cloud.
 //
+// The actual workspace manipulation lives in the plain shell script
+// scripts/pingcap/tidb/prepare-bazel-workspace.sh (available in the
+// agent workspace via the ci repo checkout), so no fragile shell
+// escaping is needed in Groovy. Configuration flows to the script
+// through BAZEL_* env vars computed by workspaceEnv().
+//
 // The cloud environment is selected through the CI_CLOUD_ENV env var
 // (injected globally by Jenkins), defaulting to 'gcp'. To onboard a new
 // cloud, add an entry to envConfig() and adjust the pod templates'
@@ -56,140 +62,63 @@ def stripPattern(List<String> urls) {
     return urls.collect { it.replaceAll(/\./, '[.]') }.join('|')
 }
 
-// Generate the script that cleans legacy bazel cache/mirror references
-// from the checked out workspace. Run it inside the repo dir.
+// Compute the BAZEL_* environment map consumed by resources/bazel/prepare-workspace.sh.
 //
 // opts:
 //   cloud:            override cloud env name (default: CI_CLOUD_ENV or 'gcp')
 //   stripUrls:        override stale URLs to remove (default: envConfig)
-//   patchCheckTarget: patch Makefile "check:" target to drop check-bazel-prepare (default: true)
+//   patchCheckTarget: patch Makefile "check:" target (default: true)
 //   remoteCache:      null, [mode: 'disable'] or [mode: 'set', url: '...'] (default: envConfig)
 //   repositoryCache:  null, '/path' or [path: '/path', guard: true|false] (default: envConfig)
-//   ensureTmpDir:     create /home/jenkins/.tidb/tmp (default: false)
-def buildWorkspaceScript(Map opts = [:]) {
+//   ensureTmpDir:     create the bazel tmp dir (default: false)
+def workspaceEnv(Map opts = [:]) {
     def cfg = envConfig(opts.cloud)
     def stripUrls = opts.containsKey('stripUrls') ? opts.stripUrls : cfg.stripUrls
     def patchCheckTarget = opts.containsKey('patchCheckTarget') ? opts.patchCheckTarget : true
-    def remoteCache = opts.containsKey('remoteCache') ? opts.remoteCache : cfg.remoteCache
-    def repositoryCache = opts.containsKey('repositoryCache') ? opts.repositoryCache : (cfg.repositoryCachePath ? [path: cfg.repositoryCachePath, guard: true] : null)
     def ensureTmpDir = opts.containsKey('ensureTmpDir') ? opts.ensureTmpDir : false
-
+    def repositoryCache = opts.containsKey('repositoryCache') ? opts.repositoryCache : (cfg.repositoryCachePath ? [path: cfg.repositoryCachePath, guard: true] : null)
     if (repositoryCache instanceof String) {
         repositoryCache = [path: repositoryCache, guard: true]
     }
-
-    def lines = []
-    lines << '#!/usr/bin/env bash'
-    lines << 'set -euxo pipefail'
-
-    if (stripUrls) {
-        def pattern = stripPattern(stripUrls)
-        lines << '# Clean legacy bazel cache/mirror URLs that are unstable outside the legacy environment.'
-        lines << 'for f in WORKSPACE DEPS.bzl; do'
-        lines << '  [ -f "$f" ] || continue'
-        lines << "  sed -i -E '/${pattern}/d' \"\$f\""
-        lines << 'done'
-
-        if (patchCheckTarget) {
-            lines << '# Avoid "check" targets re-writing legacy cache settings during replay validation.'
-            lines << "sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true"
-        }
-
-        if (ensureTmpDir) {
-            lines << '# Ensure expected bazel tmp dir exists after mount point change.'
-            lines << 'mkdir -p /home/jenkins/.tidb/tmp'
-        }
-
-        if (repositoryCache) {
-            if (repositoryCache.guard) {
-                lines << '# Prefer shared local repository cache when writable, fallback to default path.'
-                lines << "if [ -d ${repositoryCache.path} ] && mkdir -p ${repositoryCache.path}/content_addressable/sha256 2>/dev/null; then"
-                lines << "  sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=${repositoryCache.path}|g' Makefile.common"
-                lines << "  echo \"using shared bazel repository cache: ${repositoryCache.path}\""
-                lines << 'else'
-                lines << '  echo "shared bazel repository cache unavailable or not writable, keep repository_cache=/home/jenkins/.tidb/tmp"'
-                lines << 'fi'
-            } else {
-                lines << "sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=${repositoryCache.path}|g' Makefile.common"
-            }
-        }
-
-        if (remoteCache) {
-            switch (remoteCache.mode) {
-                case 'disable':
-                    lines << '# Disable remote cache usage for this migration replay path.'
-                    lines << 'if [ -f .bazelrc ]; then'
-                    lines << "  sed -i '/^try-import \u005C/data\u005C/bazel\$/d' .bazelrc"
-                    ['build', 'test', 'run'].each { scope ->
-                        lines << "  grep -q '^${scope} --noremote_accept_cached\$' .bazelrc || echo '${scope} --noremote_accept_cached' >> .bazelrc"
-                        lines << "  grep -q '^${scope} --noremote_upload_local_results\$' .bazelrc || echo '${scope} --noremote_upload_local_results' >> .bazelrc"
-                    }
-                    lines << 'fi'
-                    break
-                case 'set':
-                    def url = remoteCache.url?.trim()
-                    if (!url) {
-                        throw new Exception('remoteCache mode "set" requires a url')
-                    }
-                    lines << '# Point bazel remote cache at the cloud cache service.'
-                    lines << 'if [ -f .bazelrc ]; then'
-                    lines << "  sed -i '/^try-import \u005C/data\u005C/bazel\$/d' .bazelrc"
-                    lines << "  sed -i '/^build --remote_cache=/d; /^test --remote_cache=/d; /^run --remote_cache=/d' .bazelrc"
-                    ['build', 'test', 'run'].each { scope ->
-                        lines << "  echo '${scope} --remote_cache=${url}' >> .bazelrc"
-                    }
-                    lines << 'fi'
-                    break
-                default:
-                    throw new Exception("unsupported remoteCache mode: ${remoteCache.mode}")
-            }
-        }
-
-        lines << '# Verify no legacy bazel cache/mirror URLs remain.'
-        lines << "grep -nE '${pattern}' WORKSPACE DEPS.bzl || true"
-        lines << "grep -n '^check:' Makefile | head -n 3 || true"
-    } else {
-        lines << "echo 'No stale bazel cache URLs configured (stripUrls empty), skip cleanup'"
+    def remoteCache = opts.containsKey('remoteCache') ? opts.remoteCache : cfg.remoteCache
+    def remoteMode = remoteCache?.mode?.trim() ?: ''
+    if (remoteMode == 'set' && !(remoteCache.url?.trim())) {
+        throw new Exception('remoteCache mode "set" requires a url')
+    }
+    if (remoteMode != '' && remoteMode != 'disable' && remoteMode != 'set') {
+        throw new Exception("unsupported remoteCache mode: ${remoteMode}")
     }
 
-    return lines.join('\n')
+    return [
+        'BAZEL_STRIP_URLS': stripUrls ? stripPattern(stripUrls) : '',
+        'BAZEL_PATCH_CHECK_TARGET': patchCheckTarget ? 'true' : 'false',
+        'BAZEL_ENSURE_TMP_DIR': ensureTmpDir ? 'true' : 'false',
+        'BAZEL_REPOSITORY_CACHE_PATH': repositoryCache ? repositoryCache.path : '',
+        'BAZEL_REPOSITORY_CACHE_GUARD': repositoryCache ? ((repositoryCache.containsKey('guard') ? repositoryCache.guard : true) ? 'true' : 'false') : '',
+        'BAZEL_REMOTE_CACHE_MODE': remoteMode,
+        'BAZEL_REMOTE_CACHE_URL': remoteMode == 'set' ? remoteCache.url : '',
+    ]
 }
 
 // Run the workspace preparation script. Must be called inside the repo dir.
 def prepareWorkspace(Map opts = [:]) {
-    sh script: buildWorkspaceScript(opts), label: 'prepare bazel workspace'
+    runBazelScript('prepare-bazel-workspace.sh', workspaceEnv(opts))
 }
 
-// Generate the lightweight cleanup script used inside matrix test stages,
-// where the workspace is restored from cache and may contain stale URLs
-// again. Run it inside the repo dir.
-//
-// opts:
-//   cloud:     override cloud env name (default: CI_CLOUD_ENV or 'gcp')
-//   stripUrls: override stale URLs to remove (default: envConfig)
-def buildStaleUrlCleanupScript(Map opts = [:]) {
-    def cfg = envConfig(opts.cloud)
-    def stripUrls = opts.containsKey('stripUrls') ? opts.stripUrls : cfg.stripUrls
-
-    if (!stripUrls) {
-        return '#!/usr/bin/env bash\nset -euxo pipefail\necho "No stale bazel cache URLs configured, skip cleanup"'
-    }
-    def pattern = stripPattern(stripUrls)
-    return """#!/usr/bin/env bash
-set -euxo pipefail
-if grep -qE '${pattern}' WORKSPACE DEPS.bzl 2>/dev/null; then
-  for f in WORKSPACE DEPS.bzl; do
-    [ -f "\$f" ] || continue
-    sed -i -E '/${pattern}/d' "\$f"
-  done
-  sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-else
-  echo "No legacy bazel deps URL found in WORKSPACE/DEPS.bzl."
-fi
-"""
-}
-
-// Run the lightweight stale URL cleanup. Must be called inside the repo dir.
+// Lightweight cleanup for matrix test stages, where the workspace is
+// restored from cache and may contain stale URLs again. Must be called
+// inside the repo dir.
 def reapplyStaleUrlCleanup(Map opts = [:]) {
-    sh script: buildStaleUrlCleanupScript(opts), label: 're-apply bazel deps URL cleanup'
+    def env = workspaceEnv(opts)
+    env['BAZEL_GUARDED'] = 'true'
+    runBazelScript('prepare-bazel-workspace.sh', env)
+}
+
+// Run the workspace preparation script with the given BAZEL_* env vars.
+// Must be called inside the repo dir; the script is looked up in the ci
+// repo checkout in the agent workspace.
+def runBazelScript(String scriptName, Map bazelEnv) {
+    withEnv(bazelEnv.collect { key, value -> "${key}=${value}" }) {
+        sh "bash \${WORKSPACE}/scripts/pingcap/tidb/${scriptName}"
+    }
 }

--- a/scripts/pingcap/tidb/prepare-bazel-workspace.sh
+++ b/scripts/pingcap/tidb/prepare-bazel-workspace.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Prepare a checked-out bazel workspace for CI builds.
+#
+# Centralizes the legacy per-pipeline "Hotfix bazel deps/cache (temporary)"
+# logic. Configuration is passed through environment variables set by the
+# bazel.groovy shared library:
+#
+#   BAZEL_STRIP_URLS             sed -E alternation of legacy cache/mirror
+#                                URLs to remove from WORKSPACE/DEPS.bzl
+#   BAZEL_PATCH_CHECK_TARGET     "true" to drop check-bazel-prepare from the
+#                                Makefile "check:" target (default: true)
+#   BAZEL_ENSURE_TMP_DIR         "true" to create the bazel tmp dir
+#   BAZEL_TMP_DIR                bazel tmp dir (default: /home/jenkins/.tidb/tmp)
+#   BAZEL_REPOSITORY_CACHE_PATH  shared repository cache dir, empty to keep
+#                                the default path (default: empty)
+#   BAZEL_REPOSITORY_CACHE_GUARD "true" to only use the shared cache when it
+#                                is writable (default: true)
+#   BAZEL_REMOTE_CACHE_MODE      "disable" to turn remote cache off in
+#                                .bazelrc, "set" to point it at
+#                                BAZEL_REMOTE_CACHE_URL (default: empty)
+#   BAZEL_REMOTE_CACHE_URL       cache service URL used with mode "set"
+#   BAZEL_GUARDED                "true" to skip everything when no stale URL
+#                                is present (used after workspace cache
+#                                restore in matrix stages)
+set -euxo pipefail
+
+# Portable in-place sed (GNU and BSD).
+if sed --version >/dev/null 2>&1; then
+    SED_I=(sed -i)
+else
+    SED_I=(sed -i '')
+fi
+
+if [ -z "${BAZEL_STRIP_URLS:-}" ]; then
+    echo "No stale bazel cache URLs configured (BAZEL_STRIP_URLS empty), skip cleanup"
+    exit 0
+fi
+
+if [ "${BAZEL_GUARDED:-false}" = "true" ] && ! grep -qE "${BAZEL_STRIP_URLS}" WORKSPACE DEPS.bzl 2>/dev/null; then
+    echo "No legacy bazel deps URL found in WORKSPACE/DEPS.bzl, skip cleanup"
+    exit 0
+fi
+
+# Clean legacy cache/mirror URLs that are unstable outside the legacy environment.
+for f in WORKSPACE DEPS.bzl; do
+    [ -f "$f" ] || continue
+    "${SED_I[@]}" -E "/${BAZEL_STRIP_URLS}/d" "$f"
+done
+
+# Avoid "check" targets re-writing legacy cache settings during replay validation.
+if [ "${BAZEL_PATCH_CHECK_TARGET:-true}" = "true" ]; then
+    "${SED_I[@]}" 's/^check: check-bazel-prepare /check: /' Makefile || true
+fi
+
+if [ "${BAZEL_ENSURE_TMP_DIR:-false}" = "true" ]; then
+    mkdir -p "${BAZEL_TMP_DIR:-/home/jenkins/.tidb/tmp}"
+fi
+
+# Prefer shared local repository cache when writable, fallback to default path.
+if [ -n "${BAZEL_REPOSITORY_CACHE_PATH:-}" ]; then
+    if [ "${BAZEL_REPOSITORY_CACHE_GUARD:-true}" = "true" ]; then
+        if [ -d "${BAZEL_REPOSITORY_CACHE_PATH}" ] && mkdir -p "${BAZEL_REPOSITORY_CACHE_PATH}/content_addressable/sha256" 2>/dev/null; then
+            "${SED_I[@]}" "s|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=${BAZEL_REPOSITORY_CACHE_PATH}|g" Makefile.common
+            echo "using shared bazel repository cache: ${BAZEL_REPOSITORY_CACHE_PATH}"
+        else
+            echo "shared bazel repository cache unavailable or not writable, keep repository_cache=/home/jenkins/.tidb/tmp"
+        fi
+    else
+        "${SED_I[@]}" "s|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=${BAZEL_REPOSITORY_CACHE_PATH}|g" Makefile.common
+    fi
+fi
+
+# Remote cache handling in .bazelrc.
+if [ -n "${BAZEL_REMOTE_CACHE_MODE:-}" ]; then
+    if [ -f .bazelrc ]; then
+        "${SED_I[@]}" '/^try-import \/data\/bazel$/d' .bazelrc
+        case "${BAZEL_REMOTE_CACHE_MODE}" in
+            disable)
+                for scope in build test run; do
+                    grep -q "^${scope} --noremote_accept_cached$" .bazelrc || echo "${scope} --noremote_accept_cached" >> .bazelrc
+                    grep -q "^${scope} --noremote_upload_local_results$" .bazelrc || echo "${scope} --noremote_upload_local_results" >> .bazelrc
+                done
+                ;;
+            set)
+                if [ -z "${BAZEL_REMOTE_CACHE_URL:-}" ]; then
+                    echo "BAZEL_REMOTE_CACHE_URL is required when BAZEL_REMOTE_CACHE_MODE=set" >&2
+                    exit 1
+                fi
+                "${SED_I[@]}" '/^build --remote_cache=/d; /^test --remote_cache=/d; /^run --remote_cache=/d' .bazelrc
+                for scope in build test run; do
+                    echo "${scope} --remote_cache=${BAZEL_REMOTE_CACHE_URL}" >> .bazelrc
+                done
+                ;;
+            *)
+                echo "unsupported BAZEL_REMOTE_CACHE_MODE: ${BAZEL_REMOTE_CACHE_MODE}" >&2
+                exit 1
+                ;;
+        esac
+    fi
+fi
+
+# Verify no legacy bazel cache/mirror URLs remain.
+grep -nE "${BAZEL_STRIP_URLS}" WORKSPACE DEPS.bzl || true
+grep -n '^check:' Makefile | head -n 3 || true


### PR DESCRIPTION
## What changed

Refactor the bazel workspace helpers added in #4874: instead of generating the cleanup script as a Groovy string literal, the logic now lives in a plain shell script.

- **New**: `scripts/pingcap/tidb/prepare-bazel-workspace.sh` — full cleanup logic in plain bash (works with GNU and BSD sed), executed from the ci repo checkout in the agent workspace
- **`bazel.groovy`**: `buildWorkspaceScript`/`buildStaleUrlCleanupScript` replaced by `workspaceEnv()` (pure, computes the `BAZEL_*` env map) + `prepareWorkspace()`/`reapplyStaleUrlCleanup()` which run the script with those env vars
- **`TestBazel.groovy`**: env-map tests + functional tests that actually run the shell script against fixture workspaces (26 cases)

## Why

The previous string-generation approach failed on the Jenkins master (Groovy 2): the `\u005C` unicode escape used to work around a Groovy 5 lexer quirk is an invalid escape there, breaking `prepareWorkspace` at compile time (observed in the ghpr_check replay, Jenkins build 6512). Moving the shell logic into a plain script file removes the escaping problem entirely and makes the logic reviewable/testable as bash.

The public call sites are unchanged (`bazel.prepareWorkspace()`, `bazel.reapplyStaleUrlCleanup()`), so no pipeline migration PR needs changes.

## Verification

- `groovy libraries/tipipeline/tests/TestBazel.groovy`: 26/26 pass on Groovy 5 (local, BSD sed) and on the CI image groovy:4.0.32-jdk17 (GNU sed)
- `workspaceEnv` verified on Groovy 2.4 (Jenkins master runtime)
- `TestComponent` regression: 10/10
- `bash -n` clean