### PR TITLE
ci(prow): migrate tidb-test ghpr_build to target jenkins

### DIFF
--- a/.ci/verify-jenkins-migration.sh
+++ b/.ci/verify-jenkins-migration.sh
@@ -202,10 +202,10 @@ collect_flipped_jobs() {
 # Extract parameters from a build URL on the from jenkins; exits non-zero when
 # the build does not exist.
 get_params_from_build() {
-    local url="$1"
-    curl -fsS -g "${CURL_AUTH_FROM[@]}" "$url" | \
-        jq -c '[.actions[]?.parameters[]? | select(.name? != null) | {name, value: ((.value // "") | tostring)}]' | \
-        jq -r '.[] | @base64'
+    local url="$1" body
+    body="$(curl -fsS -g "${CURL_AUTH_FROM[@]}" "$url" 2>/dev/null || curl -fsS -g "$url" 2>/dev/null)" || return 1
+    jq -c '[.actions[]?.parameters[]? | select(.name? != null) | {name, value: ((.value // "") | tostring)}]' <<<"$body" | \
+        jq -r '.[] | @base64' || return 1
 }
 
 # Output base64-encoded JSON records {name,value} of the parameters used to

--- a/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build


### PR DESCRIPTION
Part of #4942 (jenkins migration), Phase 3.

## Summary
Flip `pingcap-qe/tidb-test/ghpr_build` to run on the target jenkins (`labels.master` 1 -> 0).

Verified **success** on the target jenkins in the #4986 verification run.

Part of #4942
