### PR TITLE
fix(pipelines): point tidb-test TIDB_SERVER_PATH to tidb/bin/tidb-server

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -118,12 +118,12 @@ pipeline {
                                         if [[ "${TEST_STORE}" == "tikv" ]]; then
                                             echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
                                             bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb/bin/tidb-server"
                                             export TIKV_PATH="127.0.0.1:2379"
                                             export TIDB_TEST_STORE_NAME="tikv"
                                             cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
                                         else
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb/bin/tidb-server"
                                             export TIDB_TEST_STORE_NAME="unistore"
                                             cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
                                         fi

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -107,6 +107,11 @@ pipeline {
                             }
                             dir('tidb-test') {
                                 unstash name: WORKSPACE_STASH_NAME
+                                sh label: 'copy tidb binaries', script: """
+                                    mkdir -p bin
+                                    cp ${WORKSPACE}/tidb/bin/* bin/ && chmod +x bin/*
+                                    ls -alh bin/
+                                """
                                 sh label: "test_params=${TEST_PARAMS} ", script: """
                                     #!/usr/bin/env bash
                                     params_array=(\${TEST_PARAMS})

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -117,12 +117,12 @@ pipeline {
                                     if [[ "${TEST_STORE}" == "tikv" ]]; then
                                         echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
                                         cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
                                     else
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb/bin/tidb-server"
                                         export TIDB_TEST_STORE_NAME="unistore"
                                         cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
                                     fi

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -122,12 +122,12 @@ pipeline {
                                         if [[ "${TEST_STORE}" == "tikv" ]]; then
                                             echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
                                             bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb/bin/tidb-server"
                                             export TIKV_PATH="127.0.0.1:2379"
                                             export TIDB_TEST_STORE_NAME="tikv"
                                             cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
                                         else
-                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                            export TIDB_SERVER_PATH="${WORKSPACE}/tidb/bin/tidb-server"
                                             export TIDB_TEST_STORE_NAME="unistore"
                                             cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
                                         fi

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -117,12 +117,12 @@ pipeline {
                                     if [[ "${TEST_STORE}" == "tikv" ]]; then
                                         echo '[storage]\nreserve-space = "0MB"'> tikv_config.toml
                                         bash ${WORKSPACE}/scripts/PingCAP-QE/tidb-test/start_tikv.sh
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
                                         cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
                                     else
-                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/bin/tidb-server"
+                                        export TIDB_SERVER_PATH="${WORKSPACE}/tidb/bin/tidb-server"
                                         export TIDB_TEST_STORE_NAME="unistore"
                                         cd \${TEST_DIR} && chmod +x *.sh && \${TEST_SCRIPT}
                                     fi


### PR DESCRIPTION
### Problem

`ghpr_integration_python_orm_test` and 3 sibling tidb-test integration pipelines fail on the staging Jenkins with:

```
tidb-server(PID: 22) started
ERROR 2002 (HY000): Can't connect to server on '127.0.0.1' (115)
./test.sh: line 10: /.../tidb-test/bin/tidb-server: No such file or directory
```

Root cause: after #4716 switched the `pipelines/pingcap-qe/tidb-test/latest/*` pipelines from cache/shared-workspace to stash/unstash, the `tidb-server`/`pd-server`/`tikv-server` binaries are built under `tidb/` and stashed as `tidb-bin`, then unstashed into `dir('tidb')` in the test stage. The old "copy binaries into `tidb-test/bin/`" step was removed, but `TIDB_SERVER_PATH` still pointed to `${WORKSPACE}/tidb-test/bin/tidb-server` (a path that no longer exists). As a result the server never starts and ORM/JDBC tests fail to connect.

### Change

Point `TIDB_SERVER_PATH` to `${WORKSPACE}/tidb/bin/tidb-server` (where the binaries actually land) in the 4 affected pipelines, consistent with `ghpr_mysql_test` which already uses this path:

- `pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy`
- `pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy`
- `pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy`
- `pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy`

### Verification

- All 374 Jenkins pipelines validated successfully via `.ci/verify-jenkins-pipelines.sh` (exit 0).
- Verified the other tidb-test pipelines (nodejs/mysql_test/next_gen/release-*) either keep a copy step or already point to the correct location.