### PR TITLE
fix(libraries): create git askpass helper in shared workspace

### DIFF
--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -63,8 +63,15 @@ def withGitAskPass(String credentialsId, Closure body) {
     def tmpAskPassScript
 
     try {
-        tmpAskPassScript = sh(script: 'mktemp "${TMPDIR:-/tmp}/git-askpass.XXXXXX"', returnStdout: true).trim()
+        // Keep the askpass script inside the shared workspace volume but outside
+        // the Git worktree. Every caller clones into a workspace subdirectory via
+        // dir(), so the workspace root is never touched by git clean/checkout.
+        // Let writeFile create the file (it runs as the JNLP agent user); a file
+        // pre-created by an sh step would be owned by the container's root user
+        // and not writable by the agent, and a plain /tmp path would sit on a
+        // different filesystem than the container that runs Git.
         final askPassScript = libraryResource 'scripts/git_askpass.sh'
+        tmpAskPassScript = "${env.WORKSPACE}/git-askpass-${UUID.randomUUID().toString()}"
         writeFile(file: tmpAskPassScript, text: askPassScript)
         sh label: 'Prepare Git HTTP credential helper', script: "chmod 700 '${tmpAskPassScript}'"
         withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'TIPIPELINE_GIT_USERNAME', passwordVariable: 'TIPIPELINE_GIT_PASSWORD')]) {

--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -60,18 +60,17 @@ def checkoutRefs(refs, credentialsId = '', timeout = 5, withSubmodule = false, g
  * because checkout cleanup and the pipeline cache operate on the workspace.
  */
 def withGitAskPass(String credentialsId, Closure body) {
-    def tmpAskPassScript
+    // Keep the askpass script inside the shared workspace volume but outside
+    // the Git worktree. Every caller clones into a workspace subdirectory via
+    // dir(), so the workspace root is never touched by git clean/checkout.
+    // Let writeFile create the file (it runs as the JNLP agent user); a file
+    // pre-created by an sh step would be owned by the container's root user
+    // and not writable by the agent, and a plain /tmp path would sit on a
+    // different filesystem than the container that runs Git.
+    final askPassScript = libraryResource 'scripts/git_askpass.sh'
+    final tmpAskPassScript = "${env.WORKSPACE}/git-askpass-${UUID.randomUUID().toString()}"
 
     try {
-        // Keep the askpass script inside the shared workspace volume but outside
-        // the Git worktree. Every caller clones into a workspace subdirectory via
-        // dir(), so the workspace root is never touched by git clean/checkout.
-        // Let writeFile create the file (it runs as the JNLP agent user); a file
-        // pre-created by an sh step would be owned by the container's root user
-        // and not writable by the agent, and a plain /tmp path would sit on a
-        // different filesystem than the container that runs Git.
-        final askPassScript = libraryResource 'scripts/git_askpass.sh'
-        tmpAskPassScript = "${env.WORKSPACE}/git-askpass-${UUID.randomUUID().toString()}"
         writeFile(file: tmpAskPassScript, text: askPassScript)
         sh label: 'Prepare Git HTTP credential helper', script: "chmod 700 '${tmpAskPassScript}'"
         withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'TIPIPELINE_GIT_USERNAME', passwordVariable: 'TIPIPELINE_GIT_PASSWORD')]) {
@@ -80,9 +79,7 @@ def withGitAskPass(String credentialsId, Closure body) {
             }
         }
     } finally {
-        if (tmpAskPassScript) {
-            sh label: 'Remove Git HTTP credential helper', script: "rm -f '${tmpAskPassScript}'"
-        }
+        sh label: 'Remove Git HTTP credential helper', script: "rm -f '${tmpAskPassScript}'"
     }
 }
 


### PR DESCRIPTION
## Summary

Fix empty Git askpass helper that broke private submodule clones (e.g. tiflash `merged_build` cloning `tidbcloud/cloud-storage-engine`) when Git URLs are rewritten to the in-cluster git-cdn.

## Root cause

`withGitAskPass` created the helper via `mktemp` under `/tmp`, then populated it with Jenkins `writeFile`:

- `sh` steps run in the pod tool container (as root), so `/tmp/git-askpass.XXXXXX` lived in that container's filesystem.
- `writeFile` executes through the agent FilePath in the **JNLP** container, a different filesystem.
- Result: the file Git executed (`GIT_ASKPASS`) was the empty file left by `mktemp`; askpass returned no credentials; GitHub answered `Repository not found / Authentication failed`.

## Fix

- Put the helper under the shared workspace volume instead of `/tmp` — the volume is mounted in both the agent and the tool container.
- Keep it outside the Git worktree (every caller clones into a workspace subdirectory via `dir()`, so the workspace root is never touched by `git clean`/checkout).
- Let `writeFile` create the file so its owner is the agent user; a file pre-created by an `sh` (`mktemp`) step would be owned by the container's root user and unwritable by the agent (AccessDenied).
- Unique name via UUID to avoid collisions.

Verified: with a faithful agent pod (same builder image, git 2.43.5, real creds, same env), the private submodule clones successfully through git-cdn; an empty askpass reproduces the original error byte-for-byte.