### PR TITLE
ci(prow): migrate 30 verified latest jobs

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_heavy
       labels:
-        master: "1"
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-pulsar-integration-heavy
@@ -134,7 +134,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_light_v8_1
       labels:
-        master: "1"
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: false
       optional: true
@@ -146,7 +146,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy_v8_1
       labels:
-        master: "1"
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: false
       optional: true

--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
       name: pingcap/tidb/merged_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/e2e-test
@@ -22,7 +22,7 @@ postsubmits:
       name: pingcap/tidb/merged_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/common-test
@@ -33,7 +33,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: ci/integration-jdbc-test
       skip_if_only_changed: *skip_if_only_changed
@@ -44,7 +44,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-mysql-test
@@ -66,7 +66,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-copr-test
@@ -77,7 +77,7 @@ postsubmits:
       name: pingcap/tidb/merged_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test
@@ -88,7 +88,7 @@ postsubmits:
       name: pingcap/tidb/merged_unit_test_ddlv1
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/unit-test-ddlv1 # TODO: change to ci/ after test.
@@ -99,7 +99,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/integration-python-orm-test

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       name: pingcap/tidb/ghpr_build
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/build
@@ -30,7 +30,7 @@ presubmits:
       name: pingcap/tidb/ghpr_check
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/check_dev
@@ -52,7 +52,7 @@ presubmits:
       name: pingcap/tidb/ghpr_mysql_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/mysql-test
@@ -63,7 +63,7 @@ presubmits:
       name: pingcap/tidb/ghpr_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/unit-test
@@ -119,7 +119,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_jdbc_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-jdbc-test
@@ -130,7 +130,7 @@ presubmits:
       name: pingcap/tidb/pull_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-e2e-test
@@ -141,7 +141,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-integration-e2e-test
@@ -163,7 +163,7 @@ presubmits:
       name: pingcap/tidb/pull_lightning_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-lightning-integration-test
       run_if_changed: "(lightning|pkg/(domain|statistics|ddl|infoschema)|br/pkg/(checksum|httputil|membuf|pdutil|restore/split|storage))/.*"
@@ -174,7 +174,7 @@ presubmits:
       name: pingcap/tidb/pull_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-common-test
@@ -197,7 +197,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -210,7 +210,7 @@ presubmits:
       name: pingcap/tidb/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-sqllogic-test
@@ -221,7 +221,7 @@ presubmits:
       name: pingcap/tidb/pull_mysql_client_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-mysql-client-test
@@ -232,7 +232,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_nodejs_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-nodejs-test
@@ -243,7 +243,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_python_orm_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-python-orm-test

--- a/prow-jobs/pingcap/tiflow/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     - name: pingcap/tiflow/merged_unit_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/unit-test

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -94,7 +94,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_kafka_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -148,7 +148,7 @@ presubmits:
     - name: pingcap/tiflow/pull_dm_compatibility_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -174,7 +174,7 @@ presubmits:
     - name: pingcap/tiflow/pull_syncdiff_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed
@@ -186,7 +186,7 @@ presubmits:
     - name: pingcap/tiflow/ghpr_verify
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: pull-verify


### PR DESCRIPTION
## Summary

Migrate the 30 latest-branch Jenkins jobs that passed the full migration verification of PingCAP-QE/ci#5096 by setting `labels.master` to `"0"`.

The source PR now retains only its 22 jobs that did not verify successfully, preventing duplicate migration changes.

## Verified jobs

- 22 TiDB jobs
- 3 TiCDC jobs
- 5 TiFlow jobs

## Validation

- `.ci/update-prow-job-kustomization.sh`
- YAML parsing with `yq`
- `git diff --check`
- full migration verification: 30 success, 12 failed, 7 infra-fail, 3 skipped