### PR TITLE
fix(pipelines/tiflash): unblock pull_integration_test pod scheduling

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_build.yaml
@@ -16,11 +16,9 @@ spec:
         requests:
           memory: 32Gi
           cpu: "12"
-          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"
           name: "tmp"

--- a/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_build.yaml
@@ -16,7 +16,6 @@ spec:
         limits:
           memory: 48Gi
           cpu: "12"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"
           name: "tmp"

--- a/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml
@@ -16,11 +16,9 @@ spec:
         limits:
           memory: "32Gi"
           cpu: "8"
-          ephemeral-storage: 150Gi
         requests:
           memory: "16Gi"
           cpu: "4"
-          ephemeral-storage: 20Gi
       securityContext:
         privileged: true
       tty: false
@@ -44,11 +42,9 @@ spec:
         requests:
           memory: "16Gi"
           cpu: "4"
-          ephemeral-storage: 10Gi
         limits:
           memory: "32Gi"
           cpu: "8"
-          ephemeral-storage: 50Gi
       tty: true
       volumeMounts:
         - mountPath: "/tmp"

--- a/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_test.groovy
@@ -20,7 +20,6 @@ pipeline {
             workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'ci-rwo')
             defaultContainer 'runner'
             retries 2
-            customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
     environment {
@@ -217,7 +216,6 @@ pipeline {
                         workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'ci-rwo')
                         defaultContainer 'docker'
                         retries 2
-                        customWorkspace "/home/jenkins/agent/workspace/tiflash-integration-test"
                     }
                 }
                 when {


### PR DESCRIPTION
## Problem
tiflash latest jobs on the target Jenkins (jenkins-staging) are **permanently Unschedulable**: the runner/dockerd containers' `limits.ephemeral-storage: 150Gi` cannot fit the `ci-worker` nodes (~44-70Gi allocatable) → `Insufficient ephemeral-storage`; Karpenter cannot provision a ci-worker instance with >=150Gi disk.

Docker graph + workspace already use `ci-rwo` PVCs (200Gi / 300Gi), so node ephemeral-storage is not actually needed.

## Change (4 files)
- `pipelines/pingcap/tiflash/latest/pod-pull_integration_test.yaml`: drop `ephemeral-storage` from dockerd/docker containers (150Gi/50Gi limits, 20Gi/10Gi requests).
- `pipelines/pingcap/tiflash/latest/pod-pull_build.yaml`: drop runner `ephemeral-storage` limit (150Gi).
- `pipelines/pingcap/tiflash/latest/pod-merged_build.yaml`: drop runner `ephemeral-storage` (150Gi limit, 20Gi request).
- `pipelines/pingcap/tiflash/latest/pull_integration_test.groovy`: drop the two `customWorkspace` directives (workspace falls back to default; pipeline paths are `${WORKSPACE}`-relative).

## Validation
- YAML valid; no residual `ephemeral-storage: 150Gi` in migrated (non-nextgen) tiflash latest pods.
- CI: `pull-verify-jenkins-pipelines` + `pull-verify-k8s-pod-yaml` validate groovy/yaml.
- Related: tiflash migration PR #4989; after this merges, retry verification.
