### PR TITLE
chore(prow-jobs): migrate 2 verified pingcap/tiproxy latest jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiproxy/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiproxy/latest-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: pingcap/tiproxy/merged_mysql_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: merged-mysql-test # need change this.

--- a/prow-jobs/pingcap/tiproxy/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiproxy/latest-presubmits.yaml
@@ -112,7 +112,7 @@ presubmits:
     - name: pingcap/tiproxy/pull_mysql_connector_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.md|Dockerfile|OWNERS|OWNERS_ALIASES)$"


### PR DESCRIPTION
Part of #4952 (Phase 3: pingcap/tiproxy latest). Split from #4988.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 2 tiproxy latest jobs verified SUCCESS on the **to** Jenkins:

- `pingcap/tiproxy/pull_mysql_connector_test`
- `pingcap/tiproxy/merged_mysql_test`

## Verification
Each job has a SUCCESS build on `do.pingcap.net/jenkins-staging`. The unverified tiproxy jobs stay in #4988.

Part of #4946
Part of #4942
