### PR TITLE
chore(prow-jobs): migrate tikv/migration latest jobs to target jenkins

### DIFF
--- a/prow-jobs/tikv/migration/latest-presubmits.yaml
+++ b/prow-jobs/tikv/migration/latest-presubmits.yaml
@@ -7,7 +7,7 @@ global_definitions:
   jenkins_job: &jenkins_job
     agent: jenkins
     labels:
-      master: "1" # run on GCP
+      master: "0" # run on GCP
     decorate: false
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit


### PR DESCRIPTION
Part of #4956 (Phase 3: tikv/migration latest).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 5 jenkins-agent `latest` jobs in `prow-jobs/tikv/migration/latest-presubmits.yaml` so they are scheduled on the **to** Jenkins.

## Verification
Hold before merge; run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins after merge.

Part of #4946
Part of #4942