### PR TITLE
feat(libraries): support Git CDN HTTP credentials

### DIFF
--- a/libraries/tipipeline/scripts/git_askpass.sh
+++ b/libraries/tipipeline/scripts/git_askpass.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+case "$1" in
+Username*) echo "$TIPIPELINE_GIT_USERNAME" ;;
+Password*) echo "$TIPIPELINE_GIT_PASSWORD" ;;
+esac

--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -36,15 +36,7 @@ def checkoutRefs(refs, credentialsId = '', timeout = 5, withSubmodule = false, g
 
     def checkoutWithHttpCredentials = {
         if (cdnEnabled && httpCredentialsId) {
-            withCredentials([
-                usernamePassword(
-                    credentialsId: httpCredentialsId,
-                    usernameVariable: 'GIT_CDN_USERNAME',
-                    passwordVariable: 'GIT_CDN_PASSWORD'
-                )
-            ]) {
-                withGitAskPass(checkout)
-            }
+            withGitAskPass(httpCredentialsId, checkout)
         } else {
             checkout()
         }
@@ -67,24 +59,15 @@ def checkoutRefs(refs, credentialsId = '', timeout = 5, withSubmodule = false, g
  * after the server asks for credentials. The script is outside the workspace
  * because checkout cleanup and the pipeline cache operate on the workspace.
  */
-def withGitAskPass(Closure body) {
-    final askPassPath = sh(script: 'mktemp "${TMPDIR:-/tmp}/git-askpass.XXXXXX"', returnStdout: true).trim()
+def withGitAskPass(String credentialsId, Closure body) {
+    final tmpAskPassScript = sh(script: 'mktemp "${TMPDIR:-/tmp}/git-askpass.XXXXXX"', returnStdout: true).trim()
+    final askPassScript = libraryResource 'scripts/git_askpass.sh'
+
     try {
-        sh label: 'Prepare Git HTTP credential helper', script: """#!/usr/bin/env bash
-            set -e
-            cat > '${askPassPath}' <<'EOF'
-#!/bin/sh
-case \"\$1\" in
-  *Username*) printf '%s\\n' \"\$GIT_CDN_USERNAME\" ;;
-  *) printf '%s\\n' \"\$GIT_CDN_PASSWORD\" ;;
-esac
-EOF
-            chmod 700 '${askPassPath}'
-        """
-        withEnv([
-            "GIT_ASKPASS=${askPassPath}",
-            'GIT_TERMINAL_PROMPT=0'
-        ]) {
+        writeFile(file: tmpAskPassScript, text: askPassScript)
+        sh label: 'Prepare Git HTTP credential helper', script: "chmod 700 '${tmpAskPassScript}'"
+        withCredentials([usernamePassword(credentialsId: credentialsId,  usernameVariable: 'TIPIPELINE_GIT_USERNAME', passwordVariable: 'TIPIPELINE_GIT_PASSWORD')]) {
+            withEnv(["GIT_ASKPASS=${tmpAskPassScript}", 'GIT_TERMINAL_PROMPT=0']) {
             body()
         }
     } finally {

--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -16,10 +16,79 @@ def checkoutRefsWithCache(refs, timeout = 5, credentialsId = '', withSubmodule =
 }
 
 def checkoutRefs(refs, credentialsId = '', timeout = 5, withSubmodule = false, gitBaseUrl = 'https://github.com') {
-    if (credentialsId?.trim()) {
-        checkoutPrivateRefs(refs, credentialsId, timeout, withSubmodule, gitBaseUrl)
+    final explicitCredentialsId = credentialsId?.trim()
+    final sshCredentialsId = explicitCredentialsId ?: (
+        withSubmodule ? env.GIT_SSH_CREDENTIALS_ID?.trim() : ''
+    )
+    final cdnEnabled = env.GIT_CDN_ENABLED?.trim()?.toBoolean()
+    final httpCredentialsId = env.GIT_HTTP_CREDENTIALS_ID?.trim()
+
+    // Keep the existing URL selection: an explicit credential means that the
+    // main repository uses SSH. TKE can rewrite that URL to the CDN, while
+    // GCP continues to use the SSH agent directly.
+    def checkout = {
+        if (explicitCredentialsId) {
+            checkoutPrivateRefs(refs, explicitCredentialsId, timeout, withSubmodule, gitBaseUrl)
+        } else {
+            checkoutPublicRefs(refs, timeout, withSubmodule, gitBaseUrl)
+        }
+    }
+
+    def checkoutWithHttpCredentials = {
+        if (cdnEnabled && httpCredentialsId) {
+            withCredentials([
+                usernamePassword(
+                    credentialsId: httpCredentialsId,
+                    usernameVariable: 'GIT_CDN_USERNAME',
+                    passwordVariable: 'GIT_CDN_PASSWORD'
+                )
+            ]) {
+                withGitAskPass(checkout)
+            }
+        } else {
+            checkout()
+        }
+    }
+
+    // A job that only passes an empty credentialsId can still have private
+    // SSH submodules. Use the cluster-provided default SSH credential for
+    // the checkout scope without changing the public HTTPS main URL.
+    if (sshCredentialsId && !explicitCredentialsId) {
+        sshagent(credentials: [sshCredentialsId]) {
+            checkoutWithHttpCredentials()
+        }
     } else {
-        checkoutPublicRefs(refs, timeout, withSubmodule, gitBaseUrl)
+        checkoutWithHttpCredentials()
+    }
+}
+
+/*
+ * Let Git try an anonymous HTTP request first and provide Jenkins' PAT only
+ * after the server asks for credentials. The script is outside the workspace
+ * because checkout cleanup and the pipeline cache operate on the workspace.
+ */
+def withGitAskPass(Closure body) {
+    final askPassPath = sh(script: 'mktemp "${TMPDIR:-/tmp}/git-askpass.XXXXXX"', returnStdout: true).trim()
+    try {
+        sh label: 'Prepare Git HTTP credential helper', script: """#!/usr/bin/env bash
+            set -e
+            cat > '${askPassPath}' <<'EOF'
+#!/bin/sh
+case \"\$1\" in
+  *Username*) printf '%s\\n' \"\$GIT_CDN_USERNAME\" ;;
+  *) printf '%s\\n' \"\$GIT_CDN_PASSWORD\" ;;
+esac
+EOF
+            chmod 700 '${askPassPath}'
+        """
+        withEnv([
+            "GIT_ASKPASS=${askPassPath}",
+            'GIT_TERMINAL_PROMPT=0'
+        ]) {
+            body()
+        }
+    } finally {
+        sh label: 'Remove Git HTTP credential helper', script: "rm -f '${askPassPath}'"
     }
 }
 
@@ -57,10 +126,15 @@ def checkoutPrivateRefs(refs, credentialsId, timeout = 5, withSubmodule = false,
 
     final remoteUrl = "${gitBaseUrl}:${refs.org}/${refs.repo}.git"
     sshagent(credentials: [credentialsId]) {
-        sh label: 'Know hosts', script: """
-            [ -d ~/.ssh ] || mkdir ~/.ssh && chmod 0700 ~/.ssh
-            ssh-keyscan -t rsa,ecdsa,ed25519 ${knownHost} >> ~/.ssh/known_hosts
-        """
+        // GitHub SSH URLs are rewritten to the CDN in TKE, so avoid an
+        // unnecessary GitHub network call there. Keep host-key setup for
+        // direct SSH and non-GitHub SSH hosts.
+        if (!env.GIT_CDN_ENABLED?.trim()?.toBoolean() || knownHost != 'github.com') {
+            sh label: 'Know hosts', script: """
+                [ -d ~/.ssh ] || mkdir ~/.ssh && chmod 0700 ~/.ssh
+                ssh-keyscan -t rsa,ecdsa,ed25519 ${knownHost} >> ~/.ssh/known_hosts
+            """
+        }
         _checkoutRefsImpl(refs, remoteUrl, timeout, withSubmodule)
     }
 }


### PR DESCRIPTION
## Summary
- keep the existing `credentialsId` behavior, including SSH checkout for private repositories
- use `GIT_SSH_CREDENTIALS_ID` as a default checkout-scope SSH credential for jobs with private submodules
- use `GIT_HTTP_CREDENTIALS_ID` and a temporary `GIT_ASKPASS` helper when `GIT_CDN_ENABLED=true`
- let Git try anonymous CDN access first and provide the PAT only after an HTTP 401
- keep the askpass helper outside the workspace so `git clean -ffdx` and pipeline cache do not remove or store it
- skip the unnecessary GitHub host-key scan when GitHub SSH URLs are being rewritten by the CDN

## Behavior

- GCP: existing direct SSH/HTTPS behavior remains unchanged when `GIT_CDN_ENABLED` is false.
- TKE: both HTTPS and SSH-style GitHub URLs can be rewritten by Jenkins global Git configuration; private requests use the HTTP credential after a 401.
- `refs/pull/*` refspecs and recursive submodule checkout remain unchanged.

## Dependency

The companion `PingCAP-QE/ee-ops` PR adds the matching Jenkins credentials and TKE Git rewrite environment. Merge this PR before enabling the feature in ee-ops.

## Validation

- `groovy -e 'new GroovyShell().parse(new File("libraries/tipipeline/vars/prow.groovy"))'`
- Git `insteadOf` verification for HTTPS, `git@github.com:` and `ssh://git@github.com/` URL forms
- `git diff --check`
