### PR TITLE
refactor(pipelines): remove unused DM codecov/coveralls credential declarations in tiflow

### DIFF
--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -132,10 +132,6 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -135,10 +135,6 @@ pipeline {
                 }
                 stages {
                     stage("Test") {
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5-fips/pull_dm_integration_test.groovy
@@ -137,10 +137,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
@@ -166,10 +166,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
@@ -166,10 +166,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.2/pull_dm_integration_test.groovy
@@ -134,10 +134,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.3/pull_dm_integration_test.groovy
@@ -134,10 +134,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 40, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.4/pull_dm_integration_test.groovy
@@ -133,10 +133,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
@@ -166,10 +166,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.6/pull_dm_integration_test.groovy
@@ -133,10 +133,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.0/pull_dm_integration_test.groovy
@@ -134,10 +134,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
@@ -166,10 +166,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.2/pull_dm_integration_test.groovy
@@ -134,10 +134,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.3/pull_dm_integration_test.groovy
@@ -134,10 +134,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.4/pull_dm_integration_test.groovy
@@ -134,10 +134,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -166,10 +166,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_dm_integration_test.groovy
@@ -156,10 +156,6 @@ pipeline {
                 stages {
                     stage("Test") {
                         options { timeout(time: 50, unit: 'MINUTES') }
-                        environment {
-                            DM_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            DM_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
-                        }
                         steps {
                             container("mysql1") {
                                 sh label: "copy mysql certs", script: """


### PR DESCRIPTION
Part of #4942 (jenkins migration).

## Summary
Remove the unused `DM_CODECOV_TOKEN` / `DM_COVERALLS_TOKEN` declarations from all 17 tiflow `pull_dm_integration_test` pipelines (`latest`, `latest/pull_dm_integration_test_next_gen`, and every `release-*` branch).

## Why
- These env vars are declared from Jenkins credentials (`codecov-token-tiflow`, `coveralls-token-tiflow`) but are **never consumed** by the tiflow code:
  - tiflow Makefile uses `COVERALLS_TOKEN` only in `integration_test_coverage` (CDC coverage), not in DM.
  - `dm_coverage` and `dm/tests/run_group.sh` reference neither `DM_CODECOV_TOKEN` nor `DM_COVERALLS_TOKEN`.
- On the target Jenkins, the `credentials('coveralls-token-tiflow')` step fails with `ERROR: coveralls-token-tiflow` (credential not provisioned), failing the whole build even though the value is unused. Removing the declarations removes that hard dependency.

## Scope
17 files changed (68 deletions), each removing the 4-line `environment { DM_CODECOV_TOKEN ...; DM_COVERALLS_TOKEN ... }` block from the matrix `Test` stage.

Part of #4942
