### PR TITLE
ci(prow): migrate pingcap/tidb release-8.5 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -22,7 +22,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_check
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -33,7 +33,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_check2
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -44,7 +44,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_mysql_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -55,7 +55,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -66,7 +66,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_unit_test_ddlv1
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "pkg/(ddl|meta)/.*"
       context: pull-unit-test-ddlv1
@@ -77,7 +77,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       run_if_changed: "(br|pkg/(ddl|domain|infoschema))/.*"
@@ -88,7 +88,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_lightning_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false
@@ -102,7 +102,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -115,7 +115,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_mysql_client_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -129,7 +129,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -141,7 +141,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -153,7 +153,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -166,7 +166,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -179,7 +179,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -192,7 +192,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -205,7 +205,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -218,7 +218,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -231,7 +231,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -244,7 +244,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -257,7 +257,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_tidb_tools_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Part of #4959.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942