### PR TITLE
ci(prow): roll back tidb/ticdc/tiflow latest-branch jenkins-agent jobs to from Jenkins (master: "0" -> "1")

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_light
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-mysql-integration-light
@@ -27,7 +27,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-mysql-integration-heavy
@@ -47,7 +47,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_heavy
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-kafka-integration-heavy
@@ -58,7 +58,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_light
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-pulsar-integration-light
@@ -70,7 +70,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_heavy
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-pulsar-integration-heavy
@@ -82,7 +82,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_light
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-storage-integration-light
@@ -93,7 +93,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_storage_integration_heavy
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-storage-integration-heavy
@@ -104,7 +104,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_light_v7_5
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: false
       optional: true
@@ -116,7 +116,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy_v7_5
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: false
       optional: true
@@ -134,7 +134,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_light_v8_1
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: false
       optional: true
@@ -146,7 +146,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy_v8_1
       labels:
-        master: "0"
+        master: "1"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: false
       optional: true

--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
       name: pingcap/tidb/merged_e2e_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/e2e-test
@@ -22,7 +22,7 @@ postsubmits:
       name: pingcap/tidb/merged_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/common-test
@@ -33,7 +33,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: ci/integration-jdbc-test
       skip_if_only_changed: *skip_if_only_changed
@@ -44,7 +44,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-mysql-test
@@ -55,7 +55,7 @@ postsubmits:
       name: pingcap/tidb/merged_sqllogic_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/sqllogic-test
@@ -66,7 +66,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-copr-test
@@ -77,7 +77,7 @@ postsubmits:
       name: pingcap/tidb/merged_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test
@@ -88,7 +88,7 @@ postsubmits:
       name: pingcap/tidb/merged_unit_test_ddlv1
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/unit-test-ddlv1 # TODO: change to ci/ after test.
@@ -99,7 +99,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-python-orm-test
@@ -110,7 +110,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_lightning_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/integration-lightning-test

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       name: pingcap/tidb/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/build
@@ -30,7 +30,7 @@ presubmits:
       name: pingcap/tidb/ghpr_check
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/check_dev
@@ -41,7 +41,7 @@ presubmits:
       name: pingcap/tidb/ghpr_check2
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -52,7 +52,7 @@ presubmits:
       name: pingcap/tidb/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/mysql-test
@@ -63,7 +63,7 @@ presubmits:
       name: pingcap/tidb/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/unit-test
@@ -74,7 +74,7 @@ presubmits:
       name: pingcap/tidb/pull_unit_test_ddlv1
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       run_if_changed: "pkg/(ddl|meta)/.*"
       context: pull-unit-test-ddlv1
@@ -85,7 +85,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       optional: true
       context: pull-integration-mysql-test
@@ -96,7 +96,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_tici_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-tici-test
@@ -108,7 +108,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       optional: true
       context: pull-integration-copr-test
@@ -119,7 +119,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       optional: true
       context: pull-integration-jdbc-test
@@ -130,7 +130,7 @@ presubmits:
       name: pingcap/tidb/pull_e2e_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       optional: true
       context: pull-e2e-test
@@ -141,7 +141,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_e2e_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-e2e-test
@@ -152,7 +152,7 @@ presubmits:
       name: pingcap/tidb/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: pull-br-integration-test
       run_if_changed: "(br|pkg/(ddl|domain|infoschema))/.*"
@@ -163,7 +163,7 @@ presubmits:
       name: pingcap/tidb/pull_lightning_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       run_if_changed: "(lightning|pkg/(domain|statistics|ddl|infoschema)|br/pkg/(checksum|httputil|membuf|pdutil|restore/split|storage))/.*"
@@ -174,7 +174,7 @@ presubmits:
       name: pingcap/tidb/pull_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       optional: true
       context: pull-common-test
@@ -185,7 +185,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       # never run before
       decorate: false # need add this.
       optional: true
@@ -197,7 +197,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -210,7 +210,7 @@ presubmits:
       name: pingcap/tidb/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       optional: true
       context: pull-sqllogic-test
@@ -221,7 +221,7 @@ presubmits:
       name: pingcap/tidb/pull_mysql_client_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-mysql-client-test
@@ -232,7 +232,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       optional: true
       context: pull-integration-nodejs-test
@@ -243,7 +243,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       optional: true
       context: pull-integration-python-orm-test
@@ -254,7 +254,7 @@ presubmits:
       name: pingcap/tidb/pull_tiflash_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       # this job never run before.
       decorate: false # need add this.
       optional: true

--- a/prow-jobs/pingcap/tiflow/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     - name: pingcap/tiflow/merged_unit_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -94,7 +94,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_kafka_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -109,7 +109,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -122,7 +122,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_storage_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -135,7 +135,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_pulsar_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -148,7 +148,7 @@ presubmits:
     - name: pingcap/tiflow/pull_dm_compatibility_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -161,7 +161,7 @@ presubmits:
     - name: pingcap/tiflow/pull_dm_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       run_if_changed: "^(dm/.*|pkg/.*|sync_diff_inspector/.*|go\\.mod)$"
@@ -174,7 +174,7 @@ presubmits:
     - name: pingcap/tiflow/pull_syncdiff_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -186,7 +186,7 @@ presubmits:
     - name: pingcap/tiflow/ghpr_verify
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify


### PR DESCRIPTION
## Summary
Roll back latest-branch jenkins-agent Prow jobs for **pingcap/tidb, pingcap/ticdc, pingcap/tiflow** to run on the **from Jenkins** (`labels.master: "0" -> "1"`).

**52 jobs across 5 files**:
- pingcap/tidb: latest-presubmits (22) + latest-postsubmits (10)
- pingcap/ticdc: latest-presubmits (11)
- pingcap/tiflow: latest-presubmits (8) + latest-postsubmits (1)

**Excluded from this rollback** (stay on `master: "0"`): pingcap/tiproxy, pingcap-qe/tidb-test, tikv/*.

## Why (measured, not assumed)
The target Jenkins (tencentcloud staging, `do.pingcap.net/jenkins-staging`, cluster `tke-cls-9zpon9y1`) is not yet able to run these heavy Rust/Go CI jobs to completion within the migration verify window. Evidence collected during 08-25 ~ 08-28 verification:

1. **Compile throughput ~26.5x slower than from-Jenkins**
   - Same job `tikv/tikv/pull_unit_test`:
     - from-Jenkins build [#442](https://prow.tidb.net/jenkins/job/tikv/job/tikv/job/pull_unit_test/442): **22 min SUCCESS** (full clippy + build + 2 test partitions, 2418+2377 tests passed).
     - target build [#1](https://do.pingcap.net/jenkins-staging/job/tikv/job/tikv/job/pull_unit_test/1): **582 min SUCCESS** (9.7h, no pipeline timeout at the time).
   - 582/22 ≈ **26.5x**.
2. **Even with the rustup/cargo mirror fix (ee-ops#2296), builds still exhaust the 50-min pipeline timeout inside `make clippy`**
   - target [#13](https://do.pingcap.net/jenkins-staging/job/tikv/job/tikv/job/pull_unit_test/13): 61 min ABORTED — rustup download was fast (mirror effective), but the 50-min budget ran out in `cargo install cargo-deny`; never reached clippy-all / build / tests.
   - target [#12](https://do.pingcap.net/jenkins-staging/job/tikv/job/tikv/job/pull_unit_test/12): 51 min ABORTED — rustup `downloading 3 components` from `static.rust-lang.org` stalled ~45 min (pre-mirror).
3. **~20 min overhead per build before the pipeline even starts** (from #13 pod events)
   - Scheduling: `SucceedSetPodIP setDuration=10m8s` — the 24Gi/6CPU + ENI-IP pod could not fit any of 28-35 nodes (16-21 `Insufficient memory`, ~10 `Insufficient cpu`, 8 affinity mismatch, 2-3 `eni-ip-unavailable`; hosting node memory ~93% allocated, load ~9.76).
   - Image pull: `ghcr.io/pingcap-qe/ci/jenkins/tikv` 971MB took **9m50.73s** (~1.57 MB/s) over international egress.
4. **Restricted international egress on the target cluster** (network, not code)
   - `github.com` resolves to internal mirror `10.0.20.2` (vs from-Jenkins direct `140.82.113.3`); artifacts to Tencent COS ap-beijing; no internal rustup/crates mirror until ee-ops#2296.
5. **Verify toolchain hard caps make these un-verifiable on the target**
   - `pull-verify-jenkins-migration`: prow job `timeout: 4h` and script `--timeout 7200` (2h per-job wait) → a 9.7h cold build can never complete a green verification.
   - Consequence: migration PRs #4987/#4989/#4990/#4986/#5031 all blocked on this required check purely for infra/performance reasons.
6. **The same jobs are green on from-Jenkins** (e.g. #442 above; ticdc/tiflow/tidb histories) — the failure is environmental, not a migration-logic problem.

## Re-migrating later
Re-enabling = single `git revert` of this PR.

## Validation
- Only `master: "0"` -> `"1"` changes (52 lines, no other content changes).
- No 1->0 flips → `pull-verify-jenkins-migration` is a no-op.
- Ref: PingCAP-QE/ci#5042