### PR TITLE
chore(pipelines/tidb): move unit-test repository cache to workspace volume

### DIFF
--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_unit_test.yaml
@@ -15,16 +15,12 @@ spec:
         requests:
           memory: 48Gi
           cpu: "24"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 200Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - mountPath: /share/.cache/bazel-repository-cache
-          name: bazel-repository-cache
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -47,8 +43,6 @@ spec:
               requests:
                 storage: 300Gi
             storageClassName: ci-rwo
-    - name: bazel-repository-cache
-      emptyDir: {}
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap-inc/tidb/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pull_unit_test.groovy
@@ -64,7 +64,8 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     sh """
-                        sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
+                        mkdir -p $WORKSPACE/.cache
+                        sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=$WORKSPACE/.cache|g' Makefile.common
                         git diff .
                         git status
                     """

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_ddlv1.groovy
@@ -36,7 +36,7 @@ pipeline {
             environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
             steps {
                 dir(REFS.repo) {
-                    script { bazel.prepareWorkspace(repositoryCache: '/share/.cache/bazel-repository-cache', ensureTmpDir: true) }
+                    script { bazel.prepareWorkspace(ensureTmpDir: true) }
 
                     sh '''#!/usr/bin/env bash
                         set -euxo pipefail

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pipeline.groovy
@@ -60,7 +60,8 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     sh """
-                        sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
+                        mkdir -p $WORKSPACE/.cache
+                        sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=$WORKSPACE/.cache|g' Makefile.common
                         git diff .
                         git status
                     """

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
@@ -15,16 +15,12 @@ spec:
         requests:
           memory: 60Gi
           cpu: "20"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "20"
-          ephemeral-storage: 300Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - mountPath: /share/.cache/bazel-repository-cache
-          name: bazel-repository-cache
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -47,8 +43,6 @@ spec:
               requests:
                 storage: 300Gi
             storageClassName: ci-rwo
-    - name: bazel-repository-cache
-      emptyDir: {}
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
@@ -15,16 +15,12 @@ spec:
         requests:
           memory: 48Gi
           cpu: "24"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 200Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - mountPath: /share/.cache/bazel-repository-cache
-          name: bazel-repository-cache
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -47,8 +43,6 @@ spec:
               requests:
                 storage: 300Gi
             storageClassName: ci-rwo
-    - name: bazel-repository-cache
-      emptyDir: {}
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-8.5/pull_unit_test.groovy
@@ -64,7 +64,8 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     sh """
-                        sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
+                        mkdir -p $WORKSPACE/.cache
+                        sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=$WORKSPACE/.cache|g' Makefile.common
                         git diff .
                         git status
                     """

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_unit_test.yaml
@@ -15,16 +15,12 @@ spec:
         requests:
           memory: 48Gi
           cpu: "24"
-          ephemeral-storage: 20Gi
         limits:
           memory: 64Gi
           cpu: "24"
-          ephemeral-storage: 200Gi
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - mountPath: /share/.cache/bazel-repository-cache
-          name: bazel-repository-cache
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -47,8 +43,6 @@ spec:
               requests:
                 storage: 300Gi
             storageClassName: ci-rwo
-    - name: bazel-repository-cache
-      emptyDir: {}
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/release-9.0-beta/pull_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pull_unit_test.groovy
@@ -64,7 +64,8 @@ pipeline {
             steps {
                 dir(REFS.repo) {
                     sh """
-                        sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=/share/.cache/bazel-repository-cache|g' Makefile.common
+                        mkdir -p $WORKSPACE/.cache
+                        sed -i 's|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=$WORKSPACE/.cache|g' Makefile.common
                         git diff .
                         git status
                     """


### PR DESCRIPTION
## What problem does this PR solve?

`pull_unit_test` jobs redirected the bazel `repository_cache` to a node-local `/share/.cache/bazel-repository-cache` emptyDir, which forced an `ephemeral-storage` reservation on the pod. ci-worker nodes only expose ~44-70Gi ephemeral-storage (see #5057), so the node-local cache is both scarce and unnecessary now that a ci-rwo volume is available.

## What is changed and how it works?

- Pod templates (`pull_unit_test` on latest next-gen, release-8.5, release-9.0-beta, pingcap-inc release-8.5): drop the `bazel-repository-cache` emptyDir volume/mount and the `ephemeral-storage` request/limit.
- Pipelines: point `repository_cache` at `$WORKSPACE/.cache` (with a `mkdir -p` before the sed) so the cache lives on the ci-rwo workspace volume.
- latest `pull_unit_test_ddlv1`: drop the inert `/share/.cache/...` `repositoryCache` argument in `bazel.prepareWorkspace` (that pod never mounts `/share`), so the cache stays on the ci-rwo bazel-out volume by default.

## Related changes

- Parent issue: #5089
- Closes: #5093
- #5087: drop ephemeral-storage from the remaining bazel pod templates

## Check List

- [x] No formatting changes
- [x] No documentation changes
