### PR TITLE
ci(prow): bump migration verification concurrency to 50

### DIFF
--- a/prow-jobs/pingcap-qe/ci/presubmits.yaml
+++ b/prow-jobs/pingcap-qe/ci/presubmits.yaml
@@ -154,7 +154,8 @@ presubmits:
                   --base-sha "${PULL_BASE_SHA:-}" \
                   --head-sha "${PULL_PULL_SHA:-}" \
                   --wait \
-                  --parallel 10 \
+                  --parallel 50 \
+                  --max-jobs 100 \
                   --timeout 7200 \
                   --poll-interval 20 \
                   --retries 3 \


### PR DESCRIPTION
## Summary

`pull-verify-jenkins-migration` runs inside a single prow pod whose effective runtime is capped at **2h** (the entrypoint default): on this prow deployment job-level `timeout:` is not mapped to `prowjob.spec.timeout`, so the pod is killed at 2h regardless of the yaml `timeout: 4h`.

In the PingCAP-QE/ci#5096 verification run this cut off the long-tail integration jobs (51 of 52 jobs had finished; the last one was still building when the pod was killed).

## Change

- `--parallel 10` → `--parallel 50`: start all migrated jobs as early as possible so the wall clock is bounded by the longest single job instead of by queueing.
- Add `--max-jobs 100` explicitly so a 52-job run no longer trips the script's `MAX_JOBS=40` default and aborts.

## Note

A longer-term fix belongs on the prow side (make job `timeout` set `prowjob.spec.timeout` / raise the entrypoint default); this change makes the verification resilient within the current 2h pod budget.