### PR TITLE
chore(pipelines): switch jenkins image to ghcr.io registry

### DIFF
--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_mysql_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_common_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: java
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
@@ -18,7 +18,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: java
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       command:
         - sh
         - -c
@@ -20,7 +20,7 @@ spec:
           name: "tidb-temp-dir-volume"
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml
@@ -5,7 +5,7 @@ spec:
     runAsUser: 0
   containers:
     - name: nodejs
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pod-pull_mysql_client_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_mysql_client_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
@@ -19,7 +19,7 @@ spec:
           mountPath: /git
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pod.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       command:
         - sh
         - -c
@@ -20,7 +20,7 @@ spec:
           name: "tidb-temp-dir-volume"
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_binlog_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_ddl_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_tidb_tools_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_sqllogic_test.yaml
@@ -19,7 +19,7 @@ spec:
           mountPath: /git
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_tiflash_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       command:
         - sh
         - -c
@@ -20,7 +20,7 @@ spec:
           name: "tidb-temp-dir-volume"
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_binlog_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_ddl_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_nodejs_test.yaml
@@ -5,7 +5,7 @@ spec:
     runAsUser: 0
   containers:
     - name: nodejs
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_python_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_tidb_tools_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_mysql_client_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_mysql_client_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_sqllogic_test.yaml
@@ -19,7 +19,7 @@ spec:
           mountPath: /git
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_tiflash_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_br_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: init-mysql-config
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       command:
         - sh
         - -c
@@ -20,7 +20,7 @@ spec:
           name: "tidb-temp-dir-volume"
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_binlog_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_ddl_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_nodejs_test.yaml
@@ -5,7 +5,7 @@ spec:
     runAsUser: 0
   containers:
     - name: nodejs
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_python_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_tidb_tools_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_lightning_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_lightning_integration_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_mysql_client_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_mysql_client_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_sqllogic_test.yaml
@@ -19,7 +19,7 @@ spec:
           mountPath: /git
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_tiflash_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_ddl_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_nodejs_test.yaml
@@ -5,7 +5,7 @@ spec:
     runAsUser: 0
   containers:
     - name: nodejs
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_python_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_tidb_tools_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_mysql_client_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_mysql_client_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_sqllogic_test.yaml
@@ -19,7 +19,7 @@ spec:
           mountPath: /git
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_br_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_common_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_copr_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_ddl_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_e2e_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_jdbc_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_nodejs_test.yaml
@@ -5,7 +5,7 @@ spec:
     runAsUser: 0
   containers:
     - name: nodejs
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_python_orm_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_tidb_tools_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_mysql_client_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_mysql_client_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_mysql_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_sqllogic_test.yaml
@@ -19,7 +19,7 @@ spec:
           mountPath: /git
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
+      image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
       env:
         - name: GOPROXY


### PR DESCRIPTION
Replace `us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins` with `ghcr.io/pingcap-qe/ci/jenkins` in all pod templates under `pipelines/` (98 files).