### PR TITLE
fix(tekton): remove stale notify-config workspace binding from tidbx delivery trigger

### DIFF
--- a/tekton/v1/triggers/triggers/env-gcp/_/notify/notified-successful-image-delivery-tidbx.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/notify/notified-successful-image-delivery-tidbx.yaml
@@ -33,7 +33,3 @@ spec:
                 value: "http://publisher.publisher.svc"
             taskRef:
               name: pingcap-notify-to-deliver-images-to-cloud-tidbx
-            workspaces:
-              - name: notify-config
-                secret:
-                  secretName: image-delivery-notify-config-tidbx


### PR DESCRIPTION
## What

Remove the stale `notify-config` workspace binding from the `notified-successful-image-delivery-tidbx` trigger.

## Why

The task `pingcap-notify-to-deliver-images-to-cloud-tidbx` no longer declares the `notify-config` workspace since #4940 removed it, but the trigger still bound it to the generated TaskRun. This caused every TaskRun to fail with:

```
[User error] workspace binding "notify-config" does not match any declared workspace
```

## Test

- `kubectl kustomize tekton/v1/triggers/triggers/env-gcp` passes.
- No task workspace/param changes; only the trigger TaskRun spec is aligned with the task spec.