### PR TITLE
ci(prow-jobs): use GOPROXY=direct for error-log-review presubmits

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -225,7 +225,7 @@ presubmits:
                   exit 0
                 fi
                 wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
-                go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
+                GOPROXY=direct go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"
             env:

--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -232,7 +232,7 @@ presubmits:
                   exit 0
                 fi
                 wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
-                go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
+                GOPROXY=direct go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"
             env:

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -216,7 +216,7 @@ presubmits:
                   exit 0
                 fi
                 wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
-                go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
+                GOPROXY=direct go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"
             env:

--- a/prow-jobs/tikv/pd/latest-presubmits.yaml
+++ b/prow-jobs/tikv/pd/latest-presubmits.yaml
@@ -124,7 +124,7 @@ presubmits:
                   exit 0
                 fi
                 wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
-                go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
+                GOPROXY=direct go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"
             env:

--- a/prow-jobs/tikv/tikv/latest-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/latest-presubmits.yaml
@@ -97,7 +97,7 @@ presubmits:
                   exit 0
                 fi
                 wget -O /tmp/config.yaml https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/configs/error-log-review/config.yaml
-                go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
+                GOPROXY=direct go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
                   -config /tmp/config.yaml \
                   -pr "${REPO_OWNER}/${REPO_NAME}#${PULL_NUMBER}"
             env:


### PR DESCRIPTION
### What is changed

In the `error-log-review` presubmit jobs, resolve the tool module directly from GitHub instead of through the Go module proxy:

```diff
- go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
+ GOPROXY=direct go run github.com/PingCAP-QE/ci/tools/error-log-review@main \
```

### Why

Go module proxies (`proxy.golang.org`, `goproxy.cn`) cache branch-query resolutions (`@v/main.info`), so right after pushing to `main`, `go run ...@main` can still resolve to an older pseudo-version for a while. `GOPROXY=direct` makes the go command resolve `@main` against GitHub directly (via `git ls-remote`), always picking up the latest commit immediately.

### Changed files

- `prow-jobs/pingcap/ticdc/latest-presubmits.yaml`
- `prow-jobs/pingcap/tiflash/latest-presubmits.yaml`
- `prow-jobs/pingcap/tiflow/latest-presubmits.yaml`
- `prow-jobs/tikv/pd/latest-presubmits.yaml`
- `prow-jobs/tikv/tikv/latest-presubmits.yaml`

### Validation

- `.ci/update-prow-job-kustomization.sh` passes; `prow-jobs/kustomization.yaml` unchanged.
- Verified `GOPROXY=direct go list -m github.com/PingCAP-QE/ci/tools/error-log-review@main` resolves to `v0.0.0-20260812064751-59c6f447d8b9` (current `main` head), while the proxies' `@v/main.info` still returned a stale hash at the time of writing.