### PR TITLE
ci(prow): migrate pingcap-qe/tidb-test release-7.1 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap-qe/tidb-test/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap-qe/tidb-test/release-7.1-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.md)$"
       context: ci/build
@@ -20,7 +20,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|jdbc_test)/.*"
       context: ci/common-test
@@ -31,7 +31,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "(jdbc8_test|mybatis_test|jooq_test|tidb_jdbc_test)/.*"
       context: ci/integration-jdbc-test
@@ -42,7 +42,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_integration_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "randgen-test/.*"
       context: ci/integration-common-test
@@ -53,7 +53,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "mysql_test/.*"
       context: ci/integration-mysql-test
@@ -64,7 +64,7 @@ presubmits:
     - name: pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       run_if_changed: "mysql_test/.*"
       decorate: false # need add this.
       context: ci/mysql-test


### PR DESCRIPTION
Part of #4961 (Phase 4: pingcap-qe/tidb-test release branches).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the 6 jenkins-agent presubmit jobs in `prow-jobs/pingcap-qe/tidb-test/release-7.1-presubmits.yaml` so they are scheduled on the **to** Jenkins:

- `ghpr_build`, `ghpr_common_test`, `ghpr_integration_jdbc_test`, `ghpr_integration_common_test`, `ghpr_integration_mysql_test`, `ghpr_mysql_test`

## Verification
Run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins.

Part of #4947
Part of #4942