### PR TITLE
refactor(pipelines): migrate tidb release-6.5 pipelines to bazel.prepareWorkspace

### DIFF
--- a/pipelines/pingcap/tidb/release-6.5/ghpr_build.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_build.groovy
@@ -55,19 +55,10 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps URL (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
-                    '''
+                    script { bazel.prepareWorkspace() }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check.groovy
@@ -36,19 +36,10 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps URL (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
-                    '''
+                    script { bazel.prepareWorkspace() }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -110,7 +110,7 @@ pipeline {
                                 unstash 'ws'
                                 sh "ls -l rev-${REFS.pulls[0].sha}" // sanity: restored from stash.
 
-                                sh 'chmod +x ../scripts/pingcap/tidb/*.sh' 
+                                sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -50,22 +50,13 @@ pipeline {
                             }
                         }
                     }
-                    sh '''#!/usr/bin/env bash
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
-                    '''
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            mv bin/tidb-server bin/integration_test_tidb-server
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    script { bazel.prepareWorkspace() }
+                    // Back up the prepared workspace for the matrix test pods (S3-backed stash).
+                    sh """
+                        mv bin/tidb-server bin/integration_test_tidb-server
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,24 +107,10 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}"
-                                }
-                                sh '''#!/usr/bin/env bash
-                                    set -euxo pipefail
-                                    if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
-                                        for f in WORKSPACE DEPS.bzl; do
-                                          [ -f "$f" ] || continue
-                                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                                        done
-                                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                                    fi
-                                '''
-                                sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
-                                sh """
-                                git diff .
-                                git status
-                                """
+                                unstash 'ws'
+                                sh "ls -l rev-${REFS.pulls[0].sha}" // sanity: restored from stash.
+
+                                sh 'chmod +x ../scripts/pingcap/tidb/*.sh' 
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }
                         }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
@@ -42,14 +42,7 @@ pipeline {
                     }
                 }
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                    '''
+                    script { bazel.prepareWorkspace() }
                     cache(path: "./bin", includes: '**/*', key: "binary/pingcap/tidb/tidb-server/rev-${REFS.base_sha}-${REFS.pulls[0].sha}") {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_unit_test.groovy
@@ -32,19 +32,10 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps URL (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                    set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
-                    '''
+                    script { bazel.prepareWorkspace() }
                 }
             }
         }


### PR DESCRIPTION
Part of #4885, closes #4896.

## What changed

Migrate all 5 hotfix-carrying pipelines in `pipelines/pingcap/tidb/release-6.5/` to the shared bazel workspace helpers:

| File | Before | After |
|---|---|---|
| ghpr_check | `Hotfix bazel deps URL` stage | `bazel.prepareWorkspace()` |
| ghpr_unit_test | `Hotfix bazel deps URL` stage | `bazel.prepareWorkspace()` |
| ghpr_build | `Hotfix deps URL (temporary CI workaround)` stage | `bazel.prepareWorkspace()` |
| ghpr_mysql_test | inline cleanup | `bazel.prepareWorkspace()` |
| ghpr_check2 | inline cleanup + cache handoff + matrix fallback | `prepareWorkspace()` + **stash/unstash handoff** (aligned with latest ghpr_check2, design #4890); fallback + git debug removed |

Behavior is unchanged (the shared script performs the same cleanup, verified by the functional tests in `TestBazel.groovy`); replay validation runs via `pull-replay-jenkins-pipelines` in parallel mode.