### PR TITLE
ci(prow): migrate pingcap/tiflash release-6.5 pull_unit_test to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflash/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflash/release-6.5-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     - name: pingcap/tiflash/release-6.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test


### PR DESCRIPTION
Split from #5146 (only the verified-successful job).

## Evidence
- Migration verify for #5146 (run `pull-verify-jenkins-migration`) shows:
  - `pingcap/tiflash/release-6.5/pull_unit_test` => **SUCCESS** on the to Jenkins
  - `pull_integration_test` => FAILURE (not migrated here)
- Flip `labels.master` `"1"` -> `"0"` for `pull_unit_test` only.

Part of #4962 / #4947 / #4942.