### PR TITLE
ci(prow): migrate tikv/pd release-7.1 job to target jenkins

### DIFF
--- a/prow-jobs/tikv/pd/release-7.1-presubmits.yaml
+++ b/prow-jobs/tikv/pd/release-7.1-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
     - name: tikv/pd/release-7.1/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       context: pull-integration-copr-test


### PR DESCRIPTION
Part of #4965 (Phase 4: tikv/pd release branches).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent presubmit job `tikv/pd/release-7.1/pull_integration_copr_test` in `prow-jobs/tikv/pd/release-7.1-presubmits.yaml` so it is scheduled on the **to** Jenkins.

## Verification
Run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins.

Part of #4947
Part of #4942