### PR TITLE
ci(prow): migrate 4 verified pingcap/ticdc latest jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -26,6 +26,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-mysql-integration-heavy
@@ -44,6 +46,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_heavy
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-kafka-integration-heavy
@@ -77,6 +81,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_light
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-storage-integration-light
@@ -135,6 +141,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy_v8_1
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: false
       optional: true


### PR DESCRIPTION
Part of #4942 (jenkins migration), Phase 3.

## Summary
Flip the following verified-green ticdc latest jobs to run on the target jenkins (`labels.master` 1 -> 0):
- `pingcap/ticdc/pull_cdc_mysql_integration_heavy`
- `pingcap/ticdc/pull_cdc_kafka_integration_heavy`
- `pingcap/ticdc/pull_cdc_storage_integration_light`
- `pingcap/ticdc/pull_cdc_mysql_integration_heavy_v8_1`

All 4 passed verification on the target jenkins in the #4987 run.

Part of #4942
