### PR TITLE
Revert "chore(pipelines/pingcap/tidb): reduce check2 golang container memory to 12Gi"

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -14,11 +14,11 @@ spec:
           value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
-          memory: 12Gi
+          memory: 24Gi
           cpu: "3"
           ephemeral-storage: 20Gi
         limits:
-          memory: 12Gi
+          memory: 24Gi
           cpu: "3"
           ephemeral-storage: 120Gi
       volumeMounts:


### PR DESCRIPTION
Reverts PingCAP-QE/ci#5032