### PR TITLE
fix(pipelines/enterprise-extensions): drop bazel-out-data PVC from pr-verify pod template

### DIFF
--- a/pipelines/pingcap-inc/enterprise-extensions/latest/pod-pr-verify.yaml
+++ b/pipelines/pingcap-inc/enterprise-extensions/latest/pod-pr-verify.yaml
@@ -5,22 +5,20 @@ spec:
     fsGroup: 1000
   containers:
     - name: golang
-      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
       securityContext:
         privileged: true
       tty: true
       resources:
+        requests:
+          memory: 48Gi
+          cpu: "24"
         limits:
           memory: 64Gi
-          cpu: "16"
+          cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
+        - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - name: bazel-out-lower
-          subPath: tidb/go1.19.2
-          mountPath: /bazel-out-lower
-        - name: bazel-out-overlay
-          mountPath: /bazel-out-overlay
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,16 +31,19 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-lower
-      persistentVolumeClaim:
-        claimName: bazel-out-data
-    - name: bazel-out-overlay
-      emptyDir: {}
     - name: bazel-out-merged
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
-      secret:
-        secretName: bazel
+      configMap:
+        name: bazel
     - name: containerinfo
       downwardAPI:
         items:


### PR DESCRIPTION
Fixes #5097.

## Problem
`enterprise-extensions` `pr-verify` pod template mounted a static PVC **`bazel-out-data`** (legacy overlayfs bazel cache) that does not exist in any CI cluster → the pod can never schedule (`persistentvolumeclaim "bazel-out-data" not found`, verified 0/66 Unschedulable on the from Jenkins) → the job has **zero build history** and cannot be auto-verified.

The template is a leftover copy of the retired tidb `pull_check_next_gen` pod (same PVC + personal dev image), and also referenced the `bazel` **secret**, which exists only on the from-Jenkins GCP cluster (not on the to-Jenkins Tencent cluster).

## Fix (Option B)
Rework the template to match the working tidb-master bazel jobs (`pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml`):
- replace the static PVC + emptyDir overlay/merge volumes with a single `ephemeral` volumeClaimTemplate (`ci-rwo`, 200Gi) mounted at `/home/jenkins/.tidb` — provisioned per pod on any cluster;
- use the `bazel` **configMap** (present on both clusters) instead of the `bazel` **secret**;
- align image (`wangweizhen/tidb_image:go12520260122`) and resources to the tidb-master bazel image — the pipeline checks out `pingcap/tidb` at `master`, which the older go1.23 image cannot build.

## Validation
- `pipelines/**` only; pod yaml reuses the exact structure of the working `pod-ghpr_unit_test.yaml`.
- `pull-verify-storage-class-policy` / `pull-verify-jenkins-pipelines` will validate the storage class literal and pipeline syntax.
