### PR TITLE
fix(tekton): run delivery scripts via /bin/sh instead of chmod +x

### DIFF
--- a/tekton/v0/tasks/pingcap-deliver-image.yaml
+++ b/tekton/v0/tasks/pingcap-deliver-image.yaml
@@ -50,10 +50,9 @@ spec:
           exit 0
         fi
 
-        chmod +x $script
         tries=0
         max_retries=3
-        until $script; do
+        until /bin/sh $script; do
           tries=$((tries + 1))
           if [ $tries -ge $max_retries ]; then
             echo "Script '$script' failed after $max_retries attempts."

--- a/tekton/v1/tasks/delivery/pingcap-deliver-images.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-deliver-images.yaml
@@ -83,10 +83,9 @@ spec:
         set -e
 
         script="/workspace/delivery.sh"
-        chmod +x $script
         tries=0
         max_retries=$(params.retries)
-        until $script; do
+        until /bin/sh $script; do
           tries=$((tries + 1))
           if [ $tries -ge $max_retries ]; then
             echo "Script '$script' failed after $max_retries attempts."


### PR DESCRIPTION
## What

`pingcap-deliver-images` fails in `step-run` with `chmod: /workspace/delivery.sh: Operation not permitted`, and all retries fail.

## Root cause

`crane/debug:latest` upstream (google/go-containerregistry) changed its image user to **non-root** `65532:65532` (commit `3f4ff3c`, PR #2419, 2026-08-21). The `generate` step runs as root (deno) and writes `/workspace/delivery.sh` owned by `root:root` mode 0644. The `run` step now runs as uid 65532 and can no longer `chmod +x` a root-owned file in the shared emptyDir workspace.

This also explains why arm64 runs "succeeded": `generated=false` (no delivery rules matched arm64 tags) so `step-run` was skipped and never hit the chmod.

## Fix

Run the generated `delivery.sh` via `/bin/sh` instead of relying on the executable bit:

```sh
- chmod +x $script
- until $script; do
+ until /bin/sh $script; do
```

Applied to:
- `tekton/v1/tasks/delivery/pingcap-deliver-images.yaml` (affected)
- `tekton/v0/tasks/pingcap-deliver-image.yaml` (same cross-container chmod pattern)

## Not affected

`tag-and-deliver-rc2ga-on-oci-artifacts.yaml` creates and chmods the script within the same step (release utils image, root) — no cross-container permission issue.

## Validation

- `kubectl create --dry-run=client` passes for both edited Task YAMLs.