### PR TITLE
ci(prow): migrate ticdc kafka integration light test to target jenkins

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -37,6 +37,8 @@ presubmits:
 
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_light
+      labels:
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-kafka-integration-light


### PR DESCRIPTION
Part of #4942 (jenkins migration), Phase 3 (#4951).

## Summary
Flip `pingcap/ticdc/pull_cdc_kafka_integration_light` to run on the target jenkins (`labels.master` 1 -> 0).

This is the **required** (`run_before_merge: true`, non-optional) ticdc kafka light integration job. Its previous verify failure is being investigated separately; splitting it into its own PR isolates it from the two optional v7.5 jobs (#4987).

Part of #4942
Part of #4951
