### PR TITLE
ci(prow): migrate 5 optional tidb-test tiproxy jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/latest-presubmits.yaml
@@ -101,7 +101,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_tiproxy_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -114,7 +114,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_tiproxy_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -127,7 +127,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_tiproxy_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -140,7 +140,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_tiproxy_ruby_orm_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -153,7 +153,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/pull_tiproxy_mysql_connector_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Split the 5 **optional** (and never-run) `pull_tiproxy_*` jobs out of #4986:

- `pull_tiproxy_mysql_test`
- `pull_tiproxy_common_test`
- `pull_tiproxy_jdbc_test`
- `pull_tiproxy_ruby_orm_test`
- `pull_tiproxy_mysql_connector_test`

These jobs have **0 builds on from-Jenkins** (no lastSuccessfulBuild → `pull-verify-jenkins-migration` cannot verify them with params; they were never triggered because they are `optional: true` + `always_run: false`). Flipping `master: "0"` is low risk since they effectively never run. The 5 **required** tidb-test jobs stay in #4986.