### PR TITLE
ci(prow): migrate pingcap-qe/tidb-test release-6.5 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap-qe/tidb-test/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/release-6.5-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-6.5/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build
@@ -16,7 +16,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-6.5/ghpr_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test
@@ -28,7 +28,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-6.5/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test


### PR DESCRIPTION
Part of #4961 (Phase 4: pingcap-qe/tidb-test release branches).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 3 jenkins-agent presubmit jobs in `prow-jobs/pingcap-qe/tidb-test/release-6.5-presubmits.yaml` so they are scheduled on the **to** Jenkins:

- `ghpr_build`, `ghpr_integration_mysql_test`, `ghpr_mysql_test`

## Verification
Run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins.

Part of #4947
Part of #4942