### PR TITLE
chore(prow-jobs): migrate 5 verified pingcap/tidb latest pre-submits to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       name: pingcap/tidb/ghpr_check
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/check_dev
@@ -63,7 +63,7 @@ presubmits:
       name: pingcap/tidb/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/unit-test
@@ -74,7 +74,7 @@ presubmits:
       name: pingcap/tidb/pull_unit_test_ddlv1
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "pkg/(ddl|meta)/.*"
       context: pull-unit-test-ddlv1
@@ -130,7 +130,7 @@ presubmits:
       name: pingcap/tidb/pull_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-e2e-test
@@ -141,7 +141,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-e2e-test


### PR DESCRIPTION
Part of #4945 (Phase 2: pingcap/tidb latest pre-submit migration). Split from #4970.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 5 pre-submits that **passed** `pull-verify-jenkins-migration` on the **to** Jenkins (`do.pingcap.net/jenkins-staging`):

- `pingcap/tidb/ghpr_check`
- `pingcap/tidb/ghpr_unit_test`
- `pingcap/tidb/pull_unit_test_ddlv1`
- `pingcap/tidb/pull_e2e_test`
- `pingcap/tidb/pull_integration_e2e_test`

## Test results (latest build on the to Jenkins)
| Job | Result |
|---|---|
| ghpr_check | SUCCESS |
| ghpr_unit_test | SUCCESS |
| pull_unit_test_ddlv1 | SUCCESS |
| pull_e2e_test | SUCCESS |
| pull_integration_e2e_test | SUCCESS |

The remaining unverified pre-submits stay in #4970.

Part of #4942
