### PR TITLE
chore(prow-jobs): migrate 3 more verified pingcap/tidb latest pre-submits to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -197,7 +197,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -232,7 +232,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-nodejs-test
@@ -243,7 +243,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-python-orm-test


### PR DESCRIPTION
Part of #4945 (Phase 2: pingcap/tidb latest pre-submit migration). Split from #4970.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the pre-submits that passed `pull-verify-jenkins-migration` on the **to** Jenkins (`do.pingcap.net/jenkins-staging`):

- `pingcap/tidb/pull_integration_ddl_test`
- `pingcap/tidb/pull_integration_nodejs_test`
- `pingcap/tidb/pull_integration_python_orm_test`

## Test results (latest build on the to Jenkins)
| Job | Result |
|---|---|
| pull_integration_ddl_test | SUCCESS |
| pull_integration_nodejs_test | SUCCESS |
| pull_integration_python_orm_test | SUCCESS |

The remaining unverified pre-submits stay in #4970.

Part of #4942
