### PR TITLE
chore(pipelines): remove GOPROXY env var from pod templates

### DIFF
--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_build.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           cpu: "24"

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check2.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check2.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         limits:
           memory: 32Gi

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_unit_test.yaml
@@ -11,9 +11,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/pipelines/pingcap/tidb/latest/ghpr_build/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/ghpr_build/pod.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           cpu: "2"

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 24Gi

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -11,9 +11,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 6Gi

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 6Gi

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 6Gi

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
@@ -11,9 +11,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 16Gi

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
@@ -11,9 +11,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
@@ -22,9 +22,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: nodejs
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 16Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
@@ -21,9 +21,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/latest/pull_build_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_build_next_gen/pod.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 32Gi

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pod.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pod.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_client_test_next_gen/pod.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pod.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
@@ -11,9 +11,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 60Gi

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           cpu: "2"

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_build.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           cpu: "2"

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
@@ -11,9 +11,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml
@@ -22,9 +22,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_binlog_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_copr_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_ddl_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_jdbc_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_tidb_tools_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_sqllogic_test.yaml
@@ -21,9 +21,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_tiflash_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_build.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           cpu: "2"

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml
@@ -11,9 +11,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml
@@ -22,9 +22,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_binlog_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_copr_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_ddl_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_jdbc_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_nodejs_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: nodejs
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_python_orm_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_tidb_tools_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_sqllogic_test.yaml
@@ -21,9 +21,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_tiflash_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_build.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           cpu: "2"

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_unit_test.yaml
@@ -11,9 +11,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_br_integration_test.yaml
@@ -22,9 +22,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_binlog_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_copr_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_ddl_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_jdbc_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_nodejs_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: nodejs
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_python_orm_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_tidb_tools_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_lightning_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_lightning_integration_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 16Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_sqllogic_test.yaml
@@ -21,9 +21,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_tiflash_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           cpu: "24"

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_check.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_check.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_check2.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 24Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_copr_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_ddl_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_jdbc_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 32Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_mysql_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_nodejs_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: nodejs
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       volumeMounts:
         - mountPath: /tmp/tidb
           name: tidb-tmp

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_python_orm_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_tidb_tools_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_sqllogic_test.yaml
@@ -21,9 +21,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
@@ -11,9 +11,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_build.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_build.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           cpu: "24"

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check2.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 16Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_br_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_common_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_common_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_copr_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_ddl_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_e2e_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_jdbc_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 4Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_lightning_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 32Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_mysql_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_nodejs_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: nodejs
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.1.18-8-gbb5ada9-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       volumeMounts:
         - mountPath: /tmp/tidb
           name: tidb-tmp

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_python_orm_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_tidb_tools_test.yaml
@@ -7,9 +7,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_sqllogic_test.yaml
@@ -21,9 +21,6 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 8Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_unit_test.yaml
@@ -11,9 +11,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 48Gi

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml
@@ -9,9 +9,6 @@ spec:
       securityContext:
         privileged: true
       tty: true
-      env:
-        - name: GOPROXY
-          value: "https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct"
       resources:
         requests:
           memory: 24Gi


### PR DESCRIPTION
Remove the GOPROXY environment variable from Jenkins pod templates under `pipelines/` so Go toolchain defaults (or Jenkins-level config) apply instead of the hardcoded `https://us-go.pkg.dev/pingcap-testing-account/go-proxy-remote|https://proxy.golang.org,direct`.

- 129 pod YAML files updated across `pipelines/pingcap/tidb` (latest, release-6.5/7.1/7.5/8.1/8.5/9.0-beta), `pipelines/pingcap-inc/tidb`, and `pipelines/tidbcloud/cloud-storage-engine`.
- Removed the now-empty `env:` block in each container.
- No pipeline `.groovy` files reference GOPROXY.