### PR TITLE
ci(prow): migrate pingcap/tiflow release-8.5 jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
@@ -93,7 +93,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -106,7 +106,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -132,7 +132,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files


### PR DESCRIPTION
Part of #4960.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942