### PR TITLE
feat(tekton): request kernel image sync after tidbx image delivery

### DIFF
--- a/tekton/v1/tasks/delivery/pingcap-notify-to-deliver-images-to-cloud-tidbx.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-notify-to-deliver-images-to-cloud-tidbx.yaml
@@ -108,7 +108,8 @@ spec:
           echo "✅ Delivery request posted for $stage: #$issue_number"
         done
 
-    - name: request-kernel-image-sync
+
+    - name: request-kernel-image-sync-dev
       args:
         - "$(params.publisher-url)"
       script: |
@@ -117,7 +118,7 @@ spec:
 
         publisher_url="$1"
 
-        for stage in dev prod; do
+        for stage in dev; do
           while read -r image; do
             [ -z "$image" ] && continue
             echo "🚀 Requesting kernel image sync for $image ($stage) ..."
@@ -125,7 +126,7 @@ spec:
             jq -n --arg stage "$stage" --arg image "$image" \
               '{ stage: $stage, image: $image }' > "$body_file"
             curl --fail -X POST -H "Content-Type: application/json" -d "@$body_file" \
-              "$publisher_url/tidbcloud/devops/kernel-images/build-callback"
+              "$publisher_url/tidbcloud/sync-kernel-images"
             rm -f "$body_file"
           done < <(yq '.images[]' /workspace/images.yaml)
         done

--- a/tekton/v1/tasks/delivery/pingcap-notify-to-deliver-images-to-cloud-tidbx.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-notify-to-deliver-images-to-cloud-tidbx.yaml
@@ -15,6 +15,10 @@ spec:
   params:
     - name: src
       description: images list
+    - name: publisher-url
+      type: string
+      description: publisher url
+      default: "http://publisher.publisher.svc"
   workspaces:
     - name: notify-config
       description: |
@@ -103,3 +107,27 @@ spec:
 
           echo "✅ Delivery request posted for $stage: #$issue_number"
         done
+
+    - name: request-kernel-image-sync
+      args:
+        - "$(params.publisher-url)"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        publisher_url="$1"
+
+        for stage in dev prod; do
+          while read -r image; do
+            [ -z "$image" ] && continue
+            echo "🚀 Requesting kernel image sync for $image ($stage) ..."
+            body_file=$(mktemp)
+            jq -n --arg stage "$stage" --arg image "$image" \
+              '{ stage: $stage, image: $image }' > "$body_file"
+            curl --fail -X POST -H "Content-Type: application/json" -d "@$body_file" \
+              "$publisher_url/tidbcloud/devops/kernel-images/build-callback"
+            rm -f "$body_file"
+          done < <(yq '.images[]' /workspace/images.yaml)
+        done
+
+        echo "🎉 Kernel image sync requests sent!"

--- a/tekton/v1/triggers/triggers/env-gcp/_/notify/notified-successful-image-delivery-tidbx.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/notify/notified-successful-image-delivery-tidbx.yaml
@@ -29,6 +29,8 @@ spec:
             params:
               - name: src
                 value: $(tt.params.data)
+              - name: publisher-url
+                value: "http://publisher.publisher.svc"
             taskRef:
               name: pingcap-notify-to-deliver-images-to-cloud-tidbx
             workspaces:


### PR DESCRIPTION
## What

After images are delivered to cloud tidbx, request kernel image sync via the new publisher API `tidbcloud.request-sync-kernel-image` (`POST /tidbcloud/devops/kernel-images/build-callback`).

## Changes

- `pingcap-notify-to-deliver-images-to-cloud-tidbx`: add `publisher-url` param and a new `request-kernel-image-sync` step that, for each stage (dev/prod) and each delivered image, posts `{stage, image}` to the publisher API. No image name filtering — all delivered tidbx images are treated as kernel images.
- `notified-successful-image-delivery-tidbx` trigger: pass `publisher-url` explicitly.

## Dependency

Depends on https://github.com/PingCAP-QE/ee-apps/pull/591 (publisher `request-sync-kernel-image` endpoint). Do not merge until that PR is merged and released.