### PR TITLE
chore(pipelines/tiflash): drop ephemeral-storage from build and integration pods

### DIFF
--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-build.yaml
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-build.yaml
@@ -16,11 +16,9 @@ spec:
         requests:
           memory: 24Gi
           cpu: "6"
-          ephemeral-storage: 20Gi
         limits:
           memory: 32Gi
           cpu: "8"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"
           name: "tmp"

--- a/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pull_integration_next_gen_columnar/pod-test.yaml
@@ -19,11 +19,9 @@ spec:
         requests:
           memory: 16Gi
           cpu: "4"
-          ephemeral-storage: 20Gi
         limits:
           memory: 32Gi
           cpu: "8"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"
           name: "tmp"
@@ -43,11 +41,9 @@ spec:
         requests:
           memory: 16Gi
           cpu: "4"
-          ephemeral-storage: 10Gi
         limits:
           memory: 32Gi
           cpu: "8"
-          ephemeral-storage: 50Gi
       tty: true
       volumeMounts:
         - mountPath: "/tmp"

--- a/pipelines/pingcap/tiflash/release-6.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-6.5/pod-pull_build.yaml
@@ -15,11 +15,9 @@ spec:
         requests:
           memory: 24Gi
           cpu: "6"
-          ephemeral-storage: 20Gi
         limits:
           memory: 32Gi
           cpu: "8"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"
           name: "tmp"

--- a/pipelines/pingcap/tiflash/release-6.5/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-6.5/pod-pull_integration_test.yaml
@@ -23,11 +23,9 @@ spec:
         limits:
           memory: "32Gi"
           cpu: "8"
-          ephemeral-storage: 150Gi
         requests:
           memory: "16Gi"
           cpu: "4"
-          ephemeral-storage: 20Gi
       securityContext:
         privileged: true
       tty: false
@@ -51,11 +49,9 @@ spec:
         requests:
           memory: "16Gi"
           cpu: "4"
-          ephemeral-storage: 10Gi
         limits:
           memory: "32Gi"
           cpu: "8"
-          ephemeral-storage: 50Gi
       tty: true
       volumeMounts:
         - mountPath: "/tmp"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-merged_build.yaml
@@ -16,11 +16,9 @@ spec:
         requests:
           memory: 32Gi
           cpu: "12"
-          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"
           name: "tmp"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_build.yaml
@@ -15,11 +15,9 @@ spec:
         requests:
           memory: 24Gi
           cpu: "6"
-          ephemeral-storage: 20Gi
         limits:
           memory: 32Gi
           cpu: "8"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: "/tmp"
           name: "tmp"

--- a/pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml
+++ b/pipelines/pingcap/tiflash/release-8.5/pod-pull_integration_test.yaml
@@ -16,11 +16,9 @@ spec:
         limits:
           memory: "32Gi"
           cpu: "8"
-          ephemeral-storage: 150Gi
         requests:
           memory: "16Gi"
           cpu: "4"
-          ephemeral-storage: 20Gi
       securityContext:
         privileged: true
       tty: false
@@ -44,11 +42,9 @@ spec:
         requests:
           memory: "16Gi"
           cpu: "4"
-          ephemeral-storage: 10Gi
         limits:
           memory: "32Gi"
           cpu: "8"
-          ephemeral-storage: 50Gi
       tty: true
       volumeMounts:
         - mountPath: "/tmp"


### PR DESCRIPTION
## What problem does this PR solve?

Aligns release-6.5 / release-8.5 and the latest next-gen columnar build/integration pod templates with the already-fixed tiflash latest non-nextgen pods (#5057). The docker-graph and the Jenkins workspace already sit on `ci-rwo` volumes, so container-level `ephemeral-storage` requests are unnecessary, and the 150Gi/50Gi limits can never be satisfied by ci-worker nodes (~44-70Gi ephemeral-storage allocatable).

## What is changed and how it works?

Remove `requests/limits.ephemeral-storage` from the runner/dockerd/docker containers of:

- `release-8.5`: `pod-merged_build`, `pod-pull_build`, `pod-pull_integration_test`
- `release-6.5`: `pod-pull_build`, `pod-pull_integration_test`
- `latest/pull_integration_next_gen_columnar`: `pod-build`, `pod-test`

Memory/cpu requests/limits are untouched.

## Related changes

- Parent issue: #5089
- Closes: #5091
- #5057: drop ephemeral-storage from tiflash latest non-nextgen pods
- #5085: same cleanup for the tiflash unit-test pods

## Check List

- [x] No formatting changes
- [x] No documentation changes
