### PR TITLE
refactor(pipelines): use shared bazel.prepareWorkspace in tidb latest pipelines

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_build/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_build/pipeline.groovy
@@ -34,20 +34,10 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps/cache (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                        set -euxo pipefail
-                        for f in WORKSPACE DEPS.bzl; do
-                          [ -f "$f" ] || continue
-                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                        done
-                        if [ -f Makefile ]; then
-                          sed -i 's/^check: check-bazel-prepare /check: /' Makefile
-                        fi
-                        grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    '''
+                    script { bazel.prepareWorkspace() }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -51,26 +51,13 @@ pipeline {
                             }
                         }
                     }
-                    sh '''#!/usr/bin/env bash
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-
-                    # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
-                    '''
-                    // cache it for other pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            mv bin/tidb-server bin/integration_test_tidb-server
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    script { bazel.prepareWorkspace() }
+                    // Back up the prepared workspace for the matrix test pods (S3-backed stash).
+                    sh """
+                        mv bin/tidb-server bin/integration_test_tidb-server
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -122,27 +109,10 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
-                                }
-
-                                // Lightweight fallback: only re-apply when stale URLs are still present in restored cache.
-                                sh '''#!/usr/bin/env bash
-                                    set -euxo pipefail
-                                    if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
-                                        for f in WORKSPACE DEPS.bzl; do
-                                          [ -f "$f" ] || continue
-                                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                                        done
-                                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                                    fi
-                                '''
+                                unstash 'ws'
+                                sh "ls -l rev-${REFS.pulls[0].sha}" // sanity: restored from stash.
 
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
-                                sh """
-                                git diff .
-                                git status
-                                """
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -32,19 +32,13 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps URL (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
+                    script { bazel.prepareWorkspace() }
+
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-
-                    # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
                     # Replay-only skip for flaky target in this environment:
                     # //pkg/sessionctx/variable/tests:tests_test (goleak flake on shard 18/47).
                     # Guard this hotfix so newer branches that removed the package keep working.
@@ -53,9 +47,6 @@ pipeline {
                     else
                       echo 'Skip adding //pkg/sessionctx/variable/tests:tests_test exclusion: package not found'
                     fi
-
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
                     grep -n 'pkg/sessionctx/variable/tests:tests_test' Makefile || true
                     '''
                 }

--- a/pipelines/pingcap/tidb/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_unit_test.groovy
@@ -30,22 +30,10 @@ pipeline {
                 }
             }
         }
-        stage('Clean Legacy Bazel URL') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                        set -euxo pipefail
-
-                        if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
-                            for f in WORKSPACE DEPS.bzl; do
-                                [ -f "$f" ] || continue
-                                sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                            done
-                            sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                        else
-                            echo "No legacy bazel deps URL found in WORKSPACE/DEPS.bzl."
-                        fi
-                    '''
+                    script { bazel.reapplyStaleUrlCleanup() }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/merged_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_unit_test_ddlv1.groovy
@@ -31,19 +31,13 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps URL (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
+                    script { bazel.prepareWorkspace() }
+
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-
-                    # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
                     # Replay-only skip for flaky target in this environment:
                     # //pkg/sessionctx/variable/tests:tests_test (goleak flake on shard 18/47).
                     # Guard this hotfix so newer branches that removed the package keep working.
@@ -52,18 +46,13 @@ pipeline {
                     else
                       echo 'Skip adding //pkg/sessionctx/variable/tests:tests_test exclusion: package not found'
                     fi
-
                     # Replay-only timeout hotfix: raise ci shard timeout to avoid 150s timeout flakes.
                     if [ -f .bazelrc ]; then
                       echo 'test:ci --test_timeout=600,900,1800,3600' >> .bazelrc
                     fi
-
                     # Replay-only robustness fix: avoid argument list overflow in failpoint enable/disable.
                     sed -i 's|xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable|xargs -n 200 bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- enable|' Makefile || true
                     sed -i 's|xargs bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable|xargs -n 200 bazel $(BAZEL_GLOBAL_CONFIG) run $(BAZEL_CMD_CONFIG) @com_github_pingcap_failpoint//failpoint-ctl:failpoint-ctl -- disable|' Makefile || true
-
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
                     grep -n 'pkg/sessionctx/variable/tests:tests_test' Makefile || true
                     grep -n 'xargs -n 200 bazel .*failpoint-ctl:failpoint-ctl --' Makefile | head -n 4 || true
                     grep -n 'test:ci --test_timeout=' .bazelrc | tail -n 3 || true

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
@@ -36,30 +36,10 @@ pipeline {
             environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
             steps {
                 dir(REFS.repo) {
+                    script { bazel.prepareWorkspace(repositoryCache: '/share/.cache/bazel-repository-cache', ensureTmpDir: true) }
+
                     sh '''#!/usr/bin/env bash
                         set -euxo pipefail
-
-                        # Clean legacy cache/mirror URLs that are unstable on GCP workers.
-                        for file in WORKSPACE DEPS.bzl; do
-                            [ -f "$file" ] || continue
-                            sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$file"
-                        done
-                        echo "removed legacy bazel mirrors from WORKSPACE/DEPS.bzl for gcp replay"
-
-                        # Avoid "check" targets re-writing legacy cache settings during migration replay.
-                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
-                        # Ensure expected bazel tmp dir exists after mount point change.
-                        mkdir -p /home/jenkins/.tidb/tmp
-
-                        # Prefer shared local repository cache when writable, fallback to default path.
-                        if [ -d /share/.cache/bazel-repository-cache ] && mkdir -p /share/.cache/bazel-repository-cache/content_addressable/sha256 2>/dev/null; then
-                            sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
-                            echo "using shared bazel repository cache: /share/.cache/bazel-repository-cache"
-                        else
-                            echo "shared bazel repository cache unavailable or not writable, keep repository_cache=/home/jenkins/.tidb/tmp"
-                        fi
-
                         git diff .
                         git status
                     '''


### PR DESCRIPTION
## What changed

Migrate the remaining `pipelines/pingcap/tidb/latest` (non-next-gen) pipelines to the shared bazel workspace helpers (#4874, #4876). This is the first batch of the per-directory migration (latest only; release branches and next-gen come in follow-up PRs).

| File | Before | After |
|---|---|---|
| ghpr_build/pipeline.groovy | `Hotfix bazel deps/cache` stage | `bazel.prepareWorkspace()` |
| ghpr_check2.groovy | inline cleanup in Checkout & Prepare + matrix fallback | `prepareWorkspace()` + `reapplyStaleUrlCleanup()` |
| ghpr_unit_test.groovy | `Hotfix bazel deps URL` stage | `prepareWorkspace()`; replay-only sessionctx exclusion kept |
| merged_unit_test.groovy | `Clean Legacy Bazel URL` guarded stage | `reapplyStaleUrlCleanup()` |
| merged_unit_test_ddlv1.groovy | `Hotfix bazel deps URL` stage | `prepareWorkspace()`; replay-only hacks kept |
| pull_unit_test_ddlv1.groovy | inline cleanup in Test stage | `prepareWorkspace(repositoryCache: ..., ensureTmpDir: true)` |

Replay-only hacks (test_timeout, flaky-target exclusions, failpoint xargs) stay in place for now and will be moved to their own stage in a follow-up PR.

Behavior is unchanged — the shared script performs the same cleanup (verified by the functional tests in `TestBazel.groovy`). The replay check will validate each job on Jenkins.