### PR TITLE
chore(pipelines/pingcap/tidb): reduce check2 golang container memory to 12Gi

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -14,11 +14,11 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 24Gi
+          memory: 12Gi
           cpu: "3"
           ephemeral-storage: 20Gi
         limits:
-          memory: 24Gi
+          memory: 12Gi
           cpu: "3"
           ephemeral-storage: 120Gi
       volumeMounts:


### PR DESCRIPTION
## Summary

Reduce the `ghpr_check2` pod's `golang` container memory from `24Gi` to `12Gi` in `pod-ghpr_check2.yaml` (latest branch), aligning requests and limits.

## Background

Current `requests.memory`/`limits.memory` is `24Gi` (set in #4982 to prevent kubelet eviction). The bazel build peak usage was ~12.3Gi, so 24Gi is over-provisioned. This PR brings memory down to 12Gi to improve node packing efficiency.

## Changes

- `pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml`: `memory: 24Gi` → `12Gi` for both requests and limits of the `golang` container.

## Validation

- [ ] Verify no kubelet evictions / OOM on `latest` branch with a replay build.