### PR TITLE
ci(prow): migrate tikv/tikv release-7.5 verified jobs to target jenkins

### DIFF
--- a/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
+++ b/prow-jobs/tikv/tikv/release-7.5-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - name: tikv/tikv/release-7.5/pull_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-unit-test


### PR DESCRIPTION
Split from #5155 — only the jobs that verified **SUCCESS** on the to Jenkins (verify runid 2095812213846577152):
- `pull_unit_test`
