### PR TITLE
chore(tekton): bump tikv timeout to 4h for fake-github triggers

### DIFF
--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push-single-platform.yaml
@@ -126,7 +126,7 @@ spec:
                     'memory': '32Gi'
                   },
                   'tikv': {
-                    'timeout': '2h30m',
+                    'timeout': '4h',
                     'sourceWsSize': '100Gi',
                     'cpu': '16',
                     'memory': '64Gi'

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-branch-push.yaml
@@ -126,7 +126,7 @@ spec:
                     'memory': '32Gi'
                   },
                   'tikv': {
-                    'timeout': '2h30m',
+                    'timeout': '4h',
                     'sourceWsSize': '100Gi',
                     'cpu': '16',
                     'memory': '64Gi'

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr-single-platform.yaml
@@ -126,7 +126,7 @@ spec:
                     'memory': '32Gi'
                   },
                   'tikv': {
-                    'timeout': '2h30m',
+                    'timeout': '4h',
                     'sourceWsSize': '100Gi',
                     'cpu': '16',
                     'memory': '64Gi'

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-pr.yaml
@@ -126,7 +126,7 @@ spec:
                     'memory': '32Gi'
                   },
                   'tikv': {
-                    'timeout': '2h30m',
+                    'timeout': '4h',
                     'sourceWsSize': '100Gi',
                     'cpu': '16',
                     'memory': '64Gi'

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create-single-platform.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create-single-platform.yaml
@@ -128,7 +128,7 @@ spec:
                     'memory': '32Gi'
                   },
                   'tikv': {
-                    'timeout': '2h30m',
+                    'timeout': '4h',
                     'sourceWsSize': '100Gi',
                     'cpu': '16',
                     'memory': '64Gi'

--- a/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create.yaml
+++ b/tekton/v1/triggers/triggers/env-prod2/_/fake-github/fake-github-tag-create.yaml
@@ -126,7 +126,7 @@ spec:
                     'memory': '32Gi'
                   },
                   'tikv': {
-                    'timeout': '2h30m',
+                    'timeout': '4h',
                     'sourceWsSize': '100Gi',
                     'cpu': '16',
                     'memory': '64Gi'


### PR DESCRIPTION
Bump tikv job timeout from 2h30m to 4h in env-prod2 fake-github triggers (branch-push, pr, tag-create, and single-platform variants).