### PR TITLE
chore(prow-jobs): migrate verified ghpr_integration_mysql_test to target jenkins

### DIFF
--- a/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
@@ -53,7 +53,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test


### PR DESCRIPTION
Part of #4950 (Phase 3: pingcap-qe/tidb-test latest). Split from #4986.

## Summary
Flip `labels.master` `"1"` -> `"0"` for `pingcap-qe/tidb-test/ghpr_integration_mysql_test`, verified **SUCCESS** on the **to** Jenkins (build #4).

## Verification
- Latest build on `do.pingcap.net/jenkins-staging`: SUCCESS.
- Held; `/approve` + `/unhold` only after this PR's `pull-verify-jenkins-migration` turns green.

Part of #4946
Part of #4942
