### PR TITLE
ci(prow): migrate pingcap/tidb release-8.1 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/ghpr_build
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -43,7 +43,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -104,7 +104,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_mysql_client_test
       agent: jenkins
       labels:
-        master: "0"
+        master: "1"
       decorate: false # need add this.
       always_run: false
       optional: true

--- a/prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -43,7 +43,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -78,7 +78,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_lightning_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false
@@ -91,7 +91,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -104,7 +104,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_mysql_client_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -117,7 +117,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -129,7 +129,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -142,7 +142,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -168,7 +168,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -181,7 +181,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -194,7 +194,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -207,7 +207,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_tiflash_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -220,7 +220,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -233,7 +233,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -246,7 +246,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_integration_tidb_tools_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -259,7 +259,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_integration_binlog_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Part of #4959.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942