### PR TITLE
feat(pipelines): skip ghpr_check2 prepare sub-steps on matrix cache hit

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -37,16 +37,27 @@ pipeline {
                     script {
                         prow.checkoutRefsWithCacheLock(REFS, timeout = 5, credentialsId = GIT_CREDENTIALS_ID)
                     }
+                    // Skip the expensive prepare sub-steps on re-runs of the same refs; the
+                    // cache restores keep the workspace complete for the stash below.
                     cache(path: "./bin", includes: 'tidb-server', key: prow.getCacheKey('binary', REFS)) {
-                        sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
+                        script {
+                            if (!matrixCache.shouldSkip(REFS, 'Prepare', [:]) || !fileExists('bin/tidb-server')) {
+                                sh label: 'tidb-server', script: 'ls bin/tidb-server || make server'
+                            }
+                        }
                     }
-                    container("utils") {
-                        dir("bin") {
-                            script {
-                                retry(2) {
-                                    sh label: "download tidb components", script: """
-                                        ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
-                                    """
+                    cache(path: "./bin", includes: 'pd-server,tikv-server', key: prow.getCacheKey('components', REFS)) {
+                        container("utils") {
+                            dir("bin") {
+                                script {
+                                    if (!matrixCache.shouldSkip(REFS, 'Prepare', [:]) || !fileExists('pd-server') || !fileExists('tikv-server')) {
+                                        retry(2) {
+                                            sh label: "download tidb components", script: """
+                                                ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV}
+                                            """
+                                        }
+                                        matrixCache.markDone(REFS, 'Prepare', [:])
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Part of #5010 (Apply matrixCache to the Checkout & Prepare stage).

## Summary
Apply the existing `matrixCache` to the expensive sub-steps of the `Checkout & Prepare` stage in `pipelines/pingcap/tidb/latest/ghpr_check2.groovy`, so re-runs of the same refs skip the costly work when a previous build already prepared successfully.

## Approach (safe: the ws stash always happens)
- `prow.checkoutRefsWithCacheLock` always runs.
- `make server` is guarded by `matrixCache.shouldSkip(REFS, 'Prepare', [:])` (rebuild also when `bin/tidb-server` is missing, in case the binary cache was evicted).
- PD/TiKV download is guarded by the same key inside a `cache(path: "./bin", includes: 'pd-server,tikv-server', key: prow.getCacheKey('components', REFS))` block, so re-runs restore them from cache while skipping the network download.
- `matrixCache.markDone(REFS, 'Prepare', [:])` is written only after tidb-server build + component download succeed.
- `bazel.prepareWorkspace()`, the `mv`/`touch`, and `stash name: 'ws'` always run -> the matrix `Test` stages always get a complete workspace (the user requirement).
- Existing `Test` matrixCache usage is unchanged.

## Notes
- `matrixCache` lives in `libraries/tisys/vars/matrixCache.groovy` (loaded via the tipipeline library); the key is `MD5(org/repo/baseSha/pullShas/stageName/extras)`.
- Only `latest/ghpr_check2.groovy` shares the exact structure; the `release-*` branches have byte-identical copies and could be a follow-up.

Part of #4942
