### PR TITLE
ci(prow): migrate pingcap/tidb release-7.5 verified jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.5-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/ghpr_check
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -53,7 +53,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -141,7 +141,7 @@ presubmits:
     - name: pingcap/tidb/release-7.5/pull_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Split from #5136 — only the jobs that verified **SUCCESS** on the to Jenkins (verify runid 2095811292349599744):
- `ghpr_check`
- `ghpr_unit_test`
- `pull_e2e_test`
