### PR TITLE
chore(jobs): add description to pingcap/tidb ghpr_build job

### DIFF
--- a/jobs/pingcap/tidb/latest/ghpr_build.groovy
+++ b/jobs/pingcap/tidb/latest/ghpr_build.groovy
@@ -4,6 +4,7 @@ final branchAlias = 'latest' // For trunk and latest release branches.
 final jobName = 'ghpr_build'
 
 pipelineJob("${fullRepo}/${jobName}") {
+    description("Build tidb artifacts (${fullRepo}/${jobName})")
     logRotator {
         daysToKeep(30)
     }


### PR DESCRIPTION
## Test PR: verify the seed post-submit (#4977) propagates job DSL to both Jenkins

This is a **test change** to exercise the reworked `seed` post-submit. It changes a `jobs/**/*.groovy` file, so on merge the `seed` post-submit fires and each pod container triggers the `seed` job on its Jenkins instance:

- `jenkins-master-1` -> **from** Jenkins
- `jenkins-master-0` -> **to** Jenkins

Expected after merge:
1. `seed` post-submit runs and both containers trigger their `seed` builds successfully.
2. The `ghpr_build` job description is updated on **both** Jenkins instances (observable diff via `job/pingcap/tidb/ghpr_build/api/json` -> `description`).

The description added is the change being propagated; it can be reverted/adjusted after validation.