### PR TITLE
fix(prow-jobs): handle containers without an explicit command in validator

### DIFF
--- a/.ci/verify-prow-jobs-run.sh
+++ b/.ci/verify-prow-jobs-run.sh
@@ -170,7 +170,7 @@ static_check_job() {
   while read -r c; do
     local image cmd args0 has_req has_lim
     image="$(jq -r '.image // ""' <<<"${c}")"
-    cmd="$(jq -r '.command | join(" ") // ""' <<<"${c}")"
+    cmd="$(jq -r '(.command // []) | join(" ") // ""' <<<"${c}")"
     args0="$(jq -r '.args[0] // ""' <<<"${c}")"
     has_req="$(jq -r 'if (.resources.requests != null) then "1" else "0" end' <<<"${c}")"
     has_lim="$(jq -r 'if (.resources.limits != null) then "1" else "0" end' <<<"${c}")"


### PR DESCRIPTION
### Summary
`pull-verify-prow-jobs-run` crashed with `jq: Cannot iterate over null` when validating jobs whose containers have no `command` (they rely on the image entrypoint, e.g. the new `apache/skywalking-eyes`-based `pull-license-check`).

Fix: `static_check_job` now uses `(.command // []) | join(" ")` so entrypoint-based containers are handled.