### PR TITLE
fix(prow): remove replay pipeline concurrency limit

### DIFF
--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -55,7 +55,6 @@ presubmits:
       decorate: true
       always_run: false
       optional: true
-      max_concurrency: 1
       trigger: "(?m)^/test (?:.*? )?pull-replay-jenkins-pipelines(?: .*?)?$"
       rerun_command: "/test pull-replay-jenkins-pipelines"
       run_if_changed: "^pipelines/.*\\.groovy$"


### PR DESCRIPTION
## Summary
- remove the Prow `max_concurrency: 1` limit from `pull-replay-jenkins-pipelines`
- keep the replay script internal parallelism unchanged

## Testing
- `git diff --check`
- `bash .ci/update-prow-job-kustomization.sh`
- `yq e . prow-jobs/pingcap-qe/ci/presubmits.yaml`
- repository Prow static validation was attempted with `SKIP_CREATE=1`, but its first-time `crane` download hung and was terminated