### PR TITLE
fix(prow-jobs): use serviceAccountName field for ee-infra gcp terraform job

### DIFF
--- a/prow-jobs/pingcap-qe/ee-infra/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ee-infra/presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       branches:
         - ^main$
       spec:
-        service_account_name: terraform-plan-reader
+        serviceAccountName: terraform-plan-reader
         containers:
           - name: main
             image: ghcr.io/opentofu/opentofu:1.12


### PR DESCRIPTION
The ee-infra gcp terraform presubmit used `service_account_name` (snake_case) which prow silently drops when parsing the pod spec (the field is `serviceAccountName`), so the job always ran as the unbound default KSA and failed `tofu plan` with 403 IAM_PERMISSION_DENIED.

Switch to the correct `serviceAccountName` field so the job runs as the `terraform-plan-reader` service account, which already has the required project roles (artifactregistry.reader, iam.securityReviewer, etc.).