### PR TITLE
fix(libraries): make component SCM checkout work with git-cdn HTTP auth

### DIFF
--- a/libraries/tipipeline/tests/TestComponent.groovy
+++ b/libraries/tipipeline/tests/TestComponent.groovy
@@ -17,6 +17,13 @@ class TestComponent {
             new File("libraries/tipipeline/vars/component.groovy"))
     }
 
+    private static def loadScriptWithBindings(Map steps = [:]) {
+        def binding = new Binding()
+        steps.each { name, value -> binding.setVariable(name, value) }
+        new GroovyShell(binding).parse(
+            new File("libraries/tipipeline/vars/component.groovy"))
+    }
+
     // ============================================================
     // parseCIParamsFromPRTitle
     // ============================================================
@@ -300,6 +307,111 @@ class TestComponent {
             cases.each { branch ->
                 assertEquals("unchanged: ${branch}", branch, peerBranch(branch))
             }
+        }
+    }
+
+    // ============================================================
+    // Git CDN aware component checkouts (git-cdn askpass)
+    // ============================================================
+    static class GitCdnCheckout {
+        @Test
+        void shouldInstallHttpAskPassWhenCdnEnabled() {
+            def events = []
+            def script = loadScriptWithBindings([
+                env: [GIT_CDN_ENABLED: 'true', GIT_HTTP_CREDENTIALS_ID: 'github-bot-https', WORKSPACE: '/ws'],
+                libraryResource: { String path ->
+                    events << "resource:${path}".toString()
+                    'askpass helper'
+                },
+                writeFile: { Map args -> events << "write:${args.file}".toString() },
+                sh: { Map args -> events << "sh:${args.label}".toString() },
+                usernamePassword: { Map args -> args },
+                withCredentials: { List creds, Closure body ->
+                    events << "credentials:${creds[0].credentialsId}".toString()
+                    body()
+                },
+                withEnv: { List environment, Closure body ->
+                    events << "env:${environment}".toString()
+                    body()
+                },
+            ])
+
+            script.withGitCdnAskPass { events << 'body' }
+
+            assertTrue(events.contains('resource:scripts/git_askpass.sh'))
+            assertTrue(events.contains('sh:Prepare Git HTTP credential helper'))
+            assertTrue(events.contains('credentials:github-bot-https'))
+            assertTrue('body must run while GIT_ASKPASS is active',
+                events.indexOf('credentials:github-bot-https') < events.indexOf('body'))
+            assertTrue('askpass script must be cleaned up',
+                events.contains('sh:Remove Git HTTP credential helper'))
+        }
+
+        @Test
+        void shouldSkipAskPassWhenCdnDisabled() {
+            def events = []
+            def script = loadScriptWithBindings([
+                env: [:],
+                writeFile: { Map args -> events << 'write' },
+                sh: { Map args -> events << 'sh' },
+                withCredentials: { List creds, Closure body -> events << 'credentials'; body() },
+                withEnv: { List environment, Closure body -> events << 'env'; body() },
+            ])
+
+            script.withGitCdnAskPass { events << 'body' }
+
+            assertEquals(['body'], events)
+        }
+
+        @Test
+        void shouldSkipAskPassWhenCdnEnabledWithoutHttpCredential() {
+            def events = []
+            def script = loadScriptWithBindings([
+                env: [GIT_CDN_ENABLED: 'true', WORKSPACE: '/ws'],
+            ])
+
+            script.withGitCdnAskPass { events << 'body' }
+
+            assertEquals(['body'], events)
+        }
+
+        @Test
+        void shouldDropSshCredentialWhenCdnEnabledDuringScmCheckout() {
+            def events = []
+            def scmArg = null
+            def script = loadScriptWithBindings([
+                env: [GIT_CDN_ENABLED: 'true', GIT_HTTP_CREDENTIALS_ID: 'github-bot-https', WORKSPACE: '/ws'],
+                libraryResource: { String path -> events << "resource:${path}".toString(); 'askpass helper' },
+                writeFile: { Map args -> events << 'write' },
+                sh: { Map args -> events << "sh:${args.label}".toString() },
+                usernamePassword: { Map args -> args },
+                withCredentials: { List creds, Closure body -> events << 'credentials'; body() },
+                withEnv: { List environment, Closure body -> events << 'env'; body() },
+                checkout: { Map args -> scmArg = args; events << 'checkout' },
+            ])
+
+            script.checkoutSingle('git@github.com:PingCAP-QE/tidb-test.git', 'master', 'master', 'github-sre-bot-ssh')
+
+            assertNotNull(scmArg)
+            def remote = scmArg.scm.userRemoteConfigs[0]
+            assertEquals('git@github.com:PingCAP-QE/tidb-test.git', remote.url)
+            assertEquals('SSH credential must not be used on git-cdn', '', remote.credentialsId)
+            assertTrue('askpass must be active during the SCM checkout',
+                events.indexOf('env') < events.indexOf('checkout'))
+        }
+
+        @Test
+        void shouldKeepSshCredentialWhenCdnDisabled() {
+            def scmArg = null
+            def script = loadScriptWithBindings([
+                env: [:],
+                checkout: { Map args -> scmArg = args },
+            ])
+
+            script.checkoutSingle('git@github.com:PingCAP-QE/tidb-test.git', 'master', 'master', 'github-sre-bot-ssh')
+
+            assertNotNull(scmArg)
+            assertEquals('github-sre-bot-ssh', scmArg.scm.userRemoteConfigs[0].credentialsId)
         }
     }
 }

--- a/libraries/tipipeline/tests/TestComponent.groovy
+++ b/libraries/tipipeline/tests/TestComponent.groovy
@@ -376,32 +376,55 @@ class TestComponent {
         }
 
         @Test
-        void shouldDropSshCredentialWhenCdnEnabledDuringScmCheckout() {
-            def events = []
+        void shouldRewriteGithubUrlAndUseHttpCredentialWhenCdnEnabled() {
             def scmArg = null
             def script = loadScriptWithBindings([
-                env: [GIT_CDN_ENABLED: 'true', GIT_HTTP_CREDENTIALS_ID: 'github-bot-https', WORKSPACE: '/ws'],
-                libraryResource: { String path -> events << "resource:${path}".toString(); 'askpass helper' },
-                writeFile: { Map args -> events << 'write' },
-                sh: { Map args -> events << "sh:${args.label}".toString() },
-                usernamePassword: { Map args -> args },
-                withCredentials: { List creds, Closure body -> events << 'credentials'; body() },
-                withEnv: { List environment, Closure body -> events << 'env'; body() },
-                checkout: { Map args -> scmArg = args; events << 'checkout' },
+                env: [GIT_CDN_ENABLED: 'true', GIT_HTTP_CREDENTIALS_ID: 'github-bot-https'],
+                checkout: { Map args -> scmArg = args },
             ])
 
             script.checkoutSingle('git@github.com:PingCAP-QE/tidb-test.git', 'master', 'master', 'github-sre-bot-ssh')
 
             assertNotNull(scmArg)
             def remote = scmArg.scm.userRemoteConfigs[0]
-            assertEquals('git@github.com:PingCAP-QE/tidb-test.git', remote.url)
-            assertEquals('SSH credential must not be used on git-cdn', '', remote.credentialsId)
-            assertTrue('askpass must be active during the SCM checkout',
-                events.indexOf('env') < events.indexOf('checkout'))
+            assertEquals('http://git-cdn.cache.svc:8000/PingCAP-QE/tidb-test.git', remote.url)
+            assertEquals('github-bot-https', remote.credentialsId)
         }
 
         @Test
-        void shouldKeepSshCredentialWhenCdnDisabled() {
+        void shouldRewriteGithubHttpsUrlWhenCdnEnabled() {
+            def scmArg = null
+            def script = loadScriptWithBindings([
+                env: [GIT_CDN_ENABLED: 'true', GIT_HTTP_CREDENTIALS_ID: 'github-bot-https'],
+                checkout: { Map args -> scmArg = args },
+            ])
+
+            script.checkoutSingle('https://github.com/PingCAP-QE/tidb-test.git', 'master', 'master', 'github-sre-bot-ssh')
+
+            assertNotNull(scmArg)
+            def remote = scmArg.scm.userRemoteConfigs[0]
+            assertEquals('http://git-cdn.cache.svc:8000/PingCAP-QE/tidb-test.git', remote.url)
+            assertEquals('github-bot-https', remote.credentialsId)
+        }
+
+        @Test
+        void shouldRewriteUrlWithoutCredentialWhenNoHttpCredentialConfigured() {
+            def scmArg = null
+            def script = loadScriptWithBindings([
+                env: [GIT_CDN_ENABLED: 'true'],
+                checkout: { Map args -> scmArg = args },
+            ])
+
+            script.checkoutSingle('git@github.com:PingCAP-QE/tidb-test.git', 'master', 'master', 'github-sre-bot-ssh')
+
+            assertNotNull(scmArg)
+            def remote = scmArg.scm.userRemoteConfigs[0]
+            assertEquals('http://git-cdn.cache.svc:8000/PingCAP-QE/tidb-test.git', remote.url)
+            assertEquals('', remote.credentialsId)
+        }
+
+        @Test
+        void shouldKeepSshUrlAndCredentialWhenCdnDisabled() {
             def scmArg = null
             def script = loadScriptWithBindings([
                 env: [:],
@@ -411,7 +434,26 @@ class TestComponent {
             script.checkoutSingle('git@github.com:PingCAP-QE/tidb-test.git', 'master', 'master', 'github-sre-bot-ssh')
 
             assertNotNull(scmArg)
-            assertEquals('github-sre-bot-ssh', scmArg.scm.userRemoteConfigs[0].credentialsId)
+            def remote = scmArg.scm.userRemoteConfigs[0]
+            assertEquals('git@github.com:PingCAP-QE/tidb-test.git', remote.url)
+            assertEquals('github-sre-bot-ssh', remote.credentialsId)
+        }
+
+        @Test
+        void shouldNotRewriteNonGithubUrlEvenWhenCdnEnabled() {
+            def scmArg = null
+            def script = loadScriptWithBindings([
+                env: [GIT_CDN_ENABLED: 'true', GIT_HTTP_CREDENTIALS_ID: 'github-bot-https'],
+                checkout: { Map args -> scmArg = args },
+            ])
+
+            script.checkoutSingle('git@gitlab.example.com:foo/bar.git', 'master', 'master', 'some-ssh-cred')
+
+            assertNotNull(scmArg)
+            def remote = scmArg.scm.userRemoteConfigs[0]
+            assertEquals('git@gitlab.example.com:foo/bar.git', remote.url)
+            assertEquals('some-ssh-cred', remote.credentialsId)
         }
     }
+
 }

--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -196,6 +196,52 @@ def computeBranchFromPR(String component, String prTargetBranch, String prTitle,
     return componentBranch
 }
 
+// Route GitHub checkouts through the in-cluster git-cdn when the Jenkins
+// instance enables it. git-cdn serves anonymous public requests first and
+// returns 401 for private repositories, so Git must be able to answer with the
+// github-bot-https credential after the URL is rewritten to git-cdn.
+// See prow.withGitAskPass and ee-ops docs/git-cdn-jenkins-auth.md.
+private Boolean isGitCdnEnabled() {
+    return env.GIT_CDN_ENABLED?.trim()?.toBoolean()
+}
+
+private String gitCdnHttpCredentialsId() {
+    def id = env.GIT_HTTP_CREDENTIALS_ID?.trim()
+    return isGitCdnEnabled() && id ? id : ''
+}
+
+/*
+ * Let Git try an anonymous HTTP request first and provide Jenkins' PAT only
+ * after the server asks for credentials. Kept in sync with prow.withGitAskPass.
+ */
+def withGitAskPass(String credentialsId, Closure body) {
+    final askPassScript = libraryResource 'scripts/git_askpass.sh'
+    final tmpAskPassScript = "${env.WORKSPACE}/git-askpass-${UUID.randomUUID().toString()}"
+
+    try {
+        writeFile(file: tmpAskPassScript, text: askPassScript)
+        sh label: 'Prepare Git HTTP credential helper', script: "chmod 700 '${tmpAskPassScript}'"
+        withCredentials([usernamePassword(credentialsId: credentialsId, usernameVariable: 'TIPIPELINE_GIT_USERNAME', passwordVariable: 'TIPIPELINE_GIT_PASSWORD')]) {
+            withEnv(["GIT_ASKPASS=${tmpAskPassScript}", 'GIT_TERMINAL_PROMPT=0']) {
+                body()
+            }
+        }
+    } finally {
+        sh label: 'Remove Git HTTP credential helper', script: "rm -f '${tmpAskPassScript}'"
+    }
+}
+
+// Run a git checkout body with the git-cdn HTTP credential helper installed
+// when the Jenkins instance routes GitHub URLs through git-cdn.
+def withGitCdnAskPass(Closure body) {
+    final httpCredentialsId = gitCdnHttpCredentialsId()
+    if (httpCredentialsId) {
+        withGitAskPass(httpCredentialsId, body)
+    } else {
+        body()
+    }
+}
+
 // checkout component src from git repo.
 def checkout(gitUrl, component, prTargetBranch, prTitle, credentialsId="", trunkBranch="master", timeout=5) {
     def componentBranch = computeBranchFromPR(component, prTargetBranch, prTitle,  trunkBranch)
@@ -206,26 +252,32 @@ def checkout(gitUrl, component, prTargetBranch, prTitle, credentialsId="", trunk
         componentBranch = "origin/${componentBranch}/head"
     }
 
-    checkout(
-        changelog: false,
-        poll: true,
-        scm: [
-            $class: 'GitSCM',
-            branches: [[name: componentBranch]],
-            doGenerateSubmoduleConfigurations: false,
-            extensions: [
-                [$class: 'PruneStaleBranch'],
-                [$class: 'CleanBeforeCheckout'],
-                [$class: 'CloneOption', timeout: timeout],
-            ],
-            submoduleCfg: [],
-            userRemoteConfigs: [[
-                credentialsId: credentialsId,
-                refspec: pluginSpec,
-                url: gitUrl,
-            ]]
-        ]
-    )
+    // When git-cdn is enabled GitHub URLs are rewritten to HTTP, so the SSH
+    // credential cannot authenticate there. Drop it from the SCM config and let
+    // withGitCdnAskPass answer the git-cdn 401 with the HTTP credential.
+    final scmCredentialsId = isGitCdnEnabled() ? '' : credentialsId
+    withGitCdnAskPass {
+        checkout(
+            changelog: false,
+            poll: true,
+            scm: [
+                $class: 'GitSCM',
+                branches: [[name: componentBranch]],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [
+                    [$class: 'PruneStaleBranch'],
+                    [$class: 'CleanBeforeCheckout'],
+                    [$class: 'CloneOption', timeout: timeout],
+                ],
+                submoduleCfg: [],
+                userRemoteConfigs: [[
+                    credentialsId: scmCredentialsId,
+                    refspec: pluginSpec,
+                    url: gitUrl,
+                ]]
+            ]
+        )
+    }
 }
 
 def checkoutV2(gitUrl, component, prTargetBranch, prTitle, credentialsId="", trunkBranch="master", timeout=5) {
@@ -240,26 +292,32 @@ def checkoutV2(gitUrl, component, prTargetBranch, prTitle, credentialsId="", tru
     println(gitUrl)
     println(pluginSpec)
 
-    checkout(
-        changelog: false,
-        poll: true,
-        scm: [
-            $class: 'GitSCM',
-            branches: [[name: componentBranch]],
-            doGenerateSubmoduleConfigurations: false,
-            extensions: [
-                [$class: 'PruneStaleBranch'],
-                [$class: 'CleanBeforeCheckout'],
-                [$class: 'CloneOption', timeout: timeout],
-            ],
-            submoduleCfg: [],
-            userRemoteConfigs: [[
-                credentialsId: credentialsId,
-                refspec: pluginSpec,
-                url: gitUrl,
-            ]]
-        ]
-    )
+    // When git-cdn is enabled GitHub URLs are rewritten to HTTP, so the SSH
+    // credential cannot authenticate there. Drop it from the SCM config and let
+    // withGitCdnAskPass answer the git-cdn 401 with the HTTP credential.
+    final scmCredentialsId = isGitCdnEnabled() ? '' : credentialsId
+    withGitCdnAskPass {
+        checkout(
+            changelog: false,
+            poll: true,
+            scm: [
+                $class: 'GitSCM',
+                branches: [[name: componentBranch]],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [
+                    [$class: 'PruneStaleBranch'],
+                    [$class: 'CleanBeforeCheckout'],
+                    [$class: 'CloneOption', timeout: timeout],
+                ],
+                submoduleCfg: [],
+                userRemoteConfigs: [[
+                    credentialsId: scmCredentialsId,
+                    refspec: pluginSpec,
+                    url: gitUrl,
+                ]]
+            ]
+        )
+    }
 }
 
 
@@ -322,36 +380,43 @@ def checkoutSingle(gitUrl, prTargetBranch, branchOrCommit, credentialsId, timeou
         println("branchOrCommit is sha1, fetch pr refs and use it as refSpec")
         refSpec += " +refs/pull/*/head:refs/remotes/origin/pr/*"
     }
-    checkout(
-        changelog: false,
-        poll: true,
-        scm: [
-            $class: 'GitSCM',
-            branches: [[name: branchOrCommit]],
-            doGenerateSubmoduleConfigurations: false,
-            extensions: [
-                [$class: 'PruneStaleBranch'],
-                [$class: 'CleanBeforeCheckout'],
-                [$class: 'CloneOption', timeout: timeout],
-            ],
-            submoduleCfg: [],
-            userRemoteConfigs: [[
-                credentialsId: credentialsId,
-                refspec: refSpec,
-                url: gitUrl,
-            ]]
-        ]
-    )
+    // When git-cdn is enabled GitHub URLs are rewritten to HTTP, so the SSH
+    // credential cannot authenticate there. Drop it from the SCM config and let
+    // withGitCdnAskPass answer the git-cdn 401 with the HTTP credential.
+    final scmCredentialsId = isGitCdnEnabled() ? '' : credentialsId
+    withGitCdnAskPass {
+        checkout(
+            changelog: false,
+            poll: true,
+            scm: [
+                $class: 'GitSCM',
+                branches: [[name: branchOrCommit]],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [
+                    [$class: 'PruneStaleBranch'],
+                    [$class: 'CleanBeforeCheckout'],
+                    [$class: 'CloneOption', timeout: timeout],
+                ],
+                submoduleCfg: [],
+                userRemoteConfigs: [[
+                    credentialsId: scmCredentialsId,
+                    refspec: refSpec,
+                    url: gitUrl,
+                ]]
+            ]
+        )
+    }
 }
 
 def checkoutPRWithPreMerge(gitUrl, prTargetBranch, tidbTestRefsList, credentialsId) {
     // iterate over tidbTestRefs and checkout all pr with pre-merge
-    sshagent(credentials: [credentialsId]) {
-        sh label: 'Know hosts', script: """#!/usr/bin/env bash
-            [ -d ~/.ssh ] || mkdir ~/.ssh && chmod 0700 ~/.ssh
-            ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts
-        """
-        sh(label: 'checkout', script: """#!/usr/bin/env bash
+    withGitCdnAskPass {
+        sshagent(credentials: [credentialsId]) {
+            sh label: 'Know hosts', script: """#!/usr/bin/env bash
+                [ -d ~/.ssh ] || mkdir ~/.ssh && chmod 0700 ~/.ssh
+                ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts
+            """
+            sh(label: 'checkout', script: """#!/usr/bin/env bash
             set -e
             git --version
             git init
@@ -403,7 +468,8 @@ def checkoutPRWithPreMerge(gitUrl, prTargetBranch, tidbTestRefsList, credentials
 
             echo "✅ ~~~~~ All done. ~~~~~~"
             """
-        )
+            )
+        }
     }
 }
 
@@ -416,7 +482,8 @@ def checkoutWithMergeBase(gitUrl, component, prTargetBranch, prTitle, trunkBranc
     // componentBranch = release-6.2
     // componentBranch = master
     def componentBranch = computeBranchFromPR(component, prTargetBranch, prTitle, trunkBranch)
-    sh(label: 'checkout', script: """#!/usr/bin/env bash
+    withGitCdnAskPass {
+        sh(label: 'checkout', script: """#!/usr/bin/env bash
         set -e
         git --version
         git init
@@ -470,7 +537,8 @@ def checkoutWithMergeBase(gitUrl, component, prTargetBranch, prTitle, trunkBranc
         git status -s .
 
         echo "✅ ~~~~~ All done. ~~~~~~"
-    """)
+        """)
+    }
 }
 
 // fetch component artifact from artifactory(current http server)

--- a/libraries/tipipeline/vars/component.groovy
+++ b/libraries/tipipeline/vars/component.groovy
@@ -210,6 +210,21 @@ private String gitCdnHttpCredentialsId() {
     return isGitCdnEnabled() && id ? id : ''
 }
 
+// Rewrite a GitHub SSH/HTTPS URL to the in-cluster git-cdn HTTP URL when the
+// Jenkins instance routes GitHub through git-cdn. Non-GitHub URLs and CDN-disabled
+// instances are returned unchanged so the caller keeps its original transport.
+private String gitCdnRewriteUrl(String gitUrl) {
+    if (!isGitCdnEnabled()) {
+        return gitUrl
+    }
+    def matcher = (gitUrl =~ /^(?:git@github\.com:|https:\/\/github\.com\/|ssh:\/\/git@github\.com\/)([^\/\s]+)\/([^\/\s]+?)(\.git)?$/)
+    if (!matcher) {
+        return gitUrl
+    }
+    final cdnBase = env.GIT_CDN_URL?.trim() ?: 'http://git-cdn.cache.svc:8000'
+    return "${cdnBase}/${matcher[0][1]}/${matcher[0][2]}.git"
+}
+
 /*
  * Let Git try an anonymous HTTP request first and provide Jenkins' PAT only
  * after the server asks for credentials. Kept in sync with prow.withGitAskPass.
@@ -252,12 +267,13 @@ def checkout(gitUrl, component, prTargetBranch, prTitle, credentialsId="", trunk
         componentBranch = "origin/${componentBranch}/head"
     }
 
-    // When git-cdn is enabled GitHub URLs are rewritten to HTTP, so the SSH
-    // credential cannot authenticate there. Drop it from the SCM config and let
-    // withGitCdnAskPass answer the git-cdn 401 with the HTTP credential.
-    final scmCredentialsId = isGitCdnEnabled() ? '' : credentialsId
-    withGitCdnAskPass {
-        checkout(
+    // When git-cdn is enabled the agent rewrites GitHub URLs to HTTP where the
+    // SSH key cannot authenticate. Point the SCM at the git-cdn HTTP URL and bind
+    // the git-cdn HTTP credential natively so the plugin manages basic auth.
+    // Non-CDN instances keep the original SSH URL and credential.
+    final cdnUrl = gitCdnRewriteUrl(gitUrl)
+    final scmCredentialsId = (cdnUrl != gitUrl) ? gitCdnHttpCredentialsId() : credentialsId
+    checkout(
             changelog: false,
             poll: true,
             scm: [
@@ -273,11 +289,10 @@ def checkout(gitUrl, component, prTargetBranch, prTitle, credentialsId="", trunk
                 userRemoteConfigs: [[
                     credentialsId: scmCredentialsId,
                     refspec: pluginSpec,
-                    url: gitUrl,
+                    url: cdnUrl,
                 ]]
             ]
         )
-    }
 }
 
 def checkoutV2(gitUrl, component, prTargetBranch, prTitle, credentialsId="", trunkBranch="master", timeout=5) {
@@ -292,12 +307,13 @@ def checkoutV2(gitUrl, component, prTargetBranch, prTitle, credentialsId="", tru
     println(gitUrl)
     println(pluginSpec)
 
-    // When git-cdn is enabled GitHub URLs are rewritten to HTTP, so the SSH
-    // credential cannot authenticate there. Drop it from the SCM config and let
-    // withGitCdnAskPass answer the git-cdn 401 with the HTTP credential.
-    final scmCredentialsId = isGitCdnEnabled() ? '' : credentialsId
-    withGitCdnAskPass {
-        checkout(
+    // When git-cdn is enabled the agent rewrites GitHub URLs to HTTP where the
+    // SSH key cannot authenticate. Point the SCM at the git-cdn HTTP URL and bind
+    // the git-cdn HTTP credential natively so the plugin manages basic auth.
+    // Non-CDN instances keep the original SSH URL and credential.
+    final cdnUrl = gitCdnRewriteUrl(gitUrl)
+    final scmCredentialsId = (cdnUrl != gitUrl) ? gitCdnHttpCredentialsId() : credentialsId
+    checkout(
             changelog: false,
             poll: true,
             scm: [
@@ -313,11 +329,10 @@ def checkoutV2(gitUrl, component, prTargetBranch, prTitle, credentialsId="", tru
                 userRemoteConfigs: [[
                     credentialsId: scmCredentialsId,
                     refspec: pluginSpec,
-                    url: gitUrl,
+                    url: cdnUrl,
                 ]]
             ]
         )
-    }
 }
 
 
@@ -380,12 +395,13 @@ def checkoutSingle(gitUrl, prTargetBranch, branchOrCommit, credentialsId, timeou
         println("branchOrCommit is sha1, fetch pr refs and use it as refSpec")
         refSpec += " +refs/pull/*/head:refs/remotes/origin/pr/*"
     }
-    // When git-cdn is enabled GitHub URLs are rewritten to HTTP, so the SSH
-    // credential cannot authenticate there. Drop it from the SCM config and let
-    // withGitCdnAskPass answer the git-cdn 401 with the HTTP credential.
-    final scmCredentialsId = isGitCdnEnabled() ? '' : credentialsId
-    withGitCdnAskPass {
-        checkout(
+    // When git-cdn is enabled the agent rewrites GitHub URLs to HTTP where the
+    // SSH key cannot authenticate. Point the SCM at the git-cdn HTTP URL and bind
+    // the git-cdn HTTP credential natively so the plugin manages basic auth.
+    // Non-CDN instances keep the original SSH URL and credential.
+    final cdnUrl = gitCdnRewriteUrl(gitUrl)
+    final scmCredentialsId = (cdnUrl != gitUrl) ? gitCdnHttpCredentialsId() : credentialsId
+    checkout(
             changelog: false,
             poll: true,
             scm: [
@@ -401,11 +417,10 @@ def checkoutSingle(gitUrl, prTargetBranch, branchOrCommit, credentialsId, timeou
                 userRemoteConfigs: [[
                     credentialsId: scmCredentialsId,
                     refspec: refSpec,
-                    url: gitUrl,
+                    url: cdnUrl,
                 ]]
             ]
         )
-    }
 }
 
 def checkoutPRWithPreMerge(gitUrl, prTargetBranch, tidbTestRefsList, credentialsId) {


### PR DESCRIPTION
## Summary

In the `pull-verify-jenkins-migration` run for #5096, 16 tidb jenkins-agent jobs
(`ghpr_build`, `ghpr_mysql_test`, `merged_common_test`, `merged_integration_*`,
`pull_common_test`, `pull_integration_*`, `pull_sqllogic_test`, ...) all failed
with the same git-cdn auth error at the component (`tidb-test`) SCM checkout:

```
ERROR: Error fetching remote repo 'origin'
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'http://git-cdn.cache.svc:8000/PingCAP-QE/tidb-test.git/'
```

Root cause: `component.checkout/checkoutV2/checkoutSingle` run the Jenkins
GitSCM `checkout` step bound to the SSH credential `github-sre-bot-ssh`. On the
Tencent Cloud staging Jenkins the global git config rewrites
`git@github.com:`/`https://github.com/` to the in-cluster git-cdn
(`http://git-cdn.cache.svc:8000`), where an SSH key cannot authenticate. The
main-repo checkout path already handles this via `prow.checkoutRefs`
(`GIT_ASKPASS` + `github-bot-https`); the component/test-repo SCM helpers never
got the same treatment.

## Changes

- Add `withGitAskPass` / `withGitCdnAskPass` helpers to `component.groovy`
  (same askpass mechanism as `prow.withGitAskPass`).
- `checkout`, `checkoutV2`, `checkoutSingle`: when `GIT_CDN_ENABLED=true`,
  drop the SSH `credentialsId` from the SCM config and run the checkout with the
  git-cdn HTTP askpass (`GIT_HTTP_CREDENTIALS_ID`, e.g. `github-bot-https`).
  When CDN is not enabled the previous SSH checkout behavior is unchanged.
- `checkoutPRWithPreMerge`, `checkoutWithMergeBase` (raw git): wrap with the
  same askpass when CDN is enabled.
- Add 5 unit tests in `TestComponent.groovy` covering the askpass scope and the
  SCM credential selection (TestComponent: 17/17 passing locally).

## Validation / next steps

- Requires merge to `main` first (the tipipeline library is loaded as
  `tipipeline@main`), then replay 2-3 representative jobs that previously hit
  this git-cdn auth failure on `do.pingcap.net/jenkins-staging` to confirm the
  fetch succeeds.