### PR TITLE
fix(scripts): skip creating empty OWNERS sync PRs

### DIFF
--- a/scripts/pingcap/community/prow-owners-updater.ts
+++ b/scripts/pingcap/community/prow-owners-updater.ts
@@ -283,12 +283,16 @@ class RepoUpdater {
     }
 
     if (mergedRepoProwOwners.owners["/"]) {
+      // compare against the merged result: the repo's OWNERS_ALIASES usually
+      // contains extra manually-maintained aliases beyond the synced
+      // 'sig-community-*' ones, so comparing current against the new subset
+      // would never be equal and empty PRs would be created.
       const rootIsSame = sameObjects(
         curRepoProwOwners.owners["/"],
-        newRepoProwOwners.owners["/"],
+        mergedRepoProwOwners.owners["/"],
       ) && sameObjects(
         curRepoProwOwners.aliases,
-        newRepoProwOwners.aliases,
+        mergedRepoProwOwners.aliases,
       );
 
       if (rootIsSame) {
@@ -305,7 +309,22 @@ class RepoUpdater {
     const updateFileAndContents = await this.toUpdateFileAndContents(
       mergedRepoProwOwners,
     );
-    if (Object.keys(updateFileAndContents).length == 0) {
+
+    // Drop files whose content is identical to the base branch, otherwise the
+    // contents API creates empty commits and a PR with no file changes.
+    const changedFileAndContents: Record<string, string> = {};
+    for (const [filePath, content] of Object.entries(updateFileAndContents)) {
+      const currentContent = await this.getFileContent(filePath);
+      if (currentContent === content) {
+        console.debug(
+          `content of file '${filePath}' is unchanged for repo ${this.owner}/${this.repo}, skip.`,
+        );
+        continue;
+      }
+      changedFileAndContents[filePath] = content;
+    }
+
+    if (Object.keys(changedFileAndContents).length == 0) {
       console.debug(
         `🏃 no need to create PR for repo ${this.owner}/${this.repo}: no differences found`,
       );
@@ -325,7 +344,7 @@ class RepoUpdater {
     );
 
     await Promise.all(
-      Object.entries(updateFileAndContents).map(
+      Object.entries(changedFileAndContents).map(
         async ([filePath, content], index) => {
           // wait for some seconds to avoid conflicts on fetch the sha of file blob.
           await new Promise((resolve) => setTimeout(resolve, 5000 * index));

--- a/scripts/pingcap/community/prow-owners.ts
+++ b/scripts/pingcap/community/prow-owners.ts
@@ -153,8 +153,8 @@ function sameObjects(a: object, b: object) {
   return orderJSONStringify(a) === orderJSONStringify(b);
 }
 
-function orderJSONStringify(owners: object) {
-  const sortedArray = Object.entries(owners).sort(([keyA], [keyB]) =>
+function orderJSONStringify(owners?: object) {
+  const sortedArray = Object.entries(owners ?? {}).sort(([keyA], [keyB]) =>
     keyA.localeCompare(keyB)
   );
   const sortedDictionary = Object.fromEntries(sortedArray);


### PR DESCRIPTION
### Problem
The `create-updating-owners-pr` prow job sometimes creates PRs with **no file changes** (e.g. pingcap/kvproto#1521, which had 2 commits and 0 changed files).

Two bugs in `scripts/pingcap/community/prow-owners-updater.ts`:

1. The no-op guard compared `curRepoProwOwners.aliases` (the repo's **full** `OWNERS_ALIASES`, including manually-maintained aliases like `sig-approvers`, `emeritus-approvers`, `sig-approvers-pb-*`) against `newRepoProwOwners.aliases` (only the synced `sig-community-*` subset). For repos like kvproto these are never equal, so the early-return never fired.
2. Every generated file was written unconditionally via the contents API. When the content was byte-identical to the base branch, GitHub still created an empty commit, producing a PR with zero file changes.

### Solution
- Compare current state against the **merged** result, so the no-op guard works even when the repo has extra manual aliases.
- Filter generated files per-file against the current base-branch content; skip unchanged files, and skip the PR entirely if nothing actually differs.
- Make `orderJSONStringify` null-safe (`prow-owners.ts`), since a repo may have no root `OWNERS` yet.

### Verification
- `deno check` passes on both modified files.