### PR TITLE
ci(prow): migrate pingcap/ticdc release-9.0-beta jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/ticdc/release-9.0-beta-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/release-9.0-beta-presubmits.yaml
@@ -9,7 +9,7 @@ global_definitions:
     decorate: false # need add this.
     max_concurrency: 2
     labels:
-      master: "1"
+      master: "0"
 # struct ref: https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Presubmit
 presubmits:
   pingcap/ticdc:


### PR DESCRIPTION
Part of #4963.

## Summary
Flip `labels.master` `"1"` -> `"0"` for the jenkins-agent jobs in `prow-jobs/pingcap/ticdc/release-9.0-beta-presubmits.yaml` so they are scheduled on the **to** Jenkins.

Part of #4947 / #4942