### PR TITLE
fix(tekton): TTL 10m for Harbor multi-arch compose TaskRuns

### DIFF
--- a/tekton/v1/triggers/templates/_/collect-multi-arch-image.yaml
+++ b/tekton/v1/triggers/templates/_/collect-multi-arch-image.yaml
@@ -14,6 +14,9 @@ spec:
       metadata:
         generateName: auto-compose-multi-arch-image-run-
       spec:
+        # Auto-delete completed TaskRun (and owned Pods) after 10 minutes so
+        # Harbor-triggered compose does not accumulate on nodes / etcd.
+        ttlSecondsAfterFinished: 600
         serviceAccountName: image-releaser
         taskRef:
           name: multi-arch-image-collect


### PR DESCRIPTION
Auto-delete completed auto-compose TaskRuns so Completed Pods do not accumulate on KCE worker nodes under Harbor webhook load.