### PR TITLE
ci(prow): migrate pingcap/tiflash release-8.5 postsubmit jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflash/release-8.5-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-8.5-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: pingcap/tiflash/release-8.5/merged_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: merged-unit-test
       max_concurrency: 1
@@ -14,7 +14,7 @@ postsubmits:
     - name: pingcap/tiflash/release-8.5/merged_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: merged-build
       max_concurrency: 1


### PR DESCRIPTION
Part of #4962.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/tiflash/release-8.5-postsubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942