### PR TITLE
chore(prow-jobs): migrate 6 verified pingcap/tiflow latest jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -109,7 +109,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -122,7 +122,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_storage_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -135,7 +135,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_pulsar_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -148,7 +148,7 @@ presubmits:
     - name: pingcap/tiflow/pull_dm_compatibility_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -174,7 +174,7 @@ presubmits:
     - name: pingcap/tiflow/pull_syncdiff_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -186,7 +186,7 @@ presubmits:
     - name: pingcap/tiflow/ghpr_verify
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify


### PR DESCRIPTION
Part of #4949 (Phase 3: pingcap/tiflow latest). Split from #4985.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 6 tiflow latest jobs verified SUCCESS on the **to** Jenkins:

- `pingcap/tiflow/ghpr_verify`
- `pingcap/tiflow/pull_dm_compatibility_test`
- `pingcap/tiflow/pull_syncdiff_integration_test`
- `pingcap/tiflow/pull_cdc_integration_test`
- `pingcap/tiflow/pull_cdc_integration_storage_test`
- `pingcap/tiflow/pull_cdc_integration_pulsar_test`

## Verification
Each job has a SUCCESS build on `do.pingcap.net/jenkins-staging`. The unverified tiflow jobs (pull_dm_integration_test, merged_unit_test, pull_cdc_integration_kafka_test) stay in #4985.

Part of #4946
Part of #4942
