### PR TITLE
chore(prow-jobs): migrate tikv/pd latest jobs to target jenkins

### DIFF
--- a/prow-jobs/tikv/pd/latest-presubmits.yaml
+++ b/prow-jobs/tikv/pd/latest-presubmits.yaml
@@ -82,7 +82,7 @@ presubmits:
       name: tikv/pd/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -94,7 +94,7 @@ presubmits:
       name: tikv/pd/pull_integration_realcluster_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: true
       optional: false


### PR DESCRIPTION
Part of #4955 (Phase 3: tikv/pd latest).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 2 jenkins-agent `latest` jobs in `prow-jobs/tikv/pd/latest-presubmits.yaml` so they are scheduled on the **to** Jenkins.

## Verification
Hold before merge; run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins after merge.

Part of #4946
Part of #4942