### PR TITLE
chore(prow-jobs): migrate tikv/copr-test latest jobs to target jenkins

### DIFF
--- a/prow-jobs/tikv/copr-test/latest-presubmits.yaml
+++ b/prow-jobs/tikv/copr-test/latest-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       name: tikv/copr-test/pull_integration_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       always_run: false


### PR DESCRIPTION
Part of #4957 (Phase 3: tikv/copr-test latest).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 1 jenkins-agent `latest` jobs in `prow-jobs/tikv/copr-test/latest-presubmits.yaml` so they are scheduled on the **to** Jenkins.

## Verification
Hold before merge; run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins after merge.

Part of #4946
Part of #4942