### PR TITLE
chore(prow-jobs): migrate pingcap/tidb latest post-submits to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
       name: pingcap/tidb/merged_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/e2e-test
@@ -22,7 +22,7 @@ postsubmits:
       name: pingcap/tidb/merged_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/common-test
@@ -33,7 +33,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: ci/integration-jdbc-test
       skip_if_only_changed: *skip_if_only_changed
@@ -44,7 +44,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-mysql-test
@@ -55,7 +55,7 @@ postsubmits:
       name: pingcap/tidb/merged_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/sqllogic-test
@@ -66,7 +66,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-copr-test
@@ -77,7 +77,7 @@ postsubmits:
       name: pingcap/tidb/merged_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test
@@ -88,7 +88,7 @@ postsubmits:
       name: pingcap/tidb/merged_unit_test_ddlv1
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/unit-test-ddlv1 # TODO: change to ci/ after test.
@@ -99,7 +99,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-python-orm-test
@@ -110,7 +110,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_lightning_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/integration-lightning-test

--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -22,7 +22,7 @@ postsubmits:
       name: pingcap/tidb/merged_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/common-test
@@ -33,7 +33,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: ci/integration-jdbc-test
       skip_if_only_changed: *skip_if_only_changed
@@ -44,7 +44,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-mysql-test
@@ -88,7 +88,7 @@ postsubmits:
       name: pingcap/tidb/merged_unit_test_ddlv1
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/unit-test-ddlv1 # TODO: change to ci/ after test.

--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -77,7 +77,7 @@ postsubmits:
       name: pingcap/tidb/merged_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test

--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -55,7 +55,7 @@ postsubmits:
       name: pingcap/tidb/merged_sqllogic_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/sqllogic-test
@@ -66,7 +66,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-copr-test


### PR DESCRIPTION
Closes #4944 (Phase 1: pingcap/tidb latest post-submit migration).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 10 jenkins-agent post-submit jobs in `prow-jobs/pingcap/tidb/latest-postsubmits.yaml` so they are scheduled on the **to** Jenkins:

- `pingcap/tidb/merged_e2e_test`
- `pingcap/tidb/merged_common_test`
- `pingcap/tidb/merged_integration_jdbc_test`
- `pingcap/tidb/merged_integration_mysql_test`
- `pingcap/tidb/merged_sqllogic_test`
- `pingcap/tidb/merged_integration_copr_test`
- `pingcap/tidb/merged_unit_test`
- `pingcap/tidb/merged_unit_test_ddlv1`
- `pingcap/tidb/merged_integration_python_orm_test`
- `pingcap/tidb/merged_integration_lightning_test`

The kubernetes-agent `merged-tidb-build` post-submit is unchanged.

## Verification
Hold before merge; run `/test pull-verify-jenkins-migration` (requires #4968 toolchain merged) and observe the migrated post-submits on the **to** Jenkins after merge.

Part of #4942