### PR TITLE
chore(prow-jobs): migrate 4 verified pingcap/ticdc latest jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -15,6 +15,8 @@ presubmits:
   pingcap/ticdc:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_light
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-mysql-integration-light
@@ -51,6 +53,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_light
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-pulsar-integration-light
@@ -61,6 +65,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_heavy
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-pulsar-integration-heavy
@@ -80,6 +86,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_heavy
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-storage-integration-heavy


### PR DESCRIPTION
Part of #4951 (Phase 3: pingcap/ticdc latest). Split from #4987.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 4 ticdc latest jobs verified SUCCESS on the **to** Jenkins:

- `pingcap/ticdc/pull_cdc_mysql_integration_light`
- `pingcap/ticdc/pull_cdc_pulsar_integration_heavy`
- `pingcap/ticdc/pull_cdc_pulsar_integration_light`
- `pingcap/ticdc/pull_cdc_storage_integration_heavy`

## Verification
Each job has a SUCCESS build on `do.pingcap.net/jenkins-staging`. The unverified ticdc jobs stay in #4987.

Part of #4946
Part of #4942
