### PR TITLE
fix(tekton): add / to PATH so crane is resolvable in deliver steps

### DIFF
--- a/tekton/v0/tasks/pingcap-deliver-image.yaml
+++ b/tekton/v0/tasks/pingcap-deliver-image.yaml
@@ -40,6 +40,9 @@ spec:
           --outfile=/workspace/delivery.sh
     - name: run-commands
       image: gcr.io/go-containerregistry/crane/debug:latest
+      env:
+        - name: PATH
+          value: /:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox
       script: |
         #!/busybox/sh
         set -e

--- a/tekton/v1/tasks/delivery/pingcap-deliver-images.yaml
+++ b/tekton/v1/tasks/delivery/pingcap-deliver-images.yaml
@@ -74,6 +74,9 @@ spec:
           operator: in
           values: ["true"]
       image: gcr.io/go-containerregistry/crane/debug:latest
+      env:
+        - name: PATH
+          value: /:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox
       computeResources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## What

Follow-up to #5004/#5005. `pingcap-deliver-images` now fails in `step-run` with:
```
/workspace/delivery.sh: line 1: crane: not found
```

## Root cause

`crane/debug:latest` upstream (google/go-containerregistry) migrated its build to Cloud Build (PR #2412/#2419). The crane binary moved from `/ko-app/crane` to `/crane`, and the new image's `PATH` no longer includes the binary's directory:

- Current image `PATH`: `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox`
- Binary is at `/crane` (root)

The generated `delivery.sh` contains bare `crane copy ...` commands, so `crane` is not found.

## Fix

Prepend `/` to `PATH` in the `run` step env so bare `crane` resolves to `/crane`:

```yaml
env:
  - name: PATH
    value: /:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox
```

Applied to:
- `tekton/v1/tasks/delivery/pingcap-deliver-images.yaml`
- `tekton/v0/tasks/pingcap-deliver-image.yaml`

## Validation

- Confirmed via `crane export`: binary is a regular executable at `/crane`, not in any PATH dir.
- `kubectl create --dry-run=client` passes for both edited Task YAMLs.