### PR TITLE
feat(libraries): add Git HTTP askpass helper

### DIFF
--- a/libraries/tipipeline/scripts/git_askpass.sh
+++ b/libraries/tipipeline/scripts/git_askpass.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+case "${1-}" in
+Username*)
+    printf '%s\n' "${TIPIPELINE_GIT_USERNAME-}"
+    ;;
+Password*)
+    printf '%s\n' "${TIPIPELINE_GIT_PASSWORD-}"
+    ;;
+*)
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add a small Git `GIT_ASKPASS` helper for Jenkins HTTP authentication
- return the configured username or password only for the matching Git prompt
- fail closed for unsupported prompts

## Dependency
This is the first PR in a two-PR fix for Git CDN authentication. The companion `prow.groovy` integration PR is based on this branch and must be merged after this PR.

## Validation
- exercised username and password prompts with test environment variables
- verified unsupported prompts return a non-zero exit code
- `git diff --check`
