### PR TITLE
refactor(pipelines): use Jenkins global vars for OCI artifact hosts

### DIFF
--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -63,7 +63,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -63,7 +63,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -61,7 +61,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -58,7 +58,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -60,7 +60,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -63,7 +63,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -64,7 +64,7 @@ pipeline {
                                     sh label: "download tidb components", script: """
                                         export script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
                                         chmod +x \$script
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                         \$script \
                                             --pd=${OCI_TAG_PD} \
                                             --pd-ctl=${OCI_TAG_PD} \

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_check2.groovy
@@ -20,7 +20,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_check2.groovy
@@ -20,7 +20,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
@@ -21,7 +21,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
@@ -21,7 +21,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_e2e_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')
@@ -66,7 +66,7 @@ pipeline {
                                 """
                                 sh label: 'download ticdc binary', script: """
                                     # download ticdc
-                                    OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \
+                                    OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \
                                     ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
                                         --ticdc-new=${OCI_TAG_TICDC}
                                 """

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_e2e_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_regression_test/pipeline.groovy
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_regression_test/pipeline.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 12, unit: 'HOURS')

--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_regression_test/pipeline.groovy
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_regression_test/pipeline.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 12, unit: 'HOURS')

--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pipeline.groovy
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pipeline.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 6, unit: 'HOURS')

--- a/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pipeline.groovy
+++ b/pipelines/pingcap-inc/tiflash-scripts/latest/pull_schrodinger_test/pipeline.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 6, unit: 'HOURS')

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -23,7 +23,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -56,7 +56,7 @@ pipeline {
                                 retry(2) {
                                     sh label: "download tidb", script: """
                                         script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                     """
                                     sh label: "download other tidb components", script: """
                                         script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -23,7 +23,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -23,7 +23,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -56,7 +56,7 @@ pipeline {
                                 retry(2) {
                                     sh label: "download tidb", script: """
                                         script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                     """
                                     sh label: "download other tidb components", script: """
                                         script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -23,7 +23,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -23,7 +23,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -55,7 +55,7 @@ pipeline {
                                 retry(2) {
                                     sh label: "download tidb", script: """
                                         script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                     """
                                     sh label: "download other tidb components", script: """
                                         script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -23,7 +23,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -23,7 +23,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')
@@ -56,7 +56,7 @@ pipeline {
                                 retry(2) {
                                     sh label: "download tidb", script: """
                                         script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh
-                                        OCI_ARTIFACT_HOST=us-docker.pkg.dev/pingcap-testing-account/internal \$script --tidb=${OCI_TAG_TIDB}
+                                        OCI_ARTIFACT_HOST=${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL} \$script --tidb=${OCI_TAG_TIDB}
                                     """
                                     sh label: "download other tidb components", script: """
                                         script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -23,7 +23,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -16,7 +16,7 @@ final TIDB_BIN_STASH_NAME = 'tidb-bin'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -16,7 +16,7 @@ final TIDB_BIN_STASH_NAME = 'tidb-bin'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -16,7 +16,7 @@ final TIDB_BIN_STASH_NAME = 'tidb-bin'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -16,7 +16,7 @@ final TIDB_BIN_STASH_NAME = 'tidb-bin'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -16,7 +16,7 @@ final TIDB_BIN_STASH_NAME = 'tidb-bin'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -16,7 +16,7 @@ final TIDB_BIN_STASH_NAME = 'tidb-bin'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -15,7 +15,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -15,7 +15,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -16,7 +16,7 @@ final TIDB_BIN_STASH_NAME = 'tidb-bin'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -16,7 +16,7 @@ final TIDB_BIN_STASH_NAME = 'tidb-bin'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -16,7 +16,7 @@ final TIDB_BIN_STASH_NAME = 'tidb-bin'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -16,7 +16,7 @@ final TIDB_BIN_STASH_NAME = 'tidb-bin'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -19,7 +19,7 @@ pipeline {
     agent none
     environment {
         NEXT_GEN = '1'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -19,7 +19,7 @@ pipeline {
     agent none
     environment {
         NEXT_GEN = '1'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -19,7 +19,7 @@ pipeline {
     agent none
     environment {
         NEXT_GEN = '1'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -19,7 +19,7 @@ pipeline {
     agent none
     environment {
         NEXT_GEN = '1'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -13,7 +13,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -13,7 +13,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -13,7 +13,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -13,7 +13,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
@@ -13,7 +13,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
@@ -13,7 +13,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -13,7 +13,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -13,7 +13,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -13,7 +13,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -13,7 +13,7 @@ final WORKSPACE_STASH_NAME = 'tidb-test-workspace'
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_integration_mysql_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_integration_mysql_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_jdbc_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,7 +25,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,7 +25,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,7 +25,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,7 +25,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
@@ -25,7 +25,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
@@ -25,7 +25,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -24,7 +24,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -24,7 +24,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
@@ -25,7 +25,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
@@ -25,7 +25,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -24,7 +24,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -24,7 +24,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
@@ -24,7 +24,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
@@ -24,7 +24,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
@@ -24,7 +24,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
@@ -24,7 +24,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
@@ -25,7 +25,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
@@ -25,7 +25,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -24,7 +24,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -24,7 +24,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -23,7 +23,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
@@ -25,7 +25,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
@@ -25,7 +25,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -24,7 +24,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -24,7 +24,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,7 +25,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,7 +25,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     agent none
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,7 +25,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,7 +25,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/latest/merged_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_common_test.groovy
@@ -20,8 +20,8 @@ pipeline {
     }
     environment {
         GITHUB_TOKEN = credentials('github-bot-token')
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-        OCI_ARTIFACT_HOST_COMMUNITY = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST_COMMUNITY = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
     environment {
         GITHUB_TOKEN = credentials('github-bot-token')
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
-        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
     environment {
         GITHUB_TOKEN = credentials('github-bot-token')
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
-        OCI_ARTIFACT_HOST_COMMUNITY = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_common_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
     environment {
         GITHUB_TOKEN = credentials('github-bot-token')
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
         OCI_ARTIFACT_HOST_COMMUNITY = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {

--- a/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_e2e_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -29,7 +29,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -29,7 +29,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {

--- a/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_copr_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
         GITHUB_TOKEN = credentials('github-bot-token')
     }
     options {

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_jdbc_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
@@ -27,7 +27,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
-        OCI_ARTIFACT_HOST_COMMUNITY = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
@@ -26,8 +26,8 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
-        OCI_ARTIFACT_HOST_COMMUNITY = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST_COMMUNITY = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
         OCI_ARTIFACT_HOST_COMMUNITY = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
     environment {
         GITHUB_TOKEN = credentials('github-bot-token')
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
     environment {
         GITHUB_TOKEN = credentials('github-bot-token')
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_python_orm_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_sqllogic_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_tiflash_integration_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
@@ -27,7 +27,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
@@ -25,7 +25,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
@@ -25,7 +25,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
@@ -28,7 +28,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
@@ -28,7 +28,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -30,7 +30,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -30,7 +30,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
@@ -33,7 +33,7 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
@@ -33,7 +33,7 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1'
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -26,7 +26,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1'
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_tiflash_integration_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.2/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.3/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.4/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
         ENABLE_FIPS = 1
     }
     options {

--- a/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5-fips/pull_br_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
         ENABLE_FIPS = 1
     }
     options {

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-6.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_e2e_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_e2e_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_binlog_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_binlog_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_copr_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_copr_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_ddl_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_jdbc_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_mysql_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_tidb_tools_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-6.5/pull_integration_tidb_tools_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-6.6/ghpr_check2.groovy
@@ -18,7 +18,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.0/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_binlog_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_binlog_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.2/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.3/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.4/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_binlog_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_binlog_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.6/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.0/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.0/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.1/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/ghpr_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_binlog_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_binlog_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_binlog_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.2/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.2/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_br_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_lightning_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.2/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.2/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.3/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.3/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_br_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_lightning_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.3/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.3/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.4/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.4/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_br_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_lightning_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.4/pull_tiflash_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.4/pull_tiflash_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-8.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_e2e_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_check2.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_check2.groovy
@@ -19,7 +19,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     stages {
         stage('Checkout & Prepare') {

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_e2e_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_common_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_copr_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_copr_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_ddl_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_e2e_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_e2e_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_e2e_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_jdbc_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
@@ -19,7 +19,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_mysql_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 75, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_python_orm_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_tidb_tools_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_tidb_tools_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -29,7 +29,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -29,7 +29,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
@@ -20,7 +20,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -24,7 +24,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -24,7 +24,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -24,7 +24,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -24,7 +24,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-7.1/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-7.1/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-7.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_unit_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-7.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_unit_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.1/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.1/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.2/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.2/pull_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.2/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.2/pull_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.2/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.2/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.2/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.2/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.3/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.3/pull_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.3/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.3/pull_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.3/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.3/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.3/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.3/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.4/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.4/pull_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.4/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.4/pull_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.4/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.4/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.4/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.4/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
@@ -27,7 +27,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
@@ -27,7 +27,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_unit_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_unit_test.groovy
@@ -27,7 +27,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
@@ -26,7 +26,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_unit_test.groovy
@@ -25,7 +25,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -21,7 +21,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -21,7 +21,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -21,7 +21,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -21,7 +21,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -21,7 +21,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -21,7 +21,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -21,7 +21,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -21,7 +21,7 @@ prow.setPRDescription(REFS)
 pipeline {
     agent none
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -24,7 +24,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -24,7 +24,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
         NEXT_GEN = '1'
     }
     options {

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -23,7 +23,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
         NEXT_GEN = '1'
     }
     options {

--- a/pipelines/pingcap/tiflow/latest/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_syncdiff_integration_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_syncdiff_integration_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.2/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_compatibility_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1.0/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_cdc_integration_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_kafka_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_mysql_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/ghpr_verify.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_kafka_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_mysql_test.groovy
@@ -16,7 +16,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/ghpr_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -17,7 +17,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_syncdiff_integration_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_syncdiff_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_syncdiff_integration_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_verify.groovy
@@ -18,7 +18,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
@@ -19,7 +19,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_common_test.groovy
@@ -19,7 +19,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_jdbc_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
@@ -19,7 +19,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_nodejs_test.groovy
@@ -19,7 +19,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_python_orm_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
@@ -19,7 +19,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_ruby_orm_test.groovy
@@ -19,7 +19,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
@@ -19,7 +19,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_integration_sequelize_test.groovy
@@ -19,7 +19,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/merged_sqllogic_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_common_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_jdbc_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_nodejs_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_python_orm_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_integration_ruby_orm_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_connector_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_connector_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_connector_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_connector_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_mysql_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
 
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 45, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
     environment {
         CI = "1"
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
+++ b/pipelines/pingcap/tiproxy/latest/pull_sqllogic_test.groovy
@@ -20,7 +20,7 @@ pipeline {
     }
     environment {
         CI = "1"
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/qa/qa-release-br-integration-test.groovy
+++ b/pipelines/qa/qa-release-br-integration-test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/qa/qa-release-br-integration-test.groovy
+++ b/pipelines/qa/qa-release-br-integration-test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/qa/qa-release-lightning-integration-test.groovy
+++ b/pipelines/qa/qa-release-lightning-integration-test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/qa/qa-release-lightning-integration-test.groovy
+++ b/pipelines/qa/qa-release-lightning-integration-test.groovy
@@ -20,7 +20,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -31,7 +31,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
     }
     stages {
         stage('Checkout') {

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -31,7 +31,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
     }
     stages {
         stage('Checkout') {

--- a/pipelines/tikv/copr-test/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/copr-test/latest/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/copr-test/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/copr-test/latest/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
@@ -30,7 +30,7 @@ pipeline {
         // tidb-server: hub-zot.pingcap.net/mirrors/hub/pingcap/tidb/package:<tag>_linux_amd64
         // tikv-server: hub-zot.pingcap.net/mirrors/hub/tikv/tikv/package:<tag>_linux_amd64
         // pd-server:   hub-zot.pingcap.net/mirrors/hub/tikv/pd/package:<tag>_linux_amd64
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
@@ -30,7 +30,7 @@ pipeline {
         // tidb-server: hub-zot.pingcap.net/mirrors/hub/pingcap/tidb/package:<tag>_linux_amd64
         // tikv-server: hub-zot.pingcap.net/mirrors/hub/tikv/tikv/package:<tag>_linux_amd64
         // pd-server:   hub-zot.pingcap.net/mirrors/hub/tikv/pd/package:<tag>_linux_amd64
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/tikv/migration/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_test.groovy
@@ -30,7 +30,7 @@ pipeline {
         // tidb-server: hub-zot.pingcap.net/mirrors/hub/pingcap/tidb/package:<tag>_linux_amd64
         // tikv-server: hub-zot.pingcap.net/mirrors/hub/tikv/tikv/package:<tag>_linux_amd64
         // pd-server:   hub-zot.pingcap.net/mirrors/hub/tikv/pd/package:<tag>_linux_amd64
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/tikv/migration/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_test.groovy
@@ -30,7 +30,7 @@ pipeline {
         // tidb-server: hub-zot.pingcap.net/mirrors/hub/pingcap/tidb/package:<tag>_linux_amd64
         // tikv-server: hub-zot.pingcap.net/mirrors/hub/tikv/tikv/package:<tag>_linux_amd64
         // pd-server:   hub-zot.pingcap.net/mirrors/hub/tikv/pd/package:<tag>_linux_amd64
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_copr_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -33,7 +33,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
     }
     stages {
         stage('Checkout') {

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -33,7 +33,7 @@ pipeline {
     }
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/tidbx'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_TIDBX
     }
     stages {
         stage('Checkout') {

--- a/pipelines/tikv/pd/release-7.1/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-7.1/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-7.1/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-7.1/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-7.5/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-7.5/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-7.5/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-7.5/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-8.1/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-8.1/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-8.1/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-8.1/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-8.5/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-8.5/pull_integration_copr_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-8.5/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-8.5/pull_integration_copr_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-9.0-beta/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-9.0-beta/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/pd/release-9.0-beta/pull_integration_copr_test.groovy
+++ b/pipelines/tikv/pd/release-9.0-beta/pull_integration_copr_test.groovy
@@ -19,7 +19,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-6.5/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-6.5/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-6.5/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-6.5/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-7.1/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-7.1/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-7.1/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-7.1/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-7.5/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-7.5/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-7.5/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-7.5/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-8.1/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-8.1/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = 'us-docker.pkg.dev/pingcap-testing-account/hub'
+        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
     }
     options {
         timeout(time: 50, unit: 'MINUTES')

--- a/pipelines/tikv/tikv/release-8.1/pull_integration_test.groovy
+++ b/pipelines/tikv/tikv/release-8.1/pull_integration_test.groovy
@@ -21,7 +21,7 @@ pipeline {
         }
     }
     environment {
-        OCI_ARTIFACT_HOST = env._JENKINS_OCI_ARTIFACT_HOST_HUB
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 50, unit: 'MINUTES')


### PR DESCRIPTION
### What
Replace hardcoded OCI artifact hosts in pipelines with Jenkins global environment variables (`env._JENKINS_OCI_ARTIFACT_HOST_*`):

| Old value | New reference |
|---|---|
| `us-docker.pkg.dev/pingcap-testing-account/hub` (329 occurrences) | `env._JENKINS_OCI_ARTIFACT_HOST_HUB` |
| `us-docker.pkg.dev/pingcap-testing-account/tidbx` (27 occurrences) | `env._JENKINS_OCI_ARTIFACT_HOST_TIDBX` |
| `us-docker.pkg.dev/pingcap-testing-account/internal` (12 occurrences, inline in sh) | `${env._JENKINS_OCI_ARTIFACT_HOST_INTERNAL}` |
| `OCI_ARTIFACT_HOST_COMMUNITY` (2 occurrences) | `env._JENKINS_OCI_ARTIFACT_HOST_HUB` |

356 files changed, 370 replacements, all under `pipelines/`.

### Why
Jenkins instances on different clouds (gcp/tencentcloud) need different OCI repository addresses (gcp uses `us-docker.pkg.dev/...`, tencentcloud uses `cr-qcloud.pingcap.net/mirrors/...`). With Jenkins global variable injection, pipeline code no longer needs to know which cloud it runs on.

### Dependencies
- ⚠️ **Depends on [PingCAP-QE/ee-ops#2217](https://github.com/PingCAP-QE/ee-ops/pull/2217)**: that PR declares these global variables on each Jenkins instance. This PR must only be merged after that one takes effect, otherwise `env._JENKINS_OCI_ARTIFACT_HOST_*` will be empty and artifact downloads will fail.
- Suggested merge order: merge ee-ops#2217 first, wait for Flux to sync (~5 min), then merge this PR.

### Note
- `pipelines/pingcap/tidb/release-6.5/pull_tiflash_test.groovy:76` uses `docker build -t us-docker.pkg.dev/pingcap-testing-account/hub/...` (image push, not download) and is out of scope for this change; it can be handled separately later.
- `jenkins/pipelines/cd/` references the GCP registry for image pushes (CD scope) and is not modified.