### PR TITLE
chore(prow-jobs): migrate verified pull_common_test pre-submit to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -174,7 +174,7 @@ presubmits:
       name: pingcap/tidb/pull_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-common-test


### PR DESCRIPTION
Part of #4945 (Phase 2: pingcap/tidb latest pre-submit migration). Split from #4970.

## Summary
Flip `labels.master` `"1"` -> `"0"` for `pull_common_test`, verified SUCCESS on the **to** Jenkins (`do.pingcap.net/jenkins-staging`).

## Verification
- Latest build on the to Jenkins: SUCCESS.
- Held; `/approve` + `/unhold` only after this PR's `pull-verify-jenkins-migration` turns green.

Part of #4942
