### PR TITLE
ci(prow): migrate pingcap/tiflow release-9.0-beta jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflow/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-9.0-beta-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - name: pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -24,7 +24,7 @@ presubmits:
     - name: pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -37,7 +37,7 @@ presubmits:
     - name: pingcap/tiflow/release-9.0-beta/pull_cdc_integration_pulsar_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -50,7 +50,7 @@ presubmits:
     - name: pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -63,7 +63,7 @@ presubmits:
     - name: pingcap/tiflow/release-9.0-beta/pull_dm_compatibility_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -76,7 +76,7 @@ presubmits:
     - name: pingcap/tiflow/release-9.0-beta/pull_dm_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -89,7 +89,7 @@ presubmits:
     - name: pingcap/tiflow/release-9.0-beta/pull_syncdiff_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -101,7 +101,7 @@ presubmits:
     - name: pingcap/tiflow/release-9.0-beta/pull_verify
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify


### PR DESCRIPTION
Part of #4960.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tiflow/release-9.0-beta-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942