### PR TITLE
ci(prow): migrate tiflow kafka integration test and merged unit test to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflow/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     - name: pingcap/tiflow/merged_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -94,7 +94,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_kafka_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files


### PR DESCRIPTION
Part of #4942 (jenkins migration), Phase 3.

## Summary
Flip the following tiflow jobs to run on the target jenkins (`master: "0"`):
- `pingcap/tiflow/pull_cdc_integration_kafka_test` (latest-presubmits)
- `pingcap/tiflow/merged_unit_test` (latest-postsubmits)

Both verified green on the target jenkins (builds in PR description of #4985).

Part of #4942
