### PR TITLE
ci(prow): migrate pingcap/tidb release-7.1 verified jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
@@ -103,7 +103,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Split from #5135 — only the jobs that verified **SUCCESS** on the to Jenkins (verify runid 2095811252558237696):
- `pull_integration_copr_test`
