### PR TITLE
refactor(pipelines): drop manual tidbx-docker-config ~/.docker copies

### DIFF
--- a/.ci/replay-jenkins-build.sh
+++ b/.ci/replay-jenkins-build.sh
@@ -143,38 +143,87 @@ build_inline_script_with_pod_yaml() {
     local script_file="$1"
     local pod_template_file="$2"
     local out_file="$3"
-    local pod_b64
-    pod_b64="$(base64 < "$pod_template_file" | tr -d '\n')"
 
-    # Build the replacement string in shell and use portable awk/sub() to perform the substitution.
-    # If no substitution is performed, exit with status 2 to preserve previous behavior.
-    local repl
-    repl="yaml new String(java.util.Base64.decoder.decode(\"${pod_b64}\"), 'UTF-8')"
+    # Collect pod template variable declarations (final/def VAR = '<pipeline-relative path>') from the
+    # pipeline script, mapping each variable to its declared pod yaml. This handles pipelines that use
+    # more than one pod template (e.g. tiflash pull_integration_test uses POD_TEMPLATE_FILE for the
+    # build phase and POD_INTEGRATIONTEST_TEMPLATE_FILE for the integration-test phase).
+    # Regexes are stored in variables for bash 3.2 compatibility with [[ =~ ]].
+    local decl_re="^[[:space:]]*(final|def)[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*[\"']([^\"']+\.ya?ml)[\"'][[:space:]]*$"
+    local yaml_file_re="(^|[^A-Za-z0-9_])yamlFile[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*(#.*)?$"
+    local with_ci_labels_re="(.*)yaml[[:space:]]+pod_label\.withCiLabels\([[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*,[[:space:]]*(.*)\)([[:space:]]*#.*)?[[:space:]]*$"
+    local -a pod_vars=()
+    local -a pod_b64s=()
+    local decl_line var path
+    while IFS= read -r decl_line; do
+        if [[ "$decl_line" =~ $decl_re ]]; then
+            var="${BASH_REMATCH[2]}"
+            path="${BASH_REMATCH[3]}"
+            if [[ "$path" == pipelines/* && -f "$path" ]]; then
+                pod_vars+=("$var")
+                pod_b64s+=("$(base64 < "$path" | tr -d '\n')")
+            fi
+        fi
+    done < "$script_file"
 
-    awk -v repl="$repl" '
-    BEGIN {
-        found=0
-        # Core patterns for legacy/new declarative forms.
-        p1 = "yamlFile[[:space:]]+POD_TEMPLATE_FILE"
-        p2 = "yaml[[:space:]]+pod_label\\.withCiLabels\\([[:space:]]*POD_TEMPLATE_FILE[[:space:]]*,[[:space:]]*REFS[[:space:]]*\\)"
-        suffix = "([[:space:]]*#.*)?[[:space:]]*$"
+    # Fallback b64 for the single-pod-template case (variable declared elsewhere or file missing).
+    # Matches the previous behavior: substitute only POD_TEMPLATE_FILE on the first occurrence.
+    local fallback_b64=""
+    if (( ${#pod_vars[@]} == 0 )); then
+        fallback_b64="$(base64 < "$pod_template_file" | tr -d '\n')"
+    fi
+
+    pod_var_b64() {
+        local v="$1" i n="${#pod_vars[@]}"
+        for (( i = 0; i < n; i++ )); do
+            if [[ "${pod_vars[$i]}" == "$v" ]]; then
+                printf '%s' "${pod_b64s[$i]}"
+                return 0
+            fi
+        done
+        return 1
     }
-    {
-        line = $0
+
+    local found=0
+    : > "$out_file"
+    local line out_line b64 prefix comment repl
+    while IFS= read -r line; do
+        out_line="$line"
         # Declarative form before ci-label migration (allow trailing inline comments).
-        if (line ~ ("^[[:space:]]*" p1 suffix)) {
-            sub(p1, repl, line)
-            found = 1
+        if [[ "$line" =~ $yaml_file_re ]]; then
+            var="${BASH_REMATCH[2]}"
+            b64="$(pod_var_b64 "$var" || true)"
+            if [[ -z "$b64" && -n "$fallback_b64" && "$var" == "POD_TEMPLATE_FILE" && "$found" == "0" ]]; then
+                b64="$fallback_b64"
+            fi
+            if [[ -n "$b64" ]]; then
+                out_line="${line/yamlFile ${var}/yaml new String(java.util.Base64.decoder.decode(\"${b64}\"), 'UTF-8')}"
+                found=1
+            fi
         # Declarative form after ci-label migration (allow trailing inline comments).
-        } else if (line ~ ("^[[:space:]]*" p2 suffix)) {
-            sub(p2, repl, line)
-            found = 1
-        }
-        print line
-    }
-    END {
-        if (found == 0) exit 2
-    }' "$script_file" > "$out_file"
+        elif [[ "$line" =~ $with_ci_labels_re ]]; then
+            var="${BASH_REMATCH[2]}"
+            b64="$(pod_var_b64 "$var" || true)"
+            if [[ -z "$b64" && -n "$fallback_b64" && "$var" == "POD_TEMPLATE_FILE" && "$found" == "0" ]]; then
+                b64="$fallback_b64"
+            fi
+            if [[ -n "$b64" ]]; then
+                prefix="${BASH_REMATCH[1]}"
+                comment="${BASH_REMATCH[4]}"
+                repl="yaml new String(java.util.Base64.decoder.decode(\"${b64}\"), 'UTF-8')"
+                out_line="${prefix}${repl}"
+                [[ -n "$comment" ]] && out_line+=" ${comment}"
+                found=1
+            fi
+        fi
+        printf '%s\n' "$out_line" >> "$out_file"
+    done < "$script_file"
+
+    if (( found == 0 )); then
+        rm -f "$out_file"
+        return 2
+    fi
+    return 0
 }
 
 prepare_script_for_replay() {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -58,12 +58,6 @@ pipeline {
                     // Prepare component binaries.
                     dir('bin') {
                         container("utils") {
-                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                sh label: "prepare docker auth", script: '''
-                                    mkdir -p ~/.docker
-                                    cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                                '''
-                            }
                             sh """
                                 script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
                                 chmod +x \$script

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -58,12 +58,6 @@ pipeline {
                     // Prepare component binaries.
                     dir('bin') {
                         container("utils") {
-                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                sh label: "prepare docker auth", script: '''
-                                    mkdir -p ~/.docker
-                                    cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                                '''
-                            }
                             sh """
                                 script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
                                 chmod +x \$script

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
@@ -58,12 +58,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -58,12 +58,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
@@ -58,12 +58,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -58,12 +58,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
@@ -55,12 +55,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -55,12 +55,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
@@ -55,12 +55,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -55,12 +55,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
@@ -57,12 +57,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -57,12 +57,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
@@ -57,12 +57,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -57,12 +57,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
@@ -58,12 +58,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -58,12 +58,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
@@ -58,12 +58,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -58,12 +58,6 @@ pipeline {
                     }
                     // Download other binaries
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir("bin") {
                             script {
                                 retry(2) {

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test_next_gen/pipeline.groovy
@@ -50,12 +50,6 @@ pipeline {
                     sh label: 'br test binary', script: 'make build_for_br_integration_test'
                     dir('bin') {
                         container("utils") {
-                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                sh label: "prepare docker auth", script: '''
-                                    mkdir -p ~/.docker
-                                    cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                                '''
-                            }
                             sh """
                                 script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
                                 chmod +x \$script

--- a/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_ddl_test_next_gen/pipeline.groovy
@@ -61,12 +61,6 @@ pipeline {
                 dir('tidb-test') {
                     dir('bin') {
                         container('utils') {
-                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                sh label: 'prepare docker auth', script: '''
-                                    mkdir -p ~/.docker
-                                    cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                                '''
-                            }
                             sh label: 'download binary', script: """
                                 script="${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
                                 chmod +x \$script

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
@@ -47,12 +47,6 @@ pipeline {
             steps {
                 dir("${REFS.repo}/tests/integrationtest2/third_bin") {
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         sh """
                             script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"
                             chmod +x \$script

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -56,12 +56,6 @@ pipeline {
                         sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
                     }
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir('bin') {
                             sh """
                                 script="\${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh"

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -242,45 +242,41 @@ pipeline {
                                         "MINIO_IMAGE=quay.io/minio/minio:${MINIO_VERSION}",
                                         "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
                                     ]) {
-                                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                            sh label: "prepare docker images", script: '''
-                                                    set -eux
-                                                    mkdir -p ~/.docker
-                                                    cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
-                                                    for i in $(seq 1 30); do
-                                                        if docker version; then
-                                                            break
-                                                        fi
-                                                        sleep 2
-                                                    done
-                                                    docker ps -a
+    sh label: "prepare docker images", script: '''
+            set -eux
+            for i in $(seq 1 30); do
+                if docker version; then
+                    break
+                fi
+                sleep 2
+            done
+            docker ps -a
 
-                                                    timeout 300 docker pull "${PD_IMAGE}"
-                                                    timeout 300 docker pull "${TIKV_IMAGE}"
-                                                    timeout 300 docker pull "${TIDB_IMAGE}"
-                                                    timeout 300 docker pull "${MINIO_IMAGE}"
-                                                    timeout 600 docker pull "${TIFLASH_IMAGE}"
+            timeout 300 docker pull "${PD_IMAGE}"
+            timeout 300 docker pull "${TIKV_IMAGE}"
+            timeout 300 docker pull "${TIDB_IMAGE}"
+            timeout 300 docker pull "${MINIO_IMAGE}"
+            timeout 600 docker pull "${TIFLASH_IMAGE}"
 
-                                                    find ../docker . -name '*.yaml' -type f -exec sed -i \
-                                                        -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
-                                                        -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
-                                                        -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
-                                                        -e 's#${MINIO_IMAGE:[^}]*}#'"${MINIO_IMAGE}"'#g' \
-                                                        -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
-                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
-                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
-                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
-                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/test-infra/minio:latest#${MINIO_IMAGE}#g" \
-                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
-                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
-                                                        -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
-                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                        -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                        {} +
-                                                    rm -rf ~/.docker
-                                                '''
-                                        }
+            find ../docker . -name '*.yaml' -type f -exec sed -i \
+                -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
+                -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
+                -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
+                -e 's#${MINIO_IMAGE:[^}]*}#'"${MINIO_IMAGE}"'#g' \
+                -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/test-infra/minio:latest#${MINIO_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                {} +
+            rm -rf ~/.docker
+        '''
 
                                         sh label: "run the tests", script: "TAG=${REFS.pulls[0].sha} BRANCH=${REFS.base_ref} ENABLE_NEXT_GEN=true ./run.sh"
                                     }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pipeline.groovy
@@ -168,29 +168,25 @@ pipeline {
                                         "MINIO_IMAGE=quay.io/minio/minio:${MINIO_VERSION}",
                                         "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
                                     ]) {
-                                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                            sh label: "prepare docker images", script: '''
-                                                set -eux
-                                                mkdir -p ~/.docker
-                                                cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
-                                                for i in $(seq 1 30); do
-                                                    if docker version; then
-                                                        break
-                                                    fi
-                                                    sleep 2
-                                                done
-                                                docker version
-                                                docker ps -a
+    sh label: "prepare docker images", script: '''
+        set -eux
+        for i in $(seq 1 30); do
+            if docker version; then
+                break
+            fi
+            sleep 2
+        done
+        docker version
+        docker ps -a
 
-                                                timeout 300 docker pull "${PD_IMAGE}"
-                                                timeout 300 docker pull "${TIKV_IMAGE}"
-                                                timeout 300 docker pull "${TIDB_IMAGE}"
-                                                timeout 300 docker pull "${MINIO_IMAGE}"
-                                                timeout 600 docker pull "${TIFLASH_IMAGE}"
+        timeout 300 docker pull "${PD_IMAGE}"
+        timeout 300 docker pull "${TIKV_IMAGE}"
+        timeout 300 docker pull "${TIDB_IMAGE}"
+        timeout 300 docker pull "${MINIO_IMAGE}"
+        timeout 600 docker pull "${TIFLASH_IMAGE}"
 
-                                                rm -rf ~/.docker
-                                            '''
-                                        }
+        rm -rf ~/.docker
+    '''
                                         sh label: "run columnar integration test", script: """#!/usr/bin/env bash
                                             set -o pipefail
                                             chmod +x ./run.sh

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -251,54 +251,50 @@ pipeline {
                                             "TIDB_FAILPOINT_IMAGE=${tidbFailpointImage}",
                                             "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
                                         ]) {
-                                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                                sh label: "prepare docker images", script: '''
-                                                        set -eux
-                                                        mkdir -p ~/.docker
-                                                        cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
-                                                        for i in $(seq 1 30); do
-                                                            if docker version; then
-                                                                break
-                                                            fi
-                                                            sleep 2
-                                                        done
-                                                        docker ps -a
+    sh label: "prepare docker images", script: '''
+            set -eux
+            for i in $(seq 1 30); do
+                if docker version; then
+                    break
+                fi
+                sleep 2
+            done
+            docker ps -a
 
-                                                        timeout 300 docker pull "${PD_IMAGE}"
-                                                        timeout 300 docker pull "${TIKV_IMAGE}"
-                                                        timeout 300 docker pull "${TIDB_IMAGE}"
-                                                        timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
-                                                        timeout 600 docker pull "${TIFLASH_IMAGE}"
+            timeout 300 docker pull "${PD_IMAGE}"
+            timeout 300 docker pull "${TIKV_IMAGE}"
+            timeout 300 docker pull "${TIDB_IMAGE}"
+            timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
+            timeout 600 docker pull "${TIFLASH_IMAGE}"
 
-                                                        find ../docker . -name '*.yaml' -type f -exec sed -i \
-                                                            -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
-                                                            -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e 's#${TIDB_IMAGE:[^}]*-failpoint}#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:master#${PD_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:master#${TIKV_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master#${TIDB_IMAGE}#g" \
-                                                            {} +
-                                                        rm -rf ~/.docker
-                                                    '''
-                                            }
+            find ../docker . -name '*.yaml' -type f -exec sed -i \
+                -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
+                -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
+                -e 's#${TIDB_IMAGE:[^}]*-failpoint}#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
+                -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:master#${PD_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:master#${TIKV_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master#${TIDB_IMAGE}#g" \
+                {} +
+            rm -rf ~/.docker
+        '''
 
                                             sh label: "run integration tests", script: """
                                                 PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${REFS.pulls[0].sha} BRANCH=${REFS.base_ref} ./run.sh

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -251,71 +251,67 @@ pipeline {
                                             "TIDB_FAILPOINT_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint",
                                             "TIFLASH_IT_BASE_IMAGE=${TIFLASH_IT_BASE_IMAGE}",
                                         ]) {
-                                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                                sh label: "prepare docker images", script: '''
-                                                        set -eux
-                                                        mkdir -p ~/.docker
-                                                        cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
-                                                        for i in $(seq 1 30); do
-                                                            if docker version; then
-                                                                break
-                                                            fi
-                                                            sleep 2
-                                                        done
-                                                        docker ps -a
+    sh label: "prepare docker images", script: '''
+            set -eux
+            for i in $(seq 1 30); do
+                if docker version; then
+                    break
+                fi
+                sleep 2
+            done
+            docker ps -a
 
-                                                        timeout 300 docker pull "${PD_IMAGE}"
-                                                        timeout 300 docker pull "${TIKV_IMAGE}"
-                                                        timeout 300 docker pull "${TIDB_IMAGE}"
-                                                        # release-6.5: OCI may still publish a :failpoint tag, but it does not expose
-                                                        # enableTestAPI (fail-point-tests fail on curl_tidb get fail/.../enableTestAPI).
-                                                        # Always use the regular TiDB image and skip suites that need real failpoints.
-                                                        timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
-                                                        echo "WARN: release-6.5 TiDB failpoint image is not usable for IT; falling back to ${TIDB_IMAGE}"
-                                                        TIDB_FAILPOINT_IMAGE="${TIDB_IMAGE}"
-                                                        if [ -f ./run.sh ] && grep -q 'tidb-ci/fail-point-tests' ./run.sh; then
-                                                            echo "WARN: skipping tidb-ci/fail-point-tests"
-                                                            sed -i -e 's#./run-test.sh tidb-ci/fail-point-tests && ##g' ./run.sh
-                                                        fi
-                                                        # Old hub.pingcap.net/tiflash/tiflash-ci-base included mysql client for run-test.sh.
-                                                        # Builder images do not; rebuild the historical runtime locally (see tiflash_ci_base Dockerfile).
-                                                        timeout 600 docker pull "${TIFLASH_IT_BASE_IMAGE}"
-                                                        docker build -t tiflash-ci-base-local:with-mysql - <<EOF
+            timeout 300 docker pull "${PD_IMAGE}"
+            timeout 300 docker pull "${TIKV_IMAGE}"
+            timeout 300 docker pull "${TIDB_IMAGE}"
+            # release-6.5: OCI may still publish a :failpoint tag, but it does not expose
+            # enableTestAPI (fail-point-tests fail on curl_tidb get fail/.../enableTestAPI).
+            # Always use the regular TiDB image and skip suites that need real failpoints.
+            timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
+            echo "WARN: release-6.5 TiDB failpoint image is not usable for IT; falling back to ${TIDB_IMAGE}"
+            TIDB_FAILPOINT_IMAGE="${TIDB_IMAGE}"
+            if [ -f ./run.sh ] && grep -q 'tidb-ci/fail-point-tests' ./run.sh; then
+                echo "WARN: skipping tidb-ci/fail-point-tests"
+                sed -i -e 's#./run-test.sh tidb-ci/fail-point-tests && ##g' ./run.sh
+            fi
+            # Old hub.pingcap.net/tiflash/tiflash-ci-base included mysql client for run-test.sh.
+            # Builder images do not; rebuild the historical runtime locally (see tiflash_ci_base Dockerfile).
+            timeout 600 docker pull "${TIFLASH_IT_BASE_IMAGE}"
+            docker build -t tiflash-ci-base-local:with-mysql - <<EOF
 FROM ${TIFLASH_IT_BASE_IMAGE}
 RUN yum install -y mysql
 EOF
-                                                        TIFLASH_IMAGE=tiflash-ci-base-local:with-mysql
+            TIFLASH_IMAGE=tiflash-ci-base-local:with-mysql
 
-                                                        find ../docker . -name '*.yaml' -type f -exec sed -i \
-                                                            -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
-                                                            -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e 's#${TIDB_IMAGE:[^}]*-failpoint}#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base$#'"${TIFLASH_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:master#${PD_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:master#${TIKV_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master#${TIDB_IMAGE}#g" \
-                                                            {} +
-                                                        rm -rf ~/.docker
-                                                    '''
-                                            }
+            find ../docker . -name '*.yaml' -type f -exec sed -i \
+                -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
+                -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
+                -e 's#${TIDB_IMAGE:[^}]*-failpoint}#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
+                -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base$#'"${TIFLASH_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:master#${PD_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:master#${TIKV_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master#${TIDB_IMAGE}#g" \
+                {} +
+            rm -rf ~/.docker
+        '''
 
                                             sh label: "run integration tests", script: """
                                                 PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -259,54 +259,50 @@ pipeline {
                                             "TIDB_FAILPOINT_IMAGE=${OCI_ARTIFACT_HOST}/pingcap/tidb/images/tidb-server:${tidbBranch}-failpoint",
                                             "TIFLASH_IMAGE=${TIFLASH_TEST_IMAGE}",
                                         ]) {
-                                            withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                                sh label: "prepare docker images", script: '''
-                                                        set -eux
-                                                        mkdir -p ~/.docker
-                                                        cp "${DOCKER_CONFIG_JSON}" ~/.docker/config.json
-                                                        for i in $(seq 1 30); do
-                                                            if docker version; then
-                                                                break
-                                                            fi
-                                                            sleep 2
-                                                        done
-                                                        docker ps -a
+    sh label: "prepare docker images", script: '''
+            set -eux
+            for i in $(seq 1 30); do
+                if docker version; then
+                    break
+                fi
+                sleep 2
+            done
+            docker ps -a
 
-                                                        timeout 300 docker pull "${PD_IMAGE}"
-                                                        timeout 300 docker pull "${TIKV_IMAGE}"
-                                                        timeout 300 docker pull "${TIDB_IMAGE}"
-                                                        timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
-                                                        timeout 600 docker pull "${TIFLASH_IMAGE}"
+            timeout 300 docker pull "${PD_IMAGE}"
+            timeout 300 docker pull "${TIKV_IMAGE}"
+            timeout 300 docker pull "${TIDB_IMAGE}"
+            timeout 300 docker pull "${TIDB_FAILPOINT_IMAGE}" || true
+            timeout 600 docker pull "${TIFLASH_IMAGE}"
 
-                                                        find ../docker . -name '*.yaml' -type f -exec sed -i \
-                                                            -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
-                                                            -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e 's#${TIDB_IMAGE:[^}]*-failpoint}#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
-                                                            -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:master#${PD_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:master#${TIKV_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
-                                                            -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master#${TIDB_IMAGE}#g" \
-                                                            {} +
-                                                        rm -rf ~/.docker
-                                                    '''
-                                            }
+            find ../docker . -name '*.yaml' -type f -exec sed -i \
+                -e 's#${PD_IMAGE:[^}]*}#'"${PD_IMAGE}"'#g' \
+                -e 's#${TIKV_IMAGE:[^}]*}#'"${TIKV_IMAGE}"'#g' \
+                -e 's#${TIDB_IMAGE:[^}]*-failpoint}#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                -e 's#${TIDB_IMAGE:[^}]*}#'"${TIDB_IMAGE}"'#g' \
+                -e 's#${TIFLASH_IMAGE:[^}]*}#'"${TIFLASH_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky8-20241028#${TIFLASH_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tiflash-ci-base:rocky9-20250529#${TIFLASH_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tiflash/tics:${TAG:-master}#'"${TIFLASH_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/pd/image:master#${PD_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/tikv/tikv/image:master#${TIKV_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/pingcap/tidb/images/tidb-server:master#${TIDB_IMAGE}#g" \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:${PD_BRANCH:-master}#'"${PD_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:${TIKV_BRANCH:-master}#'"${TIKV_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}-failpoint#'"${TIDB_FAILPOINT_IMAGE}"'#g' \
+                -e 's#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:${TIDB_BRANCH:-master}#'"${TIDB_IMAGE}"'#g' \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/pd:master#${PD_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tikv:master#${TIKV_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master-failpoint#${TIDB_FAILPOINT_IMAGE}#g" \
+                -e "s#[[:alnum:].-]*[.][[:alnum:].-]*/qa/tidb:master#${TIDB_IMAGE}#g" \
+                {} +
+            rm -rf ~/.docker
+        '''
 
                                             sh label: "run integration tests", script: """
                                                 PD_BRANCH=${pdBranch} TIKV_BRANCH=${tikvBranch} TIDB_BRANCH=${tidbBranch} TAG=${tiflash_commit_hash} BRANCH=${REFS.base_ref} ./run.sh

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -47,12 +47,6 @@ pipeline {
                         retry(2) {
                             sh label: "prepare third_party dir", script: "mkdir -p bin"
                             container("utils") {
-                                withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                                    sh label: "prepare docker auth", script: '''
-                                        mkdir -p ~/.docker
-                                        cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                                    '''
-                                }
                                 dir("bin") {
                                     sh label: "download third_party from OCI", script: """
                                         script=${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -88,12 +88,6 @@ pipeline {
                 }
                 dir('tidb') {
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir('bin') {
                             sh label: 'download peer component binaries', script: """#!/usr/bin/env bash
                                 set -eo pipefail

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -71,12 +71,6 @@ pipeline {
                 }
                 dir('tidb') {
                     container("utils") {
-                        withCredentials([file(credentialsId: 'tidbx-docker-config', variable: 'DOCKER_CONFIG_JSON')]) {
-                            sh label: "prepare docker auth", script: '''
-                                mkdir -p ~/.docker
-                                cp ${DOCKER_CONFIG_JSON} ~/.docker/config.json
-                            '''
-                        }
                         dir('bin') {
                             sh label: 'download peer component binaries', script: """#!/usr/bin/env bash
                                 set -eo pipefail


### PR DESCRIPTION
## Summary

Removes the redundant `withCredentials('tidbx-docker-config')` → `~/.docker/config.json` copies from 30 integration pipelines.

Registry auth is now injected automatically by **Kyverno** on the CI clusters (PingCAP-QE/ee-ops `inject-registry-config` policy, merged in ee-ops #2240/#2241): the `utils` container receives a `ci-registry-auth` volume at `/var/run/ci/registry` plus `DOCKER_CONFIG=/var/run/ci/registry`. oras (1.2.x) and the docker CLI honor `DOCKER_CONFIG`, so the manual copies are no longer needed.

## Changes

- **25 pipelines** (`prepare docker auth` blocks): removed the entire `withCredentials` + copy block.
- **5 tiflash pipelines** (`prepare docker images` blocks): removed the `withCredentials` wrapper and the `mkdir`/`cp` lines only; docker pulls, yaml rewrites and `rm -rf ~/.docker` cleanup are preserved.

## Validation

- No residual `tidbx-docker-config` / `DOCKER_CONFIG_JSON` references.
- All 30 modified files pass `groovy --parse-check`.
- CI registry auth injection already validated in production on both tencentcloud and gcp clusters.

## Related

- Design: PingCAP-QE/ee-ops `docs/ci-registry-auth-injection.md`
- ee-ops #2240 (tencentcloud policies), #2241 (gcp Policy A)