### PR TITLE
ci(prow): migrate verified tidb jobs

### DIFF
--- a/prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-6.5-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     - name: pingcap/tidb/release-6.5/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build

--- a/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/build
@@ -218,7 +218,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -231,7 +231,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Migrate only Jenkins jobs that passed the release migration verification round.

Included jobs:
- pingcap/tidb/release-6.5/ghpr_build (verified by #5134)
- pingcap/tidb/release-8.5/pull_build (verified by #5138)
- pingcap/tidb/release-8.5/pull_integration_nodejs_test (verified by #5138)
- pingcap/tidb/release-8.5/pull_integration_python_orm_test (verified by #5138)

The successful pingcap/tidb/release-7.1/ghpr_build from #5135 is already present on main via #5174, so it is not duplicated here.

Verification: `.ci/verify-prow-jobs-run.sh` passed with dynamic creation disabled.