### PR TITLE
feat(prow-jobs): allow concurrent pull-verify-jenkins-migration runs

### DIFF
--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -82,7 +82,6 @@ presubmits:
       decorate: true
       always_run: false
       optional: true
-      max_concurrency: 1
       trigger: "(?m)^/test (?:.*? )?pull-verify-jenkins-migration(?: .*?)?$"
       rerun_command: "/test pull-verify-jenkins-migration"
       run_if_changed: "^prow-jobs/.*\\.ya?ml$"


### PR DESCRIPTION
Closes #4973 (remove prow-job level concurrency limit for the verification presubmit).

## Summary
Remove `max_concurrency: 1` from the `pull-verify-jenkins-migration` presubmit so multiple migration PRs can be verified concurrently instead of being serialized. Prow default (0) = unlimited.

This accelerates the migration effort when several migration PRs are in flight.