### PR TITLE
refactor(pipelines): migrate tidb release-7.5 pipelines to bazel.prepareWorkspace

### DIFF
--- a/pipelines/pingcap/tidb/release-7.5/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_build.groovy
@@ -33,20 +33,10 @@ pipeline {
                 }
             }
         }
-        stage("Hotfix deps URL (temporary CI workaround)") {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-                    if [ -f Makefile ]; then
-                      sed -i 's/^check: check-bazel-prepare /check: /' Makefile
-                    fi
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    '''
+                    script { bazel.prepareWorkspace() }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check.groovy
@@ -37,22 +37,10 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps URL (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-
-                    # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
-                    '''
+                    script { bazel.prepareWorkspace() }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -51,26 +51,13 @@ pipeline {
                             }
                         }
                     }
-                    sh '''#!/usr/bin/env bash
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-
-                    # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
-                    '''
-                    // cache it for other pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            mv bin/tidb-server bin/integration_test_tidb-server
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    script { bazel.prepareWorkspace() }
+                    // Back up the prepared workspace for the matrix test pods (S3-backed stash).
+                    sh """
+                        mv bin/tidb-server bin/integration_test_tidb-server
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -121,27 +108,10 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
-                                }
+                                unstash 'ws'
+                                sh "ls -l rev-${REFS.pulls[0].sha}" // sanity: restored from stash.
 
-                                // Lightweight fallback: only re-apply when stale URLs are still present in restored cache.
-                                sh '''#!/usr/bin/env bash
-                                    set -euxo pipefail
-                                    if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
-                                        for f in WORKSPACE DEPS.bzl; do
-                                          [ -f "$f" ] || continue
-                                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                                        done
-                                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                                    fi
-                                '''
-
-                                sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
-                                sh """
-                                git diff .
-                                git status
-                                """
+                                sh 'chmod +x ../scripts/pingcap/tidb/*.sh' 
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -111,7 +111,7 @@ pipeline {
                                 unstash 'ws'
                                 sh "ls -l rev-${REFS.pulls[0].sha}" // sanity: restored from stash.
 
-                                sh 'chmod +x ../scripts/pingcap/tidb/*.sh' 
+                                sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_unit_test.groovy
@@ -32,22 +32,10 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps URL (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-
-                    # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
-                    '''
+                    script { bazel.prepareWorkspace() }
                 }
             }
         }


### PR DESCRIPTION
Part of #4885, closes #4894.

## What changed

Migrate all 4 hotfix-carrying pipelines in `pipelines/pingcap/tidb/release-7.5/` to the shared bazel workspace helpers:

| File | Before | After |
|---|---|---|
| ghpr_check | `Hotfix bazel deps URL` stage | `bazel.prepareWorkspace()` |
| ghpr_unit_test | `Hotfix bazel deps URL` stage | `bazel.prepareWorkspace()` |
| ghpr_build | `Hotfix deps URL (temporary CI workaround)` stage | `bazel.prepareWorkspace()` |
| ghpr_check2 | inline cleanup + cache handoff + matrix fallback | `prepareWorkspace()` + **stash/unstash handoff** (aligned with latest ghpr_check2, design #4890); fallback + git debug removed |

Behavior is unchanged (the shared script performs the same cleanup, verified by the functional tests in `TestBazel.groovy`); replay validation runs via `pull-replay-jenkins-pipelines` in parallel mode.