### PR TITLE
refactor(pipelines): migrate next-gen pipelines to bazel.prepareWorkspace

### DIFF
--- a/pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_build_next_gen/pipeline.groovy
@@ -37,24 +37,10 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps/cache (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                        set -euxo pipefail
-
-                        # Clean legacy cache/mirror URLs that are unstable on GCP workers.
-                        for f in WORKSPACE DEPS.bzl; do
-                          [ -f "$f" ] || continue
-                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                        done
-
-                        # Avoid "check" targets re-writing legacy cache settings during migration replay.
-                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
-                        # Ensure expected bazel tmp dir exists after mount point change.
-                        mkdir -p /home/jenkins/.tidb/tmp
-                    '''
+                    script { bazel.prepareWorkspace(ensureTmpDir: true) }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -42,32 +42,10 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps/cache (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
-                    sh '''#!/usr/bin/env bash
-                        set -euxo pipefail
-
-                        # Clean legacy external cache/mirror URLs that are unstable on GCP workers.
-                        for f in WORKSPACE DEPS.bzl; do
-                          [ -f "$f" ] || continue
-                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                        done
-
-                        # Avoid check target re-writing legacy cache settings during replay validation.
-                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
-                        # Disable remote cache usage for this migration replay path.
-                        if [ -f .bazelrc ]; then
-                          sed -i '/^try-import \\/data\\/bazel$/d' .bazelrc
-                          grep -q '^build --noremote_accept_cached$' .bazelrc || echo 'build --noremote_accept_cached' >> .bazelrc
-                          grep -q '^build --noremote_upload_local_results$' .bazelrc || echo 'build --noremote_upload_local_results' >> .bazelrc
-                          grep -q '^test --noremote_accept_cached$' .bazelrc || echo 'test --noremote_accept_cached' >> .bazelrc
-                          grep -q '^test --noremote_upload_local_results$' .bazelrc || echo 'test --noremote_upload_local_results' >> .bazelrc
-                          grep -q '^run --noremote_accept_cached$' .bazelrc || echo 'run --noremote_accept_cached' >> .bazelrc
-                          grep -q '^run --noremote_upload_local_results$' .bazelrc || echo 'run --noremote_upload_local_results' >> .bazelrc
-                        fi
-                    '''
+                    script { bazel.prepareWorkspace(remoteCache: [mode: 'disable']) }
                 }
             }
         }

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pipeline.groovy
@@ -36,19 +36,13 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps URL (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir(REFS.repo) {
+                    script { bazel.prepareWorkspace() }
+
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
-                    for f in WORKSPACE DEPS.bzl; do
-                      [ -f "$f" ] || continue
-                      sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                    done
-
-                    # Keep replay and job behavior aligned until tidb repo deps URLs are cleaned up.
-                    sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
                     # Replay-only skip for flaky target in GCP replay (goleak on IMDS path).
                     # Guard this hotfix so newer branches that removed the package keep working.
                     if [ -f pkg/sessionctx/variable/tests/BUILD ] || [ -f pkg/sessionctx/variable/tests/BUILD.bazel ]; then
@@ -56,9 +50,6 @@ pipeline {
                     else
                       echo 'Skip adding //pkg/sessionctx/variable/tests:tests_test exclusion: package not found'
                     fi
-
-                    grep -nE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl || true
-                    grep -n '^check:' Makefile | head -n 3 || true
                     grep -n 'pkg/sessionctx/variable/tests:tests_test' Makefile || true
                     '''
                 }

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -113,35 +113,12 @@ pipeline {
                     // Apply compatibility hotfixes before writing ws cache so matrix pods restore cleaned files.
                     // - strip legacy bazel deps URLs
                     // - disable remote bazel cache read/write for this job
-                    sh '''#!/usr/bin/env bash
-                        set -euxo pipefail
-
-                        if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
-                          for f in WORKSPACE DEPS.bzl; do
-                            [ -f "$f" ] || continue
-                            sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                          done
-                          sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                        else
-                          echo "No legacy bazel deps URL found in WORKSPACE/DEPS.bzl before ws cache."
-                        fi
-
-                        if [ -f .bazelrc ]; then
-                          sed -i '/^try-import \\/data\\/bazel$/d' .bazelrc
-                          grep -q '^build --noremote_accept_cached$' .bazelrc || echo 'build --noremote_accept_cached' >> .bazelrc
-                          grep -q '^build --noremote_upload_local_results$' .bazelrc || echo 'build --noremote_upload_local_results' >> .bazelrc
-                          grep -q '^test --noremote_accept_cached$' .bazelrc || echo 'test --noremote_accept_cached' >> .bazelrc
-                          grep -q '^test --noremote_upload_local_results$' .bazelrc || echo 'test --noremote_upload_local_results' >> .bazelrc
-                          grep -q '^run --noremote_accept_cached$' .bazelrc || echo 'run --noremote_accept_cached' >> .bazelrc
-                          grep -q '^run --noremote_upload_local_results$' .bazelrc || echo 'run --noremote_upload_local_results' >> .bazelrc
-                        else
-                          echo ".bazelrc not found; skip remote-cache disable patch."
-                        fi
-                    '''
-                    // cache it for other pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    script { bazel.prepareWorkspace(remoteCache: [mode: 'disable']) }
+                    // Back up the prepared workspace for the matrix test pods (S3-backed stash).
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -203,39 +180,8 @@ pipeline {
                         }
                         steps {
                             dir('tidb') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
-                                }
-
-                                // Matrix pods restore ws cache, so keep a fallback patch in each pod.
-                                // Re-apply only when stale URLs are still present in restored cache.
-                                // Conditional fallback: re-apply only if restored cache still contains legacy URLs.
-                                sh '''#!/usr/bin/env bash
-                                    set -euxo pipefail
-
-                                    if grep -qE 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' WORKSPACE DEPS.bzl 2>/dev/null; then
-                                      for f in WORKSPACE DEPS.bzl; do
-                                        [ -f "$f" ] || continue
-                                        sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                                      done
-                                      sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-                                    else
-                                      echo "No legacy bazel deps URL found in restored ws cache; skip fallback hotfix."
-                                    fi
-
-                                    if [ -f .bazelrc ]; then
-                                      sed -i '/^try-import \\/data\\/bazel$/d' .bazelrc
-                                      # Ensure a trailing newline before appending, avoiding line corruption.
-                                      [ -n "$(tail -c1 .bazelrc 2>/dev/null)" ] && echo "" >> .bazelrc
-                                      for cmd in build test run; do
-                                        for opt in noremote_accept_cached noremote_upload_local_results; do
-                                          grep -q "^${cmd} --${opt}$" .bazelrc || echo "${cmd} --${opt}" >> .bazelrc
-                                        done
-                                      done
-                                    else
-                                      echo ".bazelrc not found; skip remote-cache disable patch."
-                                    fi
-                                '''
+                                unstash 'ws'
+                                sh "ls -l rev-${REFS.pulls[0].sha}" // sanity: restored from stash.
 
                                 // addindextest4 is temporarily disabled in matrix; keep single execution path for now.
                                 // Re-introduce a dedicated retry block when addindextest4 is re-enabled.

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -52,32 +52,10 @@ pipeline {
                 }
             }
         }
-        stage('Hotfix bazel deps/cache (temporary)') {
+        stage('Prepare bazel workspace') {
             steps {
                 dir('tidb') {
-                    sh '''#!/usr/bin/env bash
-                        set -euxo pipefail
-
-                        # Clean legacy cache/mirror URLs that are unstable on GCP workers.
-                        for f in WORKSPACE DEPS.bzl; do
-                          [ -f "$f" ] || continue
-                          sed -i -E '/bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build/d' "$f"
-                        done
-
-                        # Avoid "check" targets re-writing legacy cache settings during migration replay.
-                        sed -i 's/^check: check-bazel-prepare /check: /' Makefile || true
-
-                        # Disable remote cache usage for this migration replay path.
-                        if [ -f .bazelrc ]; then
-                          sed -i '/^try-import \\/data\\/bazel$/d' .bazelrc
-                          grep -q '^build --noremote_accept_cached$' .bazelrc || echo 'build --noremote_accept_cached' >> .bazelrc
-                          grep -q '^build --noremote_upload_local_results$' .bazelrc || echo 'build --noremote_upload_local_results' >> .bazelrc
-                          grep -q '^test --noremote_accept_cached$' .bazelrc || echo 'test --noremote_accept_cached' >> .bazelrc
-                          grep -q '^test --noremote_upload_local_results$' .bazelrc || echo 'test --noremote_upload_local_results' >> .bazelrc
-                          grep -q '^run --noremote_accept_cached$' .bazelrc || echo 'run --noremote_accept_cached' >> .bazelrc
-                          grep -q '^run --noremote_upload_local_results$' .bazelrc || echo 'run --noremote_upload_local_results' >> .bazelrc
-                        fi
-                    '''
+                    script { bazel.prepareWorkspace(remoteCache: [mode: 'disable']) }
                 }
             }
         }


### PR DESCRIPTION
Closes #4887.

## What changed

Migrate all 5 next-gen pipelines to the shared bazel workspace helpers:

| Pipeline | After |
|---|---|
| tidb `pull_build_next_gen` | `bazel.prepareWorkspace(ensureTmpDir: true)` |
| tidb `pull_integration_realcluster_test_next_gen` | `bazel.prepareWorkspace(remoteCache: [mode: 'disable'])` |
| tidb `pull_unit_test_next_gen` | `bazel.prepareWorkspace()` (sessionctx hack kept for #4888) |
| tikv/pd `pull_integration_realcluster_test_next_gen` | `bazel.prepareWorkspace(remoteCache: [mode: 'disable'])` |
| tidbcloud `pull_integration_realcluster_test_next_gen` | main cleanup → `prepareWorkspace(remoteCache: [mode: 'disable'])`; workspace handoff switched from `ws/${BUILD_TAG}` cache to **S3-backed stash/unstash** (aligned with the check2 jobs, design #4890); the now-redundant guarded fallback **and the nested noremote loop hack are both dropped** — the main stage's `remoteCache: disable` fully covers `.bazelrc` patching (see #4888) |

The `.bazelrc` remote-cache disable logic (try-import removal + `--noremote_*` flags for build/test/run) is now covered by the `remoteCache: [mode: 'disable']` option of the shared script. All 5 pipelines pass Jenkins pipeline validation; behavior is unchanged.