### PR TITLE
refactor(pipelines): migrate tidb ws cache handoff to stash/unstash

### DIFF
--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
@@ -87,9 +87,8 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -120,9 +119,8 @@ pipeline {
                         options { timeout(time: 90, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     if [ "${TEST_GROUP}" = "G08" ]; then
                                         echo "Applying temporary G08 hotfix: relax key_types count check to current observed value"

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_mysql_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_mysql_test.groovy
@@ -47,9 +47,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -83,11 +82,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh  1 ${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh  1 ${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,12 +78,11 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        // TODO: fix the test.sh to correct the parameter parsing and numerical comparison.
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    // TODO: fix the test.sh to correct the parameter parsing and numerical comparison.
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/merged_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_common_test.groovy
@@ -61,12 +61,11 @@ pipeline {
                             """
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'cache tidb-test', script: """
-                            cp -r ../tidb/bin/tidb-server bin/
-                            touch ws-${BUILD_TAG}
-                        """
-                    }
+                    sh label: 'cache tidb-test', script: """
+                        cp -r ../tidb/bin/tidb-server bin/
+                        touch ws-${BUILD_TAG}
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -99,14 +98,13 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    container("java") {
-                                        sh 'chmod +x bin/* && ls -alh bin/'
-                                        sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                            cd ${TEST_DIR} && ${TEST_CMD}
-                                        """
-                                    }
+                                unstash 'tidb-test'
+                                container("java") {
+                                    sh 'chmod +x bin/* && ls -alh bin/'
+                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        cd ${TEST_DIR} && ${TEST_CMD}
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -94,12 +94,11 @@ pipeline {
                         chmod +x br/tests/*.sh
                         ./br/tests/run_group_br_tests.sh others
                     """
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh label: "prepare cache", script: """
-                            touch ${CACHE_MARKER}
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare cache", script: """
+                        touch ${CACHE_MARKER}
+                        ls -alh ./bin
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -129,17 +128,16 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls ${CACHE_MARKER}"
-                                    sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
-                                        if [ "${TEST_GROUP}" = "G07" ] || [ "${TEST_GROUP}" = "G08" ]; then
-                                            echo "Temporary hotfix: skip ${TEST_GROUP} due flaky/long-running BR cases during migration validation"
-                                            exit 0
-                                        fi
-                                        chmod +x br/tests/*.sh
-                                        ./br/tests/run_group_br_tests.sh ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'ws'
+                                sh "ls ${CACHE_MARKER}"
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
+                                    if [ "${TEST_GROUP}" = "G07" ] || [ "${TEST_GROUP}" = "G08" ]; then
+                                        echo "Temporary hotfix: skip ${TEST_GROUP} due flaky/long-running BR cases during migration validation"
+                                        exit 0
+                                    fi
+                                    chmod +x br/tests/*.sh
+                                    ./br/tests/run_group_br_tests.sh ${TEST_GROUP}
+                                """
                             }
 
                         }

--- a/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_common_test.groovy
@@ -62,12 +62,11 @@ pipeline {
                             """
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'cache tidb-test', script: """
-                            cp -r ../tidb/bin/tidb-server bin/
-                            touch ws-${BUILD_TAG}
-                        """
-                    }
+                    sh label: 'cache tidb-test', script: """
+                        cp -r ../tidb/bin/tidb-server bin/
+                        touch ws-${BUILD_TAG}
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -99,29 +98,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                    ls -alh bin/
-                                    ./bin/pd-server -V
-                                    ./bin/tikv-server -V
-                                    ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                ls -alh bin/
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -59,12 +59,11 @@ pipeline {
                             """
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'cache tidb-test', script: """
-                            cp -r ../tidb/bin/tidb-server bin/
-                            touch ws-${BUILD_TAG}
-                        """
-                    }
+                    sh label: 'cache tidb-test', script: """
+                        cp -r ../tidb/bin/tidb-server bin/
+                        touch ws-${BUILD_TAG}
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -101,14 +100,13 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                    ls -alh bin/
-                                    ./bin/pd-server -V
-                                    ./bin/tikv-server -V
-                                    ./bin/tidb-server -V
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh """
+                                ls -alh bin/
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tidb-server -V
+                                """
                                 container("java") {
                                     sh label: "test_params=${TEST_PARAMS} ", script: """
                                         #!/usr/bin/env bash

--- a/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
@@ -87,12 +87,11 @@ pipeline {
                         ls -alh ./bin
                         ./bin/tidb-server -V
                     """
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/lightning-tests") {
-                        sh label: "prepare cache binary", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare cache binary", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'lightning-tests', includes: '**/*'
                 }
             }
         }
@@ -121,12 +120,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/lightning-tests") {
-                                    sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
-                                        chmod +x lightning/tests/*.sh
-                                        ./lightning/tests/run_group_lightning_tests.sh ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'lightning-tests'
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
+                                    chmod +x lightning/tests/*.sh
+                                    ./lightning/tests/run_group_lightning_tests.sh ${TEST_GROUP}
+                                """
                             }
 
                         }

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -60,12 +60,11 @@ pipeline {
                             """
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'cache tidb-test', script: """
-                            cp -r ../tidb/bin/tidb-server bin/
-                            touch ws-${BUILD_TAG}
-                        """
-                    }
+                    sh label: 'cache tidb-test', script: """
+                        cp -r ../tidb/bin/tidb-server bin/
+                        touch ws-${BUILD_TAG}
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -98,29 +97,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                    ls -alh bin/
-                                    ./bin/pd-server -V
-                                    ./bin/tikv-server -V
-                                    ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                ls -alh bin/
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_nodejs_test.groovy
@@ -56,12 +56,11 @@ pipeline {
                             """
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'cache tidb-test', script: """
-                            cp -r ../tidb/bin/tidb-server bin/ && chmod +x bin/*
-                            touch ws-${BUILD_TAG}
-                        """
-                    }
+                    sh label: 'cache tidb-test', script: """
+                        cp -r ../tidb/bin/tidb-server bin/ && chmod +x bin/*
+                        touch ws-${BUILD_TAG}
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -89,24 +88,23 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        chown -R 1000:1000 bin/
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="tikv"
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIKV_PATH="127.0.0.1:2379"
+                                unstash 'tidb-test'
+                                sh """
+                                    chown -R 1000:1000 bin/
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="tikv"
+                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                    export TIKV_PATH="127.0.0.1:2379"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
@@ -59,12 +59,11 @@ pipeline {
                             """
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'cache tidb-test', script: """
-                            cp -r ../tidb/bin/tidb-server bin/
-                            touch ws-${BUILD_TAG}
-                        """
-                    }
+                    sh label: 'cache tidb-test', script: """
+                        cp -r ../tidb/bin/tidb-server bin/
+                        touch ws-${BUILD_TAG}
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -97,117 +96,116 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                    ls -alh bin/
-                                    ./bin/pd-server -V
-                                    ./bin/tikv-server -V
-                                    ./bin/tidb-server -V
-                                    """
-                                    container("python") {
-                                        sh label: 'prepare python orm deps', script: '''#!/usr/bin/env bash
-                                            set -euo pipefail
+                                unstash 'tidb-test'
+                                sh """
+                                ls -alh bin/
+                                ./bin/pd-server -V
+                                ./bin/tikv-server -V
+                                ./bin/tidb-server -V
+                                """
+                                container("python") {
+                                    sh label: 'prepare python orm deps', script: '''#!/usr/bin/env bash
+                                        set -euo pipefail
 
-                                            apt_update_with_archive_fallback() {
-                                                apt-get update || {
-                                                    # Old images may still point to EOL Debian mirrors.
-                                                    sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list || true
-                                                    sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list || true
-                                                    sed -i '/buster-updates/d' /etc/apt/sources.list || true
-                                                    apt-get -o Acquire::Check-Valid-Until=false update
-                                                }
+                                        apt_update_with_archive_fallback() {
+                                            apt-get update || {
+                                                # Old images may still point to EOL Debian mirrors.
+                                                sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list || true
+                                                sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list || true
+                                                sed -i '/buster-updates/d' /etc/apt/sources.list || true
+                                                apt-get -o Acquire::Check-Valid-Until=false update
                                             }
+                                        }
 
-                                            if ! command -v pytest >/dev/null 2>&1; then
-                                                pip3 install pytest
-                                            fi
+                                        if ! command -v pytest >/dev/null 2>&1; then
+                                            pip3 install pytest
+                                        fi
 
-                                            if [[ "${TEST_PARAMS}" == django_test/* ]]; then
-                                                pip3 install Pillow
-                                            fi
+                                        if [[ "${TEST_PARAMS}" == django_test/* ]]; then
+                                            pip3 install Pillow
+                                        fi
 
-                                            if [[ "${TEST_PARAMS}" == sqlalchemy_test/* ]]; then
-                                                pip3 install 'sqlalchemy>=1.4,<2' alembic
-                                                if ! python3 -c 'import MySQLdb' >/dev/null 2>&1; then
-                                                    pip3 install mysqlclient || {
-                                                        if command -v apt-get >/dev/null 2>&1; then
-                                                            # Temporary fallback for legacy images without mysqlclient build deps.
-                                                            # Prefer baking these deps into the base image for long-term stability.
-                                                            if [ "$(id -u)" -ne 0 ]; then
-                                                                echo "mysqlclient build dependencies are missing and apt-get requires root. Please update the python image."
-                                                                exit 1
-                                                            fi
-                                                            apt_update_with_archive_fallback
-                                                            DEBIAN_FRONTEND=noninteractive apt-get install -y gcc python3-dev pkg-config default-libmysqlclient-dev
-                                                        elif command -v yum >/dev/null 2>&1; then
-                                                            yum install -y gcc python3-devel pkgconfig mariadb-connector-c-devel || yum install -y gcc python3-devel pkgconfig mariadb-devel
-                                                        elif command -v apk >/dev/null 2>&1; then
-                                                            apk add --no-cache gcc musl-dev python3-dev pkgconf mariadb-dev
+                                        if [[ "${TEST_PARAMS}" == sqlalchemy_test/* ]]; then
+                                            pip3 install 'sqlalchemy>=1.4,<2' alembic
+                                            if ! python3 -c 'import MySQLdb' >/dev/null 2>&1; then
+                                                pip3 install mysqlclient || {
+                                                    if command -v apt-get >/dev/null 2>&1; then
+                                                        # Temporary fallback for legacy images without mysqlclient build deps.
+                                                        # Prefer baking these deps into the base image for long-term stability.
+                                                        if [ "$(id -u)" -ne 0 ]; then
+                                                            echo "mysqlclient build dependencies are missing and apt-get requires root. Please update the python image."
+                                                            exit 1
                                                         fi
-                                                        pip3 install mysqlclient
-                                                    }
-                                                fi
-                                                if [[ -f sqlalchemy_test/sqlalchemy-test/requirements.txt ]]; then
-                                                    pip3 install -r sqlalchemy_test/sqlalchemy-test/requirements.txt
-                                                fi
+                                                        apt_update_with_archive_fallback
+                                                        DEBIAN_FRONTEND=noninteractive apt-get install -y gcc python3-dev pkg-config default-libmysqlclient-dev
+                                                    elif command -v yum >/dev/null 2>&1; then
+                                                        yum install -y gcc python3-devel pkgconfig mariadb-connector-c-devel || yum install -y gcc python3-devel pkgconfig mariadb-devel
+                                                    elif command -v apk >/dev/null 2>&1; then
+                                                        apk add --no-cache gcc musl-dev python3-dev pkgconf mariadb-dev
+                                                    fi
+                                                    pip3 install mysqlclient
+                                                }
                                             fi
-
-                                            if ! command -v mysql >/dev/null 2>&1; then
-                                                if command -v apt-get >/dev/null 2>&1; then
-                                                    apt_update_with_archive_fallback
-                                                    DEBIAN_FRONTEND=noninteractive apt-get install -y default-mysql-client || DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-client
-                                                elif command -v yum >/dev/null 2>&1; then
-                                                    yum install -y mysql || yum install -y mariadb
-                                                elif command -v apk >/dev/null 2>&1; then
-                                                    apk add --no-cache mysql-client
-                                                fi
+                                            if [[ -f sqlalchemy_test/sqlalchemy-test/requirements.txt ]]; then
+                                                pip3 install -r sqlalchemy_test/sqlalchemy-test/requirements.txt
                                             fi
+                                        fi
 
-                                            command -v pytest
-                                            command -v mysql
-                                        '''
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            set -- \${TEST_PARAMS}
-                                            TEST_DIR=\$1
-                                            TEST_SCRIPT=\$2
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
-
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                            export TIDB_TEST_STORE_NAME="unistore"
-
-                                            TEST_LOG="${WORKSPACE}/tidb-test/test-\$(echo "\${TEST_DIR}" | tr '/' '_').log"
-                                            set +e
-                                            cd \${TEST_DIR}
-                                            chmod +x *.sh
-                                            \${TEST_SCRIPT} 2>&1 | tee "\${TEST_LOG}"
-                                            TEST_RC=\${PIPESTATUS[0]}
-                                            set -e
-
-                                            if [[ "\${TEST_PARAMS}" == sqlalchemy_test/* && \${TEST_RC} -ne 0 ]]; then
-                                                KNOWN_FLAKY=1
-                                                # TODO: move known flaky patterns to a shared config in tidb-test for easier maintenance.
-                                                for pattern in \\
-                                                    "FAILED test/test_engin_transaction.py::FutureTransactionTest_tidb+mysqldb_9_0_0::test_no_autocommit_w_autobegin" \\
-                                                    "FAILED test/test_engin_transaction.py::FutureTransactionTest_tidb+mysqldb_9_0_0::test_no_autocommit_w_begin" \\
-                                                    "FAILED test/test_engin_transaction.py::FutureTransactionTest_tidb+mysqldb_9_0_0::test_no_double_begin" \\
-                                                    "FAILED test/test_suite.py::DateTest_tidb+mysqldb_9_0_0::test_select_direct" \\
-                                                    "FAILED test/test_suite.py::DateTimeCoercedToDateTimeTest_tidb+mysqldb_9_0_0::test_select_direct" \\
-                                                    "FAILED test/test_suite.py::DateTimeTest_tidb+mysqldb_9_0_0::test_select_direct" \\
-                                                    "FAILED test/test_suite.py::TimeTest_tidb+mysqldb_9_0_0::test_select_direct"; do
-                                                    grep -Fq "\${pattern}" "\${TEST_LOG}" || KNOWN_FLAKY=0
-                                                done
-                                                grep -Fq "7 failed, 881 passed, 244 skipped" "\${TEST_LOG}" || KNOWN_FLAKY=0
-
-                                                if [[ \${KNOWN_FLAKY} -eq 1 ]]; then
-                                                    echo "Known flaky sqlalchemy cases detected, hotfix as non-blocking in merged_integration_python_orm_test."
-                                                    TEST_RC=0
-                                                fi
+                                        if ! command -v mysql >/dev/null 2>&1; then
+                                            if command -v apt-get >/dev/null 2>&1; then
+                                                apt_update_with_archive_fallback
+                                                DEBIAN_FRONTEND=noninteractive apt-get install -y default-mysql-client || DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-client
+                                            elif command -v yum >/dev/null 2>&1; then
+                                                yum install -y mysql || yum install -y mariadb
+                                            elif command -v apk >/dev/null 2>&1; then
+                                                apk add --no-cache mysql-client
                                             fi
+                                        fi
 
-                                            exit \${TEST_RC}
-                                        """
-                                    }
+                                        command -v pytest
+                                        command -v mysql
+                                    '''
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        set -- \${TEST_PARAMS}
+                                        TEST_DIR=\$1
+                                        TEST_SCRIPT=\$2
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        export TIDB_TEST_STORE_NAME="unistore"
+
+                                        TEST_LOG="${WORKSPACE}/tidb-test/test-\$(echo "\${TEST_DIR}" | tr '/' '_').log"
+                                        set +e
+                                        cd \${TEST_DIR}
+                                        chmod +x *.sh
+                                        \${TEST_SCRIPT} 2>&1 | tee "\${TEST_LOG}"
+                                        TEST_RC=\${PIPESTATUS[0]}
+                                        set -e
+
+                                        if [[ "\${TEST_PARAMS}" == sqlalchemy_test/* && \${TEST_RC} -ne 0 ]]; then
+                                            KNOWN_FLAKY=1
+                                            # TODO: move known flaky patterns to a shared config in tidb-test for easier maintenance.
+                                            for pattern in \\
+                                                "FAILED test/test_engin_transaction.py::FutureTransactionTest_tidb+mysqldb_9_0_0::test_no_autocommit_w_autobegin" \\
+                                                "FAILED test/test_engin_transaction.py::FutureTransactionTest_tidb+mysqldb_9_0_0::test_no_autocommit_w_begin" \\
+                                                "FAILED test/test_engin_transaction.py::FutureTransactionTest_tidb+mysqldb_9_0_0::test_no_double_begin" \\
+                                                "FAILED test/test_suite.py::DateTest_tidb+mysqldb_9_0_0::test_select_direct" \\
+                                                "FAILED test/test_suite.py::DateTimeCoercedToDateTimeTest_tidb+mysqldb_9_0_0::test_select_direct" \\
+                                                "FAILED test/test_suite.py::DateTimeTest_tidb+mysqldb_9_0_0::test_select_direct" \\
+                                                "FAILED test/test_suite.py::TimeTest_tidb+mysqldb_9_0_0::test_select_direct"; do
+                                                grep -Fq "\${pattern}" "\${TEST_LOG}" || KNOWN_FLAKY=0
+                                            done
+                                            grep -Fq "7 failed, 881 passed, 244 skipped" "\${TEST_LOG}" || KNOWN_FLAKY=0
+
+                                            if [[ \${KNOWN_FLAKY} -eq 1 ]]; then
+                                                echo "Known flaky sqlalchemy cases detected, hotfix as non-blocking in merged_integration_python_orm_test."
+                                                TEST_RC=0
+                                            fi
+                                        fi
+
+                                        exit \${TEST_RC}
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
@@ -52,10 +52,9 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                        sh 'cd sqllogic_test && ./build.sh'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    sh 'cd sqllogic_test && ./build.sh'
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -97,50 +96,49 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        mkdir -p bin
-                                        cp ${WORKSPACE}/tidb/bin/tidb-server sqllogic_test/
-                                        ls -alh sqllogic_test/
+                                unstash 'tidb-test'
+                                sh """
+                                    mkdir -p bin
+                                    cp ${WORKSPACE}/tidb/bin/tidb-server sqllogic_test/
+                                    ls -alh sqllogic_test/
+                                """
+                                container("utils") {
+                                    sh label: "prepare sqllogictest data", script: """#!/usr/bin/env bash
+                                        set -euxo pipefail
+                                        if [ -d /git/sqllogictest/test/random/aggregates_n1 ]; then
+                                            exit 0
+                                        fi
+                                        cd /git
+                                        rm -rf sqllogictest sqllogictest_v20241212.tar.gz
+                                        timeout 60 oras pull "${OCI_ARTIFACT_HOST}/pingcap/case-data/sqllogic:v20241212" || true
+                                        if [ -f sqllogictest_v20241212.tar.gz ]; then
+                                            tar xzf sqllogictest_v20241212.tar.gz
+                                            rm -f sqllogictest_v20241212.tar.gz
+                                        fi
+                                        echo "Temporary hotfix: failed to download sqllogictest data after retries"
                                     """
-                                    container("utils") {
-                                        sh label: "prepare sqllogictest data", script: """#!/usr/bin/env bash
-                                            set -euxo pipefail
-                                            if [ -d /git/sqllogictest/test/random/aggregates_n1 ]; then
-                                                exit 0
-                                            fi
-                                            cd /git
-                                            rm -rf sqllogictest sqllogictest_v20241212.tar.gz
-                                            timeout 60 oras pull "${OCI_ARTIFACT_HOST}/pingcap/case-data/sqllogic:v20241212" || true
-                                            if [ -f sqllogictest_v20241212.tar.gz ]; then
-                                                tar xzf sqllogictest_v20241212.tar.gz
-                                                rm -f sqllogictest_v20241212.tar.gz
-                                            fi
-                                            echo "Temporary hotfix: failed to download sqllogictest data after retries"
-                                        """
-                                    }
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """
-                                            #!/usr/bin/env bash
-                                            if [ ! -d /git/sqllogictest/test/random/aggregates_n1 ]; then
-                                                echo "Temporary hotfix: missing sqllogictest data, skip this matrix branch"
-                                                exit 0
-                                            fi
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
-                                                TIDB_PARALLELISM=8 \
-                                                TIDB_SERVER_PATH=`pwd`/tidb-server \
-                                                CACHE_ENABLED=${CACHE_ENABLED} \
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                }
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """
+                                        #!/usr/bin/env bash
+                                        if [ ! -d /git/sqllogictest/test/random/aggregates_n1 ]; then
+                                            echo "Temporary hotfix: missing sqllogictest data, skip this matrix branch"
+                                            exit 0
+                                        fi
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
+                                            TIDB_PARALLELISM=8 \
+                                            TIDB_SERVER_PATH=`pwd`/tidb-server \
+                                            CACHE_ENABLED=${CACHE_ENABLED} \
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -185,50 +183,49 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        mkdir -p bin
-                                        cp ${WORKSPACE}/tidb/bin/tidb-server sqllogic_test/
-                                        ls -alh sqllogic_test/
+                                unstash 'tidb-test'
+                                sh """
+                                    mkdir -p bin
+                                    cp ${WORKSPACE}/tidb/bin/tidb-server sqllogic_test/
+                                    ls -alh sqllogic_test/
+                                """
+                                container("utils") {
+                                    sh label: "prepare sqllogictest data", script: """#!/usr/bin/env bash
+                                        set -euxo pipefail
+                                        if [ -d /git/sqllogictest/test/random/aggregates_n1 ]; then
+                                            exit 0
+                                        fi
+                                        cd /git
+                                        rm -rf sqllogictest sqllogictest_v20241212.tar.gz
+                                        timeout 60 oras pull "${OCI_ARTIFACT_HOST}/pingcap/case-data/sqllogic:v20241212" || true
+                                        if [ -f sqllogictest_v20241212.tar.gz ]; then
+                                            tar xzf sqllogictest_v20241212.tar.gz
+                                            rm -f sqllogictest_v20241212.tar.gz
+                                        fi
+                                        echo "Temporary hotfix: failed to download sqllogictest data after retries"
                                     """
-                                    container("utils") {
-                                        sh label: "prepare sqllogictest data", script: """#!/usr/bin/env bash
-                                            set -euxo pipefail
-                                            if [ -d /git/sqllogictest/test/random/aggregates_n1 ]; then
-                                                exit 0
-                                            fi
-                                            cd /git
-                                            rm -rf sqllogictest sqllogictest_v20241212.tar.gz
-                                            timeout 60 oras pull "${OCI_ARTIFACT_HOST}/pingcap/case-data/sqllogic:v20241212" || true
-                                            if [ -f sqllogictest_v20241212.tar.gz ]; then
-                                                tar xzf sqllogictest_v20241212.tar.gz
-                                                rm -f sqllogictest_v20241212.tar.gz
-                                            fi
-                                            echo "Temporary hotfix: failed to download sqllogictest data after retries"
-                                        """
-                                    }
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """
-                                            #!/usr/bin/env bash
-                                            if [ ! -d /git/sqllogictest/test/random/aggregates_n1 ]; then
-                                                echo "Temporary hotfix: missing sqllogictest data, skip this matrix branch"
-                                                exit 0
-                                            fi
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
-                                                TIDB_PARALLELISM=8 \
-                                                TIDB_SERVER_PATH=`pwd`/tidb-server \
-                                                CACHE_ENABLED=${CACHE_ENABLED} \
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                }
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """
+                                        #!/usr/bin/env bash
+                                        if [ ! -d /git/sqllogictest/test/random/aggregates_n1 ]; then
+                                            echo "Temporary hotfix: missing sqllogictest data, skip this matrix branch"
+                                            exit 0
+                                        fi
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
+                                            TIDB_PARALLELISM=8 \
+                                            TIDB_SERVER_PATH=`pwd`/tidb-server \
+                                            CACHE_ENABLED=${CACHE_ENABLED} \
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
@@ -75,9 +75,8 @@ pipeline {
                         sh "${WORKSPACE}/${SELF_DIR}/download_tools.sh"
                     }
                     // cache it for other pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -107,9 +106,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
-                                }
+                                unstash 'ws'
+                                sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: "chmod +x br/tests/*.sh && ./br/tests/run_group_br_tests.sh ${TEST_GROUP}"
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_common_test.groovy
@@ -46,15 +46,14 @@ pipeline {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare binary', script: """#!/usr/bin/env bash
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare binary', script: """#!/usr/bin/env bash
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -87,12 +86,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        cd ${TEST_DIR} && ${TEST_CMD}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    cd ${TEST_DIR} && ${TEST_CMD}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
@@ -64,18 +64,17 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                        touch ws-${BUILD_TAG}
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                    touch ws-${BUILD_TAG}
+                    cd tidb_test && ./build.sh && cd ..
+                    cd randgen-test && ./build.sh && cd ..
+                    mkdir -p bin
+                    cp -r ../tidb/bin/* bin/ && chmod +x bin/*
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,29 +107,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -103,26 +102,25 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
@@ -77,13 +77,12 @@ pipeline {
                             """
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'cache tidb-test', script: """
-                            cp -r ../tidb/bin/tidb-server bin/
-                            cp -r ../tidb/bin/ddltest bin/
-                            touch ws-${BUILD_TAG}
-                        """
-                    }
+                    sh label: 'cache tidb-test', script: """
+                        cp -r ../tidb/bin/tidb-server bin/
+                        cp -r ../tidb/bin/ddltest bin/
+                        touch ws-${BUILD_TAG}
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -117,26 +116,25 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,35 +107,34 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("java") {
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("java") {
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        params_array=(\${TEST_PARAMS})
+                                        TEST_DIR=\${params_array[0]}
+                                        TEST_SCRIPT=\${params_array[1]}
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            fi
-                                        """
-                                    }
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        fi
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tikv-server -V
+                        ./bin/pd-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -105,29 +104,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container('nodejs') {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
 
@@ -102,23 +101,22 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="tikv"
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIKV_PATH="127.0.0.1:2379"
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="tikv"
+                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                    export TIKV_PATH="127.0.0.1:2379"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container("golang") {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
             }
@@ -105,24 +104,23 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="\$TEST_STORE"
-                                        set -- \${TEST_PARAMS}
-                                        TEST_DIR=\$1
-                                        TEST_SCRIPT=\$2
-                                        echo "TEST_DIR=\${TEST_DIR}"
-                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
-                                        cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="\$TEST_STORE"
+                                    set -- \${TEST_PARAMS}
+                                    TEST_DIR=\$1
+                                    TEST_SCRIPT=\$2
+                                    echo "TEST_DIR=\${TEST_DIR}"
+                                    echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                    cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -75,9 +75,8 @@ pipeline {
                         }
                     }
                     // cache it for other pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -139,9 +138,8 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
-                                }
+                                unstash 'ws'
+                                sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
 
                                 sh '''
                                     mkdir -p /home/jenkins/.tidb/tmp

--- a/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
@@ -71,9 +71,8 @@ pipeline {
                         '''
                     }
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -103,9 +102,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x lightning/tests/*.sh
                                     if [ "${TEST_GROUP}" = "G00" ]; then

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -70,9 +70,8 @@ pipeline {
                         }
                     }
                     // Cache for next test stages.
-                    cache(path: './', includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'cache tidb-test', script: 'touch ws-${BUILD_TAG}'
-                    }
+                    sh label: 'cache tidb-test', script: 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -107,10 +106,9 @@ pipeline {
                         steps {
                             dir('tidb-test') {
                                 // restore the cache saved by previous stage.
-                                cache(path: './', includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    // if cache missed, it will fail(should not miss).
-                                    sh 'ls mysql_test && chmod +x bin/{tidb-server,pd-server,tikv-server,tikv-worker}'
-                                }
+                                unstash 'tidb-test'
+                                // if cache missed, it will fail(should not miss).
+                                sh 'ls mysql_test && chmod +x bin/{tidb-server,pd-server,tikv-server,tikv-worker}'
 
                                 // run the test.
                                 // TODO: use a script for next-gen, consider merging the script.

--- a/pipelines/pingcap/tidb/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_sqllogic_test.groovy
@@ -48,14 +48,13 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare tidb-test', script: """
-                            touch ws-${BUILD_TAG}
-                            cd sqllogic_test && ./build.sh
-                            cp ${WORKSPACE}/tidb/bin/tidb-server ./
-                            chmod +x tidb-server && ./tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare tidb-test', script: """
+                        touch ws-${BUILD_TAG}
+                        cd sqllogic_test && ./build.sh
+                        cp ${WORKSPACE}/tidb/bin/tidb-server ./
+                        chmod +x tidb-server && ./tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -92,29 +91,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -154,29 +152,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_mysql_test.groovy
@@ -48,9 +48,8 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -85,11 +84,10 @@ pipeline {
                                     }
                                 }
                                 dir('tidb-test') {
-                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                        sh 'ls mysql_test'
-                                        dir('mysql_test') {
-                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
-                                        }
+                                    unstash 'tidb-test'
+                                    sh 'ls mysql_test'
+                                    dir('mysql_test') {
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_mysql_test.groovy
@@ -48,9 +48,8 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -85,11 +84,10 @@ pipeline {
                                     }
                                 }
                                 dir('tidb-test') {
-                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                        sh 'ls mysql_test'
-                                        dir('mysql_test') {
-                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
-                                        }
+                                    unstash 'tidb-test'
+                                    sh 'ls mysql_test'
+                                    dir('mysql_test') {
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_mysql_test.groovy
@@ -48,9 +48,8 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -85,11 +84,10 @@ pipeline {
                                     }
                                 }
                                 dir('tidb-test') {
-                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                        sh 'ls mysql_test'
-                                        dir('mysql_test') {
-                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
-                                        }
+                                    unstash 'tidb-test'
+                                    sh 'ls mysql_test'
+                                    dir('mysql_test') {
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.5-fips/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/ghpr_check2.groovy
@@ -54,15 +54,14 @@ pipeline {
                         ls -alh ./bin/
                     """
                     // cache it for other pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            which bin/tidb-server
-                            which bin/tikv-server
-                            which bin/pd-server
-                            mv bin/tidb-server bin/explain_test_tidb-server
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        which bin/tidb-server
+                        which bin/tikv-server
+                        which bin/pd-server
+                        mv bin/tidb-server bin/explain_test_tidb-server
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -100,9 +99,8 @@ pipeline {
                         options { timeout(time: 30, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
-                                }
+                                unstash 'ws'
+                                sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
 
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
                                 sh """

--- a/pipelines/pingcap/tidb/release-6.5-fips/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/ghpr_mysql_test.groovy
@@ -58,9 +58,8 @@ pipeline {
                 }
                 dir('tidb-test') {
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -94,13 +93,12 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: """#!/usr/bin/env bash
-                                            TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}
-                                        """
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: """#!/usr/bin/env bash
+                                        TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
@@ -84,11 +84,10 @@ pipeline {
                         """
                     }
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -118,9 +117,8 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     cp ${WORKSPACE}/scripts/pingcap/tidb/br-lightning_run_group_v2.sh br/tests/run_group.sh
                                     chmod +x br/tests/*.sh

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_mysql_test.groovy
@@ -48,9 +48,8 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -85,11 +84,10 @@ pipeline {
                                     }
                                 }
                                 dir('tidb-test') {
-                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                        sh 'ls mysql_test'
-                                        dir('mysql_test') {
-                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
-                                        }
+                                    unstash 'tidb-test'
+                                    sh 'ls mysql_test'
+                                    dir('mysql_test') {
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-6.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_br_integration_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/tidb-server -V
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'br-lightning', includes: '**/*'
                 }
             }
         }
@@ -101,16 +100,15 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('tidb') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-lightning") {
-                                    sh label: "TEST_GROUP ${TEST_GROUP}", script: """
-                                        #!/usr/bin/env bash
-                                        cp ${WORKSPACE}/scripts/pingcap/tidb/br-lightning_run_group_v2.sh br/tests/run_group.sh
-                                        chmod +x br/tests/*.sh
-                                        ln -s ${WORKSPACE}/tidb/bin ${WORKSPACE}/tidb/br/bin
-                                        cd br/
-                                        ./tests/run_group.sh ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'br-lightning'
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """
+                                    #!/usr/bin/env bash
+                                    cp ${WORKSPACE}/scripts/pingcap/tidb/br-lightning_run_group_v2.sh br/tests/run_group.sh
+                                    chmod +x br/tests/*.sh
+                                    ln -s ${WORKSPACE}/tidb/bin ${WORKSPACE}/tidb/br/bin
+                                    cd br/
+                                    ./tests/run_group.sh ${TEST_GROUP}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-6.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_common_test.groovy
@@ -52,15 +52,14 @@ pipeline {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare binary', script: """#!/usr/bin/env bash
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare binary', script: """#!/usr/bin/env bash
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -93,12 +92,11 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        cd ${TEST_DIR} && ${TEST_CMD}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    cd ${TEST_DIR} && ${TEST_CMD}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
@@ -68,18 +68,17 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                        touch ws-${BUILD_TAG}
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                    touch ws-${BUILD_TAG}
+                    cd tidb_test && ./build.sh && cd ..
+                    cd randgen-test && ./build.sh && cd ..
+                    mkdir -p bin
+                    cp -r ../tidb/bin/* bin/ && chmod +x bin/*
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -112,29 +111,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
@@ -69,17 +69,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -109,26 +108,25 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
@@ -68,17 +68,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -114,35 +113,34 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("java") {
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("java") {
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        params_array=(\${TEST_PARAMS})
+                                        TEST_DIR=\${params_array[0]}
+                                        TEST_SCRIPT=\${params_array[1]}
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            fi
-                                        """
-                                    }
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        fi
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
@@ -68,17 +68,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tikv-server -V
+                        ./bin/pd-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -111,29 +110,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh -blacklist=1 -part=${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh -blacklist=1 -part=${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh -blacklist=1 -part=${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh -blacklist=1 -part=${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-6.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_sqllogic_test.groovy
@@ -54,14 +54,13 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare tidb-test', script: """
-                            touch ws-${BUILD_TAG}
-                            cd sqllogic_test && ./build.sh
-                            cp ${WORKSPACE}/tidb/bin/tidb-server ./
-                            chmod +x tidb-server && ./tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare tidb-test', script: """
+                        touch ws-${BUILD_TAG}
+                        cd sqllogic_test && ./build.sh
+                        cp ${WORKSPACE}/tidb/bin/tidb-server ./
+                        chmod +x tidb-server && ./tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -98,29 +97,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -160,29 +158,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_mysql_test.groovy
@@ -48,9 +48,8 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -85,11 +84,10 @@ pipeline {
                                     }
                                 }
                                 dir('tidb-test') {
-                                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                        sh 'ls mysql_test'
-                                        dir('mysql_test') {
-                                            sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
-                                        }
+                                    unstash 'tidb-test'
+                                    sh 'ls mysql_test'
+                                    dir('mysql_test') {
+                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -part=${PART}'
                                     }
                                 }
                             }

--- a/pipelines/pingcap/tidb/release-7.0/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.0/ghpr_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-7.1/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_common_test.groovy
@@ -46,15 +46,14 @@ pipeline {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare binary', script: """#!/usr/bin/env bash
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare binary', script: """#!/usr/bin/env bash
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -87,12 +86,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        cd ${TEST_DIR} && ${TEST_CMD}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    cd ${TEST_DIR} && ${TEST_CMD}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
@@ -64,18 +64,17 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                        touch ws-${BUILD_TAG}
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                    touch ws-${BUILD_TAG}
+                    cd tidb_test && ./build.sh && cd ..
+                    cd randgen-test && ./build.sh && cd ..
+                    mkdir -p bin
+                    cp -r ../tidb/bin/* bin/ && chmod +x bin/*
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,29 +107,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -103,26 +102,25 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,35 +107,34 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("java") {
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("java") {
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        params_array=(\${TEST_PARAMS})
+                                        TEST_DIR=\${params_array[0]}
+                                        TEST_SCRIPT=\${params_array[1]}
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            fi
-                                        """
-                                    }
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        fi
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tikv-server -V
+                        ./bin/pd-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -105,29 +104,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.1/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_sqllogic_test.groovy
@@ -48,14 +48,13 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare tidb-test', script: """
-                            touch ws-${BUILD_TAG}
-                            cd sqllogic_test && ./build.sh
-                            cp ${WORKSPACE}/tidb/bin/tidb-server ./
-                            chmod +x tidb-server && ./tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare tidb-test', script: """
+                        touch ws-${BUILD_TAG}
+                        cd sqllogic_test && ./build.sh
+                        cp ${WORKSPACE}/tidb/bin/tidb-server ./
+                        chmod +x tidb-server && ./tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -92,29 +91,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -154,29 +152,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_mysql_test.groovy
@@ -56,9 +56,8 @@ pipeline {
                 }
                 dir('tidb-test') {
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -91,11 +90,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-7.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_common_test.groovy
@@ -46,15 +46,14 @@ pipeline {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare binary', script: """#!/usr/bin/env bash
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare binary', script: """#!/usr/bin/env bash
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -87,12 +86,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        cd ${TEST_DIR} && ${TEST_CMD}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    cd ${TEST_DIR} && ${TEST_CMD}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
@@ -64,18 +64,17 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                        touch ws-${BUILD_TAG}
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                    touch ws-${BUILD_TAG}
+                    cd tidb_test && ./build.sh && cd ..
+                    cd randgen-test && ./build.sh && cd ..
+                    mkdir -p bin
+                    cp -r ../tidb/bin/* bin/ && chmod +x bin/*
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,29 +107,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -103,26 +102,25 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,35 +107,34 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("java") {
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("java") {
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        params_array=(\${TEST_PARAMS})
+                                        TEST_DIR=\${params_array[0]}
+                                        TEST_SCRIPT=\${params_array[1]}
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            fi
-                                        """
-                                    }
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        fi
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tikv-server -V
+                        ./bin/pd-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -105,29 +104,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container('nodejs') {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
 
@@ -102,23 +101,22 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="tikv"
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIKV_PATH="127.0.0.1:2379"
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="tikv"
+                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                    export TIKV_PATH="127.0.0.1:2379"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container("golang") {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
             }
@@ -105,24 +104,23 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="\$TEST_STORE"
-                                        set -- \${TEST_PARAMS}
-                                        TEST_DIR=\$1
-                                        TEST_SCRIPT=\$2
-                                        echo "TEST_DIR=\${TEST_DIR}"
-                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
-                                        cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="\$TEST_STORE"
+                                    set -- \${TEST_PARAMS}
+                                    TEST_DIR=\$1
+                                    TEST_SCRIPT=\$2
+                                    echo "TEST_DIR=\${TEST_DIR}"
+                                    echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                    cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-7.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_sqllogic_test.groovy
@@ -48,14 +48,13 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare tidb-test', script: """
-                            touch ws-${BUILD_TAG}
-                            cd sqllogic_test && ./build.sh
-                            cp ${WORKSPACE}/tidb/bin/tidb-server ./
-                            chmod +x tidb-server && ./tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare tidb-test', script: """
+                        touch ws-${BUILD_TAG}
+                        cd sqllogic_test && ./build.sh
+                        cp ${WORKSPACE}/tidb/bin/tidb-server ./
+                        chmod +x tidb-server && ./tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -92,29 +91,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -154,29 +152,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.6/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
@@ -71,9 +71,8 @@ pipeline {
                         '''
                     }
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -103,9 +102,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x lightning/tests/*.sh
                                     if [ "${TEST_GROUP}" = "G00" ]; then

--- a/pipelines/pingcap/tidb/release-8.0/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/ghpr_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
@@ -71,9 +71,8 @@ pipeline {
                         '''
                     }
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -103,9 +102,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x lightning/tests/*.sh
                                     if [ "${TEST_GROUP}" = "G00" ]; then

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-8.1/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_common_test.groovy
@@ -46,15 +46,14 @@ pipeline {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare binary', script: """#!/usr/bin/env bash
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare binary', script: """#!/usr/bin/env bash
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -87,12 +86,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        cd ${TEST_DIR} && ${TEST_CMD}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    cd ${TEST_DIR} && ${TEST_CMD}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
@@ -64,18 +64,17 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                        touch ws-${BUILD_TAG}
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                    touch ws-${BUILD_TAG}
+                    cd tidb_test && ./build.sh && cd ..
+                    cd randgen-test && ./build.sh && cd ..
+                    mkdir -p bin
+                    cp -r ../tidb/bin/* bin/ && chmod +x bin/*
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,29 +107,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -103,26 +102,25 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,35 +107,34 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("java") {
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("java") {
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        params_array=(\${TEST_PARAMS})
+                                        TEST_DIR=\${params_array[0]}
+                                        TEST_SCRIPT=\${params_array[1]}
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            fi
-                                        """
-                                    }
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        fi
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tikv-server -V
+                        ./bin/pd-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -105,29 +104,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container('nodejs') {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
 
@@ -102,23 +101,22 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="tikv"
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIKV_PATH="127.0.0.1:2379"
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="tikv"
+                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                    export TIKV_PATH="127.0.0.1:2379"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container("golang") {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
             }
@@ -105,24 +104,23 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="\$TEST_STORE"
-                                        set -- \${TEST_PARAMS}
-                                        TEST_DIR=\$1
-                                        TEST_SCRIPT=\$2
-                                        echo "TEST_DIR=\${TEST_DIR}"
-                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
-                                        cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="\$TEST_STORE"
+                                    set -- \${TEST_PARAMS}
+                                    TEST_DIR=\$1
+                                    TEST_SCRIPT=\$2
+                                    echo "TEST_DIR=\${TEST_DIR}"
+                                    echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                    cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
@@ -71,9 +71,8 @@ pipeline {
                         '''
                     }
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -103,9 +102,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x lightning/tests/*.sh
                                     if [ "${TEST_GROUP}" = "G00" ]; then

--- a/pipelines/pingcap/tidb/release-8.1/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_sqllogic_test.groovy
@@ -48,14 +48,13 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare tidb-test', script: """
-                            touch ws-${BUILD_TAG}
-                            cd sqllogic_test && ./build.sh
-                            cp ${WORKSPACE}/tidb/bin/tidb-server ./
-                            chmod +x tidb-server && ./tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare tidb-test', script: """
+                        touch ws-${BUILD_TAG}
+                        cd sqllogic_test && ./build.sh
+                        cp ${WORKSPACE}/tidb/bin/tidb-server ./
+                        chmod +x tidb-server && ./tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -92,29 +91,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -154,29 +152,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.2/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_common_test.groovy
@@ -46,15 +46,14 @@ pipeline {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare binary', script: """#!/usr/bin/env bash
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare binary', script: """#!/usr/bin/env bash
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -87,12 +86,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        cd ${TEST_DIR} && ${TEST_CMD}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    cd ${TEST_DIR} && ${TEST_CMD}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
@@ -64,18 +64,17 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                        touch ws-${BUILD_TAG}
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                    touch ws-${BUILD_TAG}
+                    cd tidb_test && ./build.sh && cd ..
+                    cd randgen-test && ./build.sh && cd ..
+                    mkdir -p bin
+                    cp -r ../tidb/bin/* bin/ && chmod +x bin/*
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,29 +107,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -103,26 +102,25 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,35 +107,34 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("java") {
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("java") {
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        params_array=(\${TEST_PARAMS})
+                                        TEST_DIR=\${params_array[0]}
+                                        TEST_SCRIPT=\${params_array[1]}
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            fi
-                                        """
-                                    }
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        fi
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
@@ -71,9 +71,8 @@ pipeline {
                         '''
                     }
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -103,9 +102,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x lightning/tests/*.sh
                                     if [ "${TEST_GROUP}" = "G00" ]; then

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tikv-server -V
+                        ./bin/pd-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -105,29 +104,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container('nodejs') {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
 
@@ -102,23 +101,22 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="tikv"
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIKV_PATH="127.0.0.1:2379"
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="tikv"
+                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                    export TIKV_PATH="127.0.0.1:2379"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container("golang") {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
             }
@@ -105,24 +104,23 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="\$TEST_STORE"
-                                        set -- \${TEST_PARAMS}
-                                        TEST_DIR=\$1
-                                        TEST_SCRIPT=\$2
-                                        echo "TEST_DIR=\${TEST_DIR}"
-                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
-                                        cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="\$TEST_STORE"
+                                    set -- \${TEST_PARAMS}
+                                    TEST_DIR=\$1
+                                    TEST_SCRIPT=\$2
+                                    echo "TEST_DIR=\${TEST_DIR}"
+                                    echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                    cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.2/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.2/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_sqllogic_test.groovy
@@ -48,14 +48,13 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare tidb-test', script: """
-                            touch ws-${BUILD_TAG}
-                            cd sqllogic_test && ./build.sh
-                            cp ${WORKSPACE}/tidb/bin/tidb-server ./
-                            chmod +x tidb-server && ./tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare tidb-test', script: """
+                        touch ws-${BUILD_TAG}
+                        cd sqllogic_test && ./build.sh
+                        cp ${WORKSPACE}/tidb/bin/tidb-server ./
+                        chmod +x tidb-server && ./tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -92,29 +91,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -154,29 +152,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.3/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_common_test.groovy
@@ -46,15 +46,14 @@ pipeline {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare binary', script: """#!/usr/bin/env bash
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare binary', script: """#!/usr/bin/env bash
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -87,12 +86,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        cd ${TEST_DIR} && ${TEST_CMD}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    cd ${TEST_DIR} && ${TEST_CMD}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
@@ -64,18 +64,17 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                        touch ws-${BUILD_TAG}
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                    touch ws-${BUILD_TAG}
+                    cd tidb_test && ./build.sh && cd ..
+                    cd randgen-test && ./build.sh && cd ..
+                    mkdir -p bin
+                    cp -r ../tidb/bin/* bin/ && chmod +x bin/*
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,29 +107,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -103,26 +102,25 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,35 +107,34 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("java") {
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("java") {
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        params_array=(\${TEST_PARAMS})
+                                        TEST_DIR=\${params_array[0]}
+                                        TEST_SCRIPT=\${params_array[1]}
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            fi
-                                        """
-                                    }
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        fi
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
@@ -71,9 +71,8 @@ pipeline {
                         '''
                     }
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -103,9 +102,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x lightning/tests/*.sh
                                     if [ "${TEST_GROUP}" = "G00" ]; then

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tikv-server -V
+                        ./bin/pd-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -105,29 +104,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container('nodejs') {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
 
@@ -102,23 +101,22 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="tikv"
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIKV_PATH="127.0.0.1:2379"
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="tikv"
+                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                    export TIKV_PATH="127.0.0.1:2379"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container("golang") {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
             }
@@ -105,24 +104,23 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="\$TEST_STORE"
-                                        set -- \${TEST_PARAMS}
-                                        TEST_DIR=\$1
-                                        TEST_SCRIPT=\$2
-                                        echo "TEST_DIR=\${TEST_DIR}"
-                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
-                                        cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="\$TEST_STORE"
+                                    set -- \${TEST_PARAMS}
+                                    TEST_DIR=\$1
+                                    TEST_SCRIPT=\$2
+                                    echo "TEST_DIR=\${TEST_DIR}"
+                                    echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                    cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.3/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.3/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_sqllogic_test.groovy
@@ -48,14 +48,13 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare tidb-test', script: """
-                            touch ws-${BUILD_TAG}
-                            cd sqllogic_test && ./build.sh
-                            cp ${WORKSPACE}/tidb/bin/tidb-server ./
-                            chmod +x tidb-server && ./tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare tidb-test', script: """
+                        touch ws-${BUILD_TAG}
+                        cd sqllogic_test && ./build.sh
+                        cp ${WORKSPACE}/tidb/bin/tidb-server ./
+                        chmod +x tidb-server && ./tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -92,29 +91,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -154,29 +152,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.4/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_common_test.groovy
@@ -46,15 +46,14 @@ pipeline {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare binary', script: """#!/usr/bin/env bash
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare binary', script: """#!/usr/bin/env bash
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -87,12 +86,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        cd ${TEST_DIR} && ${TEST_CMD}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    cd ${TEST_DIR} && ${TEST_CMD}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
@@ -82,11 +82,10 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh """
-                            touch rev-${REFS.pulls[0].sha}
-                        """
-                    }
+                    sh """
+                        touch rev-${REFS.pulls[0].sha}
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -116,9 +115,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
@@ -64,18 +64,17 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                        touch ws-${BUILD_TAG}
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                    touch ws-${BUILD_TAG}
+                    cd tidb_test && ./build.sh && cd ..
+                    cd randgen-test && ./build.sh && cd ..
+                    mkdir -p bin
+                    cp -r ../tidb/bin/* bin/ && chmod +x bin/*
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,29 +107,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -103,26 +102,25 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,35 +107,34 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("java") {
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("java") {
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        params_array=(\${TEST_PARAMS})
+                                        TEST_DIR=\${params_array[0]}
+                                        TEST_SCRIPT=\${params_array[1]}
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            fi
-                                        """
-                                    }
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        fi
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
@@ -71,9 +71,8 @@ pipeline {
                         '''
                     }
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -103,9 +102,8 @@ pipeline {
                         environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x lightning/tests/*.sh
                                     if [ "${TEST_GROUP}" = "G00" ]; then

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tikv-server -V
+                        ./bin/pd-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -105,29 +104,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container('nodejs') {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
 
@@ -102,23 +101,22 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="tikv"
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIKV_PATH="127.0.0.1:2379"
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="tikv"
+                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                    export TIKV_PATH="127.0.0.1:2379"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
@@ -61,17 +61,16 @@ pipeline {
                 }
                 container("golang") {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
             }
@@ -105,24 +104,23 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="\$TEST_STORE"
-                                        set -- \${TEST_PARAMS}
-                                        TEST_DIR=\$1
-                                        TEST_SCRIPT=\$2
-                                        echo "TEST_DIR=\${TEST_DIR}"
-                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
-                                        cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="\$TEST_STORE"
+                                    set -- \${TEST_PARAMS}
+                                    TEST_DIR=\$1
+                                    TEST_SCRIPT=\$2
+                                    echo "TEST_DIR=\${TEST_DIR}"
+                                    echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                    cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.4/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -79,11 +78,10 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh -backlist=1 -part=${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.4/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_sqllogic_test.groovy
@@ -48,14 +48,13 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare tidb-test', script: """
-                            touch ws-${BUILD_TAG}
-                            cd sqllogic_test && ./build.sh
-                            cp ${WORKSPACE}/tidb/bin/tidb-server ./
-                            chmod +x tidb-server && ./tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare tidb-test', script: """
+                        touch ws-${BUILD_TAG}
+                        cd sqllogic_test && ./build.sh
+                        cp ${WORKSPACE}/tidb/bin/tidb-server ./
+                        chmod +x tidb-server && ./tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -92,29 +91,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -154,29 +152,28 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.5/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_common_test.groovy
@@ -47,15 +47,14 @@ pipeline {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare binary', script: """#!/usr/bin/env bash
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare binary', script: """#!/usr/bin/env bash
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -89,12 +88,11 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        cd ${TEST_DIR} && ${TEST_CMD}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    cd ${TEST_DIR} && ${TEST_CMD}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -82,9 +82,8 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -115,9 +114,8 @@ pipeline {
                         options { timeout(time: 90, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
@@ -63,18 +63,17 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                        touch ws-${BUILD_TAG}
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                    touch ws-${BUILD_TAG}
+                    cd tidb_test && ./build.sh && cd ..
+                    cd randgen-test && ./build.sh && cd ..
+                    mkdir -p bin
+                    cp -r ../tidb/bin/* bin/ && chmod +x bin/*
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,29 +107,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
@@ -64,17 +64,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -105,26 +104,25 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -110,35 +109,34 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("java") {
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("java") {
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        params_array=(\${TEST_PARAMS})
+                                        TEST_DIR=\${params_array[0]}
+                                        TEST_SCRIPT=\${params_array[1]}
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            fi
-                                        """
-                                    }
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        fi
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
@@ -72,9 +72,8 @@ pipeline {
                         '''
                     }
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -105,9 +104,8 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x lightning/tests/*.sh
                                     if [ "${TEST_GROUP}" = "G00" ]; then

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tikv-server -V
+                        ./bin/pd-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -107,29 +106,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                 }
                 container('nodejs') {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
             }
@@ -103,23 +102,22 @@ pipeline {
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="tikv"
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIKV_PATH="127.0.0.1:2379"
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="tikv"
+                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                    export TIKV_PATH="127.0.0.1:2379"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                 }
                 container("golang") {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
             }
@@ -107,25 +106,24 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="\$TEST_STORE"
-                                        set -- \${TEST_PARAMS}
-                                        TEST_DIR=\$1
-                                        TEST_SCRIPT=\$2
-                                        echo "TEST_DIR=\${TEST_DIR}"
-                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="\$TEST_STORE"
+                                    set -- \${TEST_PARAMS}
+                                    TEST_DIR=\$1
+                                    TEST_SCRIPT=\$2
+                                    echo "TEST_DIR=\${TEST_DIR}"
+                                    echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -80,12 +79,11 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        // TODO: fix the test.sh to correct the parameter parsing and numerical comparison.
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    // TODO: fix the test.sh to correct the parameter parsing and numerical comparison.
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-8.5/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_sqllogic_test.groovy
@@ -49,14 +49,13 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare tidb-test', script: """
-                            touch ws-${BUILD_TAG}
-                            cd sqllogic_test && ./build.sh
-                            cp ${WORKSPACE}/tidb/bin/tidb-server ./
-                            chmod +x tidb-server && ./tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare tidb-test', script: """
+                        touch ws-${BUILD_TAG}
+                        cd sqllogic_test && ./build.sh
+                        cp ${WORKSPACE}/tidb/bin/tidb-server ./
+                        chmod +x tidb-server && ./tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -94,29 +93,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -157,29 +155,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_common_test.groovy
@@ -47,15 +47,14 @@ pipeline {
                     sh label: 'tidb-server', script: '[ -f bin/tidb-server ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare binary', script: """#!/usr/bin/env bash
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare binary', script: """#!/usr/bin/env bash
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/tidb-server bin/ && chmod +x bin/tidb-server
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -89,12 +88,11 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        cd ${TEST_DIR} && ${TEST_CMD}
-                                    """
-                                }
+                                unstash 'tidb-test'
+                                sh label: "test_dir=${TEST_DIR} ${TEST_CMD}", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    cd ${TEST_DIR} && ${TEST_CMD}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
@@ -82,9 +82,8 @@ pipeline {
                     }
 
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -115,9 +114,8 @@ pipeline {
                         options { timeout(time: 90, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x br/tests/*.sh
                                     ./br/tests/run_group_br_tests.sh ${TEST_GROUP}

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
@@ -63,18 +63,17 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                        touch ws-${BUILD_TAG}
-                        cd tidb_test && ./build.sh && cd ..
-                        cd randgen-test && ./build.sh && cd ..
-                        mkdir -p bin
-                        cp -r ../tidb/bin/* bin/ && chmod +x bin/*
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                    touch ws-${BUILD_TAG}
+                    cd tidb_test && ./build.sh && cd ..
+                    cd randgen-test && ./build.sh && cd ..
+                    mkdir -p bin
+                    cp -r ../tidb/bin/* bin/ && chmod +x bin/*
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -108,29 +107,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd ${TEST_DIR} && ./test.sh
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_dir=${TEST_DIR}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd ${TEST_DIR} && ./test.sh
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
@@ -64,17 +64,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -105,26 +104,25 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
-                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                unstash 'tidb-test'
+                                sh """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "ddl_test ${DDL_TEST}", script: """#!/usr/bin/env bash
+                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
 
-                                            cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
-                                            export log_level=debug
-                                            export PATH=`pwd`/bin:\$PATH
-                                            export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
-                                            cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
-                                        """
-                                    }
+                                        cp bin/tidb-server bin/ddltest_tidb-server && ls -alh bin/
+                                        export log_level=debug
+                                        export PATH=`pwd`/bin:\$PATH
+                                        export DDLTEST_PATH="${WORKSPACE}/tidb-test/bin/ddltest"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/ddltest_tidb-server"
+                                        cd ddl_test/ && pwd && ./test.sh -test.run="${DDL_TEST}"
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tidb-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -110,35 +109,34 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh bin/
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tidb-server -V
-                                    """
-                                    container("java") {
-                                        sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                            params_array=(\${TEST_PARAMS})
-                                            TEST_DIR=\${params_array[0]}
-                                            TEST_SCRIPT=\${params_array[1]}
-                                            echo "TEST_DIR=\${TEST_DIR}"
-                                            echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh bin/
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tidb-server -V
+                                """
+                                container("java") {
+                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                        params_array=(\${TEST_PARAMS})
+                                        TEST_DIR=\${params_array[0]}
+                                        TEST_SCRIPT=\${params_array[1]}
+                                        echo "TEST_DIR=\${TEST_DIR}"
+                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                            fi
-                                        """
-                                    }
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                        fi
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
@@ -72,9 +72,8 @@ pipeline {
                         '''
                     }
                     // cache workspace for matrix pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -105,9 +104,8 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls rev-${REFS.pulls[0].sha}"
-                                }
+                                unstash 'ws'
+                                sh "ls rev-${REFS.pulls[0].sha}"
                                 sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
                                     chmod +x lightning/tests/*.sh
                                     if [ "${TEST_GROUP}" = "G00" ]; then

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
@@ -63,17 +63,16 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: "prepare", script: """
-                            touch ws-${BUILD_TAG}
-                            mkdir -p bin
-                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/tikv-server -V
-                            ./bin/pd-server -V
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        touch ws-${BUILD_TAG}
+                        mkdir -p bin
+                        cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/tikv-server -V
+                        ./bin/pd-server -V
+                    """
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -107,29 +106,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
+                                        if [[ "${TEST_STORE}" == "tikv" ]]; then
+                                            echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                            bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIKV_PATH="127.0.0.1:2379"
+                                            export TIDB_TEST_STORE_NAME="tikv"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        else
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_TEST_STORE_NAME="unistore"
+                                            cd mysql_test/ && ./test.sh 1 ${TEST_PART}
+                                        fi
                                     """
-                                    container("golang") {
-                                        sh label: "test_store=${TEST_STORE} test_part=${TEST_PART}", script: """#!/usr/bin/env bash
-                                            if [[ "${TEST_STORE}" == "tikv" ]]; then
-                                                echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                                bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIKV_PATH="127.0.0.1:2379"
-                                                export TIDB_TEST_STORE_NAME="tikv"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            else
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                                export TIDB_TEST_STORE_NAME="unistore"
-                                                cd mysql_test/ && ./test.sh 1 ${TEST_PART}
-                                            fi
-                                        """
-                                    }
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                 }
                 container('nodejs') {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
             }
@@ -103,23 +102,22 @@ pipeline {
                         options { timeout(time: 75, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="tikv"
-                                        echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
-                                        bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIKV_PATH="127.0.0.1:2379"
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "${TEST_DIR} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="\$(pwd)/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="tikv"
+                                    echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
+                                    bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+                                    export TIKV_PATH="127.0.0.1:2379"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && ./test.sh
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
@@ -62,17 +62,16 @@ pipeline {
                 }
                 container("golang") {
                     dir('tidb-test') {
-                        cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                            sh label: "prepare", script: """
-                                touch ws-${BUILD_TAG}
-                                mkdir -p bin
-                                cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
-                                ls -alh bin/
-                                ./bin/tidb-server -V
-                                ./bin/tikv-server -V
-                                ./bin/pd-server -V
-                            """
-                        }
+                        sh label: "prepare", script: """
+                            touch ws-${BUILD_TAG}
+                            mkdir -p bin
+                            cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                            ls -alh bin/
+                            ./bin/tidb-server -V
+                            ./bin/tikv-server -V
+                            ./bin/pd-server -V
+                        """
+                        stash name: 'tidb-test', includes: '**/*'
                     }
                 }
             }
@@ -107,25 +106,24 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: 'print version', script: """
-                                        ls -alh bin/
-                                        ./bin/tidb-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/pd-server -V
-                                    """
-                                    sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
-                                        export TIDB_TEST_STORE_NAME="\$TEST_STORE"
-                                        set -- \${TEST_PARAMS}
-                                        TEST_DIR=\$1
-                                        TEST_SCRIPT=\$2
-                                        echo "TEST_DIR=\${TEST_DIR}"
-                                        echo "TEST_SCRIPT=\${TEST_SCRIPT}"
+                                unstash 'tidb-test'
+                                sh label: 'print version', script: """
+                                    ls -alh bin/
+                                    ./bin/tidb-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/pd-server -V
+                                """
+                                sh label: "test_params=${TEST_PARAMS} ", script: """#!/usr/bin/env bash
+                                    export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                    export TIDB_TEST_STORE_NAME="\$TEST_STORE"
+                                    set -- \${TEST_PARAMS}
+                                    TEST_DIR=\$1
+                                    TEST_SCRIPT=\$2
+                                    echo "TEST_DIR=\${TEST_DIR}"
+                                    echo "TEST_SCRIPT=\${TEST_SCRIPT}"
 
-                                        cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
-                                    """
-                                }
+                                    cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_mysql_test.groovy
@@ -43,9 +43,8 @@ pipeline {
                         }
                     }
                     sh "git branch && git status"
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh 'touch ws-${BUILD_TAG}'
-                    }
+                    sh 'touch ws-${BUILD_TAG}'
+                    stash name: 'tidb-test', includes: '**/*'
                 }
             }
         }
@@ -80,12 +79,11 @@ pipeline {
                                 }
                             }
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh 'ls mysql_test' // if cache missed, fail it(should not miss).
-                                    dir('mysql_test') {
-                                        // TODO: fix the test.sh to correct the parameter parsing and numerical comparison.
-                                        sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
-                                    }
+                                unstash 'tidb-test'
+                                sh 'ls mysql_test' // if cache missed, fail it(should not miss).
+                                dir('mysql_test') {
+                                    // TODO: fix the test.sh to correct the parameter parsing and numerical comparison.
+                                    sh label: "part ${PART}", script: 'TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server ./test.sh 1 ${PART}'
                                 }
                             }
                         }

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_sqllogic_test.groovy
@@ -49,14 +49,13 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                        sh label: 'prepare tidb-test', script: """
-                            touch ws-${BUILD_TAG}
-                            cd sqllogic_test && ./build.sh
-                            cp ${WORKSPACE}/tidb/bin/tidb-server ./
-                            chmod +x tidb-server && ./tidb-server -V
-                        """
-                    }
+                    sh label: 'prepare tidb-test', script: """
+                        touch ws-${BUILD_TAG}
+                        cd sqllogic_test && ./build.sh
+                        cp ${WORKSPACE}/tidb/bin/tidb-server ./
+                        chmod +x tidb-server && ./tidb-server -V
+                    """
+                    stash name: 'tidb-test', includes: 'sqllogic_test/**'
                 }
             }
         }
@@ -94,29 +93,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }
@@ -157,29 +155,28 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./sqllogic_test", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-test") {
-                                    sh label: "print version", script: """
-                                        ls -alh sqllogic_test/
-                                        ./sqllogic_test/tidb-server -V
-                                    """
-                                    container("golang") {
-                                        sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
-                                            cd sqllogic_test/
-                                            env
-                                            ulimit -n
-                                            sed -i '3i\\set -x' test.sh
+                                unstash 'tidb-test'
+                                sh label: "print version", script: """
+                                    ls -alh sqllogic_test/
+                                    ./sqllogic_test/tidb-server -V
+                                """
+                                container("golang") {
+                                    sh label: "test_path: ${TEST_PATH_STRING}, cache_enabled:${CACHE_ENABLED}", script: """#!/usr/bin/env bash
+                                        cd sqllogic_test/
+                                        env
+                                        ulimit -n
+                                        sed -i '3i\\set -x' test.sh
 
-                                            path_array=(${TEST_PATH_STRING})
-                                            for path in \${path_array[@]}; do
-                                                echo "test path: \${path}"
-                                                export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
-                                                export TIDB_PARALLELISM=8
-                                                export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
-                                                export CACHE_ENABLED="${CACHE_ENABLED}"
-                                                ./test.sh
-                                            done
-                                        """
-                                    }
+                                        path_array=(${TEST_PATH_STRING})
+                                        for path in \${path_array[@]}; do
+                                            echo "test path: \${path}"
+                                            export SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}"
+                                            export TIDB_PARALLELISM=8
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/sqllogic_test/tidb-server"
+                                            export CACHE_ENABLED="${CACHE_ENABLED}"
+                                            ./test.sh
+                                        done
+                                    """
                                 }
                             }
                         }


### PR DESCRIPTION
Part of #4890 (first batch: pingcap/tidb + pingcap-inc/tidb).

## What changed

Switch the remaining `ws/${BUILD_TAG}` cache-based workspace handoff to S3-backed stash/unstash across **137 pipelines**:

- **whole-workspace handoff** (`key: "ws/${BUILD_TAG}"`): `stash name: 'ws', includes: '**/*'` / `unstash 'ws'`
- **tidb-test handoff** (`key: "ws/${BUILD_TAG}/tidb-test"`): `stash name: 'tidb-test'` with includes matching the cached path (`'**/*'` or `'sqllogic_test/**'` for sqllogic jobs) / `unstash 'tidb-test'`
- First occurrence (main stage) becomes the stash (after its body runs); later occurrences (matrix restore) become `unstash` + body

## Excluded / notes

- `pull_mysql_client_test_next_gen`: its cache was **write-only** (never restored by any branch) — left unchanged
- Other repos (tiflow, tidb-test, tiproxy, ticdc, migration, pd, qa) follow in separate PRs

## Verification

- No `ws/${BUILD_TAG}` references remain under `pipelines/pingcap/tidb` and `pipelines/pingcap-inc/tidb`
- 137 stash / 148 unstash (matrix branches) — pairing consistent
- **All 137 pipelines pass Jenkins pipeline validation**