### PR TITLE
ci(pipelines): remove pod scheduling stage timeouts

### DIFF
--- a/.ci/replay-jenkins-build.sh
+++ b/.ci/replay-jenkins-build.sh
@@ -216,6 +216,7 @@ build_inline_script_with_pod_yaml() {
                 comment="${BASH_REMATCH[4]}"
                 pvar="_REPLAY_POD_${var}"
                 out_line="${prefix}yaml ${pvar}"
+                preludes+=("final ${pvar} = new String(java.util.Base64.decoder.decode(\"${b64}\"), 'UTF-8')")
                 [[ -n "$comment" ]] && out_line+=" ${comment}"
                 found=1
             fi

--- a/libraries/tisys/vars/pod_label.groovy
+++ b/libraries/tisys/vars/pod_label.groovy
@@ -4,7 +4,7 @@ def withCiLabels(String podTemplateFile, def refs) {
         podYaml = readTrusted(podTemplateFile)
     } catch (Exception e) {
         echo "[pod_label] ⚠️ failed to read pod template ${podTemplateFile}: ${e.message}"
-        return ''
+        throw e
     }
     if (podYaml == null || !podYaml.toString().trim()) {
         echo "[pod_label] ⚠️ empty pod template ${podTemplateFile}, skip label injection"

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_build/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_build/pipeline.groovy
@@ -26,7 +26,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_common_test/pipeline.groovy
@@ -34,7 +34,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_common_test/pipeline.groovy
@@ -34,7 +34,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_jdbc_test/pipeline.groovy
@@ -34,7 +34,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_mysql_test/pipeline.groovy
@@ -32,7 +32,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_nodejs_test/pipeline.groovy
@@ -34,7 +34,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_integration_python_orm_test/pipeline.groovy
@@ -34,7 +34,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {

--- a/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/ghpr_mysql_test/pipeline.groovy
@@ -28,7 +28,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_integration_jdbc_test_next_gen/pipeline.groovy
@@ -35,7 +35,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_mysql_test_next_gen/pipeline.groovy
@@ -35,7 +35,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb") {
                     cache(path: "./", includes: '**/*', key: "git/pingcap/tidb/rev-${REFS.pulls[0].sha}", restoreKeys: ['git/pingcap/tidb/rev-']) {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_common_test/pipeline.groovy
@@ -30,7 +30,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb-test") {
                     script {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_jdbc_test/pipeline.groovy
@@ -30,7 +30,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb-test") {
                     script {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_connector_test/pipeline.groovy
@@ -30,7 +30,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb-test") {
                     script {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_mysql_test/pipeline.groovy
@@ -30,7 +30,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb-test") {
                     script {

--- a/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
+++ b/pipelines/pingcap-qe/tidb-test/latest/pull_tiproxy_ruby_orm_test/pipeline.groovy
@@ -30,7 +30,6 @@ pipeline {
                     defaultContainer 'golang'
                 }
             }
-            options { timeout(time: 10, unit: 'MINUTES') }
             steps {
                 dir("tidb-test") {
                     script {


### PR DESCRIPTION
## Summary

- Remove stage-level `timeout(time: 10, unit: 'MINUTES')` from the 15 `pingcap-qe/tidb-test/latest` Pipeline stages that provision their own Kubernetes agent.
- Keep the 10-minute timeout in Pipelines whose Checkout stage uses the Pipeline-level agent.
- Leave Git checkout timeouts, shared-library defaults, and other stage timeouts unchanged.

## Motivation

The `ghpr_common_test` build at https://do.pingcap.net/jenkins-staging/job/pingcap-qe/job/tidb-test/job/ghpr_common_test/18/ was aborted after the Checkout & Prepare stage timeout while waiting for pod scheduling and preparation.

## Validation

- Jenkinsfile remote validation passed.
- `git diff --check` passed.
