### PR TITLE
chore(prow-jobs): migrate pingcap/tiproxy latest jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiproxy/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiproxy/latest-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: pingcap/tiproxy/merged_mysql_test
       agent: jenkins
       labels:
-        master: "0" # run on GCP
+        master: "1" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-mysql-test # need change this.

--- a/prow-jobs/pingcap/tiproxy/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiproxy/latest-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: pingcap/tiproxy/merged_mysql_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-mysql-test # need change this.
@@ -15,7 +15,7 @@ postsubmits:
     - name: pingcap/tiproxy/merged_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-python-orm-test # need change this.
@@ -26,7 +26,7 @@ postsubmits:
     - name: pingcap/tiproxy/merged_sqllogic_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-sqllogic-test # need change this.
@@ -37,7 +37,7 @@ postsubmits:
     - name: pingcap/tiproxy/merged_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-integration-jdbc-test # need change this.

--- a/prow-jobs/pingcap/tiproxy/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiproxy/latest-presubmits.yaml
@@ -112,7 +112,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_mysql_connector_test
       agent: jenkins
       labels:
-        master: "0" # run on GCP
+        master: "1" # run on GCP
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"

--- a/prow-jobs/pingcap/tiproxy/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiproxy/latest-presubmits.yaml
@@ -112,7 +112,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_mysql_connector_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -126,7 +126,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_mysql_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-mysql-test
@@ -139,7 +139,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-jdbc-test # need change this.
@@ -152,7 +152,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-common-test # need change this.
@@ -164,7 +164,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_ruby_orm_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-ruby-orm-test # need change this.
@@ -176,7 +176,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-nodejs-test
@@ -189,7 +189,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-integration-python-orm-test
@@ -202,7 +202,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       always_run: false
       context: pull-sqllogic-test


### PR DESCRIPTION
Part of #4952 (Phase 3: pingcap/tiproxy latest).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 16 jenkins-agent `latest` jobs in `prow-jobs/pingcap/tiproxy/latest-presubmits.yaml` and `latest-postsubmits.yaml` so they are scheduled on the **to** Jenkins.

## Verification
Hold before merge; run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins after merge.

Part of #4946
Part of #4942
