### PR TITLE
ci(prow): migrate tidb release-7.1 ghpr build

### DIFF
--- a/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build


### PR DESCRIPTION
## Summary

Migrate the verified `pingcap/tidb/release-7.1/ghpr_build` job to the target Jenkins by setting `labels.master` to `"0"`.

This is split from PingCAP-QE/ci#5135 after the migration verification run reported this job successful.

## Validation

- `.ci/update-prow-job-kustomization.sh`
- YAML parse with `yq`
- `git diff --check`