### PR TITLE
refactor(pipelines): drop in-pipeline license check for pull-license-check

### DIFF
--- a/pipelines/pingcap/tiflash/latest/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build.groovy
@@ -20,10 +20,6 @@ pipeline {
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
-    environment {
-        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
-        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
-    }
     options {
         timeout(time: 120, unit: 'MINUTES')
     }
@@ -96,25 +92,6 @@ pipeline {
                     sh """
                     ccache -s
                     ls -lha ${WORKSPACE}/install/tiflash
-                    """
-                }
-            }
-        }
-        stage("License check") {
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
                     """
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_build_next_gen.groovy
@@ -20,10 +20,6 @@ pipeline {
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
-    environment {
-        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
-        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
-    }
     options {
         timeout(time: 120, unit: 'MINUTES')
     }
@@ -97,25 +93,6 @@ pipeline {
                     sh """
                     ccache -s
                     ls -lha ${WORKSPACE}/install/tiflash
-                    """
-                }
-            }
-        }
-        stage("License check") {
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
                     """
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen.groovy
@@ -47,25 +47,6 @@ pipeline {
                 }
             }
         }
-        stage("License check") {
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
-                    """
-                }
-            }
-        }
         stage("Prepare Ccache") {
             steps {
                 script {

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -42,25 +42,6 @@ pipeline {
                 }
             }
         }
-        stage("License check") {
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
-                    """
-                }
-            }
-        }
         stage("Prepare Ccache") {
             steps {
                 script {

--- a/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_integration_test.groovy
@@ -137,25 +137,6 @@ pipeline {
                 }
             }
         }
-        stage("License check") {
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
-                    """
-                }
-            }
-        }
         stage("Post Build") {
             steps {
                 script {

--- a/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.1/pull_integration_test.groovy
@@ -223,25 +223,6 @@ pipeline {
                 }
             }
         }
-        stage("License check") {
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
-                    """
-                }
-            }
-        }
         stage("Post Build") {
             parallel {
                 stage("Static Analysis"){

--- a/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-7.5/pull_integration_test.groovy
@@ -249,28 +249,6 @@ pipeline {
                 }
             }
         }
-        stage("License check") {
-            when {
-                expression { !build_cache_ready }
-            }
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
-                    """
-                }
-            }
-        }
         stage("Post Build") {
             when {
                 expression { !build_cache_ready }

--- a/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.1/pull_integration_test.groovy
@@ -227,25 +227,6 @@ pipeline {
                 }
             }
         }
-        stage("License check") {
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
-                    """
-                }
-            }
-        }
 
         stage("Post Build") {
             parallel {

--- a/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_build.groovy
@@ -19,10 +19,6 @@ pipeline {
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
-    environment {
-        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
-        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
-    }
     options {
         timeout(time: 120, unit: 'MINUTES')
     }
@@ -105,25 +101,6 @@ pipeline {
                     sh """
                     ccache -s
                     ls -lha ${WORKSPACE}/install/tiflash
-                    """
-                }
-            }
-        }
-        stage("License check") {
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
                     """
                 }
             }

--- a/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_integration_test.groovy
@@ -139,25 +139,6 @@ pipeline {
                 }
             }
         }
-        stage("License check") {
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
-                    """
-                }
-            }
-        }
         stage("Post Build") {
             steps {
                 script {

--- a/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/merged_build.groovy
@@ -26,10 +26,6 @@ pipeline {
             customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
-    environment {
-        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
-        OCI_ARTIFACT_HOST_COMMUNITY = "${env._JENKINS_OCI_ARTIFACT_HOST_COMMUNITY}"
-    }
     options {
         timeout(time: 120, unit: 'MINUTES')
         parallelsAlwaysFailFast()
@@ -192,25 +188,6 @@ pipeline {
                     sh """
                     ccache -s
                     ls -lha ${WORKSPACE}/install/tiflash
-                    """
-                }
-            }
-        }
-        stage("License check") {
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
                     """
                 }
             }

--- a/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/release-9.0-beta/pull_integration_test.groovy
@@ -237,28 +237,6 @@ pipeline {
                 }
             }
         }
-        stage("License check") {
-            when {
-                expression { !build_cache_ready }
-            }
-            steps {
-                dir("${WORKSPACE}/tiflash") {
-                    container('utils') {
-                        sh label: "get license-eye tool", script: '${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh --license-eye=v0.4.0'
-                    }
-                    sh label: "license header check", script: """
-                        echo "license check"
-                        if [[ -f .github/licenserc.yml ]]; then
-                            chmod +x ./license-eye
-                            ./license-eye -c .github/licenserc.yml header check
-                        else
-                            echo "skip license check"
-                            exit 0
-                        fi
-                    """
-                }
-            }
-        }
         stage("Post Build") {
             when {
                 expression { !build_cache_ready }

--- a/prow-jobs/pingcap/tiflash/common-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/common-presubmits.yaml
@@ -22,7 +22,6 @@ presubmits:
         - ^release-9\.0-beta\.\d+-\d{8}-v9\.0\.0-beta\.\d+(-\d+)?$
         - ^release-nextgen-(\d+|\d+\.\d+\.\d+-\d{8})$
       context: pull-license-check
-      optional: false
       rerun_command: "/test pull-license-check"
       trigger: "(?m)^/test (?:.*? )?(pull-license-check)(?: .*?)?$"
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"

--- a/prow-jobs/pingcap/tiflash/common-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/common-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
         - ^release-9\.0-beta\.\d+-\d{8}-v9\.0\.0-beta\.\d+(-\d+)?$
         - ^release-nextgen-(\d+|\d+\.\d+\.\d+-\d{8})$
       context: pull-license-check
-      optional: true
+      optional: false
       rerun_command: "/test pull-license-check"
       trigger: "(?m)^/test (?:.*? )?(pull-license-check)(?: .*?)?$"
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf|gitignore)|Dockerfile|OWNERS|OWNERS_ALIASES)$"


### PR DESCRIPTION
### Summary
STEP 2 of consolidating the tiflash license check into the standalone presubmit:
- Remove the `License check` stage (and the now-unused `OCI_ARTIFACT_HOST` env in `merged_build`) from `merged_build` / `pull_integration_test` pipelines across all tiflash branches (12 files)
- Make `pull-license-check` **required** (`optional: false`) in `prow-jobs/pingcap/tiflash/common-presubmits.yaml`

The in-pipeline license steps were also broken anyway: the OCI-downloaded `license-eye` is glibc-linked while the `utils` image is glibc-less.

### Verified
- All changed Jenkins pipelines pass `.ci/verify-jenkins-pipelines.sh` (Jenkins lint)
- `pull-license-check` presubmit validated on pingcap/tiflash#11061 (pass)