### PR TITLE
ci(prow): migrate pingcap/tidb release-6.5 verified jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_check
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -33,7 +33,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_check2
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2


### PR DESCRIPTION
Split from #5134 — only the jobs that verified **SUCCESS** on the to Jenkins (verify runid 2095811216789213184):
- `ghpr_check`
- `ghpr_check2`
