### PR TITLE
ci(prow): migrate pingcap/tidb release-7.1 jobs to target jenkins

### DIFF
--- a/pipelines/pingcap/tidb/release-7.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_unit_test.groovy
@@ -43,15 +43,11 @@ pipeline {
             environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
             steps {
                 dir(REFS.repo) {
-                    sh """
-                        git diff .
-                        git status
-                    """
                     sh '''#! /usr/bin/env bash
                         set -o pipefail
 
                         ./build/jenkins_unit_test.sh 2>&1 | tee bazel-test.log
-                        '''
+                    '''
                 }
             }
             post {

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_unit_test.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_unit_test.groovy
@@ -71,34 +71,6 @@ pipeline {
                 }
             }
         }
-        stage('Test Enterprise Extensions') {
-            when {
-                expression {
-                    // Q: why this step is not existed in presubmit job of master branch?
-                    // A: we should not forbiden the community contrubutor on the unit test on private submodules.
-                    // if it failed, the enterprise extension owners should fix it.
-                    return REFS.base_ref != 'master' || REFS.pulls == null || REFS.pulls.size() == 0
-                }
-            }
-            environment { CODECOV_TOKEN = credentials('codecov-token-tidb') }
-            steps {
-                dir(REFS.repo) {
-                    sh(
-                        label: 'test enterprise extensions',
-                        script: 'go test --tags intest -coverprofile=coverage-extension.dat -covermode=atomic ./pkg/extension/enterprise/...'
-                    )
-                }
-            }
-            post {
-                success {
-                    dir(REFS.repo) {
-                        script {
-                            prow.uploadCoverageToCodecov(REFS, 'unit', './coverage-extension.dat')
-                        }
-                    }
-                }
-            }
-        }
     }
     post {
         success {

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
@@ -7,7 +7,7 @@ spec:
     - name: golang
       # TODO(wuhuizuo): using standard bazel build image to shrink the image size
       # and keep image simple,so no need to refresh image to update basic bazel out data.
-      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12520260122"
+      image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12020230220"
       securityContext:
         privileged: true
       tty: true

--- a/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -78,7 +78,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -91,7 +91,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -116,7 +116,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -21,7 +21,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_check
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -32,7 +32,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_check2
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -43,7 +43,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -54,7 +54,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -65,7 +65,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -78,7 +78,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -91,7 +91,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -116,7 +116,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -129,7 +129,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -142,7 +142,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -155,7 +155,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -168,7 +168,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -181,7 +181,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_tiflash_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -194,7 +194,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_tidb_tools_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -207,7 +207,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_binlog_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_check
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -32,7 +32,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_check2
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2

--- a/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -129,7 +129,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_e2e_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -142,7 +142,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -155,7 +155,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -168,7 +168,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -181,7 +181,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_tiflash_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -194,7 +194,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_tidb_tools_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -207,7 +207,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_binlog_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Part of #4959.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942