### PR TITLE
fix(artifacts): preserve OCI binary read permissions across containers

### DIFF
--- a/scripts/artifacts/download_pingcap_oci_artifact.sh
+++ b/scripts/artifacts/download_pingcap_oci_artifact.sh
@@ -228,7 +228,8 @@ function main() {
         echo "🚀 start download MinIO server and client"
         fetch_file_from_oci_artifact "$minio_oci_url" minio
         fetch_file_from_oci_artifact "$minio_oci_url" mc
-        chmod +x minio mc
+        # mktemp creates files as 0600; keep binaries readable by the jnlp container.
+        chmod a+rx minio mc
         echo "🎉 download MinIO server and client success"
     fi
     if [[ -n "$ETCDCTL" ]]; then
@@ -273,13 +274,13 @@ function main() {
     if [[ -n "$KES" ]]; then
         echo "🚀 start download kes"
         fetch_file_from_oci_artifact "$kes_oci_url" kes
-        chmod +x kes
+        chmod a+rx kes
         echo "🎉 download kes success"
     fi
     if [[ -n "$LICENSE_EYE" ]]; then
         echo "🚀 start download license-eye"
         fetch_file_from_oci_artifact "$license_eye_oci_url" '^license-eye$'
-        chmod +x license-eye
+        chmod a+rx license-eye
         echo "🎉 download license-eye success"
     fi
 


### PR DESCRIPTION
## Problem

After commit 33be8196, `pingcap/tidb/pull_integration_realcluster_test_next_gen` began failing during Jenkins `stash` after the OCI downloads completed. Build 8041 reports:

`entry 'bin/mc' closed at '0' before the '30531768' bytes specified in the header were written`

The `mc` layer is 30531768 bytes. The new downloader uses `mktemp`, which creates files with mode 0600. The existing `chmod +x` adds execute bits but does not restore read permission for the jnlp container that performs the stash.

## Changes

- Use `chmod a+rx` for directly fetched binaries: MinIO, `mc`, KES, and `license-eye`.
- Keep the atomic temporary-file download and incomplete-download cleanup from 33be8196.
- Keep the existing skip detection.

## Validation

- `bash -n scripts/artifacts/download_pingcap_oci_artifact.sh`
- `git diff --check`
- Local permission reproduction: `mktemp` mode 0600 followed by `chmod +x` is not readable by other users; `chmod a+rx` restores mode 0755.

Related build: https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/pull_integration_realcluster_test_next_gen/8041/