### PR TITLE
chore(prow-jobs): migrate failed pingcap/tidb post-submits (track separately)

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -55,7 +55,7 @@ postsubmits:
       name: pingcap/tidb/merged_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/sqllogic-test
@@ -66,7 +66,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-copr-test


### PR DESCRIPTION
Part of #4944 (Phase 1: pingcap/tidb latest post-submit migration). Split out of #4969.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 2 post-submits that did **not** pass verification on the **to** Jenkins (`do.pingcap.net/jenkins-staging`). They are tracked here separately so #4969 can merge the 4 verified jobs; these should not be merged until the failures are resolved.

- `pingcap/tidb/merged_sqllogic_test`
- `pingcap/tidb/merged_integration_copr_test`

## Failure details (build #2 on the to Jenkins)
| Job | Result | Note |
|---|---|---|
| merged_sqllogic_test | FAILURE | real build/test failure - needs investigation |
| merged_integration_copr_test | ABORTED | aborted, likely target Jenkins agent/infra issue |

## Status
- [ ] Investigate and fix the 2 failures
- [ ] Re-run `/test pull-verify-jenkins-migration`
- [ ] Merge once verification passes

Part of #4942
