### PR TITLE
fix(prow-jobs): install github-cli in pull-verify-jenkins-migration

### DIFF
--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -132,7 +132,7 @@ presubmits:
             command: [bash, -ceo, pipefail]
             args:
               - |
-                apk add --no-cache git jq ripgrep yq-go
+                apk add --no-cache git jq ripgrep yq-go github-cli
                 .ci/verify-jenkins-migration.sh \
                   --base-sha "${PULL_BASE_SHA:-}" \
                   --head-sha "${PULL_PULL_SHA:-}" \


### PR DESCRIPTION
## Summary
`pull-verify-jenkins-migration` posts its progress/final report via a PR comment using the `gh` CLI, but the `wbitt/network-multitool` image does not ship `gh`, so the reporting silently no-ops. Install the `github-cli` apk package in the job.

Verification itself is unaffected; this restores the single continuously-updated PR comment reporting.

Part of #4942