### PR TITLE
ci(prow): migrate pingcap/tiflow release-8.5 verified jobs to target jenkins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,15 @@ Examples:
 - `docs(agents): document Conventional Commits`
 - `test(libraries): add unit tests for parseCIParamsFromPRTitle`
 
+### GitHub PR Comments and Descriptions
+
+Be careful when writing `#NNN`-style references in GitHub PR titles, descriptions, or comments:
+
+- GitHub renders a bare `#NNN` (e.g. `#11`, `#5096`) as a cross-reference link to an issue/PR in the repo, which is usually wrong when the number refers to a Jenkins build number, a commit, a local sequence, or anything else that is not a GitHub issue/PR.
+- Use a full URL instead, or wrap the token in backticks/code (e.g. `ghpr_mysql_test #11` inside backticks renders literally) when a cross-reference is not intended.
+- When a reference to a GitHub issue/PR *is* intended, prefer the explicit form `<owner>/<repo>#NNN` (or a full URL) over a bare `#NNN` to avoid ambiguity across repos.
+- Review rendered text before posting: a wrong auto-link cannot be seen by readers as plain text.
+
 ## Common Tasks for Agents
 
 ### 1. Adding/Modifying CI Jobs

--- a/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/release-8.5-presubmits.yaml
@@ -119,7 +119,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.5/pull_cdc_integration_pulsar_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -145,7 +145,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.5/pull_dm_compatibility_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -158,7 +158,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.5/pull_dm_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -171,7 +171,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.5/pull_syncdiff_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -184,7 +184,7 @@ presubmits:
     - name: pingcap/tiflow/release-8.5/ghpr_verify
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify


### PR DESCRIPTION
Split from #5144 — only the jobs that verified **SUCCESS** on the to Jenkins (verify runid 2095811615243898880):
- `ghpr_verify`
- `pull_cdc_integration_pulsar_test`
- `pull_dm_compatibility_test`
- `pull_dm_integration_test`
- `pull_syncdiff_integration_test`

Part of #4960 / #4942