### PR TITLE
ci(prow): migrate pingcap/tidb release-7.5 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -31,7 +31,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/ghpr_check2
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -42,7 +42,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -64,7 +64,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -77,7 +77,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -90,7 +90,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_mysql_client_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -103,7 +103,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -115,7 +115,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -128,7 +128,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -154,7 +154,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -167,7 +167,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -180,7 +180,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -193,7 +193,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_tiflash_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -206,7 +206,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -219,7 +219,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -232,7 +232,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_integration_tidb_tools_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -245,7 +245,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_integration_binlog_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -42,7 +42,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test


### PR DESCRIPTION
Part of #4959.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942