### PR TITLE
ci(prow): migrate pingcap-qe/tidb-test release-8.5 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap-qe/tidb-test/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/release-8.5-presubmits.yaml
@@ -6,7 +6,7 @@ global_definitions:
     agent: jenkins
     decorate: false # need add this.
     labels:
-      master: "1"
+      master: "0"
 
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:


### PR DESCRIPTION
Part of #4961 (Phase 4: pingcap-qe/tidb-test release branches).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 6 jenkins-agent presubmit jobs in `prow-jobs/pingcap-qe/tidb-test/release-8.5-presubmits.yaml` so they are scheduled on the **to** Jenkins:

- `ghpr_build`, `ghpr_common_test`, `ghpr_integration_jdbc_test`, `ghpr_integration_common_test`, `ghpr_integration_mysql_test`, `ghpr_mysql_test`

## Verification
Run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins.

Part of #4947
Part of #4942