### PR TITLE
feat(ci): use source-build params for jenkins migration verification

### DIFF
--- a/.ci/verify-jenkins-migration.sh
+++ b/.ci/verify-jenkins-migration.sh
@@ -202,10 +202,10 @@ collect_flipped_jobs() {
 # Extract parameters from a build URL on the from jenkins; exits non-zero when
 # the build does not exist.
 get_params_from_build() {
-    local url="$1"
-    curl -fsS -g "${CURL_AUTH_FROM[@]}" "$url" | \
-        jq -c '[.actions[]?.parameters[]? | select(.name? != null) | {name, value: ((.value // "") | tostring)}]' | \
-        jq -r '.[] | @base64'
+    local url="$1" body
+    body="$(curl -fsS -g "${CURL_AUTH_FROM[@]}" "$url" 2>/dev/null || curl -fsS -g "$url" 2>/dev/null)" || return 1
+    jq -c '[.actions[]?.parameters[]? | select(.name? != null) | {name, value: ((.value // "") | tostring)}]' <<<"$body" | \
+        jq -r '.[] | @base64' || return 1
 }
 
 # Output base64-encoded JSON records {name,value} of the parameters used to

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -136,6 +136,7 @@ presubmits:
                   --timeout 7200 \
                   --poll-interval 20 \
                   --retries 3 \
+                  --source-build https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/ghpr_build/43 \
                   --verbose
             resources:
               limits:

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -85,7 +85,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-mysql-test
@@ -96,7 +96,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_tici_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-tici-test
@@ -185,7 +185,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       # never run before
       decorate: false # need add this.
       optional: true
@@ -254,7 +254,7 @@ presubmits:
       name: pingcap/tidb/pull_tiflash_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       # this job never run before.
       decorate: false # need add this.
       optional: true


### PR DESCRIPTION
Part of #4942 (jenkins migration).

## Summary
Make the migration verification use **version-matched parameters**:

1. `pull-verify-jenkins-migration` presubmit now passes
   `--source-build https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/ghpr_build/43`
   (a recent successful tidb build on the target jenkins, PR #70668, today).
   Version-sensitive jobs (`pull_integration_mysql_test`, `pull_integration_tici_test`,
   `pull_integration_common_test`, `pull_tiflash_integration_test`, ticdc v7.5
   integration) previously failed on the target jenkins because the copied
   `lastSuccessfulBuild` parameters pointed at an old tidb commit whose test
   results no longer match the current tidb-test `.result` files.
2. `verify-jenkins-migration.sh`: `get_params_from_build` now falls back to an
   anonymous fetch when the authenticated fetch fails, since the source-build
   host (`do.pingcap.net/jenkins`) is publicly readable while the from-jenkins
   credentials 401 against it.

## Effect
Open migration PRs for the version-sensitive jobs will re-verify with
version-matched params once this lands (required check gates the merge).

Part of #4942
