### PR TITLE
ci(prow): migrate pingcap/tidb release-8.1 verified jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.1-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/ghpr_check
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -32,7 +32,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/ghpr_check2
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2
@@ -54,7 +54,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/unit-test
@@ -65,7 +65,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -155,7 +155,7 @@ presubmits:
     - name: pingcap/tidb/release-8.1/pull_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Split from #5137 — only the jobs that verified **SUCCESS** on the to Jenkins (verify runid 2095811327330095104):
- `ghpr_check`
- `ghpr_check2`
- `ghpr_unit_test`
- `pull_br_integration_test`
- `pull_e2e_test`
