### PR TITLE
feat(tekton): add hotfix gomod-update trigger for release-8.5+ and refresh golang images

### DIFF
--- a/tekton/v1/triggers/triggers/env-gcp/_/git-create-branch-gomod-update.yaml
+++ b/tekton/v1/triggers/triggers/env-gcp/_/git-create-branch-gomod-update.yaml
@@ -29,10 +29,8 @@ spec:
 
   bindings:
     - ref: github-branch-create
-    - {
-        name: golang-image,
-        value: "ghcr.io/pingcap-qe/ci/base:v20231216-50-gc125b52-go1.19",
-      }
+    - name: golang-image
+      value: ghcr.io/pingcap-qe/ci/base:v20240901-30-g8c6c410-go1.19
   template:
     ref: update-pingcap-tidb-gomod-fix-ladp-for-hotfix-branch
 ---
@@ -54,17 +52,15 @@ spec:
             body.ref.matches('^release-7[.][0-3]-[0-9]+-v[0-9]+[.][0-9]+[.][0-9]+(-.+)?$')
   bindings:
     - ref: github-branch-create
-    - {
-        name: golang-image,
-        value: "ghcr.io/pingcap-qe/ci/base:v20231216-50-gc125b52-go1.20",
-      }
+    - name: golang-image
+      value: ghcr.io/pingcap-qe/ci/base:v20240901-30-g8c6c410-go1.19
   template:
     ref: update-pingcap-tidb-gomod-fix-ladp-for-hotfix-branch
 ---
 apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
-  name: branch-create-pingcap-tidb-hotfix-ge-v7.4
+  name: branch-create-pingcap-tidb-hotfix-be-v7.4-v8.4
   labels:
     type: github-branch-create
 spec:
@@ -77,13 +73,36 @@ spec:
           value: >-
             body.repository.full_name in ['pingcap/tidb', 'pingcap/tiflow'] &&
             body.ref.matches('^release-[0-9]+[.][0-9]+-[0-9]+-v[0-9]+[.][0-9]+[.][0-9]+(-.+)?$') &&
-            body.ref >= 'release-7.4'
+            body.ref >= 'release-7.4' && body.ref < 'release-8.5'
 
   bindings:
     - ref: github-branch-create
-    - {
-        name: golang-image,
-        value: "ghcr.io/pingcap-qe/ci/base:v20231216-50-gc125b52-go1.21",
-      }
+    - name: golang-image
+      value: ghcr.io/pingcap-qe/ci/base:v2024.10.8-119-g4e56df7-go1.21
+  template:
+    ref: update-pingcap-tidb-gomod-fix-ladp-for-hotfix-branch
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: branch-create-pingcap-tidb-hotfix-ge-v8.5
+  labels:
+    type: github-branch-create
+spec:
+  interceptors:
+    - name: combined filter on repo owner, name, and branch
+      ref:
+        name: cel
+      params:
+        - name: filter
+          value: >-
+            body.repository.full_name in ['pingcap/tidb', 'pingcap/tiflow'] &&
+            body.ref.matches('^release-[0-9]+[.][0-9]+-[0-9]+-v[0-9]+[.][0-9]+[.][0-9]+(-.+)?$') &&
+            body.ref >= 'release-8.5'
+
+  bindings:
+    - ref: github-branch-create
+    - name: golang-image
+      value: ghcr.io/pingcap-qe/ci/base:v2026.8.23-69-g12fa46c7-go1.25
   template:
     ref: update-pingcap-tidb-gomod-fix-ladp-for-hotfix-branch


### PR DESCRIPTION
## What

In `tekton/v1/triggers/triggers/env-gcp/_/git-create-branch-gomod-update.yaml`:

- Bump `golang-image` for the `< v7.0` and `v7.0-v7.3` hotfix triggers to `ghcr.io/pingcap-qe/ci/base:v20240901-30-g8c6c410-go1.19`.
- Restrict the existing `>= v7.4` trigger to the `release-7.4` to `release-8.4` range (renamed to `branch-create-pingcap-tidb-hotfix-be-v7.4-v8.4`) and bump its image to the go1.21 base.
- Add a new `branch-create-pingcap-tidb-hotfix-ge-v8.5` trigger for hotfix branches on `release-8.5+`, using the go1.25 base image.

## Why

Keeps the gomod-update hotfix flow working for the new `release-8.5` release line and refreshes the golang base images for older release lines.

## Test plan

```
kubectl kustomize tekton/v1/triggers/triggers/env-gcp >/dev/null
```
