### PR TITLE
ci(prow): migrate pingcap/tidb release-6.5 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -22,7 +22,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_check
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -33,7 +33,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_check2
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -44,7 +44,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -55,7 +55,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -66,7 +66,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -79,7 +79,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -92,7 +92,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -104,7 +104,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -117,7 +117,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -130,7 +130,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -143,7 +143,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -156,7 +156,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -169,7 +169,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -182,7 +182,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_tiflash_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -195,7 +195,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_tidb_tools_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -208,7 +208,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/pull_integration_binlog_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Part of #4959.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942