### PR TITLE
fix(tekton): use lowercase resourcetemplates field in tidbx notify triggers

### DIFF
--- a/tekton/v1/triggers/triggers/env-gcp/_/notify/notified-successful-image-delivery-tidbx.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/notify/notified-successful-image-delivery-tidbx.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       params:
         - name: data
-      resourceTemplates:
+      resourcetemplates:
         - apiVersion: tekton.dev/v1
           kind: TaskRun
           metadata:

--- a/tekton/v1/triggers/triggers/env-gcp/_/notify/update-ops-when-tidbx-image-distributed-to-clouds.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/notify/update-ops-when-tidbx-image-distributed-to-clouds.yaml
@@ -42,7 +42,7 @@ spec:
         - name: target_images
         - name: stage
         - name: publisher-url
-      resourceTemplates:
+      resourcetemplates:
         - apiVersion: tekton.dev/v1
           kind: TaskRun
           metadata:

--- a/tekton/v1/triggers/triggers/env-gcp/_/notify/update-tcms-when-tidbx-image-distributed-to-clouds.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/notify/update-tcms-when-tidbx-image-distributed-to-clouds.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       params:
         - name: images
-      resourceTemplates:
+      resourcetemplates:
         - apiVersion: tekton.dev/v1
           kind: TaskRun
           metadata:


### PR DESCRIPTION
## What

Rename the `resourceTemplates` field to `resourcetemplates` in the three tidbx notify Triggers under `tekton/v1/triggers/triggers/env-gcp/_/notify/`.

## Why

The `Trigger` spec field is officially `resourcetemplates` (all lowercase) — see `TriggerTemplateSpec.ResourceTemplates` with json tag `resourcetemplates` in `tektoncd/triggers` and the official docs. Tekton's defaulting webhook normalizes the field to lowercase on the server, so the cluster stores `resourcetemplates` while Flux's kustomize-controller renders camelCase `resourceTemplates`.

Because Flux applies via server-side apply with field-ownership semantics, the camelCase field in the rendered manifests never matches the lowercase field actually stored in the cluster. SSA treats them as different fields, so kustomize-controller reports `Trigger/... unchanged` and **never applies field changes**. This is the root cause why #5001 (removing the stale `notify-config` workspace binding) never took effect and TaskRuns kept failing with:

```
[User error] workspace binding "notify-config" does not match any declared workspace
```

## Test

- `kubectl kustomize tekton/v1/triggers/triggers/env-gcp` passes.
- `kubectl apply --server-side --dry-run=server` with the lowercase field correctly removes the stale `workspaces` binding (the camelCase version reported "unchanged").
- No task/param changes; only the Trigger field name is aligned with the official API.