### PR TITLE
chore(pipelines): drop ephemeral-storage from bazel pod templates

### DIFF
--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_build.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           cpu: "24"
           memory: 64Gi
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/latest/ghpr_build/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/ghpr_build/pod.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           cpu: "2"
           memory: 16Gi
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "16"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 24Gi
           cpu: "3"
-          ephemeral-storage: 20Gi
         limits:
           memory: 24Gi
           cpu: "3"
-          ephemeral-storage: 120Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -15,11 +15,9 @@ spec:
         requests:
           memory: 48Gi
           cpu: "24"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 300Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
@@ -15,11 +15,9 @@ spec:
         requests:
           memory: 16Gi
           cpu: "4"
-          ephemeral-storage: 40Gi
         limits:
           memory: 32Gi
           cpu: "8"
-          ephemeral-storage: 200Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
@@ -15,11 +15,9 @@ spec:
         requests:
           memory: 48Gi
           cpu: "24"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 300Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/latest/pull_build_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_build_next_gen/pod.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 32Gi
           cpu: "6"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "16"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 48Gi
           cpu: "12"
-          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           cpu: "2"
           memory: 16Gi
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "16"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 8Gi
           cpu: "2"
-          ephemeral-storage: 20Gi
         limits:
           memory: 32Gi
           cpu: "8"
-          ephemeral-storage: 120Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 48Gi
           cpu: "24"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 300Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_build.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           cpu: "2"
           memory: 16Gi
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "16"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 12Gi
           cpu: "3"
-          ephemeral-storage: 20Gi
         limits:
           memory: 12Gi
           cpu: "3"
-          ephemeral-storage: 120Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
@@ -15,11 +15,9 @@ spec:
         requests:
           memory: 48Gi
           cpu: "24"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 300Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_build.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           cpu: "2"
           memory: 16Gi
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "16"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 12Gi
           cpu: "3"
-          ephemeral-storage: 20Gi
         limits:
           memory: 12Gi
           cpu: "3"
-          ephemeral-storage: 120Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml
@@ -15,11 +15,9 @@ spec:
         requests:
           memory: 48Gi
           cpu: "24"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 300Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_build.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           cpu: "2"
           memory: 16Gi
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "16"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 12Gi
           cpu: "3"
-          ephemeral-storage: 20Gi
         limits:
           memory: 12Gi
           cpu: "3"
-          ephemeral-storage: 120Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_unit_test.yaml
@@ -15,11 +15,9 @@ spec:
         requests:
           memory: 48Gi
           cpu: "24"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 300Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           cpu: "24"
           memory: 64Gi
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_check2.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 24Gi
           cpu: "3"
-          ephemeral-storage: 20Gi
         limits:
           memory: 24Gi
           cpu: "3"
-          ephemeral-storage: 120Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_build.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_build.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           cpu: "24"
           memory: 64Gi
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check2.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 16Gi
           cpu: "4"
-          ephemeral-storage: 20Gi
         limits:
           memory: 32Gi
           cpu: "8"
-          ephemeral-storage: 120Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml
+++ b/pipelines/tidbcloud/cloud-storage-engine/dedicated/pull_integration_realcluster_test_next_gen/test-pod.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 24Gi
           cpu: "6"
-          ephemeral-storage: 30Gi
         limits:
           memory: 48Gi
           cpu: "12"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/test-pod.yaml
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/test-pod.yaml
@@ -13,11 +13,9 @@ spec:
         requests:
           memory: 48Gi
           cpu: "12"
-          ephemeral-storage: 20Gi
         limits:
           memory: 48Gi
           cpu: "12"
-          ephemeral-storage: 150Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged


### PR DESCRIPTION
## What problem does this PR solve?

These migrated GCP bazel jobs keep the bazel output tree (`bazel-out-merged`) and the Jenkins workspace on `ci-rwo` volumes. The golang container's `ephemeral-storage` requests (20-40Gi) only reduce node packing density, and the 120-300Gi limits exceed the ci-worker nodes' capacity (~44-70Gi allocatable, see #5057).

## What is changed and how it works?

Remove `requests/limits.ephemeral-storage` from the `golang` container of 26 pod templates covering build / check2 / unit-test / realcluster jobs across:

- pingcap/tidb (latest + release-6.5/7.1/7.5/8.1/8.5/9.0-beta)
- pingcap-inc/tidb release-8.5
- tikv/pd latest realcluster
- tidbcloud/cloud-storage-engine dedicated realcluster

Memory/cpu requests/limits are untouched.

## Related changes

- Parent issue: #5089
- Closes: #5092
- #5057: same rationale for tiflash latest pods
- #5085 / #5086: tiflash cleanup

## Check List

- [x] No formatting changes
- [x] No documentation changes
