### PR TITLE
feat(prow-jobs): add tiflash pull-license-check presubmit

### DIFF
--- a/prow-jobs/kustomization.yaml
+++ b/prow-jobs/kustomization.yaml
@@ -57,6 +57,7 @@ configMapGenerator:
       - pingcap_tidb_release-8.5-presubmits.yaml=pingcap/tidb/release-8.5-presubmits.yaml
       - pingcap_tidb_release-9.0-beta-presubmits.yaml=pingcap/tidb/release-9.0-beta-presubmits.yaml
       - pingcap_tiflash_common-postsubmits.yaml=pingcap/tiflash/common-postsubmits.yaml
+      - pingcap_tiflash_common-presubmits.yaml=pingcap/tiflash/common-presubmits.yaml
       - pingcap_tiflash_latest-postsubmits.yaml=pingcap/tiflash/latest-postsubmits.yaml
       - pingcap_tiflash_latest-presubmits-next-gen.yaml=pingcap/tiflash/latest-presubmits-next-gen.yaml
       - pingcap_tiflash_latest-presubmits.yaml=pingcap/tiflash/latest-presubmits.yaml

--- a/prow-jobs/pingcap/tiflash/common-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/common-presubmits.yaml
@@ -6,9 +6,9 @@ presubmits:
   pingcap/tiflash:
     - name: pingcap/tiflash/pull_license_check
       decorate: true
+      skip_submodules: true
       decoration_config:
         timeout: 30m
-        skip_submodules: true
       branches:
         - ^master$
         - ^feature/.+

--- a/prow-jobs/pingcap/tiflash/common-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/common-presubmits.yaml
@@ -4,7 +4,7 @@
 # instead of being duplicated per-branch presubmit file.
 presubmits:
   pingcap/tiflash:
-    - name: pingcap/tiflash/pull_license_check
+    - name: pull-license-check
       decorate: true
       skip_submodules: true
       decoration_config:
@@ -22,7 +22,6 @@ presubmits:
         - ^release-9\.0-beta\.\d+-\d{8}-v9\.0\.0-beta\.\d+(-\d+)?$
         - ^release-nextgen-(\d+|\d+\.\d+\.\d+-\d{8})$
       context: pull-license-check
-      always_run: true
       optional: true
       rerun_command: "/test pull-license-check"
       trigger: "(?m)^/test (?:.*? )?(pull-license-check)(?: .*?)?$"

--- a/prow-jobs/pingcap/tiflash/common-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/common-presubmits.yaml
@@ -1,0 +1,59 @@
+# struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
+# `pull-license-check` is branch-agnostic: the same job (download license-eye,
+# run `header check`) applies to every tiflash branch, so it lives here once
+# instead of being duplicated per-branch presubmit file.
+presubmits:
+  pingcap/tiflash:
+    - name: pingcap/tiflash/pull_license_check
+      decorate: true
+      decoration_config:
+        timeout: 30m
+        skip_submodules: true
+      branches:
+        - ^master$
+        - ^feature/.+
+        - ^release-fts-[0-9]+$
+        - ^release-6\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
+        - ^release-7\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
+        - ^release-7\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
+        - ^release-8\.1(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
+        - ^release-8\.5(\.\d+)?(-\d+)?(-v[\.\d]+)?(-\d+)?$
+        - ^release-9\.0-beta\.\d+$
+        - ^release-9\.0-beta\.\d+-\d{8}-v9\.0\.0-beta\.\d+(-\d+)?$
+        - ^release-nextgen-(\d+|\d+\.\d+\.\d+-\d{8})$
+      context: pull-license-check
+      always_run: true
+      optional: true
+      rerun_command: "/test pull-license-check"
+      trigger: "(?m)^/test (?:.*? )?(pull-license-check)(?: .*?)?$"
+      skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
+      spec:
+        containers:
+          - name: main
+            image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+            command: [/bin/bash, -ce]
+            args:
+              - |
+                if command -v curl >/dev/null 2>&1; then
+                  curl -fsSL --retry 3 -o /tmp/download_pingcap_oci_artifact.sh \
+                    https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/scripts/artifacts/download_pingcap_oci_artifact.sh
+                else
+                  wget -qO /tmp/download_pingcap_oci_artifact.sh \
+                    https://cdn.jsdelivr.net/gh/pingcap-qe/ci@main/scripts/artifacts/download_pingcap_oci_artifact.sh
+                fi
+                export OCI_ARTIFACT_HOST="us-docker.pkg.dev/pingcap-testing-account/hub"
+                export OCI_ARTIFACT_HOST_COMMUNITY="us-docker.pkg.dev/pingcap-testing-account/hub"
+                bash /tmp/download_pingcap_oci_artifact.sh --license-eye=v0.4.0
+                chmod +x license-eye
+                if [[ -f .github/licenserc.yml ]]; then
+                  ./license-eye -c .github/licenserc.yml header check
+                else
+                  echo "skip license check"
+                fi
+            resources:
+              requests:
+                cpu: "1"
+                memory: 2Gi
+              limits:
+                cpu: "1"
+                memory: 4Gi


### PR DESCRIPTION
### Summary
Add a branch-agnostic `pull-license-check` presubmit for `pingcap/tiflash`: a single decorated job in `prow-jobs/pingcap/tiflash/common-presubmits.yaml` covering master/feature/release-6.5..9.0-beta/release-nextgen branches.

It downloads `license-eye` via the OCI artifact script and runs `license-eye -c .github/licenserc.yml header check` on every PR (`skip_submodules`, docs-only changes skipped).

### Note
- `optional: true` for now; will be switched to required in a follow-up that removes the in-pipeline `License check` stages from the merged_build / pull_integration_test pipelines.
- The general prow-job validator is submitted separately (ci PR #5051).