### PR TITLE
ci(prow): migrate pingcap/tidb release-8.5 verified jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_check
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -66,7 +66,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_unit_test_ddlv1
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "pkg/(ddl|meta)/.*"
       context: pull-unit-test-ddlv1
@@ -77,7 +77,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       run_if_changed: "(br|pkg/(ddl|domain|infoschema))/.*"
@@ -88,7 +88,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_lightning_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       always_run: false
@@ -141,7 +141,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -166,7 +166,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -244,7 +244,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -257,7 +257,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_tidb_tools_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Split from #5138 — only the jobs that verified **SUCCESS** on the to Jenkins (verify runid 2095811357889794048):
- `pull_br_integration_test`
- `pull_check`
- `pull_e2e_test`
- `pull_integration_copr_test`
- `pull_integration_e2e_test`
- `pull_integration_tidb_tools_test`
- `pull_lightning_integration_test`
- `pull_unit_test_ddlv1`
