### PR TITLE
ci(prow): migrate pingcap/tidb-tools pull_verify to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb-tools/presubmits.yaml
+++ b/prow-jobs/pingcap/tidb-tools/presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     - name: pingcap/tidb-tools/pull_verify
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: true
       skip_report: false


### PR DESCRIPTION
Part of #4967 (Phase 4: pingcap/tidb-tools).

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent presubmit job `pingcap/tidb-tools/pull_verify` in `prow-jobs/pingcap/tidb-tools/presubmits.yaml` so it is scheduled on the **to** Jenkins.

## Note
This job has build history on the from Jenkins (last builds FAILURE), so `/test pull-verify-jenkins-migration` can copy real parameters.

Part of #4947
Part of #4942