### PR TITLE
refactor(tekton): extract request-kernel-image-sync step into StepAction

### DIFF
--- a/tekton/v1/step-actions/kustomization.yaml
+++ b/tekton/v1/step-actions/kustomization.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - request-kernel-image-sync.yaml

--- a/tekton/v1/step-actions/request-kernel-image-sync.yaml
+++ b/tekton/v1/step-actions/request-kernel-image-sync.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1beta1
+kind: StepAction
+metadata:
+  name: request-kernel-image-sync
+  labels:
+    app.kubernetes.io/version: "0.1.0"
+  annotations:
+    tekton.dev/pipelines.minVersion: "1.0.0"
+    tekton.dev/categories: delivery
+    tekton.dev/tags: images,delivery,cloud,tidbx
+    tekton.dev/displayName: "Request kernel image sync"
+    tekton.dev/platforms: "linux/amd64,linux/arm64"
+spec:
+  description: Request kernel image sync to cloud regions via publisher
+  params:
+    - name: src
+      description: images list
+    - name: publisher-url
+      type: string
+      description: publisher url
+      default: "http://publisher.publisher.svc"
+  env:
+    - name: IMAGES_SRC
+      value: $(params.src)
+    - name: PUBLISHER_URL
+      value: $(params.publisher-url)
+  image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.26-5-ge8130cb
+  script: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    printf '%s\n' "$IMAGES_SRC" > /workspace/images.yaml
+
+    for stage in dev prod; do
+      while read -r image; do
+        [ -z "$image" ] && continue
+        echo "🚀 Requesting kernel image sync for $image ($stage) ..."
+        body_file=$(mktemp)
+        jq -n --arg stage "$stage" --arg image "$image" \
+          '{ stage: $stage, image: $image }' > "$body_file"
+        curl --fail -X POST -H "Content-Type: application/json" -d "@$body_file" \
+          "$PUBLISHER_URL/tidbcloud/sync-kernel-images"
+        rm -f "$body_file"
+      done < <(yq '.images[]' /workspace/images.yaml)
+    done
+
+    echo "🎉 Kernel image sync requests sent!"

--- a/tekton/v1/tasks/delivery/pingcap-notify-to-deliver-images-to-cloud-tidbx.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-notify-to-deliver-images-to-cloud-tidbx.yaml
@@ -108,27 +108,12 @@ spec:
           echo "✅ Delivery request posted for $stage: #$issue_number"
         done
 
-
-    - name: request-kernel-image-sync-dev
-      args:
-        - "$(params.publisher-url)"
-      script: |
-        #!/usr/bin/env bash
-        set -euo pipefail
-
-        publisher_url="$1"
-
-        for stage in dev; do
-          while read -r image; do
-            [ -z "$image" ] && continue
-            echo "🚀 Requesting kernel image sync for $image ($stage) ..."
-            body_file=$(mktemp)
-            jq -n --arg stage "$stage" --arg image "$image" \
-              '{ stage: $stage, image: $image }' > "$body_file"
-            curl --fail -X POST -H "Content-Type: application/json" -d "@$body_file" \
-              "$publisher_url/tidbcloud/sync-kernel-images"
-            rm -f "$body_file"
-          done < <(yq '.images[]' /workspace/images.yaml)
-        done
-
-        echo "🎉 Kernel image sync requests sent!"
+    # Disabled: request kernel image sync step until the upstream service is ready.
+    # - name: request-kernel-image-sync
+    #   ref:
+    #     name: request-kernel-image-sync
+    #   params:
+    #     - name: src
+    #       value: $(params.src)
+    #     - name: publisher-url
+    #       value: $(params.publisher-url)


### PR DESCRIPTION
## What

- Add a reusable `tekton.dev/v1beta1` `StepAction` `request-kernel-image-sync` under `tekton/v1/step-actions/`
- Update `pingcap-notify-to-deliver-images-to-cloud-tidbx` task to reference the StepAction instead of an inlined step
- Temporarily disable the step (commented out) until the upstream `sync-kernel-images` service is ready

## Why

- StepAction is the reusable unit for a `Step`; the task now composes instead of duplicating the script
- Upstream publisher endpoint `/tidbcloud/sync-kernel-images` is not ready yet, so the step stays disabled

## Notes

- `apiVersion` is `tekton.dev/v1beta1` because StepAction has never been served as `tekton.dev/v1` in any Tekton release; all our clusters run v1.3.1 which serves `v1beta1` (storage)
- StepAction params are passed via `env` since `params` cannot be referenced directly inside StepAction `script`
- Validated with `kubectl apply --dry-run=server` and `kubectl kustomize`

## Validation

- [x] `kubectl apply --dry-run=server` for StepAction and Task
- [x] `kubectl kustomize tekton/v1/step-actions`, `tekton/v1/tasks`
- [x] `.ci/update-tekton-kustomizations.sh`