### PR TITLE
refactor(pipelines): extract replay-only hacks into dedicated stage

### DIFF
--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_unit_test.groovy
@@ -36,7 +36,13 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script { bazel.prepareWorkspace() }
+                }
+            }
+        }
 
+        stage('Replay workarounds (temporary)') {
+            steps {
+                dir(REFS.repo) {
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
                     # Replay-only timeout hotfix: reduce flaky timeout on heavy shards in GKE canary runs.

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_unit_test_ddlv1.groovy
@@ -40,7 +40,13 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script { bazel.prepareWorkspace() }
+                }
+            }
+        }
 
+        stage('Replay workarounds (temporary)') {
+            steps {
+                dir(REFS.repo) {
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
                     # Replay-only timeout hotfix: raise ci shard timeout to avoid 150s timeout flakes.

--- a/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_unit_test.groovy
@@ -36,7 +36,13 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script { bazel.prepareWorkspace() }
+                }
+            }
+        }
 
+        stage('Replay workarounds (temporary)') {
+            steps {
+                dir(REFS.repo) {
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
                     # Replay-only skip for flaky target in this environment:

--- a/pipelines/pingcap/tidb/latest/merged_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_unit_test_ddlv1.groovy
@@ -35,7 +35,13 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script { bazel.prepareWorkspace() }
+                }
+            }
+        }
 
+        stage('Replay workarounds (temporary)') {
+            steps {
+                dir(REFS.repo) {
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
                     # Replay-only skip for flaky target in this environment:

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
@@ -36,7 +36,13 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script { bazel.prepareWorkspace() }
+                }
+            }
+        }
 
+        stage('Replay workarounds (temporary)') {
+            steps {
+                dir(REFS.repo) {
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
                     # Replay-only timeout hotfix: reduce flaky timeout on heavy shards in GKE canary runs.

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test_ddlv1.groovy
@@ -36,7 +36,13 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script { bazel.prepareWorkspace() }
+                }
+            }
+        }
 
+        stage('Replay workarounds (temporary)') {
+            steps {
+                dir(REFS.repo) {
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
                     # Replay-only timeout hotfix: raise ci shard timeout to avoid timeout flakes.

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_unit_test.groovy
@@ -36,7 +36,13 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script { bazel.prepareWorkspace() }
+                }
+            }
+        }
 
+        stage('Replay workarounds (temporary)') {
+            steps {
+                dir(REFS.repo) {
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
                     # Replay-only timeout hotfix: reduce flaky timeout on heavy shards in GKE canary runs.

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_unit_test_ddlv1.groovy
@@ -36,7 +36,13 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     script { bazel.prepareWorkspace() }
+                }
+            }
+        }
 
+        stage('Replay workarounds (temporary)') {
+            steps {
+                dir(REFS.repo) {
                     sh '''#!/usr/bin/env bash
                     set -euxo pipefail
                     # Replay-only timeout hotfix: raise ci shard timeout to avoid timeout flakes.


### PR DESCRIPTION
Closes #4888.

## What changed

Move the replay-only workarounds embedded in the `Prepare bazel workspace` stage into a dedicated `Replay workarounds (temporary)` stage, keeping the bazel stage purpose-clean and making the temporary hacks easy to track/remove:

| File | Extracted hacks |
|---|---|
| latest ghpr_unit_test | sessionctx test exclusion |
| latest merged_unit_test_ddlv1 | sessionctx + `test:ci --test_timeout` + failpoint `xargs -n 200` |
| release-8.5 / 9.0-beta pull_unit_test | `test_timeout` + ingest_test exclusion |
| release-8.5 / 9.0-beta pull_unit_test_ddlv1 | `test_timeout` + ingest + distsqltest `moderate→long` |
| pingcap-inc release-8.5 pull_unit_test / ddlv1 | `test_timeout` |

## Not moved (kept in place)

- **next-gen `pull_unit_test_next_gen`** (sessionctx): its migration PR (#4905) hasn't landed yet; handled in a follow-up once it does
- **release-8.5 / 9.0-beta `pull_check2`** `noremote_upload_local_results` appends: they run **before the stash handoff**, so moving them after the stash would change what matrix pods restore; the matrix fallback copies stay as well

## Verification

Behavior is unchanged — hacks still run before `Test`. All 8 files pass Jenkins pipeline validation.