### PR TITLE
ci(prow): migrate pingcap/tiflow release-8.1 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflow/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.1-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -23,7 +23,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -36,7 +36,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_pulsar_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -49,7 +49,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -62,7 +62,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.1/pull_dm_compatibility_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -75,7 +75,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.1/pull_dm_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
@@ -88,7 +88,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.1/ghpr_verify
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: pull-verify


### PR DESCRIPTION
Part of #4960.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tiflow/release-8.1-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942