### PR TITLE
fix(pipelines/tidb-test): fix mysql_test stash unstash nesting and test.sh args

### DIFF
--- a/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_integration_mysql_test.groovy
@@ -102,7 +102,7 @@ pipeline {
                                         export CACHE_ENABLED=${CACHE_ENABLED}
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
-                                        ./test.sh -blacklist=1 -part=${PART}
+                                        ./test.sh 1 ${PART}
                                     """
                                 }
                             }

--- a/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-6.5/ghpr_mysql_test.groovy
@@ -98,7 +98,7 @@ pipeline {
                                     export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
                                     export CACHE_ENABLED=${CACHE_ENABLED}
                                     export TIDB_TEST_STORE_NAME="unistore"
-                                    ./test.sh -backlist=1 -part=${PART}
+                                    ./test.sh 1 ${PART}
                                     """
                                 }
                             }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_integration_mysql_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
-                                        ./test.sh -blacklist=1 -part=${PART}
+                                        ./test.sh 1 ${PART}
                                     """
                                 }
                             }

--- a/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-7.1/ghpr_mysql_test.groovy
@@ -86,13 +86,15 @@ pipeline {
                                 unstash 'tidb-server'
                                 sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'
                             }
-                            dir('tidb-test/mysql_test') {
+                            dir('tidb-test') {
                                 unstash 'mysql-test'
-                                sh label: "part ${PART}", script: """
-                                export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
-                                export TIDB_TEST_STORE_NAME="unistore"
-                                ./test.sh -backlist=1 -part=${PART}
-                                """
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: """
+                                    export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
+                                    export TIDB_TEST_STORE_NAME="unistore"
+                                    ./test.sh 1 ${PART}
+                                    """
+                                }
                             }
                         }
                         post{

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_integration_mysql_test.groovy
@@ -97,7 +97,7 @@ pipeline {
                                         export TIDB_SERVER_PATH="${WORKSPACE}/tidb-test/mysql_test/bin/tidb-server"
                                         export TIKV_PATH="127.0.0.1:2379"
                                         export TIDB_TEST_STORE_NAME="tikv"
-                                        ./test.sh -blacklist=1 -part=${PART}
+                                        ./test.sh 1 ${PART}
                                     """
                                 }
                             }

--- a/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test.groovy
+++ b/pipelines/pingcap-qe/tidb-test/release-8.5/ghpr_mysql_test.groovy
@@ -86,13 +86,15 @@ pipeline {
                                 unstash 'tidb-server'
                                 sh label: 'tidb-server', script: 'ls bin/tidb-server && chmod +x bin/tidb-server && ./bin/tidb-server -V'
                             }
-                            dir('tidb-test/mysql_test') {
+                            dir('tidb-test') {
                                 unstash 'mysql-test'
-                                sh label: "part ${PART}", script: """
-                                export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
-                                export TIDB_TEST_STORE_NAME="unistore"
-                                ./test.sh -backlist=1 -part=${PART}
-                                """
+                                dir('mysql_test') {
+                                    sh label: "part ${PART}", script: """
+                                    export TIDB_SERVER_PATH=${WORKSPACE}/tidb/bin/tidb-server
+                                    export TIDB_TEST_STORE_NAME="unistore"
+                                    ./test.sh 1 ${PART}
+                                    """
+                                }
                             }
                         }
                         post{


### PR DESCRIPTION
## Problem
The release-branch `ghpr_mysql_test` / `ghpr_integration_mysql_test` pipelines (`release-6.5/7.1/8.5`) have two bugs that break the mysql test runs **on any Jenkins** (they surfaced during to-Jenkins migration verification on #5073):

### 1. Stash/unstash double nesting (`ghpr_mysql_test` only)
The `mysql-test` stash is created in `dir('tidb-test')` with `includes: 'mysql_test/**'`, but was unstashed inside `dir('tidb-test/mysql_test')`:
- files landed under `tidb-test/mysql_test/mysql_test/`
- → `./test.sh: No such file or directory` (exit 127 in matrix PARTs)

Fix: unstash in `dir('tidb-test')` then enter `dir('mysql_test')`, mirroring the already-fixed `ghpr_integration_mysql_test` pattern (#4751). (`release-6.5 ghpr_mysql_test` uses the cache mechanism, not stash, so it is unaffected.)

### 2. Wrong test.sh argument style
`mysql_test/test.sh` parses **positional** args (`blacklist=$1; part=$2`) but the pipelines invoked:
- `ghpr_mysql_test`: `./test.sh -backlist=1 -part=${PART}` (typo: `backlist`)
- `ghpr_integration_mysql_test`: `./test.sh -blacklist=1 -part=${PART}`

→ `$1=-blacklist=1`, `$2=-part=N`; the `[[ $blacklist -eq 1 ]]` numeric comparison fails and blacklist/partition logic silently does not run.

Fix: switch to the positional form `./test.sh 1 ${PART}` used by the latest and pingcap-inc pipelines (which also carries a TODO noting the test.sh parsing issue).

## Changes
- `release-{6.5,7.1,8.5}/ghpr_mysql_test.groovy`: fix nesting (7.1/8.5) + positional args (all)
- `release-{6.5,7.1,8.5}/ghpr_integration_mysql_test.groovy`: positional args (all)
