### PR TITLE
fix(tekton): make github event simulation deliver events to the event listener

### DIFF
--- a/tekton/tests/test-github-events.ts
+++ b/tekton/tests/test-github-events.ts
@@ -48,6 +48,7 @@ async function generatePushEventPayload(
   return {
     before: "0000000000000000000000000000000000000000",
     after: await getCommitSha(owner, repoName!, ref, client),
+    created: false,
     ref,
     repository: {
       name: repoName!,
@@ -121,18 +122,24 @@ async function sendGithubEvent(
   console.dir(fetchInit);
   console.dir(fetchInit.body);
 
-  await fetch(eventUrl, fetchInit);
+  if (!eventPayload) {
+    throw new Error(`Unsupported event type: ${eventType}`);
+  }
+
+  const response = await fetch(eventUrl, fetchInit);
+  console.log("Response status:", response.status);
+  console.log("Response body:", await response.text());
 }
 
 async function main(args: CliParams) {
   const gitUrl = args.url;
   const ref = args.ref || "refs/heads/master";
-  const eventUrl = args.eventUrl || "https://example.com";
+  const eventUrl = args.eventUrl;
   const eventType = args.eventType || "push";
 
   const usage =
-    "Usage: deno run script.ts --token <github-token> --url <git-url> --eventType push|create [--ref <ref>] [--eventUrl <event-url>]";
-  if (!gitUrl || !args.token) {
+    "Usage: deno run script.ts --token <github-token> --url <git-url> --eventType push|create [--ref <ref>] --eventUrl <event-url>";
+  if (!gitUrl || !args.token || !eventUrl) {
     console.error(usage);
     Deno.exit(1);
   }
@@ -144,6 +151,11 @@ async function main(args: CliParams) {
   await sendGithubEvent(eventType, gitUrl, ref, eventUrl, octokit);
 }
 
-const args = parseArgs(Deno.args) as CliParams;
+const args = parseArgs(Deno.args, {
+  alias: {
+    "event-type": "eventType",
+    "event-url": "eventUrl",
+  },
+}) as CliParams;
 await main(args);
 Deno.exit();


### PR DESCRIPTION
## Summary

The GitHub event simulation script `tekton/tests/test-github-events.ts` failed to trigger any PipelineRun when invoked with kebab-case flags:

```bash
deno run --allow-all tekton/tests/test-github-events.ts   --token=... --url=https://github.com/tikv/pd.git   --ref=refs/heads/release-nextgen-202603   --event-type=push --event-url=http://localhost:8080
```

## Root cause

`parseArgs` from `@std/cli` does not map kebab-case flags (`--event-url`, `--event-type`) to the camelCase fields (`eventUrl`, `eventType`) the script reads. As a result `eventUrl` fell back to the default `https://example.com` and the simulated event was POSTed there instead of to the EventListener, so no PipelineRun was created.

## Changes

- Map kebab-case flags to camelCase fields via `parseArgs` aliases, so both `--eventUrl` and `--event-url` work
- Require `--eventUrl` instead of silently defaulting to `https://example.com`
- Include `created: false` in the push payload so the EventListener group interceptor (`body.created == false`) accepts the event
- Print the HTTP response status and body so future failures are visible immediately

## Verification

- `deno check tekton/tests/test-github-events.ts` passes
- A simulated push (tikv/pd, `refs/heads/release-nextgen-202603`) against the `el-github` EventListener in `ee-cd` successfully created `bp-pd-nextgen-linux-amd64-*` and `bp-pd-nextgen-linux-arm64-*` PipelineRuns