### PR TITLE
refactor(pipelines): migrate other repos ws cache handoff to stash/unstash

### DIFF
--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -75,9 +75,8 @@ pipeline {
                             }
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: "ls -alh ./bin"
-                    }
+                    sh label: "prepare", script: "ls -alh ./bin"
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -108,17 +107,16 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh """
-                                        ln -sf /usr/bin/jq ./bin/jq
-                                        make check_third_party_binary
-                                        ls -alh ./bin
-                                        ./bin/tidb-server -V
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tiflash --version
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
                                 container("kafka") {
                                     timeout(time: 6, unit: 'MINUTES') {
                                         sh label: "Waiting for kafka ready", script: """

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -75,9 +75,8 @@ pipeline {
                             }
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: "ls -alh ./bin"
-                    }
+                    sh label: "prepare", script: "ls -alh ./bin"
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -108,17 +107,16 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh """
-                                        ln -sf /usr/bin/jq ./bin/jq
-                                        make check_third_party_binary
-                                        ls -alh ./bin
-                                        ./bin/tidb-server -V
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tiflash --version
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
                                 sh label: "${TEST_GROUP}", script: """
                                     rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
                                     chmod +x ./tests/integration_tests/run_group.sh

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -74,9 +74,8 @@ pipeline {
                             }
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: "ls -alh ./bin"
-                    }
+                    sh label: "prepare", script: "ls -alh ./bin"
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -107,17 +106,16 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh """
-                                        ln -sf /usr/bin/jq ./bin/jq
-                                        make check_third_party_binary
-                                        ls -alh ./bin
-                                        ./bin/tidb-server -V
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tiflash --version
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
                                 sh label: "${TEST_GROUP}", script: """
                                     rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
                                     chmod +x ./tests/integration_tests/run_group.sh

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -75,9 +75,8 @@ pipeline {
                             }
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: "ls -alh ./bin"
-                    }
+                    sh label: "prepare", script: "ls -alh ./bin"
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -108,17 +107,16 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh """
-                                        ln -sf /usr/bin/jq ./bin/jq
-                                        make check_third_party_binary
-                                        ls -alh ./bin
-                                        ./bin/tidb-server -V
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tiflash --version
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
                                 sh label: "${TEST_GROUP}", script: """
                                     rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
                                     chmod +x ./tests/integration_tests/run_group.sh

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -50,24 +50,23 @@ pipeline {
                     }
                 }
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
-                            """
                     }
+                    sh label: "check binary", script: """
+                            pwd && ls -alh
+                            ls bin/tidb-server && ./bin/tidb-server -V
+                            ls bin/pd-server && ./bin/pd-server -V
+                            ls bin/tikv-server && ./bin/tikv-server -V
+                        """
+                    stash name: 'dependencies', includes: 'bin/**'
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -50,24 +50,23 @@ pipeline {
                     }
                 }
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
-                            """
                     }
+                    sh label: "check binary", script: """
+                            pwd && ls -alh
+                            ls bin/tidb-server && ./bin/tidb-server -V
+                            ls bin/pd-server && ./bin/pd-server -V
+                            ls bin/tikv-server && ./bin/tikv-server -V
+                        """
+                    stash name: 'dependencies', includes: 'bin/**'
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -50,24 +50,23 @@ pipeline {
                     }
                 }
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
-                            """
                     }
+                    sh label: "check binary", script: """
+                            pwd && ls -alh
+                            ls bin/tidb-server && ./bin/tidb-server -V
+                            ls bin/pd-server && ./bin/pd-server -V
+                            ls bin/tikv-server && ./bin/tikv-server -V
+                        """
+                    stash name: 'dependencies', includes: 'bin/**'
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -50,23 +50,22 @@ pipeline {
                     }
                 }
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                            ls bin/tidb-server && ./bin/tidb-server -V
-                            ls bin/pd-server && ./bin/pd-server -V
-                            ls bin/tikv-server && ./bin/tikv-server -V
-                        """
                     }
+                    sh label: "check binary", script: """
+                        ls bin/tidb-server && ./bin/tidb-server -V
+                        ls bin/pd-server && ./bin/pd-server -V
+                        ls bin/tikv-server && ./bin/tikv-server -V
+                    """
+                    stash name: 'dependencies', includes: 'bin/**'
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -50,23 +50,22 @@ pipeline {
                     }
                 }
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
-                            """
                     }
+                    sh label: "check binary", script: """
+                            ls bin/tidb-server && ./bin/tidb-server -V
+                            ls bin/pd-server && ./bin/pd-server -V
+                            ls bin/tikv-server && ./bin/tikv-server -V
+                        """
+                    stash name: 'dependencies', includes: 'bin/**'
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
@@ -44,9 +44,8 @@ pipeline {
                     }
                 }
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
-                        sh label: 'tidb-server', script: 'make'
-                    }
+                    sh label: 'tidb-server', script: 'make'
+                    stash name: 'tidb-server', includes: 'bin/**'
                     stash includes: 'bin/**', name: TIDB_BIN_STASH_NAME
                 }
                 dir('tidb-test') {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -37,25 +37,24 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        retry(2) {
-                            sh "touch ws-${BUILD_TAG}"
-                            container("utils") {
-                                dir('bin') {
-                                    sh label: 'download thirdparty binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
-                                    """
-                                }
+                    retry(2) {
+                        sh "touch ws-${BUILD_TAG}"
+                        container("utils") {
+                            dir('bin') {
+                                sh label: 'download thirdparty binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
+                                """
                             }
-                            sh label: 'prepare tiproxy binary', script: """
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiproxy --version
-                            """
                         }
+                        sh label: 'prepare tiproxy binary', script: """
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tiproxy --version
+                        """
                     }
+                    stash name: 'ws', includes: '**/*'
                     stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -37,25 +37,24 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        retry(2) {
-                            sh "touch ws-${BUILD_TAG}"
-                            container("utils") {
-                                dir('bin') {
-                                    sh label: 'download thirdparty binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
-                                    """
-                                }
+                    retry(2) {
+                        sh "touch ws-${BUILD_TAG}"
+                        container("utils") {
+                            dir('bin') {
+                                sh label: 'download thirdparty binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
+                                """
                             }
-                            sh label: 'prepare tiproxy binary', script: """
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiproxy --version
-                            """
                         }
+                        sh label: 'prepare tiproxy binary', script: """
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tiproxy --version
+                        """
                     }
+                    stash name: 'ws', includes: '**/*'
                     stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -37,25 +37,24 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-mysql-test") {
-                        retry(2) {
-                            sh "touch ws-${BUILD_TAG}"
-                            container("utils") {
-                                dir('bin') {
-                                    sh label: 'download thirdparty binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
-                                    """
-                                }
+                    retry(2) {
+                        sh "touch ws-${BUILD_TAG}"
+                        container("utils") {
+                            dir('bin') {
+                                sh label: 'download thirdparty binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
+                                """
                             }
-                            sh label: 'prepare tiproxy binary', script: """
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiproxy --version
-                            """
                         }
+                        sh label: 'prepare tiproxy binary', script: """
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tiproxy --version
+                        """
                     }
+                    stash name: 'tiproxy-mysql-test', includes: '**/*'
                     stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -37,25 +37,24 @@ pipeline {
                     }
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        retry(2) {
-                            sh "touch ws-${BUILD_TAG}"
-                            container("utils") {
-                                dir('bin') {
-                                    sh label: 'download thirdparty binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
-                                    """
-                                }
+                    retry(2) {
+                        sh "touch ws-${BUILD_TAG}"
+                        container("utils") {
+                            dir('bin') {
+                                sh label: 'download thirdparty binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --tidb=master --pd=master --tikv=master --tiproxy=main
+                                """
                             }
-                            sh label: 'prepare tiproxy binary', script: """
-                            ls -alh bin/
-                            ./bin/tidb-server -V
-                            ./bin/pd-server -V
-                            ./bin/tikv-server -V
-                            ./bin/tiproxy --version
-                            """
                         }
+                        sh label: 'prepare tiproxy binary', script: """
+                        ls -alh bin/
+                        ./bin/tidb-server -V
+                        ./bin/pd-server -V
+                        ./bin/tikv-server -V
+                        ./bin/tiproxy --version
+                        """
                     }
+                    stash name: 'ws', includes: '**/*'
                     stash includes: '**/*', name: WORKSPACE_STASH_NAME
                 }
             }

--- a/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_mysql_test.groovy
@@ -48,10 +48,9 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
-                        // FIXME: https://github.com/PingCAP-QE/tidb-test/issues/1987
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
-                    }
+                    // FIXME: https://github.com/PingCAP-QE/tidb-test/issues/1987
+                    sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
+                    stash name: 'tidb-server', includes: 'bin/**'
                 }
                 dir('tidb-test') {
                     cache(path: "./mysql_test", includes: '**/*', key: "ws/tidb-test/mysql-test/rev-${REFS.pulls[0].sha}") {
@@ -89,9 +88,8 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
-                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'
-                                }
+                                unstash 'tidb-server'
+                                sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'
                             }
                             dir('tidb-test/mysql_test') {
                                 cache(path: "./", includes: '**/*', key: "ws/tidb-test/mysql-test/rev-${REFS.pulls[0].sha}") {

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_common_test.groovy
@@ -54,23 +54,22 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
-                            """
                     }
+                    sh label: "check binary", script: """
+                            ls bin/tidb-server && ./bin/tidb-server -V
+                            ls bin/pd-server && ./bin/pd-server -V
+                            ls bin/tikv-server && ./bin/tikv-server -V
+                        """
+                    stash name: 'dependencies', includes: 'bin/**'
                 }
             }
         }
@@ -103,14 +102,13 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                                    sh label: "print version", script: """
-                                        pwd && ls -alh
-                                        ls bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && ./bin/tikv-server -V
-                                    """
-                                }
+                                unstash 'dependencies'
+                                sh label: "print version", script: """
+                                    pwd && ls -alh
+                                    ls bin/tidb-server && ./bin/tidb-server -V
+                                    ls bin/pd-server && ./bin/pd-server -V
+                                    ls bin/tikv-server && ./bin/tikv-server -V
+                                """
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test.groovy
@@ -54,24 +54,23 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
-                            """
                     }
+                    sh label: "check binary", script: """
+                            pwd && ls -alh
+                            ls bin/tidb-server && ./bin/tidb-server -V
+                            ls bin/pd-server && ./bin/pd-server -V
+                            ls bin/tikv-server && ./bin/tikv-server -V
+                        """
+                    stash name: 'dependencies', includes: 'bin/**'
                 }
             }
         }
@@ -104,14 +103,13 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                                    sh label: "print version", script: """
-                                        pwd && ls -alh
-                                        ls bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && ./bin/tikv-server -V
-                                    """
-                                }
+                                unstash 'dependencies'
+                                sh label: "print version", script: """
+                                    pwd && ls -alh
+                                    ls bin/tidb-server && ./bin/tidb-server -V
+                                    ls bin/pd-server && ./bin/pd-server -V
+                                    ls bin/tikv-server && ./bin/tikv-server -V
+                                """
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test.groovy
@@ -54,24 +54,23 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
-                            """
                     }
+                    sh label: "check binary", script: """
+                            pwd && ls -alh
+                            ls bin/tidb-server && ./bin/tidb-server -V
+                            ls bin/pd-server && ./bin/pd-server -V
+                            ls bin/tikv-server && ./bin/tikv-server -V
+                        """
+                    stash name: 'dependencies', includes: 'bin/**'
                 }
             }
         }
@@ -108,14 +107,13 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                                    sh label: "print version", script: """
-                                        pwd && ls -alh
-                                        ls bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && ./bin/tikv-server -V
-                                    """
-                                }
+                                unstash 'dependencies'
+                                sh label: "print version", script: """
+                                    pwd && ls -alh
+                                    ls bin/tidb-server && ./bin/tidb-server -V
+                                    ls bin/pd-server && ./bin/pd-server -V
+                                    ls bin/tikv-server && ./bin/tikv-server -V
+                                """
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test.groovy
@@ -48,14 +48,12 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
-                        sh label: 'tidb-server', script: 'make'
-                    }
+                    sh label: 'tidb-server', script: 'make'
+                    stash name: 'tidb-server', includes: 'bin/**'
                 }
                 dir('tidb-test') {
-                    cache(path: "./mysql_test", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
-                        sh "touch ws-${BUILD_TAG}"
-                    }
+                    sh "touch ws-${BUILD_TAG}"
+                    stash name: 'mysql-test', includes: 'mysql_test/**'
                 }
             }
         }
@@ -84,18 +82,16 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
-                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'
-                                }
+                                unstash 'tidb-server'
+                                sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'
                             }
                             dir('tidb-test/mysql_test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
-                                    sh label: "part ${PART}", script: """
-                                    export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
-                                    export TIDB_TEST_STORE_NAME="unistore"
-                                    ./test.sh -backlist=1 -part=${PART}
-                                    """
-                                }
+                                unstash 'mysql-test'
+                                sh label: "part ${PART}", script: """
+                                export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
+                                export TIDB_TEST_STORE_NAME="unistore"
+                                ./test.sh -backlist=1 -part=${PART}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
@@ -54,23 +54,22 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
-                            """
                     }
+                    sh label: "check binary", script: """
+                            ls bin/tidb-server && ./bin/tidb-server -V
+                            ls bin/pd-server && ./bin/pd-server -V
+                            ls bin/tikv-server && ./bin/tikv-server -V
+                        """
+                    stash name: 'dependencies', includes: 'bin/**'
                 }
             }
         }
@@ -103,14 +102,13 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                                    sh label: "print version", script: """
-                                        pwd && ls -alh
-                                        ls bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && ./bin/tikv-server -V
-                                    """
-                                }
+                                unstash 'dependencies'
+                                sh label: "print version", script: """
+                                    pwd && ls -alh
+                                    ls bin/tidb-server && ./bin/tidb-server -V
+                                    ls bin/pd-server && ./bin/pd-server -V
+                                    ls bin/tikv-server && ./bin/tikv-server -V
+                                """
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
@@ -54,24 +54,23 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
-                            """
                     }
+                    sh label: "check binary", script: """
+                            pwd && ls -alh
+                            ls bin/tidb-server && ./bin/tidb-server -V
+                            ls bin/pd-server && ./bin/pd-server -V
+                            ls bin/tikv-server && ./bin/tikv-server -V
+                        """
+                    stash name: 'dependencies', includes: 'bin/**'
                 }
             }
         }
@@ -104,14 +103,13 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                                    sh label: "print version", script: """
-                                        pwd && ls -alh
-                                        ls bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && ./bin/tikv-server -V
-                                    """
-                                }
+                                unstash 'dependencies'
+                                sh label: "print version", script: """
+                                    pwd && ls -alh
+                                    ls bin/tidb-server && ./bin/tidb-server -V
+                                    ls bin/pd-server && ./bin/pd-server -V
+                                    ls bin/tikv-server && ./bin/tikv-server -V
+                                """
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
@@ -54,24 +54,23 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                        sh label: 'tidb-server', script: 'make'
-                        container("utils") {
-                            dir("bin") {
-                                retry(3) {
-                                    sh label: 'download tidb components', script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
-                                }
+                    sh label: 'tidb-server', script: 'make'
+                    container("utils") {
+                        dir("bin") {
+                            retry(3) {
+                                sh label: 'download tidb components', script: """
+                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                """
                             }
                         }
-                        sh label: "check binary", script: """
-                                pwd && ls -alh
-                                ls bin/tidb-server && ./bin/tidb-server -V
-                                ls bin/pd-server && ./bin/pd-server -V
-                                ls bin/tikv-server && ./bin/tikv-server -V
-                            """
                     }
+                    sh label: "check binary", script: """
+                            pwd && ls -alh
+                            ls bin/tidb-server && ./bin/tidb-server -V
+                            ls bin/pd-server && ./bin/pd-server -V
+                            ls bin/tikv-server && ./bin/tikv-server -V
+                        """
+                    stash name: 'dependencies', includes: 'bin/**'
                 }
             }
         }
@@ -108,14 +107,13 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/dependencies") {
-                                    sh label: "print version", script: """
-                                        pwd && ls -alh
-                                        ls bin/tidb-server && ./bin/tidb-server -V
-                                        ls bin/pd-server && ./bin/pd-server -V
-                                        ls bin/tikv-server && ./bin/tikv-server -V
-                                    """
-                                }
+                                unstash 'dependencies'
+                                sh label: "print version", script: """
+                                    pwd && ls -alh
+                                    ls bin/tidb-server && ./bin/tidb-server -V
+                                    ls bin/pd-server && ./bin/pd-server -V
+                                    ls bin/tikv-server && ./bin/tikv-server -V
+                                """
                             }
                             dir('tidb-test') {
                                 cache(path: "./", includes: '**/*', key: prow.getCacheKey('git', REFS)) {

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test.groovy
@@ -48,14 +48,12 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('tidb') {
-                    cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
-                        sh label: 'tidb-server', script: 'make'
-                    }
+                    sh label: 'tidb-server', script: 'make'
+                    stash name: 'tidb-server', includes: 'bin/**'
                 }
                 dir('tidb-test') {
-                    cache(path: "./mysql_test", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
-                        sh "touch ws-${BUILD_TAG}"
-                    }
+                    sh "touch ws-${BUILD_TAG}"
+                    stash name: 'mysql-test', includes: 'mysql_test/**'
                 }
             }
         }
@@ -84,18 +82,16 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./bin", includes: '**/*', key: "ws/${BUILD_TAG}/tidb-server") {
-                                    sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'
-                                }
+                                unstash 'tidb-server'
+                                sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'
                             }
                             dir('tidb-test/mysql_test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/mysql-test") {
-                                    sh label: "part ${PART}", script: """
-                                    export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
-                                    export TIDB_TEST_STORE_NAME="unistore"
-                                    ./test.sh -backlist=1 -part=${PART}
-                                    """
-                                }
+                                unstash 'mysql-test'
+                                sh label: "part ${PART}", script: """
+                                export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
+                                export TIDB_TEST_STORE_NAME="unistore"
+                                ./test.sh -backlist=1 -part=${PART}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_heavy.groovy
@@ -83,12 +83,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'ticdc', includes: '**/*'
                 }
             }
         }
@@ -119,23 +118,22 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'ticdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        ./tests/integration_tests/run_heavy_it_in_ci.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_heavy_it_in_ci.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_kafka_integration_light.groovy
@@ -83,12 +83,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'ticdc', includes: '**/*'
                 }
             }
         }
@@ -119,23 +118,22 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'ticdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        ./tests/integration_tests/run_light_it_in_ci.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_light_it_in_ci.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_heavy.groovy
@@ -78,12 +78,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'ticdc', includes: '**/*'
                 }
             }
         }
@@ -113,11 +112,10 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        ./tests/integration_tests/run_heavy_it_in_ci.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'ticdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_heavy_it_in_ci.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_mysql_integration_light.groovy
@@ -82,12 +82,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'ticdc', includes: '**/*'
                 }
             }
         }
@@ -117,11 +116,10 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        ./tests/integration_tests/run_light_it_in_ci.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'ticdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_light_it_in_ci.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_pulsar_integration_light.groovy
@@ -82,12 +82,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'ticdc', includes: '**/*'
                 }
             }
         }
@@ -117,11 +116,10 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        ./tests/integration_tests/run_light_it_in_ci.sh pulsar ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'ticdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_light_it_in_ci.sh pulsar ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_heavy.groovy
@@ -83,12 +83,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'ticdc', includes: '**/*'
                 }
             }
         }
@@ -119,11 +118,10 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        ./tests/integration_tests/run_heavy_it_in_ci.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'ticdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_heavy_it_in_ci.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
+++ b/pipelines/pingcap/ticdc/release-9.0-beta/pull_cdc_storage_integration_light.groovy
@@ -83,12 +83,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'ticdc', includes: '**/*'
                 }
             }
         }
@@ -118,11 +117,10 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('ticdc') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/ticdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        ./tests/integration_tests/run_light_it_in_ci.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'ticdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    ./tests/integration_tests/run_light_it_in_ci.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -70,9 +70,8 @@ pipeline {
                             }
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: "ls -alh ./bin"
-                    }
+                    sh label: "prepare", script: "ls -alh ./bin"
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -103,17 +102,16 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh """
-                                        ln -sf /usr/bin/jq ./bin/jq
-                                        make check_third_party_binary
-                                        ls -alh ./bin
-                                        ./bin/tidb-server -V
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tiflash --version
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
                                 container("kafka") {
                                     timeout(time: 6, unit: 'MINUTES') {
                                         sh label: "Waiting for kafka ready", script: """

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -69,9 +69,8 @@ pipeline {
                             }
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: "ls -alh ./bin"
-                    }
+                    sh label: "prepare", script: "ls -alh ./bin"
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -102,17 +101,16 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh """
-                                        ln -sf /usr/bin/jq ./bin/jq
-                                        make check_third_party_binary
-                                        ls -alh ./bin
-                                        ./bin/tidb-server -V
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tiflash --version
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
                                 sh label: "${TEST_GROUP}", script: """
                                     rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
                                     chmod +x ./tests/integration_tests/run_group.sh

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -70,9 +70,8 @@ pipeline {
                             }
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: "ls -alh ./bin"
-                    }
+                    sh label: "prepare", script: "ls -alh ./bin"
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -103,17 +102,16 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh """
-                                        ln -sf /usr/bin/jq ./bin/jq
-                                        make check_third_party_binary
-                                        ls -alh ./bin
-                                        ./bin/tidb-server -V
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tiflash --version
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
                                 sh label: "${TEST_GROUP}", script: """
                                     rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
                                     chmod +x ./tests/integration_tests/run_group.sh

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -70,9 +70,8 @@ pipeline {
                             }
                         }
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: "ls -alh ./bin"
-                    }
+                    sh label: "prepare", script: "ls -alh ./bin"
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -103,17 +102,16 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh """
-                                        ln -sf /usr/bin/jq ./bin/jq
-                                        make check_third_party_binary
-                                        ls -alh ./bin
-                                        ./bin/tidb-server -V
-                                        ./bin/pd-server -V
-                                        ./bin/tikv-server -V
-                                        ./bin/tiflash --version
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh """
+                                    ln -sf /usr/bin/jq ./bin/jq
+                                    make check_third_party_binary
+                                    ls -alh ./bin
+                                    ./bin/tidb-server -V
+                                    ./bin/pd-server -V
+                                    ./bin/tikv-server -V
+                                    ./bin/tiflash --version
+                                """
                                 sh label: "${TEST_GROUP}", script: """
                                     rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
                                     chmod +x ./tests/integration_tests/run_group.sh

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -97,13 +97,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -147,32 +146,31 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    sh label: "wait mysql ready", script: """
-                                        pwd && ls -alh
-                                        # TODO use wait-for-mysql-ready.sh
-                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3308 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                    """
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
-                                    """
-                                }
+                                unstash 'tiflow-dm'
+                                sh label: "wait mysql ready", script: """
+                                    pwd && ls -alh
+                                    # TODO use wait-for-mysql-ready.sh
+                                    set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                    set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                    set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3308 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                """
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -106,13 +106,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm-next-gen") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm-next-gen', includes: '**/*'
                 }
             }
         }
@@ -156,32 +155,31 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm-next-gen") {
-                                    sh label: "wait mysql ready", script: """
-                                        pwd && ls -alh
-                                        # TODO use wait-for-mysql-ready.sh
-                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3308 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                    """
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
-                                    """
-                                }
+                                unstash 'tiflow-dm-next-gen'
+                                sh label: "wait mysql ready", script: """
+                                    pwd && ls -alh
+                                    # TODO use wait-for-mysql-ready.sh
+                                    set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                    set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                    set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3308 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                """
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
@@ -68,12 +68,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -108,27 +107,26 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'tiflow-cdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ../scripts/pingcap/tiflow/release-6.5-fips/cdc_run_group.sh
-                                        cp ../scripts/pingcap/tiflow/release-6.5-fips/cdc_run_group.sh tests/integration_tests/
-                                        ln -s ${WORKSPACE}/tiflow/bin ${WORKSPACE}/tiflow/tests/bin
-                                        ./tests/integration_tests/cdc_run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ../scripts/pingcap/tiflow/release-6.5-fips/cdc_run_group.sh
+                                    cp ../scripts/pingcap/tiflow/release-6.5-fips/cdc_run_group.sh tests/integration_tests/
+                                    ln -s ${WORKSPACE}/tiflow/bin ${WORKSPACE}/tiflow/tests/bin
+                                    ./tests/integration_tests/cdc_run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
@@ -68,12 +68,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -108,15 +107,14 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        ln -s ${WORKSPACE}/tiflow/bin ${WORKSPACE}/tiflow/tests/bin
-                                        chmod +x ../scripts/pingcap/tiflow/release-6.5-fips/cdc_run_group.sh
-                                        cp ../scripts/pingcap/tiflow/release-6.5-fips/cdc_run_group.sh tests/integration_tests/
-                                        ./tests/integration_tests/cdc_run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    ln -s ${WORKSPACE}/tiflow/bin ${WORKSPACE}/tiflow/tests/bin
+                                    chmod +x ../scripts/pingcap/tiflow/release-6.5-fips/cdc_run_group.sh
+                                    cp ../scripts/pingcap/tiflow/release-6.5-fips/cdc_run_group.sh tests/integration_tests/
+                                    ./tests/integration_tests/cdc_run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
@@ -101,13 +101,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -152,40 +151,39 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        chmod +x ../scripts/pingcap/tiflow/release-6.5-fips/dm_run_group.sh
-                                        cp ../scripts/pingcap/tiflow/release-6.5-fips/dm_run_group.sh dm/tests/
-
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        echo "install python requirments for test"
-	                                    pip install --user -q -r ./dm/tests/requirements.txt
-                                        cd dm && ln -sf ../bin . && cd ..
-                                        export PATH=${WORKSPACE}/tiflow/dm/bin:\$PATH
-                                        cd dm && ./tests/dm_run_group.sh "${TEST_GROUP}"
+                                unstash 'tiflow-dm'
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    chmod +x ../scripts/pingcap/tiflow/release-6.5-fips/dm_run_group.sh
+                                    cp ../scripts/pingcap/tiflow/release-6.5-fips/dm_run_group.sh dm/tests/
+
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    echo "install python requirments for test"
+	                                    pip install --user -q -r ./dm/tests/requirements.txt
+                                    cd dm && ln -sf ../bin . && cd ..
+                                    export PATH=${WORKSPACE}/tiflow/dm/bin:\$PATH
+                                    cd dm && ./tests/dm_run_group.sh "${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -101,12 +101,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -140,13 +139,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,25 +105,24 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'tiflow-cdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
@@ -98,13 +98,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -149,33 +148,32 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                unstash 'tiflow-dm'
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,25 +105,24 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'tiflow-cdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
@@ -98,13 +98,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -149,33 +148,32 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                unstash 'tiflow-dm'
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
@@ -65,12 +65,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -105,25 +104,24 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'tiflow-cdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
@@ -65,12 +65,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -105,13 +104,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
@@ -65,12 +65,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -101,23 +100,22 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    // TODO: currently we encounter some issue when using pulsar container to run shell script
-                                    // so we comment out this part now.
-                                    // container("pulsar") {
-                                    //     timeout(time: 6, unit: 'MINUTES') {
-                                    //         sh label: "Waiting for pulsar ready", script: """
-                                    //             echo "Waiting for pulsar to be ready..."
-                                    //             while ! nc -z localhost 6650; do sleep 10; done
-                                    //         """
-                                    //     }
-                                    // }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                // TODO: currently we encounter some issue when using pulsar container to run shell script
+                                // so we comment out this part now.
+                                // container("pulsar") {
+                                //     timeout(time: 6, unit: 'MINUTES') {
+                                //         sh label: "Waiting for pulsar ready", script: """
+                                //             echo "Waiting for pulsar to be ready..."
+                                //             while ! nc -z localhost 6650; do sleep 10; done
+                                //         """
+                                //     }
+                                // }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
@@ -97,13 +97,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -148,33 +147,32 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                unstash 'tiflow-dm'
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
@@ -65,12 +65,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -105,25 +104,24 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'tiflow-cdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
@@ -65,12 +65,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -105,13 +104,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
@@ -65,12 +65,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -101,23 +100,22 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    // TODO: currently we encounter some issue when using pulsar container to run shell script
-                                    // so we comment out this part now.
-                                    // container("pulsar") {
-                                    //     timeout(time: 6, unit: 'MINUTES') {
-                                    //         sh label: "Waiting for pulsar ready", script: """
-                                    //             echo "Waiting for pulsar to be ready..."
-                                    //             while ! nc -z localhost 6650; do sleep 10; done
-                                    //         """
-                                    //     }
-                                    // }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                // TODO: currently we encounter some issue when using pulsar container to run shell script
+                                // so we comment out this part now.
+                                // container("pulsar") {
+                                //     timeout(time: 6, unit: 'MINUTES') {
+                                //         sh label: "Waiting for pulsar ready", script: """
+                                //             echo "Waiting for pulsar to be ready..."
+                                //             while ! nc -z localhost 6650; do sleep 10; done
+                                //         """
+                                //     }
+                                // }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
@@ -97,13 +97,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -148,33 +147,32 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                unstash 'tiflow-dm'
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,25 +105,24 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'tiflow-cdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
@@ -65,12 +65,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -101,13 +100,12 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
@@ -98,13 +98,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -149,33 +148,32 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                unstash 'tiflow-dm'
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,25 +105,24 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'tiflow-cdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
@@ -65,12 +65,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -101,13 +100,12 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
@@ -98,13 +98,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -149,33 +148,32 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                unstash 'tiflow-dm'
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,25 +105,24 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'tiflow-cdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
@@ -65,12 +65,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -101,13 +100,12 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
@@ -98,13 +98,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -149,33 +148,32 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                unstash 'tiflow-dm'
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,25 +105,24 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'tiflow-cdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
@@ -65,12 +65,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -101,13 +100,12 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
@@ -66,12 +66,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
@@ -98,13 +98,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -149,33 +148,32 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                unstash 'tiflow-dm'
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -100,12 +100,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -140,25 +139,24 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                                unstash 'tiflow-cdc'
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -100,12 +100,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -140,13 +139,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh mysql ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -99,12 +99,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -135,13 +134,12 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh pulsar ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -100,12 +100,11 @@ pipeline {
                             ./bin/cdc version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                    """
+                    stash name: 'tiflow-cdc', includes: '**/*'
                 }
             }
         }
@@ -140,13 +139,12 @@ pipeline {
                         }
                         steps {
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-cdc") {
-                                    sh label: "${TEST_GROUP}", script: """
-                                        rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
-                                        chmod +x ./tests/integration_tests/run_group.sh
-                                        ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'tiflow-cdc'
+                                sh label: "${TEST_GROUP}", script: """
+                                    rm -rf /tmp/tidb_cdc_test && mkdir -p /tmp/tidb_cdc_test
+                                    chmod +x ./tests/integration_tests/run_group.sh
+                                    ./tests/integration_tests/run_group.sh storage ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -120,13 +120,12 @@ pipeline {
                             which ./bin/dm-test-tools/check_worker_online
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                        sh label: "prepare", script: """
-                            cp -r ../third_party_download/bin/* ./bin/
-                            ls -alh ./bin
-                            ls -alh ./bin/dm-test-tools
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        cp -r ../third_party_download/bin/* ./bin/
+                        ls -alh ./bin
+                        ls -alh ./bin/dm-test-tools
+                    """
+                    stash name: 'tiflow-dm', includes: '**/*'
                 }
             }
         }
@@ -171,33 +170,32 @@ pipeline {
                             }
 
                             dir(REFS.repo) {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiflow-dm") {
-                                    timeout(time: 10, unit: 'MINUTES') {
-                                        sh label: "wait mysql ready", script: """
-                                            pwd && ls -alh
-                                            # TODO use wait-for-mysql-ready.sh
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                            set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
-                                        """
-                                    }
-                                    sh label: "${TEST_GROUP}", script: """
-                                        if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
-                                            echo "run tls test"
-                                            echo "copy mysql certs"
-                                            sudo mkdir -p /var/lib/mysql
-                                            sudo chmod 777 /var/lib/mysql
-                                            sudo chown -R 1000:1000 /var/lib/mysql
-                                            sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
-                                            sudo chown -R 1000:1000 /var/lib/mysql/*
-                                            ls -alh /var/lib/mysql/
-                                        else
-                                            echo "run ${TEST_GROUP} test"
-                                        fi
-                                        export PATH=/usr/local/go/bin:\$PATH
-                                        mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
-                                        make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                unstash 'tiflow-dm'
+                                timeout(time: 10, unit: 'MINUTES') {
+                                    sh label: "wait mysql ready", script: """
+                                        pwd && ls -alh
+                                        # TODO use wait-for-mysql-ready.sh
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3306 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
+                                        set +e && for i in {1..90}; do mysqladmin ping -h127.0.0.1 -P 3307 -p123456 -uroot --silent; if [ \$? -eq 0 ]; then set -e; break; else if [ \$i -eq 90 ]; then set -e; exit 2; fi; sleep 2; fi; done
                                     """
                                 }
+                                sh label: "${TEST_GROUP}", script: """
+                                    if [ "TLS_GROUP" == "${TEST_GROUP}" ] ; then
+                                        echo "run tls test"
+                                        echo "copy mysql certs"
+                                        sudo mkdir -p /var/lib/mysql
+                                        sudo chmod 777 /var/lib/mysql
+                                        sudo chown -R 1000:1000 /var/lib/mysql
+                                        sudo cp -r ${WORKSPACE}/mysql-ssl/*.pem /var/lib/mysql/
+                                        sudo chown -R 1000:1000 /var/lib/mysql/*
+                                        ls -alh /var/lib/mysql/
+                                    else
+                                        echo "run ${TEST_GROUP} test"
+                                    fi
+                                    export PATH=/usr/local/go/bin:\$PATH
+                                    mkdir -p ./dm/tests/bin && cp -r ./bin/dm-test-tools/* ./dm/tests/bin/
+                                    make dm_integration_test_in_group GROUP="${TEST_GROUP}"
+                                """
                             }
                         }
                         post {

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
@@ -54,27 +54,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -105,12 +104,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_cmds=${TEST_CMDS} ", script: """
-                                        #!/usr/bin/env bash
-                                        ${TEST_CMDS}
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_cmds=${TEST_CMDS} ", script: """
+                                    #!/usr/bin/env bash
+                                    ${TEST_CMDS}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
@@ -55,27 +55,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-jdbc-test") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'tiproxy-jdbc-test', includes: '**/*'
                 }
             }
         }
@@ -106,9 +105,8 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/tiproxy-jdbc-test") {
-                                    sh "echo 'restore tidb-test workspace'"
-                                }
+                                unstash 'tiproxy-jdbc-test'
+                                sh "echo 'restore tidb-test workspace'"
                                 container("java") {
                                     sh label: "test_cmds=${TEST_CMDS} ", script: """
                                         #!/usr/bin/env bash

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
@@ -54,27 +54,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -103,12 +102,11 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_cmds=${TEST_CMDS} ", script: """
-                                        #!/usr/bin/env bash
-                                        ${TEST_CMDS}
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_cmds=${TEST_CMDS} ", script: """
+                                    #!/usr/bin/env bash
+                                    ${TEST_CMDS}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
@@ -55,27 +55,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -105,12 +104,11 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_cmds=${TEST_CMDS} ", script: """
-                                        #!/usr/bin/env bash
-                                        ${TEST_CMDS}
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_cmds=${TEST_CMDS} ", script: """
+                                    #!/usr/bin/env bash
+                                    ${TEST_CMDS}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
@@ -54,27 +54,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -102,13 +101,12 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    container("ruby") {
-                                        sh label: "test_cmds=${TEST_CMDS} ", script: """
-                                            #!/usr/bin/env bash
-                                            ${TEST_CMDS}
-                                        """
-                                    }
+                                unstash 'ws'
+                                container("ruby") {
+                                    sh label: "test_cmds=${TEST_CMDS} ", script: """
+                                        #!/usr/bin/env bash
+                                        ${TEST_CMDS}
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
@@ -54,27 +54,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -103,12 +102,11 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_cmds=${TEST_CMDS} ", script: """
-                                        #!/usr/bin/env bash
-                                        ${TEST_CMDS}
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_cmds=${TEST_CMDS} ", script: """
+                                    #!/usr/bin/env bash
+                                    ${TEST_CMDS}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
@@ -55,27 +55,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -104,12 +103,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "PART ${PART}", script: """
-                                        #!/usr/bin/env bash
-                                        make deploy-mysqltest ARGS="-b -x y -s tikv -p ${PART}"
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "PART ${PART}", script: """
+                                    #!/usr/bin/env bash
+                                    make deploy-mysqltest ARGS="-b -x y -s tikv -p ${PART}"
+                                """
                             }
                         }
                         post { success { script { matrixCache.markDone(REFS, 'Test', [part: env.PART]) } } }

--- a/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
@@ -55,27 +55,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -109,17 +108,16 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_path: ${TEST_PATH_STRING}", script: """
-                                        #!/usr/bin/env bash
-                                        path_array=(${TEST_PATH_STRING})
-                                        for path in \${path_array[@]}; do
-                                            echo "test path: \${path}"
-                                            SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
-                                            make deploy-sqllogictest ARGS="-x -c y -s tikv -p \${SQLLOGIC_TEST_PATH}"
-                                        done
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_path: ${TEST_PATH_STRING}", script: """
+                                    #!/usr/bin/env bash
+                                    path_array=(${TEST_PATH_STRING})
+                                    for path in \${path_array[@]}; do
+                                        echo "test path: \${path}"
+                                        SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
+                                        make deploy-sqllogictest ARGS="-x -c y -s tikv -p \${SQLLOGIC_TEST_PATH}"
+                                    done
+                                """
                             }
                         }
                         post { success { script { matrixCache.markDone(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } } }
@@ -155,17 +153,16 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_path: ${TEST_PATH_STRING}", script: """
-                                        #!/usr/bin/env bash
-                                        path_array=(${TEST_PATH_STRING})
-                                        for path in \${path_array[@]}; do
-                                            echo "test path: \${path}"
-                                            SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
-                                            make deploy-sqllogictest ARGS="-x -c y -s tikv -p \${SQLLOGIC_TEST_PATH}"
-                                        done
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_path: ${TEST_PATH_STRING}", script: """
+                                    #!/usr/bin/env bash
+                                    path_array=(${TEST_PATH_STRING})
+                                    for path in \${path_array[@]}; do
+                                        echo "test path: \${path}"
+                                        SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
+                                        make deploy-sqllogictest ARGS="-x -c y -s tikv -p \${SQLLOGIC_TEST_PATH}"
+                                    done
+                                """
                             }
                         }
                         post { success { script { matrixCache.markDone(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } } }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
@@ -55,27 +55,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -107,12 +106,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_cmds=${TEST_CMDS} ", script: """
-                                        #!/usr/bin/env bash
-                                        ${TEST_CMDS}
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_cmds=${TEST_CMDS} ", script: """
+                                    #!/usr/bin/env bash
+                                    ${TEST_CMDS}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
@@ -55,27 +55,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -106,13 +105,12 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    container("java") {
-                                        sh label: "test_cmds=${TEST_CMDS} ", script: """
-                                            #!/usr/bin/env bash
-                                            ${TEST_CMDS}
-                                        """
-                                    }
+                                unstash 'ws'
+                                container("java") {
+                                    sh label: "test_cmds=${TEST_CMDS} ", script: """
+                                        #!/usr/bin/env bash
+                                        ${TEST_CMDS}
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
@@ -56,27 +56,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -106,12 +105,11 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_cmds=${TEST_CMDS} ", script: """
-                                        #!/usr/bin/env bash
-                                        ${TEST_CMDS}
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_cmds=${TEST_CMDS} ", script: """
+                                    #!/usr/bin/env bash
+                                    ${TEST_CMDS}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
@@ -55,27 +55,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -105,12 +104,11 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_cmds=${TEST_CMDS} ", script: """
-                                        #!/usr/bin/env bash
-                                        ${TEST_CMDS}
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_cmds=${TEST_CMDS} ", script: """
+                                    #!/usr/bin/env bash
+                                    ${TEST_CMDS}
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
@@ -55,27 +55,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -104,32 +103,31 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    container("ruby") {
-                                        sh label: "prepare ruby test deps", script: """
-                                            #!/usr/bin/env bash
-                                            set -euxo pipefail
-                                            if ! command -v mysql >/dev/null 2>&1 || ! dpkg-query -W default-libmysqlclient-dev >/dev/null 2>&1 || ! dpkg-query -W libsqlite3-dev >/dev/null 2>&1; then
-                                                apt-get update
-                                                DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \\
-                                                    default-mysql-client \\
-                                                    build-essential \\
-                                                    default-libmysqlclient-dev \\
-                                                    libsqlite3-dev \\
-                                                    pkg-config
-                                                rm -rf /var/lib/apt/lists/*
-                                            fi
-                                            if ! gem list -i bundler -v 2.3.17 >/dev/null 2>&1; then
-                                                gem install bundler -v 2.3.17
-                                            fi
-                                            command -v mysql
-                                            bundle -v
-                                        """
-                                        sh label: "test_cmds=${TEST_CMDS} ", script: """
-                                            #!/usr/bin/env bash
-                                            ${TEST_CMDS}
-                                        """
-                                    }
+                                unstash 'ws'
+                                container("ruby") {
+                                    sh label: "prepare ruby test deps", script: """
+                                        #!/usr/bin/env bash
+                                        set -euxo pipefail
+                                        if ! command -v mysql >/dev/null 2>&1 || ! dpkg-query -W default-libmysqlclient-dev >/dev/null 2>&1 || ! dpkg-query -W libsqlite3-dev >/dev/null 2>&1; then
+                                            apt-get update
+                                            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \\
+                                                default-mysql-client \\
+                                                build-essential \\
+                                                default-libmysqlclient-dev \\
+                                                libsqlite3-dev \\
+                                                pkg-config
+                                            rm -rf /var/lib/apt/lists/*
+                                        fi
+                                        if ! gem list -i bundler -v 2.3.17 >/dev/null 2>&1; then
+                                            gem install bundler -v 2.3.17
+                                        fi
+                                        command -v mysql
+                                        bundle -v
+                                    """
+                                    sh label: "test_cmds=${TEST_CMDS} ", script: """
+                                        #!/usr/bin/env bash
+                                        ${TEST_CMDS}
+                                    """
                                 }
                             }
                         }

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
@@ -55,27 +55,26 @@ pipeline {
                     sh label: 'tiproxy', script: 'ls bin/tiproxy || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -104,12 +103,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "PART ${PART}", script: """
-                                        #!/usr/bin/env bash
-                                        make deploy-mysqltest ARGS="-b -x y -s tikv -p ${PART}"
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "PART ${PART}", script: """
+                                    #!/usr/bin/env bash
+                                    make deploy-mysqltest ARGS="-b -x y -s tikv -p ${PART}"
+                                """
                             }
                         }
                         post{

--- a/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
@@ -56,27 +56,26 @@ pipeline {
                     sh label: 'tiproxy', script: '[ -f bin/tiproxy ] || make'
                 }
                 dir('tidb-test') {
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch ws-${BUILD_TAG}"
-                        dir("bin") {
-                            container("utils") {
-                                retry(2) {
-                                    sh label: 'download binary', script: """
-                                    ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                        --tidb=master --pd=master --tikv=master
-                                    """
-                                }
+                    sh "touch ws-${BUILD_TAG}"
+                    dir("bin") {
+                        container("utils") {
+                            retry(2) {
+                                sh label: 'download binary', script: """
+                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                    --tidb=master --pd=master --tikv=master
+                                """
                             }
                         }
-                        sh label: 'prepare thirdparty binary', script: """
-                        cp ../tiproxy/bin/tiproxy ./bin/
-                        ls -alh bin/
-                        ./bin/tidb-server -V
-                        ./bin/pd-server -V
-                        ./bin/tikv-server -V
-                        ./bin/tiproxy --version
-                        """
                     }
+                    sh label: 'prepare thirdparty binary', script: """
+                    cp ../tiproxy/bin/tiproxy ./bin/
+                    ls -alh bin/
+                    ./bin/tidb-server -V
+                    ./bin/pd-server -V
+                    ./bin/tikv-server -V
+                    ./bin/tiproxy --version
+                    """
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -110,17 +109,16 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_path: ${TEST_PATH_STRING}", script: """
-                                        #!/usr/bin/env bash
-                                        path_array=(${TEST_PATH_STRING})
-                                        for path in \${path_array[@]}; do
-                                            echo "test path: \${path}"
-                                            SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
-                                            make deploy-sqllogictest ARGS="-x -c y -s tikv -p \${SQLLOGIC_TEST_PATH}"
-                                        done
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_path: ${TEST_PATH_STRING}", script: """
+                                    #!/usr/bin/env bash
+                                    path_array=(${TEST_PATH_STRING})
+                                    for path in \${path_array[@]}; do
+                                        echo "test path: \${path}"
+                                        SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
+                                        make deploy-sqllogictest ARGS="-x -c y -s tikv -p \${SQLLOGIC_TEST_PATH}"
+                                    done
+                                """
                             }
                         }
                         post { success { script { matrixCache.markDone(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } } }
@@ -156,17 +154,16 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         steps {
                             dir('tidb-test') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh label: "test_path: ${TEST_PATH_STRING}", script: """
-                                        #!/usr/bin/env bash
-                                        path_array=(${TEST_PATH_STRING})
-                                        for path in \${path_array[@]}; do
-                                            echo "test path: \${path}"
-                                            SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
-                                            make deploy-sqllogictest ARGS="-x -c y -s tikv -p \${SQLLOGIC_TEST_PATH}"
-                                        done
-                                    """
-                                }
+                                unstash 'ws'
+                                sh label: "test_path: ${TEST_PATH_STRING}", script: """
+                                    #!/usr/bin/env bash
+                                    path_array=(${TEST_PATH_STRING})
+                                    for path in \${path_array[@]}; do
+                                        echo "test path: \${path}"
+                                        SQLLOGIC_TEST_PATH="/git/sqllogictest/test/\${path}" \
+                                        make deploy-sqllogictest ARGS="-x -c y -s tikv -p \${SQLLOGIC_TEST_PATH}"
+                                    done
+                                """
                             }
                         }
                         post { success { script { matrixCache.markDone(REFS, 'Test', [test_path_string: env.TEST_PATH_STRING]) } } }

--- a/pipelines/qa/qa-release-br-integration-test.groovy
+++ b/pipelines/qa/qa-release-br-integration-test.groovy
@@ -80,11 +80,10 @@ pipeline {
                             ./tiflash --version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-tests") {
-                        sh label: "prepare", script: """
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        ls -alh ./bin
+                    """
+                    stash name: 'br-tests', includes: '**/*'
                 }
             }
         }
@@ -112,12 +111,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/br-tests") {
-                                    sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
-                                        chmod +x br/tests/*.sh
-                                        ./br/tests/run_group_br_tests.sh ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'br-tests'
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
+                                    chmod +x br/tests/*.sh
+                                    ./br/tests/run_group_br_tests.sh ${TEST_GROUP}
+                                """
                             }
                         }
                         post{

--- a/pipelines/qa/qa-release-lightning-integration-test.groovy
+++ b/pipelines/qa/qa-release-lightning-integration-test.groovy
@@ -75,11 +75,10 @@ pipeline {
                             ./tiflash --version
                         """
                     }
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/lightning-test") {
-                        sh label: "prepare", script: """
-                            ls -alh ./bin
-                        """
-                    }
+                    sh label: "prepare", script: """
+                        ls -alh ./bin
+                    """
+                    stash name: 'lightning-test', includes: '**/*'
                 }
             }
         }
@@ -107,12 +106,11 @@ pipeline {
                     stage("Test") {
                         steps {
                             dir('tidb') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}/lightning-test") {
-                                    sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
-                                        chmod +x lightning/tests/*.sh
-                                        ./lightning/tests/run_group_lightning_tests.sh ${TEST_GROUP}
-                                    """
-                                }
+                                unstash 'lightning-test'
+                                sh label: "TEST_GROUP ${TEST_GROUP}", script: """#!/usr/bin/env bash
+                                    chmod +x lightning/tests/*.sh
+                                    ./lightning/tests/run_group_lightning_tests.sh ${TEST_GROUP}
+                                """
                             }
                         }
                         post{

--- a/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
@@ -59,32 +59,31 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('migration') {
-                    cache(path: "./cdc", includes: '**/*', key: "ws/${BUILD_TAG}/tikvcdc") {
-                        container("utils") {
-                            sh label: 'download test binaries via OCI', script: """
-                                mkdir -p ./cdc/scripts/bin
-                                cd ./cdc/scripts/bin
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                    --tidb=${OCI_TAG_TIDB} \
-                                    --tikv=${OCI_TAG_TIKV} \
-                                    --pd=${OCI_TAG_PD} \
-                                    --pd-ctl=${OCI_TAG_PD} \
-                                    --etcdctl=${OCI_TAG_ETCD} \
-                                    --ycsb=${OCI_TAG_YCSB}
-                                chmod +x tidb-server tikv-server pd-server pd-ctl etcdctl go-ycsb
-                                cd ../../
-                                touch prepare_test_binaries
-                                ls -alh
-                            """
-                        }
-                        container("golang") {
-                            sh label: 'integration test prepare', script: """#!/usr/bin/env bash
-                            cd cdc/
-                            make check_third_party_binary
-                            make integration_test_build
-                            """
-                        }
+                    container("utils") {
+                        sh label: 'download test binaries via OCI', script: """
+                            mkdir -p ./cdc/scripts/bin
+                            cd ./cdc/scripts/bin
+                            ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                --tidb=${OCI_TAG_TIDB} \
+                                --tikv=${OCI_TAG_TIKV} \
+                                --pd=${OCI_TAG_PD} \
+                                --pd-ctl=${OCI_TAG_PD} \
+                                --etcdctl=${OCI_TAG_ETCD} \
+                                --ycsb=${OCI_TAG_YCSB}
+                            chmod +x tidb-server tikv-server pd-server pd-ctl etcdctl go-ycsb
+                            cd ../../
+                            touch prepare_test_binaries
+                            ls -alh
+                        """
                     }
+                    container("golang") {
+                        sh label: 'integration test prepare', script: """#!/usr/bin/env bash
+                        cd cdc/
+                        make check_third_party_binary
+                        make integration_test_build
+                        """
+                    }
+                    stash name: 'tikvcdc', includes: 'cdc/**'
                 }
             }
         }
@@ -114,25 +113,24 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('migration') {
-                               cache(path: "./cdc", includes: '**/*', key: "ws/${BUILD_TAG}/tikvcdc") {
-                                    sh "printenv"
-                                    container("kafka") {
-                                        timeout(time: 6, unit: 'MINUTES') {
-                                            sh label: "Waiting for kafka ready", script: """
-                                                echo "Waiting for zookeeper to be ready..."
-                                                while ! nc -z localhost 2181; do sleep 10; done
-                                                echo "Waiting for kafka to be ready..."
-                                                while ! nc -z localhost 9092; do sleep 10; done
-                                                echo "Waiting for kafka-broker to be ready..."
-                                                while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
-                                            """
-                                        }
+                               unstash 'tikvcdc'
+                                sh "printenv"
+                                container("kafka") {
+                                    timeout(time: 6, unit: 'MINUTES') {
+                                        sh label: "Waiting for kafka ready", script: """
+                                            echo "Waiting for zookeeper to be ready..."
+                                            while ! nc -z localhost 2181; do sleep 10; done
+                                            echo "Waiting for kafka to be ready..."
+                                            while ! nc -z localhost 9092; do sleep 10; done
+                                            echo "Waiting for kafka-broker to be ready..."
+                                            while ! echo dump | nc localhost 2181 | grep brokers | awk '{\$1=\$1;print}' | grep -F -w "/brokers/ids/1"; do sleep 10; done
+                                        """
                                     }
-                                    sh label: "TEST_GROUP ${TEST_GROUP}",script: """#!/usr/bin/env bash
-                                        cd cdc/
-                                        ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
-                                    """
-                               }
+                                }
+                                sh label: "TEST_GROUP ${TEST_GROUP}",script: """#!/usr/bin/env bash
+                                    cd cdc/
+                                    ./tests/integration_tests/run_group.sh kafka ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/tikv/migration/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_test.groovy
@@ -59,32 +59,31 @@ pipeline {
         stage('Prepare') {
             steps {
                 dir('migration') {
-                    cache(path: "./cdc", includes: '**/*', key: "ws/${BUILD_TAG}/tikvcdc") {
-                        container("utils") {
-                            sh label: 'download test binaries via OCI', script: """
-                                mkdir -p ./cdc/scripts/bin
-                                cd ./cdc/scripts/bin
-                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
-                                    --tidb=${OCI_TAG_TIDB} \
-                                    --tikv=${OCI_TAG_TIKV} \
-                                    --pd=${OCI_TAG_PD} \
-                                    --pd-ctl=${OCI_TAG_PD} \
-                                    --etcdctl=${OCI_TAG_ETCD} \
-                                    --ycsb=${OCI_TAG_YCSB}
-                                chmod +x tidb-server tikv-server pd-server pd-ctl etcdctl go-ycsb
-                                cd ../../
-                                touch prepare_test_binaries
-                                ls -alh
-                            """
-                        }
-                        container("golang") {
-                            sh label: 'integration test prepare', script: """#!/usr/bin/env bash
-                            cd cdc/
-                            make check_third_party_binary
-                            make integration_test_build
-                            """
-                        }
+                    container("utils") {
+                        sh label: 'download test binaries via OCI', script: """
+                            mkdir -p ./cdc/scripts/bin
+                            cd ./cdc/scripts/bin
+                            ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                --tidb=${OCI_TAG_TIDB} \
+                                --tikv=${OCI_TAG_TIKV} \
+                                --pd=${OCI_TAG_PD} \
+                                --pd-ctl=${OCI_TAG_PD} \
+                                --etcdctl=${OCI_TAG_ETCD} \
+                                --ycsb=${OCI_TAG_YCSB}
+                            chmod +x tidb-server tikv-server pd-server pd-ctl etcdctl go-ycsb
+                            cd ../../
+                            touch prepare_test_binaries
+                            ls -alh
+                        """
                     }
+                    container("golang") {
+                        sh label: 'integration test prepare', script: """#!/usr/bin/env bash
+                        cd cdc/
+                        make check_third_party_binary
+                        make integration_test_build
+                        """
+                    }
+                    stash name: 'tikvcdc', includes: 'cdc/**'
                 }
             }
         }
@@ -114,13 +113,12 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         steps {
                             dir('migration') {
-                               cache(path: "./cdc", includes: '**/*', key: "ws/${BUILD_TAG}/tikvcdc") {
-                                    sh "printenv"
-                                    sh label: "TEST_GROUP ${TEST_GROUP}",script: """#!/usr/bin/env bash
-                                        cd cdc/
-                                        ./tests/integration_tests/run_group.sh tikv ${TEST_GROUP}
-                                    """
-                               }
+                               unstash 'tikvcdc'
+                                sh "printenv"
+                                sh label: "TEST_GROUP ${TEST_GROUP}",script: """#!/usr/bin/env bash
+                                    cd cdc/
+                                    ./tests/integration_tests/run_group.sh tikv ${TEST_GROUP}
+                                """
                             }
                         }
                         post {

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -96,9 +96,8 @@ pipeline {
                         }
                     }
                     // cache it for other pods
-                    cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                        sh "touch rev-${REFS.pulls[0].sha}"
-                    }
+                    sh "touch rev-${REFS.pulls[0].sha}"
+                    stash name: 'ws', includes: '**/*'
                 }
             }
         }
@@ -156,9 +155,8 @@ pipeline {
                         }
                         steps {
                             dir('tidb') {
-                                cache(path: "./", includes: '**/*', key: "ws/${BUILD_TAG}") {
-                                    sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
-                                }
+                                unstash 'ws'
+                                sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
 
                                 sh """
                                 mkdir -p /home/jenkins/.tidb/tmp


### PR DESCRIPTION
Close #4890 (second batch: other repos).

## What changed

Switch the remaining `ws/${BUILD_TAG}` cache-based workspace handoff to S3-backed stash/unstash across **103 pipelines** in the other repos:

- **pingcap/tiflow + pingcap-inc/tiflow**: `tiflow-cdc` / `tiflow-dm` handoff
- **pingcap-qe/tidb-test**: tidb-test dir and `dependencies` (`bin/**`) handoff
- **pingcap/tiproxy**: whole workspace and `tiproxy-*-test` handoff
- **pingcap/ticdc**: `ticdc` dir handoff
- **tikv/migration, tikv/pd, qa**: whole workspace handoff

Stash includes are derived from the cached path (`'**/*'`, `'bin/**'`, `'cdc/**'`, `'mysql_test/**'`, ...), so matrix pods restore exactly what the cache provided. First occurrence (main stage) becomes the stash; later occurrences (matrix restore) become `unstash` + body.

## Verification

- No `ws/${BUILD_TAG}` references remain in the covered repos
- No stash-without-unstash files
- **All 103 pipelines pass Jenkins pipeline validation**

With #4910 (tidb batch), the whole #4890 scope is covered.