### PR TITLE
ci(prow): migrate more verified tidb jobs

### DIFF
--- a/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-8.5-presubmits.yaml
@@ -44,7 +44,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_mysql_test
       agent: jenkins
       labels:
-        master: "1" # run on GCP
+        master: "0" # run on GCP
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/mysql-test
@@ -102,7 +102,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_integration_ddl_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -115,7 +115,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_mysql_client_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -179,7 +179,7 @@ presubmits:
       name: pingcap/tidb/release-8.5/pull_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Migrate the next set of jobs that passed release migration verification after the previous aggregate PR was merged.

Included jobs from #5138:
- pingcap/tidb/release-8.5/pull_mysql_client_test
- pingcap/tidb/release-8.5/pull_mysql_test
- pingcap/tidb/release-8.5/pull_integration_ddl_test
- pingcap/tidb/release-8.5/pull_common_test

The previous aggregate PR #5177 has been merged. These four jobs are newly verified after the already-migrated jobs were returned to the source PR.

Verification: YAML parsing and diff checks passed.