### PR TITLE
fix(pipelines): drop imagePullPolicy Always in tikv release-7.5 pod template

### DIFF
--- a/pipelines/tikv/tikv/release-7.5/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-7.5/pod-pull_unit_test.yaml
@@ -6,7 +6,6 @@ spec:
   containers:
     - name: runner
       image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
-      imagePullPolicy: Always
       tty: true
       command:
         - "/bin/sh"

--- a/pipelines/tikv/tikv/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/tikv/tikv/release-8.5/pod-pull_unit_test.yaml
@@ -6,7 +6,6 @@ spec:
   containers:
     - name: runner
       image: "ghcr.io/pingcap-qe/ci/jenkins/tikv:v2026.3.22-4-gd9d1135"
-      imagePullPolicy: Always
       tty: true
       command:
         - "/bin/sh"


### PR DESCRIPTION
## Summary

Same cleanup as #4877 (release-8.1): the `release-7.5` `pull_unit_test` pod template was already aligned with `release-8.5` in #4747, but still carries `imagePullPolicy: Always`, which is unnecessary for a pinned image tag (default `IfNotPresent` is fine). Remove it to match the merged `release-8.1` template.

## Changes

- `pipelines/tikv/tikv/release-7.5/pod-pull_unit_test.yaml`: drop `imagePullPolicy: Always`

Note: the recent failure on the release-7.5 `pull_unit_test` job (build #30) was caused by merge-conflict markers in the PR under test (`components/engine_rocks/src/import.rs`), not by job configuration.