### PR TITLE
chore(pipelines/tiflash): drop ephemeral-storage from unit-test pods and move ccache to workspace

### DIFF
--- a/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/latest/merged_unit_test.groovy
@@ -17,7 +17,6 @@ pipeline {
             workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'ci-rwo')
             defaultContainer 'runner'
             retries 2
-            customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
     options {
@@ -39,15 +38,15 @@ pipeline {
             steps {
                 script {
                     dir("tiflash") {
-                        sh label: "config ccache", script: """
-                        ccache -o cache_dir="/tmp/.ccache"
+                        sh label: "config ccache", script: '''
+                        ccache -o cache_dir="$WORKSPACE/.ccache"
                         ccache -o max_size=2G
                         ccache -o hash_dir=false
                         ccache -o compression=true
                         ccache -o compression_level=6
                         ccache -o read_only=false
                         ccache -z
-                        """
+                        '''
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pod-merged_unit_test.yaml
@@ -14,17 +14,11 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "12"
-          ephemeral-storage: 20Gi
       volumeMounts:
-        - mountPath: "/tmp"
-          name: "tmp"
-          readOnly: false
         - mountPath: "/tmp-memfs"
           name: "tmp-memfs"
           readOnly: false
   volumes:
-    - name: "tmp"
-      emptyDir: {}
     - name: "tmp-memfs"
       emptyDir:
         medium: Memory

--- a/pipelines/pingcap/tiflash/release-6.5/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-6.5/pod-pull_unit-test.yaml
@@ -11,17 +11,11 @@ spec:
         requests:
           memory: "24Gi"
           cpu: "6"
-          ephemeral-storage: 20Gi
       volumeMounts:
-        - mountPath: "/tmp"
-          name: "tmp"
-          readOnly: false
         - mountPath: "/tmp-memfs"
           name: "tmp-memfs"
           readOnly: false
   volumes:
-    - name: "tmp"
-      emptyDir: {}
     - name: "tmp-memfs"
       emptyDir:
         medium: Memory

--- a/pipelines/pingcap/tiflash/release-6.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-6.5/pull_unit_test.groovy
@@ -18,7 +18,6 @@ pipeline {
             workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'ci-rwo')
             defaultContainer 'runner'
             retries 2
-            customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
     options {
@@ -50,15 +49,15 @@ pipeline {
             steps {
                 script {
                     dir("tiflash") {
-                        sh label: "config ccache", script: """
-                            ccache -o cache_dir="/tmp/.ccache"
+                        sh label: "config ccache", script: '''
+                            ccache -o cache_dir="$WORKSPACE/.ccache"
                             ccache -o max_size=2G
                             ccache -o hash_dir=false
                             ccache -o compression=true
                             ccache -o compression_level=6
                             ccache -o read_only=false
                             ccache -z
-                        """
+                        '''
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/merged_unit_test.groovy
@@ -16,7 +16,6 @@ pipeline {
             workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'ci-rwo')
             defaultContainer 'runner'
             retries 2
-            customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
     options {
@@ -49,15 +48,15 @@ pipeline {
             steps {
                 script {
                     dir("tiflash") {
-                        sh label: "config ccache", script: """
-                        ccache -o cache_dir="/tmp/.ccache"
+                        sh label: "config ccache", script: '''
+                        ccache -o cache_dir="$WORKSPACE/.ccache"
                         ccache -o max_size=2G
                         ccache -o hash_dir=false
                         ccache -o compression=true
                         ccache -o compression_level=6
                         ccache -o read_only=false
                         ccache -z
-                        """
+                        '''
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-merged_unit_test.yaml
@@ -14,17 +14,11 @@ spec:
         requests:
           memory: "32Gi"
           cpu: "12"
-          ephemeral-storage: 20Gi
       volumeMounts:
-        - mountPath: "/tmp"
-          name: "tmp"
-          readOnly: false
         - mountPath: "/tmp-memfs"
           name: "tmp-memfs"
           readOnly: false
   volumes:
-    - name: "tmp"
-      emptyDir: {}
     - name: "tmp-memfs"
       emptyDir:
         medium: Memory

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_unit-test.yaml
@@ -15,17 +15,11 @@ spec:
         requests:
           memory: "24Gi"
           cpu: "6"
-          ephemeral-storage: 20Gi
       volumeMounts:
-        - mountPath: "/tmp"
-          name: "tmp"
-          readOnly: false
         - mountPath: "/tmp-memfs"
           name: "tmp-memfs"
           readOnly: false
   volumes:
-    - name: "tmp"
-      emptyDir: {}
     - name: "tmp-memfs"
       emptyDir:
         medium: Memory

--- a/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tiflash/release-8.5/pull_unit_test.groovy
@@ -18,7 +18,6 @@ pipeline {
             workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'ci-rwo')
             defaultContainer 'runner'
             retries 2
-            customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
     options {
@@ -49,15 +48,15 @@ pipeline {
             steps {
                 script {
                     dir("tiflash") {
-                        sh label: "config ccache", script: """
-                            ccache -o cache_dir="/tmp/.ccache"
+                        sh label: "config ccache", script: '''
+                            ccache -o cache_dir="$WORKSPACE/.ccache"
                             ccache -o max_size=2G
                             ccache -o hash_dir=false
                             ccache -o compression=true
                             ccache -o compression_level=6
                             ccache -o read_only=false
                             ccache -z
-                        """
+                        '''
                     }
                 }
             }


### PR DESCRIPTION
## What problem does this PR solve?

Continues the cleanup started in #4869/#5057/#5064: the migrated tiflash unit-test jobs keep their disk-heavy IO on the ci-rwo workspace volume, so the node-level `ephemeral-storage` request on the pod template is unnecessary and wastes ci-worker scheduling capacity.

## What is changed and how it works?

For `merged_unit_test` (latest, release-8.5) and `pull_unit_test` (release-8.5, release-6.5):

- remove `requests.ephemeral-storage: 20Gi` and the `/tmp` emptyDir from the pod templates (keep `/tmp-memfs` tmpfs)
- move the ccache dir from `/tmp/.ccache` to `$WORKSPACE/.ccache` so it lives on the ci-rwo workspace volume
- drop `customWorkspace` so the default workspace volume is used

## Related changes

- Parent issue: #5089
- Closes: #5090
- #5057 drop ephemeral-storage from tiflash latest non-nextgen pods
- #5064 relocate ccache to the workspace volume in latest `pull_unit_test`

## Check List

- [x] No formatting changes
- [x] No documentation changes
