### PR TITLE
chore(prow-jobs): migrate pingcap/ticdc latest jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -103,6 +103,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_light_v7_5
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: false
       optional: true
@@ -113,6 +115,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy_v7_5
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: false
       optional: true


### PR DESCRIPTION
Part of #4951 (Phase 3: pingcap/ticdc latest).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 25 jenkins-agent `latest` jobs in `prow-jobs/pingcap/ticdc/latest-presubmits.yaml` so they are scheduled on the **to** Jenkins (pull_cdc_* integration tests and ghpr_* checks).

## Verification
Hold before merge; run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins after merge.

Part of #4946
Part of #4942