### PR TITLE
chore(prow-jobs): migrate 4 verified pingcap/tidb latest post-submits to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -22,7 +22,7 @@ postsubmits:
       name: pingcap/tidb/merged_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/common-test
@@ -33,7 +33,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: ci/integration-jdbc-test
       skip_if_only_changed: *skip_if_only_changed
@@ -44,7 +44,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-mysql-test
@@ -88,7 +88,7 @@ postsubmits:
       name: pingcap/tidb/merged_unit_test_ddlv1
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/unit-test-ddlv1 # TODO: change to ci/ after test.


### PR DESCRIPTION
Part of #4944 (Phase 1: pingcap/tidb latest post-submit migration). Split from #4969.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 4 post-submits that **passed** the `pull-verify-jenkins-migration` verification on the **to** Jenkins (`do.pingcap.net/jenkins-staging`):

- `pingcap/tidb/merged_common_test`
- `pingcap/tidb/merged_integration_jdbc_test`
- `pingcap/tidb/merged_integration_mysql_test`
- `pingcap/tidb/merged_unit_test_ddlv1`

## Test results (pull-verify-jenkins-migration on #4969)
| Job | Result |
|---|---|
| merged_common_test | SUCCESS |
| merged_integration_jdbc_test | SUCCESS |
| merged_integration_mysql_test | SUCCESS |
| merged_unit_test_ddlv1 | SUCCESS |
| merged_integration_copr_test | ABORTED |
| merged_integration_python_orm_test | ABORTED |
| merged_e2e_test | ABORTED |
| merged_integration_lightning_test | ABORTED |
| merged_sqllogic_test | ABORTED |
| merged_unit_test | still running |

The 5 ABORTED jobs and the still-running `merged_unit_test` remain in #4969 (their builds were aborted, likely related to the target Jenkins agent issue under investigation).

Part of #4942
