### PR TITLE
chore(prow-jobs): migrate pull_br/lightning integration tests to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -152,7 +152,7 @@ presubmits:
       name: pingcap/tidb/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       run_if_changed: "(br|pkg/(ddl|domain|infoschema))/.*"
@@ -163,7 +163,7 @@ presubmits:
       name: pingcap/tidb/pull_lightning_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       run_if_changed: "(lightning|pkg/(domain|statistics|ddl|infoschema)|br/pkg/(checksum|httputil|membuf|pdutil|restore/split|storage))/.*"


### PR DESCRIPTION
Part of #4945 (Phase 2: pingcap/tidb latest pre-submit migration).

## Summary
Flip `labels.master` `"1"` -> `"0"` for:
- `pingcap/tidb/pull_br_integration_test`
- `pingcap/tidb/pull_lightning_integration_test`

## Background
Both jobs pass on the **from** Jenkins (latest SUCCESS). Their failures on the **to** Jenkins were **ABORTED** (infra/agent) not real test failures - see analysis in #4970.

## Verification
Held; `/approve` + `/unhold` only after this PR's `pull-verify-jenkins-migration` turns green.

Part of #4942
