### PR TITLE
fix(pipelines/tidb-tools): download server binaries from OCI instead of sunset fileserver

### DIFF
--- a/pipelines/pingcap/tidb-tools/latest/pod-pull_verify.yaml
+++ b/pipelines/pingcap/tidb-tools/latest/pod-pull_verify.yaml
@@ -11,6 +11,16 @@ spec:
         limits:
           memory: 8Gi
           cpu: "4"
+    - name: utils
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      tty: true
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          cpu: "1"
+          memory: 4Gi
     - name: mysql
       image: docker.io/library/mysql:5.7
       tty: true

--- a/pipelines/pingcap/tidb-tools/latest/pull_verify.groovy
+++ b/pipelines/pingcap/tidb-tools/latest/pull_verify.groovy
@@ -8,6 +8,15 @@ final GIT_FULL_REPO_NAME = 'pingcap/tidb-tools'
 final POD_TEMPLATE_FILE = 'pipelines/pingcap/tidb-tools/latest/pod-pull_verify.yaml'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 
+// Server/dumpling binaries are pulled from OCI artifact packages instead of the
+// (decommissioned) file server. Tags follow the tidb-tools PR base branch, and
+// PR titles may pin a peer component (e.g. "... | tidb=release-8.5") which
+// computeArtifactOciTagFromPR resolves per component.
+final OCI_TAG_TIDB = component.computeArtifactOciTagFromPR('tidb', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_TIKV = component.computeArtifactOciTagFromPR('tikv', REFS.base_ref, REFS.pulls[0].title, 'master')
+final OCI_TAG_DUMPLING = component.computeArtifactOciTagFromPR('dumpling', REFS.base_ref, REFS.pulls[0].title, 'master')
+
 prow.setPRDescription(REFS)
 pipeline {
     agent {
@@ -19,7 +28,7 @@ pipeline {
         }
     }
     environment {
-        FILE_SERVER_URL = 'http://sunset-fileserver.pingcap.net'
+        OCI_ARTIFACT_HOST = "${env._JENKINS_OCI_ARTIFACT_HOST_HUB}"
     }
     options {
         timeout(time: 40, unit: 'MINUTES')
@@ -66,14 +75,16 @@ pipeline {
         stage('Integration Test') {
             steps {
                 dir("tidb-tools") {
-                    script {
-                        component.fetchAndExtractArtifact(FILE_SERVER_URL, 'dumpling', REFS.base_ref, REFS.pulls[0].title, 'centos7/dumpling.tar.gz', 'bin')
-                        component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tikv', REFS.base_ref, REFS.pulls[0].title, 'centos7/tikv-server.tar.gz', 'bin')
-                        component.fetchAndExtractArtifact(FILE_SERVER_URL, 'pd', REFS.base_ref, REFS.pulls[0].title, 'centos7/pd-server.tar.gz', 'bin')
-                        component.fetchAndExtractArtifact(FILE_SERVER_URL, 'tidb', REFS.base_ref, REFS.pulls[0].title, 'centos7/tidb-server.tar.gz', 'bin')
+                    container('utils') {
+                        dir('bin') {
+                            sh label: 'download tidb/tikv/pd/dumpling from OCI', script: """
+                            ${WORKSPACE}/scripts/artifacts/download_pingcap_oci_artifact.sh \
+                                --tidb=${OCI_TAG_TIDB} --pd=${OCI_TAG_PD} --tikv=${OCI_TAG_TIKV} --dumpling=${OCI_TAG_DUMPLING}
+                            """
+                        }
                     }
                     sh label: "download enterprise-tools-nightly", script: """
-                        wget --no-verbose --retry-connrefused --waitretry=1 -t 3 -O tidb-enterprise-tools-nightly-linux-amd64.tar.gz https://download.pingcap.com/tidb-enterprise-tools-nightly-linux-amd64.tar.gz
+                        curl -fsSL --retry 3 -o tidb-enterprise-tools-nightly-linux-amd64.tar.gz https://download.pingcap.com/tidb-enterprise-tools-nightly-linux-amd64.tar.gz
                         tar -xzf tidb-enterprise-tools-nightly-linux-amd64.tar.gz
                         mv tidb-enterprise-tools-nightly-linux-amd64/bin/loader bin/
                         rm -r tidb-enterprise-tools-nightly-linux-amd64

--- a/pipelines/pingcap/tidb-tools/latest/pull_verify.groovy
+++ b/pipelines/pingcap/tidb-tools/latest/pull_verify.groovy
@@ -96,7 +96,6 @@ pipeline {
                         which bin/dumpling
                         which bin/importer
                         ls -alh ./bin/
-                        chmod +x bin/*
                         ./bin/dumpling --version
                         ./bin/tikv-server -V
                         ./bin/pd-server -V


### PR DESCRIPTION
Fixes #5101.

## Problem
`pingcap/tidb-tools/pull_verify` Integration Test downloads `tidb-server`/`pd-server`/`tikv-server`/`dumpling` from the **decommissioned** `sunset-fileserver.pingcap.net` (DNS no longer resolves), so the job always fails on both the from and to Jenkins with `curl: (6) Could not resolve host`.

## Fix
- Replace the four `fetchAndExtractArtifact(FILE_SERVER_URL, ...)` calls with OCI artifact downloads via `scripts/artifacts/download_pingcap_oci_artifact.sh --tidb/--pd/--tikv/--dumpling`.
- OCI tags are derived per component from the PR base branch, honoring PR-title peer-component pins (e.g. `... | tidb=release-8.5`) via `component.computeArtifactOciTagFromPR`.
- Add a `utils` container (`ghcr.io/pingcap-qe/cd/utils/release`, has oras/yq + registry auth) to `pod-pull_verify.yaml`, matching other OCI-download pipelines.
- `loader` is kept from `download.pingcap.com/tidb-enterprise-tools-nightly` (no OCI package; deprecated tool still used by the sync_diff_inspector test); switched wget -> curl.

## Validation
- Replay the changed pipeline on the from Jenkins against a historical pull_verify build.
- `pull-verify-jenkins-pipelines` / `pull-verify-k8s-pod-yaml` / `pull-verify-storage-class-policy` will validate syntax/storage class.
