### PR TITLE
chore(prow-jobs): migrate 5 verified tidb latest pre-submits to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       name: pingcap/tidb/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/build
@@ -52,7 +52,7 @@ presubmits:
       name: pingcap/tidb/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/mysql-test
@@ -108,7 +108,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-copr-test
@@ -119,7 +119,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-jdbc-test
@@ -210,7 +210,7 @@ presubmits:
       name: pingcap/tidb/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-sqllogic-test
@@ -221,7 +221,7 @@ presubmits:
       name: pingcap/tidb/pull_mysql_client_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-mysql-client-test

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -210,7 +210,7 @@ presubmits:
       name: pingcap/tidb/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       optional: true
       context: pull-sqllogic-test


### PR DESCRIPTION
Part of #4945 (Phase 2: pingcap/tidb latest pre-submit migration).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 5 jenkins-agent pre-submits verified with **SUCCESS** on the **to** Jenkins (`do.pingcap.net/jenkins-staging`), split out of #4970:

- `pingcap/tidb/ghpr_build`
- `pingcap/tidb/ghpr_mysql_test`
- `pingcap/tidb/pull_integration_copr_test`
- `pingcap/tidb/pull_integration_jdbc_test`
- `pingcap/tidb/pull_mysql_client_test`

`pull_sqllogic_test` was dropped from this PR (its build was **ABORTED** on the **to** Jenkins); it stays on `master: "1"` until re-verified.

## Verification
Each job has at least one SUCCESS build on `do.pingcap.net/jenkins-staging`:

| job | result |
| --- | --- |
| ghpr_build | SUCCESS |
| ghpr_mysql_test | SUCCESS |
| pull_integration_copr_test | SUCCESS |
| pull_integration_jdbc_test | SUCCESS |
| pull_mysql_client_test | SUCCESS |

Part of #4942
