### PR TITLE
fix(pipelines): redirect lightning DDL ingest tmp to workspace volume via postStart

### DIFF
--- a/.ci/replay-jenkins-build.sh
+++ b/.ci/replay-jenkins-build.sh
@@ -188,7 +188,23 @@ build_inline_script_with_pod_yaml() {
     : > "$out_file"
     local -a out_lines=()
     local -a preludes=()
+    local -a prelude_vars=()
     local line out_line b64 prefix comment repl pvar
+
+    prelude_declared() {
+        local v="$1" i n="${#prelude_vars[@]}"
+        for (( i = 0; i < n; i++ )); do
+            [[ "${prelude_vars[$i]}" == "$v" ]] && return 0
+        done
+        return 1
+    }
+    append_prelude() {
+        local v="$1" b="$2"
+        if ! prelude_declared "$v"; then
+            prelude_vars+=("$v")
+            preludes+=("final ${v} = new String(java.util.Base64.decoder.decode(\"${b}\"), 'UTF-8')")
+        fi
+    }
     while IFS= read -r line; do
         out_line="$line"
         # Declarative form before ci-label migration (allow trailing inline comments).
@@ -201,7 +217,7 @@ build_inline_script_with_pod_yaml() {
             if [[ -n "$b64" ]]; then
                 pvar="_REPLAY_POD_${var}"
                 out_line="${line/yamlFile ${var}/yaml ${pvar}}"
-                preludes+=("final ${pvar} = new String(java.util.Base64.decoder.decode(\"${b64}\"), 'UTF-8')")
+                append_prelude "$pvar" "$b64"
                 found=1
             fi
         # Declarative form after ci-label migration (allow trailing inline comments).
@@ -216,7 +232,7 @@ build_inline_script_with_pod_yaml() {
                 comment="${BASH_REMATCH[4]}"
                 pvar="_REPLAY_POD_${var}"
                 out_line="${prefix}yaml ${pvar}"
-                preludes+=("final ${pvar} = new String(java.util.Base64.decoder.decode(\"${b64}\"), 'UTF-8')")
+                append_prelude "$pvar" "$b64"
                 [[ -n "$comment" ]] && out_line+=" ${comment}"
                 found=1
             fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Follow the **Conventional Commits** specification for commit messages:
 
 Examples:
 - `ci(prow): add presubmit for tiflow lint`
-- `pipelines(tiflow): increase pipeline timeout`
+- `fix(tiflow): increase pipeline timeout`
 - `docs(agents): document Conventional Commits`
 - `test(libraries): add unit tests for parseCIParamsFromPRTitle`
 

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml
@@ -7,6 +7,17 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                if [ ! -e /tmp/tidb ]; then
+                  mkdir -p /home/jenkins/agent/tidb-tmp
+                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
+                fi
       resources:
         requests:
           memory: 12Gi

--- a/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
@@ -7,6 +7,17 @@ spec:
     - name: golang
       image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                if [ ! -e /tmp/tidb ]; then
+                  mkdir -p /home/jenkins/agent/tidb-tmp
+                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
+                fi
       resources:
         requests:
           memory: 16Gi

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_lightning_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_lightning_integration_test.yaml
@@ -7,6 +7,17 @@ spec:
     - name: golang
       image: "ghcr.io/pingcap-qe/ci/jenkins:v2026.3.29-14-g90ae7ef-go1.25"
       tty: true
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                if [ ! -e /tmp/tidb ]; then
+                  mkdir -p /home/jenkins/agent/tidb-tmp
+                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
+                fi
       resources:
         requests:
           memory: 16Gi

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml
@@ -7,6 +7,17 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                if [ ! -e /tmp/tidb ]; then
+                  mkdir -p /home/jenkins/agent/tidb-tmp
+                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
+                fi
       resources:
         requests:
           memory: 32Gi

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_lightning_test.yaml
@@ -7,6 +7,17 @@ spec:
     - name: golang
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/jenkins/centos7_golang-1.23:latest"
       tty: true
+      lifecycle:
+        postStart:
+          exec:
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                if [ ! -e /tmp/tidb ]; then
+                  mkdir -p /home/jenkins/agent/tidb-tmp
+                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
+                fi
       resources:
         requests:
           memory: 32Gi


### PR DESCRIPTION
### What problem does this PR solve?

The lightning integration test fails in the `lightning_add_index` case (Jenkins build `` `pull_lightning_integration_test #12` `` on group G08) because TiDB DDL ingest backfill writes its sort data to `${tidb temp-dir}/tmp_ddl-{port}` == `/tmp/tidb/tmp_ddl-4000` by default. The pod-local `/tmp` sits on the shared node disk and only had ~14.78 GB free while the add-index task needed ~17.03 GB, returning error 8256 (`ErrIngestCheckEnvFailed`). G02/G06 were aborted by the parallel fail-fast policy, not independent root causes.

TiDB's `temp-dir` is a hard-coded `/tmp/tidb` default (`pkg/config/config.go` `DefTempDir`) and cannot be overridden by an env var. The 150 Gi `ci-rwo` workspace volume is already mounted at `/home/jenkins/agent` in these pods.

### What is changed?

Add a `postStart` hook on the `golang` container that symlinks `/tmp/tidb` to `/home/jenkins/agent/tidb-tmp` (on the large workspace volume). It is non-root and idempotent (`[ ! -e /tmp/tidb ]` guard) and never touches `/tmp` itself, so it cannot break the container.

Redirects DDL ingest sort data to the big disk without any code/test changes in the tidb repo.

Applied to all lightning pod templates:
- `pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml`
- `pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml`
- `pipelines/pingcap/tidb/release-8.1/pod-pull_lightning_integration_test.yaml`
- `pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml`
- `pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_lightning_test.yaml`

(`pipelines/qa/qa-release-lightning-integration-test.groovy` reuses the latest pull pod template, so it is covered automatically.)

### Tests

All five YAML files pass `kubectl create --dry-run=client` schema validation.

### Limitations

Only the DDL ingest temp dir (`/tmp/tidb`) is redirected; `/tmp/lightning_test` and other pod-local writes still live on the node disk. If the same class of issue appears elsewhere, consider mounting the workspace volume at `/tmp` directly instead.