### PR TITLE
ci(prow): migrate ticdc v8.1 mysql light integration and tidb-test ghpr_mysql_test to target jenkins

### DIFF
--- a/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test

--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -123,6 +123,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_light_v8_1
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: false
       optional: true


### PR DESCRIPTION
Part of #4942 (jenkins migration), Phase 3.

## Summary
Flip the following verified-green jobs to run on the target jenkins (`labels.master` 1 -> 0):
- `pingcap/ticdc/pull_cdc_mysql_integration_light_v8_1` (latest-presubmits)
- `pingcap-qe/tidb-test/ghpr_mysql_test` (latest-presubmits)

Both passed verification on the target jenkins in the full-list PRs (#4987, #4986).

Part of #4942
