### PR TITLE
ci(prow): migrate pingcap-inc/enterprise-extensions pr-verify to target jenkins

### DIFF
--- a/prow-jobs/pingcap-inc/enterprise-extensions/presubmits.yaml
+++ b/prow-jobs/pingcap-inc/enterprise-extensions/presubmits.yaml
@@ -3,7 +3,7 @@ presubmits:
     - name: pingcap-inc/enterprise-extensions/pr-verify
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: true
       context: pr-verify


### PR DESCRIPTION
Part of #4966 (Phase 4: pingcap-inc repos).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent presubmit job `pingcap-inc/enterprise-extensions/pr-verify` in `prow-jobs/pingcap-inc/enterprise-extensions/presubmits.yaml` so it is scheduled on the **to** Jenkins.

## Verification
Run `/test pull-verify-jenkins-migration` and observe on the **to** Jenkins.

Part of #4947
Part of #4942