### PR TITLE
feat(prow-jobs): add seed post-submit for the to jenkins (master: "0")

### DIFF
--- a/prow-jobs/pingcap-qe/ci/postsubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/postsubmits.yaml
@@ -4,6 +4,11 @@ global_definitions:
     labels:
       master: "1"
     decorate: false # need add this.
+  jenkins_job_to: &jenkins_job_to
+    agent: jenkins
+    labels:
+      master: "0"
+    decorate: false # need add this.
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Postsubmit
 postsubmits:
@@ -12,6 +17,13 @@ postsubmits:
       name: seed
       run_if_changed: "^jobs/.*\\.groovy"
       context: seed
+      max_concurrency: 1
+      branches:
+        - ^main$
+    - <<: *jenkins_job_to
+      name: seed-to
+      run_if_changed: "^jobs/.*\\.groovy"
+      context: seed-to
       max_concurrency: 1
       branches:
         - ^main$

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -82,7 +82,6 @@ presubmits:
       decorate: true
       always_run: false
       optional: true
-      max_concurrency: 1
       trigger: "(?m)^/test (?:.*? )?pull-verify-jenkins-migration(?: .*?)?$"
       rerun_command: "/test pull-verify-jenkins-migration"
       run_if_changed: "^prow-jobs/.*\\.ya?ml$"


### PR DESCRIPTION
Part of #4974 (support job DSL seeding for the **to** Jenkins).

## Summary
The `seed` post-submit currently only seeds the **from** Jenkins (`labels.master: "1"`). Add a `seed-to` post-submit (`labels.master: "0"`, context `seed-to`, same `run_if_changed: ^jobs/.*\.groovy`) so the **to** Jenkins job DSL is processed on the same merges.

## Note
A Prow post-submit `name` maps to the Jenkins job path, so the **to** Jenkins needs a matching `seed-to` Jenkins job (provisioned out-of-band by the infra side) that runs the same Job DSL seeding as `seed` on the **from** Jenkins.

Part of #4942
