### PR TITLE
fix(tekton): use /busybox/sh to run delivery scripts

### DIFF
--- a/tekton/v0/tasks/pingcap-deliver-image.yaml
+++ b/tekton/v0/tasks/pingcap-deliver-image.yaml
@@ -52,7 +52,7 @@ spec:
 
         tries=0
         max_retries=3
-        until /bin/sh $script; do
+        until /busybox/sh $script; do
           tries=$((tries + 1))
           if [ $tries -ge $max_retries ]; then
             echo "Script '$script' failed after $max_retries attempts."

--- a/tekton/v1/tasks/delivery/pingcap-deliver-images.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-deliver-images.yaml
@@ -85,7 +85,7 @@ spec:
         script="/workspace/delivery.sh"
         tries=0
         max_retries=$(params.retries)
-        until /bin/sh $script; do
+        until /busybox/sh $script; do
           tries=$((tries + 1))
           if [ $tries -ge $max_retries ]; then
             echo "Script '$script' failed after $max_retries attempts."


### PR DESCRIPTION
## What

Follow-up to #5004. The `crane/debug` image ships **busybox only** — `/bin/sh` does not exist in it, so `until /bin/sh $script` fails with `line 7: /bin/sh: not found` and all retries fail.

## Fix

Use `/busybox/sh` (consistent with the step script shebang `#!/busybox/sh`):

```sh
- until /bin/sh $script; do
+ until /busybox/sh $script; do
```

Applied to:
- `tekton/v1/tasks/delivery/pingcap-deliver-images.yaml`
- `tekton/v0/tasks/pingcap-deliver-image.yaml`

## Validation

- Verified the image contents: `busybox/sh -> /busybox/busybox` symlink exists, no `/bin/sh`.
- `kubectl create --dry-run=client` passes for both edited Task YAMLs.