### PR TITLE
fix(prow-jobs): set explicit command for license-eye container

### DIFF
--- a/prow-jobs/pingcap/tiflash/common-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/common-presubmits.yaml
@@ -30,6 +30,7 @@ presubmits:
         containers:
           - name: main
             image: apache/skywalking-eyes:0.4.0
+            command: ["/bin/license-eye"]
             args: ["-c", ".github/licenserc.yml", "header", "check"]
             resources:
               requests:


### PR DESCRIPTION
### Summary
`pull-license-check` failed with `exec: "-c": executable file not found`. Prow's entrypoint wrapper does not honor the image ENTRYPOINT: when only `args` is set it treats `args[0]` (`-c`) as the executable.

Fix: set `command: ["/bin/license-eye"]` explicitly (verified on the cluster that the binary + args run and the header check executes).