### PR TITLE
ci(prow): migrate pingcap/tiflash release-9.0-beta jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflash/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-9.0-beta-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - name: pingcap/tiflash/release-9.0-beta/pull_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test
@@ -24,7 +24,7 @@ presubmits:
     - name: pingcap/tiflash/release-9.0-beta/pull_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-test


### PR DESCRIPTION
Part of #4962.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tiflash/release-9.0-beta-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942