### PR TITLE
feat(tekton): send kernel image sync images array per stage

### DIFF
--- a/tekton/v1/step-actions/request-kernel-image-sync.yaml
+++ b/tekton/v1/step-actions/request-kernel-image-sync.yaml
@@ -31,17 +31,20 @@ spec:
 
     printf '%s\n' "$IMAGES_SRC" > /workspace/images.yaml
 
+    images_json=$(yq -o=json '.images // []' /workspace/images.yaml)
+    if [ "$images_json" = "[]" ]; then
+      echo "⚠️ No images to sync, skipping."
+      exit 0
+    fi
+
     for stage in dev prod; do
-      while read -r image; do
-        [ -z "$image" ] && continue
-        echo "🚀 Requesting kernel image sync for $image ($stage) ..."
-        body_file=$(mktemp)
-        jq -n --arg stage "$stage" --arg image "$image" \
-          '{ stage: $stage, image: $image }' > "$body_file"
-        curl --fail -X POST -H "Content-Type: application/json" -d "@$body_file" \
-          "$PUBLISHER_URL/tidbcloud/sync-kernel-images"
-        rm -f "$body_file"
-      done < <(yq '.images[]' /workspace/images.yaml)
+      echo "🚀 Requesting kernel image sync for stage $stage ..."
+      body_file=$(mktemp)
+      jq -n --arg stage "$stage" --argjson images "$images_json" \
+        '{ stage: $stage, images: $images }' > "$body_file"
+      curl --fail -X POST -H "Content-Type: application/json" -d "@$body_file" \
+        "$PUBLISHER_URL/tidbcloud/sync-kernel-images"
+      rm -f "$body_file"
     done
 
     echo "🎉 Kernel image sync requests sent!"


### PR DESCRIPTION
## Summary

The publisher `/tidbcloud/sync-kernel-images` endpoint (`request-sync-kernel-image`) changed its payload from a single `image` to an `images` array so multiple images built from the same repo commit are synced in one request (PingCAP-QE/ee-apps#609).

## Changes

`tekton/v1/step-actions/request-kernel-image-sync.yaml`:
- Batch all images from `src` into one request per stage using `{ stage, images: [...] }` instead of one request per image.
- Skip the call when the images list is empty.

## Notes

The upstream endpoint requires all images in one request to share the same repo commit. The step action receives a flat image list via `src`, so it assumes the caller groups images by commit; otherwise the publisher rejects the request.

## Validation

`kubectl kustomize tekton/v1/step-actions` renders cleanly. The yq/jq payload construction was verified locally.