### PR TITLE
fix(tekton): correct stage param reference in request-kernel-image-sync

### DIFF
--- a/tekton/v1/step-actions/request-kernel-image-sync.yaml
+++ b/tekton/v1/step-actions/request-kernel-image-sync.yaml
@@ -29,7 +29,7 @@ spec:
     - name: PUBLISHER_URL
       value: $(params.publisher-url)
     - name: TARGET_STAGES
-      value: $(params.stage)
+      value: $(params.stages)
   image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.26-5-ge8130cb
   script: |
     #!/usr/bin/env bash


### PR DESCRIPTION
## Problem

`flux get kustomizations -A` shows the `ee-cd` kustomizations are not ready:

- `tekton-config-step-actions`: StepAction `request-kernel-image-sync` dry-run failed - non-existent variable in `$(params.stage)`: spec.env[TARGET_STAGES]
- `tekton-config-tasks` and `tekton-config-pipelines` fail as dependencies

## Root cause

Introduced in #4940: the StepAction `request-kernel-image-sync` referenced `$(params.stage)`, but the param is defined as `stages`.

## Fix

- tekton/v1/step-actions/request-kernel-image-sync.yaml: `$(params.stage)` -> `$(params.stages)`

## Test

Ran `flux get kustomizations -A --status-selector ready=false` after sync to confirm the kustomizations become ready.