### PR TITLE
ci(prow): migrate pingcap/tiflash release-8.5 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflash/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.5-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -23,7 +23,7 @@ presubmits:
     - name: pingcap/tiflash/release-8.5/pull_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test


### PR DESCRIPTION
Part of #4962.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tiflash/release-8.5-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942