### PR TITLE
chore(prow-jobs): migrate merged_unit_test post-submit (track separately)

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -77,7 +77,7 @@ postsubmits:
       name: pingcap/tidb/merged_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test


### PR DESCRIPTION
Part of #4944 (Phase 1: pingcap/tidb latest post-submit migration). Split out of #4969.

## Summary
Flip `labels.master` `"1"` -> `"0"` for `merged_unit_test`, tracked here separately because it **keeps failing** on the **to** Jenkins:

- build #3: FAILURE
- build #4: FAILURE

## Status
- [ ] Investigate the `merged_unit_test` failure on the to Jenkins
- [ ] Re-run `/test pull-verify-jenkins-migration`
- [ ] Merge once verification passes

Part of #4942
