### PR TITLE
fix(tekton): replace removed bitnami/git image and move ci-helper-for-pr to v1

### DIFF
--- a/tekton/v0/tasks/hotfix/create-pr-to-sync-owners.yaml
+++ b/tekton/v0/tasks/hotfix/create-pr-to-sync-owners.yaml
@@ -22,7 +22,7 @@ spec:
       type: string
   steps:
     - name: clone-community-repo
-      image: bitnami/git:2.43.0
+      image: alpine/git:v2.52.0
       workingDir: /workspace
       script: |
         git clone https://github.com/pingcap/community.git --branch master

--- a/tekton/v0/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
+++ b/tekton/v0/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
@@ -23,13 +23,13 @@ spec:
       default: ghcr.io/pingcap-qe/ci/base:v20231216-14-g77d0cd2-go1.19
   steps:
     - name: clone
-      image: bitnami/git:2.43.0
+      image: alpine/git:v2.52.0
       workingDir: /workspace
       script: |
         git clone $(params.git-url) --branch $(params.branch) /workspace/src
 
     - name: update-ladp-crt-key
-      image: bitnami/git:2.43.0
+      image: alpine/git:v2.52.0
       workingDir: /workspace/src
       script: |
         git config --global --add safe.directory `pwd`
@@ -144,7 +144,7 @@ spec:
         fi
 
     - name: create-pr
-      image: bitnami/git:2.43.0
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.12.7-4-gf33384f
       workingDir: /workspace/src
       script: |
         git config --global --add safe.directory `pwd`
@@ -202,14 +202,8 @@ spec:
           git commit -am "$go_mod_commit_msg"
         fi
 
-        # login and setup git (gh tool installation assumed to be idempotent or handled)
-        # install `gh` tool (ensure it's available)
-        type -p curl >/dev/null || ( apt update && apt install curl -y)
-        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |  dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-        && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |  tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-        && apt update \
-        && apt install gh -y
+        # login and setup git (release utils image ships `gh`; install if missing)
+        type -p gh >/dev/null || apk add --no-cache gh
 
         gh auth login --with-token < $(workspaces.github.path)/token
         gh auth setup-git

--- a/tekton/v0/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
+++ b/tekton/v0/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
@@ -144,7 +144,7 @@ spec:
         fi
 
     - name: create-pr
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.12.7-4-gf33384f
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2026.7.12-4-g372cd24
       workingDir: /workspace/src
       script: |
         git config --global --add safe.directory `pwd`

--- a/tekton/v0/tasks/kustomization.yaml
+++ b/tekton/v0/tasks/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - build/pingcap-build-binaries-darwin.yaml
   - build/pingcap-build-binaries-linux.yaml
   - build/pingcap-build-images.yaml
-  - ci/ci-helper-for-pr.yaml
   - crane-copy.yaml # crane copy task
   - echo.yaml ##### an example task.
   - gen-build-binaries-scripts.yaml

--- a/tekton/v1/tasks/ci/ci-helper-for-pr.yaml
+++ b/tekton/v1/tasks/ci/ci-helper-for-pr.yaml
@@ -1,30 +1,37 @@
-apiVersion: tekton.dev/v1beta1
+# yaml-language-server: $schema=https://github.com/redhat-developer/vscode-tekton/raw/refs/heads/main/scheme/tekton.dev/v1_Task.json
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: ci-helper-for-pr
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.29.0"
+    tekton.dev/categories: GitHub
+    tekton.dev/tags: github,ci
+    tekton.dev/displayName: "ci helper for pull requests"
+    tekton.dev/platforms: "linux/amd64"
 spec:
   description: CI helper for contribution pull requests
   params:
     - name: owner
       description: repo owner
+      type: string
     - name: repo
       description: repo short name
+      type: string
     - name: number
       description: pull request number
+      type: string
   steps:
     - name: create-pull-request
-      image: bitnami/git:2.43.0
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.12.7-4-gf33384f
       script: |
         #!/usr/bin/env bash
-        set -exo pipefail
+        set -euo pipefail
 
-        # install `gh` tool
-        type -p curl >/dev/null || ( apt update &&  apt install curl -y)
-        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |  dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-        && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |  tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-        && apt update \
-        && apt install gh -y
+        # install `gh` tool (release utils image ships `gh`; install if missing)
+        type -p gh >/dev/null || apk add --no-cache gh
 
         gh auth login --with-token < $(workspaces.github.path)/token
 

--- a/tekton/v1/tasks/ci/ci-helper-for-pr.yaml
+++ b/tekton/v1/tasks/ci/ci-helper-for-pr.yaml
@@ -25,7 +25,7 @@ spec:
       type: string
   steps:
     - name: create-pull-request
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.12.7-4-gf33384f
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2026.7.12-4-g372cd24
       script: |
         #!/usr/bin/env bash
         set -euo pipefail

--- a/tekton/v1/tasks/hotfix/create-pr-to-sync-owners.yaml
+++ b/tekton/v1/tasks/hotfix/create-pr-to-sync-owners.yaml
@@ -23,7 +23,7 @@ spec:
       type: string
   steps:
     - name: clone-community-repo
-      image: bitnami/git:2.43.0
+      image: alpine/git:v2.54.0
       workingDir: /workspace
       script: |
         git clone https://github.com/pingcap/community.git --branch master

--- a/tekton/v1/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
+++ b/tekton/v1/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
@@ -24,13 +24,13 @@ spec:
       default: ghcr.io/pingcap-qe/ci/base:v20231216-14-g77d0cd2-go1.19
   steps:
     - name: clone
-      image: bitnami/git:2.43.0
+      image: alpine/git:v2.54.0
       workingDir: /workspace
       script: |
         git clone $(params.git-url) --branch $(params.branch) /workspace/src
 
     - name: update-ladp-crt-key
-      image: bitnami/git:2.43.0
+      image: alpine/git:v2.54.0
       workingDir: /workspace/src
       script: |
         git config --global --add safe.directory `pwd`
@@ -145,7 +145,7 @@ spec:
         fi
 
     - name: create-pr
-      image: bitnami/git:2.43.0
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.12.7-4-gf33384f
       workingDir: /workspace/src
       script: |
         git config --global --add safe.directory `pwd`
@@ -203,14 +203,8 @@ spec:
           git commit -am "$go_mod_commit_msg"
         fi
 
-        # login and setup git (gh tool installation assumed to be idempotent or handled)
-        # install `gh` tool (ensure it's available)
-        type -p curl >/dev/null || ( apt update && apt install curl -y)
-        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg |  dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-        && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |  tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-        && apt update \
-        && apt install gh -y
+        # login and setup git (release utils image ships `gh`; install if missing)
+        type -p gh >/dev/null || apk add --no-cache gh
 
         gh auth login --with-token < $(workspaces.github.path)/token
         gh auth setup-git

--- a/tekton/v1/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
+++ b/tekton/v1/tasks/hotfix/create-pr-to-update-gomod-fix-ladp.yaml
@@ -145,7 +145,7 @@ spec:
         fi
 
     - name: create-pr
-      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.12.7-4-gf33384f
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2026.7.12-4-g372cd24
       workingDir: /workspace/src
       script: |
         git config --global --add safe.directory `pwd`

--- a/tekton/v1/tasks/kustomization.yaml
+++ b/tekton/v1/tasks/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ci/ci-helper-for-pr.yaml
   - ci/resolve-cherrypick-conflicts.yaml
   - delivery/pingcap-deliver-binaries.yaml
   - delivery/pingcap-deliver-images.yaml


### PR DESCRIPTION
## Summary

Fix hotfix Tekton TaskRuns failing with `ErrImagePull: docker.io/bitnami/git:2.43.0: not found`.

Bitnami removed all version-tagged images from Docker Hub, so `bitnami/git:2.43.0` no longer exists.

## Changes

- Replace `bitnami/git:2.43.0` with `alpine/git` in git-only steps and with the bundled `ghcr.io/pingcap-qe/cd/utils/release` image in gh-based PR-creation steps (`create-pr-to-sync-owners`, `create-pr-to-update-gomod-fix-ladp`, both v0/v1).
- Replace Debian/apt-based gh install in `create-pr` steps with an Alpine-safe `type -p gh || apk add gh` guard.
- Move `ci-helper-for-pr` from `tekton/v0` to `tekton/v1` (v0 is not applied by FluxCD). Updated to `tekton.dev/v1` API and v1 metadata; only the env-gcp `pr-labeled-with-needs-ok-to-test` trigger routes to it.

## Validation

- `kubectl kustomize tekton/v1/tasks` renders cleanly with the new task included.
- `.ci/update-tekton-kustomizations.sh` confirms kustomization is up to date.
- No `bitnami/git` references remain in the repo.