### PR TITLE
fix(tisys): throw when pod template read fails in withCiLabels

### DIFF
--- a/libraries/tisys/vars/pod_label.groovy
+++ b/libraries/tisys/vars/pod_label.groovy
@@ -4,7 +4,7 @@ def withCiLabels(String podTemplateFile, def refs) {
         podYaml = readTrusted(podTemplateFile)
     } catch (Exception e) {
         echo "[pod_label] ⚠️ failed to read pod template ${podTemplateFile}: ${e.message}"
-        return ''
+        throw e
     }
     if (podYaml == null || !podYaml.toString().trim()) {
         echo "[pod_label] ⚠️ empty pod template ${podTemplateFile}, skip label injection"


### PR DESCRIPTION
In `withCiLabels`, when `readTrusted(podTemplateFile)` fails, the error was swallowed and the function returned an empty string, silently skipping CI label injection.

This makes it throw the exception so the failure is surfaced instead of being silently masked.

ref: <https://github.com/PingCAP-QE/ci/blob/main/libraries/tisys/vars/pod_label.groovy>