### PR TITLE
ci(prow): migrate pingcap/tiflow release-7.5 verified jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tiflow/release-7.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-7.5-presubmits.yaml
@@ -36,7 +36,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/pull_cdc_integration_pulsar_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -62,7 +62,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/pull_dm_compatibility_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -75,7 +75,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/pull_dm_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -88,7 +88,7 @@ presubmits:
     - name: pingcap/tiflow/release-7.5/ghpr_verify
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify


### PR DESCRIPTION
Split from #5142 — only the jobs that verified **SUCCESS** on the to Jenkins (verify runid 2095811541558366208):
- `ghpr_verify`
- `pull_cdc_integration_pulsar_test`
- `pull_dm_compatibility_test`
- `pull_dm_integration_test`
