### PR TITLE
ci(prow): migrate pingcap/tiflow release-6.5 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflow/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-6.5-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.5/ghpr_verify
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify
@@ -23,7 +23,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       run_before_merge: true
@@ -38,7 +38,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.5/pull_cdc_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -53,7 +53,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.5/pull_dm_compatibility_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -68,7 +68,7 @@ presubmits:
     - name: pingcap/tiflow/release-6.5/pull_dm_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed


### PR DESCRIPTION
Part of #4960.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tiflow/release-6.5-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942