### PR TITLE
chore(prow-jobs): mark pull-verify-jenkins-migration as optional

### DIFF
--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -24,6 +24,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -24,6 +24,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap-inc/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -28,6 +28,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_integration_br_test.groovy
@@ -22,6 +22,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -24,6 +24,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -24,6 +24,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -24,6 +24,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap-inc/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -24,6 +24,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -26,6 +26,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_kafka_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -26,6 +26,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen/pipeline.groovy
@@ -26,6 +26,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,6 +25,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v7_5/pipeline.groovy
@@ -28,6 +28,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_heavy_v8_1/pipeline.groovy
@@ -28,6 +28,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light/pipeline.groovy
@@ -24,6 +24,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen/pipeline.groovy
@@ -26,6 +26,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,6 +25,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v7_5/pipeline.groovy
@@ -25,6 +25,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_mysql_integration_light_v8_1/pipeline.groovy
@@ -25,6 +25,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
@@ -24,6 +24,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen/pipeline.groovy
@@ -26,6 +26,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,6 +25,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light/pipeline.groovy
@@ -24,6 +24,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen/pipeline.groovy
@@ -26,6 +26,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -25,6 +25,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_heavy_next_gen_legacy_safepoint/pipeline.groovy
@@ -26,6 +26,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light/pipeline.groovy
@@ -28,6 +28,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/hub'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen/pipeline.groovy
@@ -27,6 +27,7 @@ pipeline {
     environment {
         // internal mirror is 'hub-zot.pingcap.net/mirrors/tidbx'
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
     }
     options {

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_storage_integration_light_next_gen_legacy_safepoint/pipeline.groovy
@@ -26,6 +26,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = 1
         LEGACY_SAFEPOINT = 1
     }

--- a/pipelines/pingcap/tidb/latest/merged_common_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_common_test.groovy
@@ -21,7 +21,7 @@ pipeline {
     environment {
         GITHUB_TOKEN = credentials('github-bot-token')
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
-        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_br_test.groovy
@@ -30,6 +30,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/latest/merged_integration_lightning_test.groovy
@@ -27,7 +27,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
-        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_br_integration_test.groovy
@@ -21,6 +21,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pipeline.groovy
@@ -29,6 +29,7 @@ pipeline {
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -31,6 +31,7 @@ pipeline {
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pipeline.groovy
@@ -34,6 +34,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     stages {
         stage('Checkout') {

--- a/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_lightning_integration_test.groovy
@@ -20,6 +20,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/pull_br_integration_test.groovy
@@ -21,6 +21,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/pull_br_integration_test.groovy
@@ -21,6 +21,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_br_integration_test.groovy
@@ -21,6 +21,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 90, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.1/pull_lightning_integration_test.groovy
@@ -20,6 +20,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_br_test.groovy
@@ -21,6 +21,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_integration_lightning_test.groovy
@@ -20,6 +20,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_br_test.groovy
@@ -21,6 +21,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 180, unit: 'MINUTES')

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_integration_lightning_test.groovy
@@ -20,6 +20,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -22,6 +22,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
@@ -22,6 +22,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -30,6 +30,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -25,6 +25,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -25,6 +25,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
@@ -27,6 +27,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -28,6 +28,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
@@ -26,6 +26,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
@@ -21,6 +21,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -26,6 +26,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
@@ -28,6 +28,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
@@ -27,6 +27,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_kafka_test.groovy
@@ -22,6 +22,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_pulsar_test.groovy
@@ -22,6 +22,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_storage_test.groovy
@@ -22,6 +22,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_cdc_integration_test.groovy
@@ -22,6 +22,7 @@ pipeline {
     agent none
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_compatibility_test.groovy
@@ -25,6 +25,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test.groovy
@@ -24,6 +24,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 120, unit: 'MINUTES')

--- a/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
+++ b/pipelines/pingcap/tiflow/latest/pull_dm_integration_test_next_gen.groovy
@@ -24,6 +24,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
         NEXT_GEN = '1'
     }
     options {

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
@@ -23,6 +23,9 @@ pipeline {
     options {
         timeout(time: 65, unit: 'MINUTES')
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_mysql_test.groovy
@@ -23,6 +23,9 @@ pipeline {
     options {
         timeout(time: 80, unit: 'MINUTES')
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_compatibility_test.groovy
@@ -28,6 +28,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Check diff files') {
             steps {

--- a/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_dm_integration_test.groovy
@@ -24,6 +24,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Check Diff & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -24,6 +24,9 @@ pipeline {
     options {
         timeout(time: 65, unit: 'MINUTES')
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_mysql_test.groovy
@@ -24,6 +24,9 @@ pipeline {
     options {
         timeout(time: 60, unit: 'MINUTES')
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -24,6 +24,9 @@ pipeline {
     options {
         timeout(time: 60, unit: 'MINUTES')
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_compatibility_test.groovy
@@ -28,6 +28,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Check diff files') {
             steps {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_dm_integration_test.groovy
@@ -24,6 +24,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Check Diff & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -24,6 +24,9 @@ pipeline {
     options {
         timeout(time: 65, unit: 'MINUTES')
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -24,6 +24,9 @@ pipeline {
     options {
         timeout(time: 60, unit: 'MINUTES')
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test.groovy
@@ -24,6 +24,9 @@ pipeline {
     options {
         timeout(time: 60, unit: 'MINUTES')
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -24,6 +24,9 @@ pipeline {
     options {
         timeout(time: 60, unit: 'MINUTES')
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_compatibility_test.groovy
@@ -28,6 +28,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Check diff files') {
             steps {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_dm_integration_test.groovy
@@ -24,6 +24,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Check Diff & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
@@ -25,6 +25,9 @@ pipeline {
         timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
@@ -25,6 +25,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test.groovy
@@ -25,6 +25,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
@@ -25,6 +25,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_compatibility_test.groovy
@@ -28,6 +28,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Check diff files') {
             steps {

--- a/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_dm_integration_test.groovy
@@ -24,6 +24,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Check Diff & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -25,6 +25,9 @@ pipeline {
         timeout(time: 65, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -25,6 +25,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test.groovy
@@ -25,6 +25,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -25,6 +25,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Checkout & Prepare') {
             agent {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_compatibility_test.groovy
@@ -28,6 +28,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Check diff files') {
             steps {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_dm_integration_test.groovy
@@ -24,6 +24,9 @@ pipeline {
         timeout(time: 60, unit: 'MINUTES')
         parallelsAlwaysFailFast()
     }
+    environment {
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
+    }
     stages {
         stage('Check Diff & Prepare') {
             agent {

--- a/pipelines/qa/qa-release-br-integration-test.groovy
+++ b/pipelines/qa/qa-release-br-integration-test.groovy
@@ -22,6 +22,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/qa/qa-release-lightning-integration-test.groovy
+++ b/pipelines/qa/qa-release-lightning-integration-test.groovy
@@ -21,6 +21,7 @@ pipeline {
     }
     environment {
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 60, unit: 'MINUTES')

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -32,6 +32,7 @@ pipeline {
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     stages {
         stage('Checkout') {

--- a/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_kafka_test.groovy
@@ -31,6 +31,7 @@ pipeline {
         // tikv-server: hub-zot.pingcap.net/mirrors/hub/tikv/tikv/package:<tag>_linux_amd64
         // pd-server:   hub-zot.pingcap.net/mirrors/hub/tikv/pd/package:<tag>_linux_amd64
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/tikv/migration/latest/pull_integration_test.groovy
+++ b/pipelines/tikv/migration/latest/pull_integration_test.groovy
@@ -31,6 +31,7 @@ pipeline {
         // tikv-server: hub-zot.pingcap.net/mirrors/hub/tikv/tikv/package:<tag>_linux_amd64
         // pd-server:   hub-zot.pingcap.net/mirrors/hub/tikv/pd/package:<tag>_linux_amd64
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     options {
         timeout(time: 65, unit: 'MINUTES')

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -34,6 +34,7 @@ pipeline {
     environment {
         NEXT_GEN = '1' // enable build and test for Next Gen kernel type.
         OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_TIDBX}"
+        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
     }
     stages {
         stage('Checkout') {

--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -80,6 +80,7 @@ presubmits:
     - name: pull-verify-jenkins-migration
       labels: *labels
       decorate: true
+      optional: true
       run_if_changed: "^prow-jobs/.*\\.ya?ml$"
       timeout: 4h
       branches:


### PR DESCRIPTION
Align `pull-verify-jenkins-migration` with the design in #4942 (optional, not a tide gate). It was missing `optional: true`, so tide treats it as required and blocks migration PRs whose verification can't pass due to target-Jenkins infra/version issues (e.g. #4987).