### PR TITLE
fix(tools/flaky-tests): replace deno.land dependencies with npm packages

### DIFF
--- a/prow-jobs/pingcap-qe/ci/periodics.yaml
+++ b/prow-jobs/pingcap-qe/ci/periodics.yaml
@@ -120,13 +120,6 @@ periodics:
   - name: periodic-reporter-flaky-tests-tidb-v85
     decorate: true # need add this.
     cron: "30 0 * * *" # Run daily at 8:30 UTC+8 (which is 0:30 UTC)
-    # hidden: true
-    extra_refs: # Periodic job doesn't clone any repo by default, needs to be added explicitly
-      - org: PingCAP-QE
-        repo: ci
-        base_ref: main
-        skip_submodules: true
-        clone_depth: 1
     spec:
       activeDeadlineSeconds: 300
       containers:

--- a/tools/reporters/ci/flaky-tests/core/ConfigLoader.ts
+++ b/tools/reporters/ci/flaky-tests/core/ConfigLoader.ts
@@ -285,7 +285,7 @@ Examples:
     if (cli.dbUrl) {
       const parsed = convertDsnToClientConfig(cli.dbUrl);
       if (!parsed) throw new Error(`Invalid --db-url: ${cli.dbUrl}`);
-      parsed.ssl = "VERIFY_IDENTITY";
+      parsed.ssl = { rejectUnauthorized: true };
       return parsed;
     }
     const host = cli.dbHost ?? "";
@@ -304,7 +304,7 @@ Examples:
       user,
       password,
       database,
-      ssl: "VERIFY_IDENTITY",
+      ssl: { rejectUnauthorized: true },
     };
   }
 

--- a/tools/reporters/ci/flaky-tests/core/ConfigLoader.ts
+++ b/tools/reporters/ci/flaky-tests/core/ConfigLoader.ts
@@ -22,7 +22,7 @@
 
 import { parseArgs } from "jsr:@std/cli/parse-args";
 import { parse as parseYaml } from "jsr:@std/yaml";
-import * as mysql from "https://deno.land/x/mysql@v2.12.1/mod.ts";
+import type { ConnectionOptions } from "npm:mysql2/promise";
 import { convertDsnToClientConfig } from "../utils/db.ts";
 
 import { CliConfig, OwnerEntry, SmtpConfig, TimeWindow } from "./types.ts";
@@ -281,30 +281,30 @@ Examples:
     return { from, to };
   }
 
-  determineDbConfig(cli: CliConfig): mysql.ClientConfig {
+  determineDbConfig(cli: CliConfig): ConnectionOptions {
     if (cli.dbUrl) {
       const parsed = convertDsnToClientConfig(cli.dbUrl);
       if (!parsed) throw new Error(`Invalid --db-url: ${cli.dbUrl}`);
-      parsed.tls = { mode: mysql.TLSMode.VERIFY_IDENTITY };
+      parsed.ssl = "VERIFY_IDENTITY";
       return parsed;
     }
-    const hostname = cli.dbHost ?? "";
+    const host = cli.dbHost ?? "";
     const port = cli.dbPort ?? 3306;
-    const username = cli.dbUser ?? "";
+    const user = cli.dbUser ?? "";
     const password = cli.dbPass ?? "";
-    const db = cli.dbName ?? "";
-    if (!hostname || !username || !db) {
+    const database = cli.dbName ?? "";
+    if (!host || !user || !database) {
       throw new Error(
         `DB connection is incomplete. Provide --db-url or --db-host/--db-user/--db-name`,
       );
     }
     return {
-      hostname,
+      host,
       port,
-      username,
+      user,
       password,
-      db,
-      tls: { mode: mysql.TLSMode.VERIFY_IDENTITY },
+      database,
+      ssl: "VERIFY_IDENTITY",
     };
   }
 

--- a/tools/reporters/ci/flaky-tests/core/Database.ts
+++ b/tools/reporters/ci/flaky-tests/core/Database.ts
@@ -15,21 +15,27 @@
 
 // deno-lint-ignore-file no-explicit-any
 
-import {
-  Client as MySQLClient,
-  ClientConfig,
-} from "https://deno.land/x/mysql@v2.12.1/mod.ts";
+import { createConnection } from "npm:mysql2/promise";
+import type { ConnectionOptions } from "npm:mysql2/promise";
 import type { OwnerEntry, ProblemCaseRunRow, TimeWindow } from "./types.ts";
 
+interface QueryConnection {
+  execute(
+    sql: string,
+    values?: unknown[],
+  ): Promise<[unknown[], unknown[]]>;
+  end(): Promise<void>;
+}
+
 export class Database {
-  private client: MySQLClient | null = null;
-  private readonly cfg: ClientConfig;
+  private client: QueryConnection | null = null;
+  private readonly cfg: ConnectionOptions;
   private readonly verbose: boolean;
   private readonly repo?: string;
   private readonly branch?: string;
 
   constructor(
-    cfg: ClientConfig,
+    cfg: ConnectionOptions,
     options?: { verbose?: boolean; repo?: string; branch?: string },
   ) {
     this.cfg = cfg;
@@ -44,13 +50,14 @@ export class Database {
    */
   async connect(): Promise<void> {
     if (this.client) return; // Already connected
-    this.client = new MySQLClient();
     if (this.verbose) {
       console.debug(
-        `[db] connecting: ${this.cfg.username}@${this.cfg.hostname}:${this.cfg.port}/${this.cfg.db}`,
+        `[db] connecting: ${this.cfg.user}@${this.cfg.host}:${this.cfg.port}/${this.cfg.database}`,
       );
     }
-    await this.client.connect(this.cfg);
+    this.client = await createConnection(
+      this.cfg,
+    ) as unknown as QueryConnection;
     if (this.verbose) {
       console.debug("[db] connected");
     }
@@ -62,7 +69,7 @@ export class Database {
   async close(): Promise<void> {
     if (!this.client) return;
     try {
-      await this.client.close();
+      await this.client.end();
       if (this.verbose) console.debug("[db] closed");
     } finally {
       this.client = null;
@@ -104,10 +111,9 @@ export class Database {
       );
     }
 
-    const res = await this.client!.execute(sql, params);
-    const rows = (res?.rows ?? []) as any[];
+    const [rows] = await this.client!.execute(sql, params);
 
-    return rows.map((r) => {
+    return (rows as any[]).map((r) => {
       const report_time: Date = r.report_time instanceof Date
         ? r.report_time
         : new Date(r.report_time);
@@ -140,8 +146,8 @@ export class Database {
         `[db] fetchOwners: table=${quotedTable}`,
       );
     }
-    const res = await this.client!.execute(sql);
-    return res?.rows ?? [];
+    const [rows] = await this.client!.execute(sql);
+    return (rows ?? []) as any[];
   }
 
   /**

--- a/tools/reporters/ci/flaky-tests/deno.json
+++ b/tools/reporters/ci/flaky-tests/deno.json
@@ -5,12 +5,14 @@
     "run": "deno run --allow-net --allow-read --allow-write --allow-env main.ts"
   },
   "imports": {
-    "@std/assert": "jsr:@std/assert@1",
-    "@std/cli": "jsr:@std/cli@^1.0.22",
-    "@std/path": "jsr:@std/path@^1.1.2",
-    "@std/yaml": "jsr:@std/yaml@^1.0.9",
-    "@octokit/rest": "npm:@octokit/rest@^22.0.0",
-    "@octokit/plugin-throttling": "npm:@octokit/plugin-throttling@^11.0.0",
-    "@octokit/plugin-retry": "npm:@octokit/plugin-retry@^8.0.0"
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/cli": "jsr:@std/cli@^1.0.32",
+    "@std/path": "jsr:@std/path@^1.1.6",
+    "@std/yaml": "jsr:@std/yaml@^1.2.0",
+    "@octokit/rest": "npm:@octokit/rest@^22.0.1",
+    "@octokit/plugin-throttling": "npm:@octokit/plugin-throttling@^11.0.5",
+    "@octokit/plugin-retry": "npm:@octokit/plugin-retry@^8.1.1",
+    "mysql2": "npm:mysql2@^3.11.5",
+    "nodemailer": "npm:nodemailer@^6.9.16"
   }
 }

--- a/tools/reporters/ci/flaky-tests/deno.lock
+++ b/tools/reporters/ci/flaky-tests/deno.lock
@@ -1,133 +1,133 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/assert@1": "1.0.14",
-    "jsr:@std/cli@*": "1.0.22",
-    "jsr:@std/cli@^1.0.22": "1.0.22",
-    "jsr:@std/internal@^1.0.10": "1.0.10",
-    "jsr:@std/path@*": "1.1.2",
-    "jsr:@std/path@^1.1.2": "1.1.2",
-    "jsr:@std/yaml@*": "1.0.9",
-    "jsr:@std/yaml@^1.0.9": "1.0.9",
-    "npm:@octokit/plugin-retry@*": "8.1.0_@octokit+core@7.0.6",
-    "npm:@octokit/plugin-retry@8": "8.1.0_@octokit+core@7.0.6",
-    "npm:@octokit/plugin-throttling@*": "11.0.3_@octokit+core@7.0.6",
-    "npm:@octokit/plugin-throttling@11": "11.0.3_@octokit+core@7.0.6",
-    "npm:@octokit/rest@*": "22.0.1_@octokit+core@7.0.6",
-    "npm:@octokit/rest@22": "22.0.1_@octokit+core@7.0.6"
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/cli@*": "1.0.32",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@*": "1.1.6",
+    "jsr:@std/yaml@*": "1.2.0",
+    "npm:@octokit/plugin-retry@*": "8.1.1_@octokit+core@7.0.7",
+    "npm:@octokit/plugin-throttling@*": "11.0.5_@octokit+core@7.0.7",
+    "npm:@octokit/rest@*": "22.0.1_@octokit+core@7.0.7",
+    "npm:mysql2@*": "3.23.3_@types+node@26.1.2",
+    "npm:nodemailer@*": "9.0.5"
   },
   "jsr": {
-    "@std/assert@1.0.14": {
-      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
-    "@std/cli@1.0.22": {
-      "integrity": "50d1e4f87887cb8a8afa29b88505ab5081188f5cad3985460c3b471fa49ff21a"
+    "@std/cli@1.0.32": {
+      "integrity": "188b3a100d6202d64e3f5bd3d799c7fa4f6d77f92cc65eb7f641c1fa0aa92a66"
     },
-    "@std/internal@1.0.10": {
-      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
     },
-    "@std/path@1.1.2": {
-      "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.14"
       ]
     },
-    "@std/yaml@1.0.9": {
-      "integrity": "6bad3dc766dd85b4b37eabcba81b6aa4eac7a392792ae29abcfb0f90602d55bb"
+    "@std/yaml@1.2.0": {
+      "integrity": "20beb41e4983ba3437dbefac62b14061ab058e8a187596f19d28ff9035f6e6cf"
     }
   },
   "npm": {
     "@octokit/auth-token@6.0.0": {
       "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="
     },
-    "@octokit/core@7.0.6": {
-      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+    "@octokit/core@7.0.7": {
+      "integrity": "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==",
       "dependencies": [
         "@octokit/auth-token",
         "@octokit/graphql",
         "@octokit/request",
         "@octokit/request-error",
-        "@octokit/types",
+        "@octokit/types@17.0.0",
         "before-after-hook",
         "universal-user-agent"
       ]
     },
-    "@octokit/endpoint@11.0.3": {
-      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+    "@octokit/endpoint@11.0.4": {
+      "integrity": "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==",
       "dependencies": [
-        "@octokit/types",
+        "@octokit/types@17.0.0",
         "universal-user-agent"
       ]
     },
-    "@octokit/graphql@9.0.3": {
-      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+    "@octokit/graphql@9.0.4": {
+      "integrity": "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==",
       "dependencies": [
         "@octokit/request",
-        "@octokit/types",
+        "@octokit/types@17.0.0",
         "universal-user-agent"
       ]
     },
     "@octokit/openapi-types@27.0.0": {
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="
     },
-    "@octokit/plugin-paginate-rest@14.0.0_@octokit+core@7.0.6": {
+    "@octokit/openapi-types@28.0.0": {
+      "integrity": "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ=="
+    },
+    "@octokit/plugin-paginate-rest@14.0.0_@octokit+core@7.0.7": {
       "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
       "dependencies": [
         "@octokit/core",
-        "@octokit/types"
+        "@octokit/types@16.0.0"
       ]
     },
-    "@octokit/plugin-request-log@6.0.0_@octokit+core@7.0.6": {
+    "@octokit/plugin-request-log@6.0.0_@octokit+core@7.0.7": {
       "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
       "dependencies": [
         "@octokit/core"
       ]
     },
-    "@octokit/plugin-rest-endpoint-methods@17.0.0_@octokit+core@7.0.6": {
+    "@octokit/plugin-rest-endpoint-methods@17.0.0_@octokit+core@7.0.7": {
       "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
       "dependencies": [
         "@octokit/core",
-        "@octokit/types"
+        "@octokit/types@16.0.0"
       ]
     },
-    "@octokit/plugin-retry@8.1.0_@octokit+core@7.0.6": {
-      "integrity": "sha512-O1FZgXeiGb2sowEr/hYTr6YunGdSAFWnr2fyW39Ah85H8O33ELASQxcvOFF5LE6Tjekcyu2ms4qAzJVhSaJxTw==",
+    "@octokit/plugin-retry@8.1.1_@octokit+core@7.0.7": {
+      "integrity": "sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==",
       "dependencies": [
         "@octokit/core",
         "@octokit/request-error",
-        "@octokit/types",
+        "@octokit/types@17.0.0",
         "bottleneck"
       ]
     },
-    "@octokit/plugin-throttling@11.0.3_@octokit+core@7.0.6": {
-      "integrity": "sha512-34eE0RkFCKycLl2D2kq7W+LovheM/ex3AwZCYN8udpi6bxsyjZidb2McXs69hZhLmJlDqTSP8cH+jSRpiaijBg==",
+    "@octokit/plugin-throttling@11.0.5_@octokit+core@7.0.7": {
+      "integrity": "sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==",
       "dependencies": [
         "@octokit/core",
-        "@octokit/types",
+        "@octokit/types@17.0.0",
         "bottleneck"
       ]
     },
-    "@octokit/request-error@7.1.0": {
-      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+    "@octokit/request-error@7.1.1": {
+      "integrity": "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==",
       "dependencies": [
-        "@octokit/types"
+        "@octokit/types@17.0.0"
       ]
     },
-    "@octokit/request@10.0.8": {
-      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+    "@octokit/request@10.0.13": {
+      "integrity": "sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==",
       "dependencies": [
         "@octokit/endpoint",
         "@octokit/request-error",
-        "@octokit/types",
-        "fast-content-type-parse",
+        "@octokit/types@17.0.0",
+        "content-type",
         "json-with-bigint",
         "universal-user-agent"
       ]
     },
-    "@octokit/rest@22.0.1_@octokit+core@7.0.6": {
+    "@octokit/rest@22.0.1_@octokit+core@7.0.7": {
       "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
       "dependencies": [
         "@octokit/core",
@@ -139,8 +139,23 @@
     "@octokit/types@16.0.0": {
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
       "dependencies": [
-        "@octokit/openapi-types"
+        "@octokit/openapi-types@27.0.0"
       ]
+    },
+    "@octokit/types@17.0.0": {
+      "integrity": "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==",
+      "dependencies": [
+        "@octokit/openapi-types@28.0.0"
+      ]
+    },
+    "@types/node@26.1.2": {
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
+    "aws-ssl-profiles@1.1.2": {
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="
     },
     "before-after-hook@4.0.0": {
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="
@@ -148,114 +163,79 @@
     "bottleneck@2.19.5": {
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
-    "fast-content-type-parse@3.0.0": {
-      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="
+    "content-type@2.0.0": {
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
     },
-    "json-with-bigint@3.5.8": {
-      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="
+    "generate-function@2.3.1": {
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dependencies": [
+        "is-property"
+      ]
+    },
+    "iconv-lite@0.7.3": {
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
+    "is-property@1.0.2": {
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
+    },
+    "json-with-bigint@3.5.10": {
+      "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w=="
+    },
+    "long@5.3.2": {
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+    },
+    "lru.min@1.1.4": {
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="
+    },
+    "mysql2@3.23.3_@types+node@26.1.2": {
+      "integrity": "sha512-ehp9HEKr4wVJaBOUVxNFa+CNrsCCCZ6363/jbGhb7WpEmSRNIXjHBjFs5K2s2cXn7j/RhDieejsQJ6nfUwD6vQ==",
+      "dependencies": [
+        "@types/node",
+        "aws-ssl-profiles",
+        "generate-function",
+        "iconv-lite",
+        "long",
+        "lru.min",
+        "named-placeholders",
+        "sql-escaper"
+      ]
+    },
+    "named-placeholders@1.1.6": {
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "dependencies": [
+        "lru.min"
+      ]
+    },
+    "nodemailer@9.0.5": {
+      "integrity": "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ=="
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sql-escaper@1.5.1": {
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg=="
+    },
+    "undici-types@8.3.0": {
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="
     },
     "universal-user-agent@7.0.3": {
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
     }
   },
-  "remote": {
-    "https://deno.land/std@0.104.0/_util/assert.ts": "2f868145a042a11d5ad0a3c748dcf580add8a0dbc0e876eaa0026303a5488f58",
-    "https://deno.land/std@0.104.0/async/deadline.ts": "1d6ac7aeaee22f75eb86e4e105d6161118aad7b41ae2dd14f4cfd3bf97472b93",
-    "https://deno.land/std@0.104.0/async/debounce.ts": "b2f693e4baa16b62793fd618de6c003b63228db50ecfe3bd51fc5f6dc0bc264b",
-    "https://deno.land/std@0.104.0/async/deferred.ts": "ce81070ad3ba3294f3f34c032af884ccde1a20922b648f6eaee54bd8fd951a1e",
-    "https://deno.land/std@0.104.0/async/delay.ts": "9de1d8d07d1927767ab7f82434b883f3d8294fb19cad819691a2ad81a728cf3d",
-    "https://deno.land/std@0.104.0/async/mod.ts": "78425176fabea7bd1046ce3819fd69ce40da85c83e0f174d17e8e224a91f7d10",
-    "https://deno.land/std@0.104.0/async/mux_async_iterator.ts": "62abff3af9ff619e8f2adc96fc70d4ca020fa48a50c23c13f12d02ed2b760dbe",
-    "https://deno.land/std@0.104.0/async/pool.ts": "353ce4f91865da203a097aa6f33de8966340c91b6f4a055611c8c5d534afd12f",
-    "https://deno.land/std@0.104.0/async/tee.ts": "6b8f1322b6dd2396202cfbe9cde9cab158d1e962cfd9197b0a97c6657bee79ce",
-    "https://deno.land/std@0.104.0/bytes/bytes_list.ts": "a13287edb03f19d27ba4927dec6d6de3e5bd46254cd4aee6f7e5815810122673",
-    "https://deno.land/std@0.104.0/bytes/mod.ts": "1ae1ccfe98c4b979f12b015982c7444f81fcb921bea7aa215bf37d84f46e1e13",
-    "https://deno.land/std@0.104.0/encoding/base64.ts": "eecae390f1f1d1cae6f6c6d732ede5276bf4b9cd29b1d281678c054dc5cc009e",
-    "https://deno.land/std@0.104.0/encoding/hex.ts": "5bc7df19af498c315cdaba69e2fce1b2aef5fc57344e8c21c08991aa8505a260",
-    "https://deno.land/std@0.104.0/fmt/colors.ts": "d2f8355f00a74404668fc5a1e4a92983ce1a9b0a6ac1d40efbd681cb8f519586",
-    "https://deno.land/std@0.104.0/fs/exists.ts": "b0d2e31654819cc2a8d37df45d6b14686c0cc1d802e9ff09e902a63e98b85a00",
-    "https://deno.land/std@0.104.0/hash/_wasm/hash.ts": "313a4820227f1c45fa7204d9c28731b4f8ce97cdcc5f1e7e4efcdf2d70540d32",
-    "https://deno.land/std@0.104.0/hash/_wasm/wasm.js": "792f612fbb9998e267f9ae3f82ed72444305cb9c77b5bbf7ff6517fd3b606ed1",
-    "https://deno.land/std@0.104.0/hash/hasher.ts": "57a9ec05dd48a9eceed319ac53463d9873490feea3832d58679df6eec51c176b",
-    "https://deno.land/std@0.104.0/hash/mod.ts": "dd339a26b094032f38d71311b85745e8d19f2085364794c1877057e057902dd9",
-    "https://deno.land/std@0.104.0/io/buffer.ts": "3ead6bb11276ebcf093c403f74f67fd2205a515dbbb9061862c468ca56f37cd8",
-    "https://deno.land/std@0.104.0/io/bufio.ts": "6024117aa37f8d21a116654bd5ca5191d803f6492bbc744e3cee5054d0e900d1",
-    "https://deno.land/std@0.104.0/io/util.ts": "85c33d61b20fd706acc094fe80d4c8ae618b04abcf3a96ca2b47071842c1c8ac",
-    "https://deno.land/std@0.104.0/log/handlers.ts": "8c7221a2408b4097e186b018f3f1a18865d20b98761aa1dccaf1ee3d57298355",
-    "https://deno.land/std@0.104.0/log/levels.ts": "088a883039ece5fa0da5f74bc7688654045ea7cb01bf200b438191a28d728eae",
-    "https://deno.land/std@0.104.0/log/logger.ts": "6b2dd8cbe6f407100b9becfe61595d7681f8ce3692412fad843de84d617a038e",
-    "https://deno.land/std@0.104.0/log/mod.ts": "91711789b28803082b1bdfb123d2c9685a7e01767f2e79c0a82706063ad964d8",
-    "https://deno.land/std@0.104.0/testing/_diff.ts": "5d3693155f561d1a5443ac751ac70aab9f5d67b4819a621d4b96b8a1a1c89620",
-    "https://deno.land/std@0.104.0/testing/asserts.ts": "e4311d45d956459d4423bc267208fe154b5294989da2ed93257b6a85cae0427e",
-    "https://deno.land/std@0.173.0/encoding/base64.ts": "7de04c2f8aeeb41453b09b186480be90f2ff357613b988e99fabb91d2eeceba1",
-    "https://deno.land/std@0.77.0/fmt/colors.ts": "c5665c66f1a67228f21c5989bbb04b36d369b98dd7ceac06f5e26856c81c2531",
-    "https://deno.land/std@0.81.0/_util/assert.ts": "e1f76e77c5ccb5a8e0dbbbe6cce3a56d2556c8cb5a9a8802fc9565af72462149",
-    "https://deno.land/std@0.81.0/bytes/mod.ts": "e4f91c6473fe13e3cf1a23649137f87f49135c10bc08fc0f83382a0fb0b03744",
-    "https://deno.land/std@0.81.0/encoding/utf8.ts": "1b7e77db9a12363c67872f8a208886ca1329f160c1ca9133b13d2ed399688b99",
-    "https://deno.land/std@0.81.0/io/bufio.ts": "3cbbe1f761c1c636d1e7128ed4e7fdca6bf21d9199aa3cae71e69972a6ae8f93",
-    "https://deno.land/std@0.81.0/textproto/mod.ts": "4c378eda3cb6216608bb4c3a34201761c65f6980c4669455ca224c330cd5b790",
-    "https://deno.land/x/bytes_formater@v1.4.0/deps.ts": "4f98f74e21145423b873a5ca6ead66dc3e674fa81e230a0a395f9b86aafeceea",
-    "https://deno.land/x/bytes_formater@v1.4.0/format.ts": "657c41b9f180c3ed0f934dcf75f77b09b6a610be98bb07525bffe2acfd5af4d5",
-    "https://deno.land/x/bytes_formater@v1.4.0/mod.ts": "c6bf35303f53d74e9134eb13f666fb388fb4c62c6b12b17542bbadade250a864",
-    "https://deno.land/x/denomailer@1.6.0/client/basic/QUE.ts": "5af1dfcc5814bf4542f098908ac1fdd8a1a1c2b1597138a121c95eaa791315d0",
-    "https://deno.land/x/denomailer@1.6.0/client/basic/client.ts": "462e4db45ae218647812ceae720d55ea33e0e928f9138fee9da5913cbb1e20f9",
-    "https://deno.land/x/denomailer@1.6.0/client/basic/connection.ts": "68de68d7551d8303629905c2b7581cb09b45646e530ce93a5786ca1aba61055c",
-    "https://deno.land/x/denomailer@1.6.0/client/basic/transforms.ts": "e630a23d24e9b397e231ae8796c0a0080770ac6f5ab9bffc105d3717706e62c9",
-    "https://deno.land/x/denomailer@1.6.0/client/mod.ts": "8ec4c25d9586f83f8629768311a077eaf03b1490dcb872030ba2e27fadb674d8",
-    "https://deno.land/x/denomailer@1.6.0/client/pool.ts": "0466e69ca8959aa85501cc6b30d7f5fd8e43b0a6ac88ecc60dab71081e801bae",
-    "https://deno.land/x/denomailer@1.6.0/client/worker/worker.ts": "a4c3a3e2e1fde0967817ece7c345a565eb44a7312acf8d46ce620d4ff4443b31",
-    "https://deno.land/x/denomailer@1.6.0/config/client.ts": "302f5c18fbb5531b5615613084b86d44120acc210e072f4135e431fa27fc4526",
-    "https://deno.land/x/denomailer@1.6.0/config/mail/attachments.ts": "1f357bddc9d5e813c3f647498db81a165a1a8a7163116c58dc10cf01427fd81e",
-    "https://deno.land/x/denomailer@1.6.0/config/mail/content.ts": "3925d4c3baaabed4e08933159d34b1450e6426b35a5bc323a0666780bef20192",
-    "https://deno.land/x/denomailer@1.6.0/config/mail/email.ts": "bb0ca104bf9cb54af6613a04b3f8cb05290f4fb012e7113f1d050cab10226a7c",
-    "https://deno.land/x/denomailer@1.6.0/config/mail/encoding.ts": "0bc5983ada3b902333925cdca225f8ea5e28fffbc2f1bd2b0ccb9a423f6f7fcc",
-    "https://deno.land/x/denomailer@1.6.0/config/mail/headers.ts": "ce94874beb5a1a7248b5b91bf1ae3b3aed2d4c0541f3f448f2bbfad6c8f570ee",
-    "https://deno.land/x/denomailer@1.6.0/config/mail/mod.ts": "a7fafa3386a45a585d7983d816b09ddc28b2f2b84097a614f1e38685b1f62868",
-    "https://deno.land/x/denomailer@1.6.0/deps.ts": "12bef188bb2a490fedc82ac1889f3d438e8a15887c423b045fee532b31a43102",
-    "https://deno.land/x/denomailer@1.6.0/mod.ts": "71a197dff098194ab53691abd3c9d22a276ef04e1382eb85f5632dbcb5a83bf3",
-    "https://deno.land/x/mysql@v2.12.1/deps.ts": "68635959a41bb08bc87db007679fb8449febc55d48202dff20b93cc23ef5820d",
-    "https://deno.land/x/mysql@v2.12.1/mod.ts": "3246c9c259434563be69cc95d5b792f8aac7ef5d10b8a6c6589aa54ebf1bd266",
-    "https://deno.land/x/mysql@v2.12.1/src/auth.ts": "129ea08b180d3e90e567c3f71e60432bb266304c224e17ea39d604bbcc1160d8",
-    "https://deno.land/x/mysql@v2.12.1/src/auth_plugin/caching_sha2_password.ts": "aab89e272382e6f408406f860ae6e79628275f4511e27a565049033543c4bdec",
-    "https://deno.land/x/mysql@v2.12.1/src/auth_plugin/crypt.ts": "8798819cce1171d95cfee8edda15fe6a652068cad4dc91f81b6e91cf90a13617",
-    "https://deno.land/x/mysql@v2.12.1/src/auth_plugin/index.ts": "8617e520ad854e38470aeefd07becdb3397c4cde16c2397dd48d5c10fdd5ab09",
-    "https://deno.land/x/mysql@v2.12.1/src/buffer.ts": "59f7e08e196f1b7e58cf5c3cf8ae8f4d0d47d1ae31430076fc468d974d3b59e7",
-    "https://deno.land/x/mysql@v2.12.1/src/client.ts": "30912964986667a2ce108c14f7153dd38e8089e55f8068e8d07697f75f2ac22f",
-    "https://deno.land/x/mysql@v2.12.1/src/connection.ts": "1d104c05441f8c94ee73123497fbbae28499f3badb0d9fef8cc82540688ada6e",
-    "https://deno.land/x/mysql@v2.12.1/src/constant/capabilities.ts": "2324c0e46ac43f59b7b03bdd878d7a14ecc5202b9e133c7e8769345a8290f2a1",
-    "https://deno.land/x/mysql@v2.12.1/src/constant/charset.ts": "253d7233679c774df623d1f974ebb358f3678c18fd6a623e25983311d97d959b",
-    "https://deno.land/x/mysql@v2.12.1/src/constant/errors.ts": "923bab27d524e43199fa21fdfcbe025580ca76d8b32254ad9505765c502f238a",
-    "https://deno.land/x/mysql@v2.12.1/src/constant/mysql_types.ts": "79c50de8eb5919b897e81e2ff2366ee1ffdbb4297f711e15003bdb787bbc8e6c",
-    "https://deno.land/x/mysql@v2.12.1/src/constant/packet.ts": "a1e7e00ce30c551c5f95c05d233b8d83f8e1fc865de97be3b317058e173630a9",
-    "https://deno.land/x/mysql@v2.12.1/src/deferred.ts": "35d087619d919961e849e382c33b2bfea15b4119f55eca2d9c9047f30512a2cb",
-    "https://deno.land/x/mysql@v2.12.1/src/logger.ts": "eb5feb3efdb9fd4887f6eccd5c06b5702591ac032af9857a12bbae86ceefe21b",
-    "https://deno.land/x/mysql@v2.12.1/src/packets/builders/auth.ts": "0b53dd5fa0269427aa54c3f6909bd830ffb426009061df89df262c504d6c9b70",
-    "https://deno.land/x/mysql@v2.12.1/src/packets/builders/client_capabilities.ts": "1000f2c1a20e0e119b9a416eb4ea4553cc1c5655d289a66e9077bf7a5993d52d",
-    "https://deno.land/x/mysql@v2.12.1/src/packets/builders/query.ts": "caf426a72ebe545ff5bab14c8b7b5e412dd8827c091322959cdf4e9aa89ef900",
-    "https://deno.land/x/mysql@v2.12.1/src/packets/builders/tls.ts": "2abb4a2fa74c47914372b221cb6f178f6015df54421daf0e10e54d80d7156498",
-    "https://deno.land/x/mysql@v2.12.1/src/packets/packet.ts": "d7800cc142226f7dfd3c5f647f03cd3ef308f9d8551b4edb2e1bfb9c758d33b6",
-    "https://deno.land/x/mysql@v2.12.1/src/packets/parsers/authswitch.ts": "aa34f21336c4907b3ae968108fcdad8f1c43a303088efd83d972e6c7b258c166",
-    "https://deno.land/x/mysql@v2.12.1/src/packets/parsers/err.ts": "4110c4ddc2ae8358d6661fa2522f8eda2e603900d1e433e3684765ed50e88ed8",
-    "https://deno.land/x/mysql@v2.12.1/src/packets/parsers/handshake.ts": "88f7ee34e9e0ef089bc5fdefacaccf256ef002b2f7a8ad684e35327682039e73",
-    "https://deno.land/x/mysql@v2.12.1/src/packets/parsers/result.ts": "8ab16f1adae67415eefcc17803b0eb828c1f4c6a24c55f25949f418e862d3ec8",
-    "https://deno.land/x/mysql@v2.12.1/src/pool.ts": "978ba2813b3886d68be007678360ad43c54dab14b1aea1c07fcdb41222fcc432",
-    "https://deno.land/x/mysql@v2.12.1/src/util.ts": "83d38e87cc3901da00ac44bfcd53c0e8d24525262f5c7647c912dccf3ed2dbb5",
-    "https://deno.land/x/smtp@v0.7.0/code.ts": "f388fae4995b4d35d99fb6b8bfded522f5a3e7e7d63babdf318a059d6db43baf",
-    "https://deno.land/x/smtp@v0.7.0/config.ts": "683a6fa684e5ef3705e809b203abea7804a90afde7b534d66c182ea3d17902d3",
-    "https://deno.land/x/smtp@v0.7.0/deps.ts": "5e2a437e3ae35f0e83719fd2e707858dcb750c1111ff5bebc729522a1380b53d",
-    "https://deno.land/x/smtp@v0.7.0/mod.ts": "9b0d8fbdacc184d1af10f727980e51486e0ddf9d2ec7227c8dfce90db5bfbcf5",
-    "https://deno.land/x/smtp@v0.7.0/smtp.ts": "47c72a99925ad07f3174037f9325dbb8b703dc1177277b9161dc6209c7fa4f90",
-    "https://deno.land/x/sql_builder@v1.9.1/util.ts": "b9855dc435972704cf82655019f4ec168ac83550ab4db596c5f6b6d201466384"
-  },
   "workspace": {
     "dependencies": [
-      "jsr:@std/assert@1",
-      "jsr:@std/cli@^1.0.22",
-      "jsr:@std/path@^1.1.2",
-      "jsr:@std/yaml@^1.0.9",
-      "npm:@octokit/plugin-retry@8",
-      "npm:@octokit/plugin-throttling@11",
-      "npm:@octokit/rest@22"
+      "jsr:@std/assert@^1.0.19",
+      "jsr:@std/cli@^1.0.32",
+      "jsr:@std/path@^1.1.6",
+      "jsr:@std/yaml@^1.2.0",
+      "npm:@octokit/plugin-retry@^8.1.1",
+      "npm:@octokit/plugin-throttling@^11.0.5",
+      "npm:@octokit/rest@^22.0.1",
+      "npm:mysql2@^3.11.5",
+      "npm:nodemailer@^6.9.16"
     ]
   }
 }

--- a/tools/reporters/ci/flaky-tests/utils/EmailClient.ts
+++ b/tools/reporters/ci/flaky-tests/utils/EmailClient.ts
@@ -20,10 +20,7 @@
  *   await mailer.sendText("from@example.com", "ops@example.com", "Ping", "Plain text body");
  */
 
-import {
-  SendConfig,
-  SMTPClient,
-} from "https://deno.land/x/denomailer@1.6.0/mod.ts";
+import nodemailer from "npm:nodemailer";
 import type { SmtpConfig } from "../core/types.ts";
 
 type Recipients = string | string[];
@@ -37,21 +34,19 @@ export class EmailClient {
     this.verbose = !!options?.verbose;
   }
 
-  private newClient() {
+  private newTransport() {
     if (this.verbose) {
       console.debug(
         `[email] connecting smtp://${this.cfg.host}:${this.cfg.port} secure=${this.cfg.secure}`,
       );
     }
-    const client = new SMTPClient({
-      connection: {
-        hostname: this.cfg.host,
-        port: this.cfg.port,
-        tls: this.cfg.secure,
-        auth: {
-          username: this.cfg.username!,
-          password: this.cfg.password!,
-        },
+    const transport = nodemailer.createTransport({
+      host: this.cfg.host,
+      port: this.cfg.port,
+      secure: this.cfg.secure,
+      auth: {
+        user: this.cfg.username!,
+        pass: this.cfg.password!,
       },
     });
     if (this.verbose) {
@@ -60,7 +55,7 @@ export class EmailClient {
       );
     }
 
-    return client;
+    return transport;
   }
 
   /**
@@ -82,31 +77,27 @@ export class EmailClient {
     if (!from) throw new Error("from is required");
     if (recipients.length === 0) throw new Error("to is required");
 
-    const client = this.newClient();
+    const transport = this.newTransport();
     try {
       if (this.verbose) {
         console.debug("[email] sending (html)", { from, to, cc, subject });
       }
 
-      const sendArgs: SendConfig = {
+      const mail: nodemailer.SendMailOptions = {
         from,
         to: recipients,
         subject,
         html,
       };
       if (cc) {
-        sendArgs.cc = this.normalizeRecipients(cc);
+        mail.cc = this.normalizeRecipients(cc);
       }
 
-      await client.send(sendArgs);
+      await transport.sendMail(mail);
       if (this.verbose) console.debug("[email] sent");
     } finally {
-      try {
-        await client.close();
-        if (this.verbose) console.debug("[email] closed");
-      } catch {
-        // ignore shutdown errors
-      }
+      transport.close();
+      if (this.verbose) console.debug("[email] closed");
     }
   }
 
@@ -129,7 +120,7 @@ export class EmailClient {
     if (!from) throw new Error("from is required");
     if (recipients.length === 0) throw new Error("to is required");
 
-    const client = this.newClient();
+    const transport = this.newTransport();
     try {
       if (this.verbose) {
         console.debug("[email] sending (text)", {
@@ -140,24 +131,20 @@ export class EmailClient {
         });
       }
 
-      const sendArgs: SendConfig = {
+      const mail: nodemailer.SendMailOptions = {
         from,
         to: recipients,
         subject,
-        content: text,
+        text,
       };
       if (cc) {
-        sendArgs.cc = this.normalizeRecipients(cc);
+        mail.cc = this.normalizeRecipients(cc);
       }
-      await client.send(sendArgs);
+      await transport.sendMail(mail);
       if (this.verbose) console.debug("[email] sent");
     } finally {
-      try {
-        await client.close();
-        if (this.verbose) console.debug("[email] closed");
-      } catch {
-        // ignore shutdown errors
-      }
+      transport.close();
+      if (this.verbose) console.debug("[email] closed");
     }
   }
 

--- a/tools/reporters/ci/flaky-tests/utils/db.ts
+++ b/tools/reporters/ci/flaky-tests/utils/db.ts
@@ -1,19 +1,19 @@
-import * as mysql from "https://deno.land/x/mysql@v2.12.1/mod.ts";
+import type { ConnectionOptions } from "npm:mysql2/promise";
 
-function convertDsnToClientConfig(dsn: string): mysql.ClientConfig {
+function convertDsnToClientConfig(dsn: string): ConnectionOptions {
   try {
     const url = new URL(dsn);
     if (url.protocol !== "mysql:") {
       throw new Error("Invalid DSN protocol. Expected 'mysql:'.");
     }
-    const config: mysql.ClientConfig = {
-      hostname: url.hostname,
+    const config: ConnectionOptions = {
+      host: url.hostname,
       port: Number(url.port),
-      username: decodeURIComponent(url.username),
+      user: decodeURIComponent(url.username),
       password: decodeURIComponent(url.password),
-      db: url.pathname.substring(1),
+      database: url.pathname.substring(1),
     };
-    if (!config.hostname || !config.port || !config.username || !config.db) {
+    if (!config.host || !config.port || !config.user || !config.database) {
       throw new Error(
         "Incomplete DSN. Must include user, host, port, and database.",
       );


### PR DESCRIPTION
## What

The flaky-tests reporter depends on two deno.land modules:

- `deno.land/x/mysql@v2.12.1` (used by `core/Database.ts`, `core/ConfigLoader.ts`, `utils/db.ts`)
- `deno.land/x/denomailer@1.6.0` (used by `utils/EmailClient.ts`)

Both pull in `deno.land/std` as transitive dependencies. Since 2026-08-13 the
deno.land CDN intermittently fails to serve these modules with a brotli
decompression error, e.g.:

```
error: Import 'https://deno.land/std@0.104.0/hash/_wasm/wasm.js' failed.
    0: brotli error
```

This makes the `periodic-reporter-flaky-tests-tidb` / `-v85` jobs fail before the
reporter logic even runs, including on reruns.

## Changes

- Replace `deno.land/x/mysql` with `npm:mysql2/promise`:
  - `new Client()` -> `createConnection()`
  - `client.close()` -> `client.end()`
  - `execute()` result `res.rows` -> destructured `[rows]`
  - config fields `hostname/username/db/tls` -> `host/user/database/ssl`
- Replace `deno.land/x/denomailer` with `npm:nodemailer`:
  - `SMTPClient.send()` -> `transport.sendMail()`
  - `client.close()` -> `transport.close()`
- Add `mysql2` / `nodemailer` to `deno.json` imports
- Regenerate `deno.lock` (all deno.land references removed)

All dependencies are now fetched from the npm registry (already used by
`@octokit/rest` etc.) and jsr.io, removing the deno.land dependency entirely.

## Verification

- `deno check main.ts` passes
- `deno test core/` passes (12 OwnerResolver + 11 GithubIssueManager tests)