### PR TITLE
fix(ci): stream parallel replay logs live with task prefix

### DIFF
--- a/.ci/replay-jenkins-build.sh
+++ b/.ci/replay-jenkins-build.sh
@@ -716,14 +716,28 @@ run_parallel_replays() {
     spawn_next() {
         local idx="$1"
         local script_file="${scripts[$idx]}"
+        local label
+        label="$(basename "$script_file")"
         (
+            # Stream log lines live with a task prefix instead of buffering
+            # them in a file, so the prow build log stays as detailed as the
+            # serial mode. The overrides apply to everything replay_one and
+            # its callees emit, thanks to bash's dynamic function scoping.
+            log() {
+                printf '[%s] [%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$label" "$*" >&2
+            }
+            vlog() {
+                if [[ "${VERBOSE:-false}" == "true" ]]; then
+                    log "$*"
+                fi
+            }
             if replay_one "$script_file" "" ""; then
                 printf '%s' "${REPLAY_LAST_RESULT}" > "${tmpdir}/${idx}.result"
                 exit 0
             fi
             printf '%s' "${REPLAY_LAST_RESULT:-failed}" > "${tmpdir}/${idx}.result"
             exit 1
-        ) >"${tmpdir}/${idx}.log" 2>&1 &
+        ) &
         pids+=($!)
         pid_to_idx[$!]="$idx"
         running=$((running+1))
@@ -758,7 +772,6 @@ run_parallel_replays() {
         result="$(cat "${tmpdir}/${done_idx}.result" 2>/dev/null || echo failed)"
         record_summary "$result"
         log "--- replay finished: ${scripts[$done_idx]} -> ${result} (exit ${exit_code}) ---"
-        cat "${tmpdir}/${done_idx}.log" || true
 
         if [[ "$exit_code" != "0" ]]; then
             failed=1


### PR DESCRIPTION
## What changed

The parallel replay runner added in #4880 buffered every task's output into a per-task log file and only printed it after the task completed, so the `pull-replay-jenkins-pipelines` build log no longer showed the detailed replay progress (source build, submitted replay URL, waiting status) until the whole job finished — and nothing for tasks aborted by `--fast-fail`.

Now each parallel task overrides `log`/`vlog` in its own subshell to stream lines **live** with a `[job-name]` prefix:

```text
[2026-08-11 14:39:14] [01.groovy] mock replaying: pipelines/tidb/01.groovy
[2026-08-11 14:39:16] [02-fail.groovy] mock failing: pipelines/tidb/02-fail.groovy
[2026-08-11 14:39:16] --- replay finished: pipelines/tidb/02-fail.groovy -> failed (exit 1) ---
[2026-08-11 14:39:16] replay summary: submitted=2, skipped=0, failed=1
```

Bash dynamic function scoping makes the override apply to `replay_one` and everything it calls, so the detail level matches the serial mode; the per-task result file mechanism is unchanged.

## Verification

Mock-tested the runner (3 tasks, 1 failing, sleep 2s, `--parallel 3`) in a bash 5 container: all detailed lines stream live with prefixes, summary `submitted=2 failed=1`, exit 1. `bash -n` and `shellcheck` clean.