### PR TITLE
chore(prow-jobs): migrate ghpr_check2 pre-submit to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
       name: pingcap/tidb/ghpr_check2
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/check_dev_2


### PR DESCRIPTION
Part of #4945 (Phase 2: pingcap/tidb latest pre-submit migration).

## Summary
Flip `labels.master` `"1"` -> `"0"` for `pingcap/tidb/ghpr_check2`, tracked separately from #4970.

## Background
- ghpr_check2 passes on the **from** Jenkins (recent SUCCESS). Its failure on the **to** Jenkins was an infra **ABORTED** (pod scheduling), not a test failure.
- Splitting it into its own PR so it can be verified independently of the version-mismatch failures (mysql/common) in #4970.

## Verification
Held; `/approve` + `/unhold` only after this PR's `pull-verify-jenkins-migration` turns green.

Part of #4942
