### PR TITLE
chore(prow-jobs): migrate pingcap-qe/tidb-test latest jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|jdbc_test)/.*"
       context: ci/common-test
@@ -29,7 +29,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|mybatis_test|jooq_test|tidb_jdbc_test)/.*"
       context: ci/integration-jdbc-test
@@ -41,7 +41,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_integration_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "randgen-test/.*"
       context: ci/integration-common-test
@@ -77,7 +77,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: ci/integration-nodejs-test
@@ -89,7 +89,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: ci/integration-python-orm-test


### PR DESCRIPTION
Part of #4950 (Phase 3: pingcap-qe/tidb-test latest).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 13 jenkins-agent `latest` jobs in `prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml` so they are scheduled on the **to** Jenkins:

- `ghpr_build`, `ghpr_common_test`, `ghpr_integration_common_test`, `ghpr_integration_jdbc_test`, `ghpr_integration_mysql_test`, `ghpr_integration_nodejs_test`, `ghpr_integration_python_orm_test`, `ghpr_mysql_test`
- `pull_tiproxy_common_test`, `pull_tiproxy_jdbc_test`, `pull_tiproxy_mysql_connector_test`, `pull_tiproxy_mysql_test`, `pull_tiproxy_ruby_orm_test`

## Verification
Hold before merge; run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins after merge.

Part of #4946
Part of #4942
