### PR TITLE
chore(prow-jobs): isolate tiflash pull unit test migration

### DIFF
--- a/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/latest-presubmits.yaml
@@ -159,7 +159,7 @@ presubmits:
     - <<: *brancher
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       context: pull-unit-test
       decorate: false # need add this.
       name: pingcap/tiflash/pull_unit_test


### PR DESCRIPTION
Split the TiFlash pull unit test migration out from #4989.

The migration verification for #4989 completed three jobs successfully; `pingcap/tiflash/pull_unit_test` was the only remaining job and was aborted after the Jenkins 2-hour timeout. This PR contains only that job's `labels.master: 1 -> 0` change so it can be verified independently.

Related: #4989