### PR TITLE
refactor(pipelines): reorganize tiflash pull_unit_next_gen job layout

### DIFF
--- a/jobs/pingcap/tiflash/latest/pull_unit_next_gen.groovy
+++ b/jobs/pingcap/tiflash/latest/pull_unit_next_gen.groovy
@@ -14,7 +14,7 @@ pipelineJob('pingcap/tiflash/pull_unit_next_gen') {
     definition {
         cpsScm {
             lightweight(true)
-            scriptPath("pipelines/pingcap/tiflash/latest/pull_unit_next_gen.groovy")
+            scriptPath("pipelines/pingcap/tiflash/latest/pull_unit_next_gen/pipeline.groovy")
             scm {
                 git{
                     remote {

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen/pipeline.groovy
@@ -5,7 +5,7 @@
 
 final K8S_NAMESPACE = "jenkins-tiflash"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pod-pull_unit-test.yaml'
+final POD_TEMPLATE_FILE = "pipelines/pingcap/tiflash/latest/${JOB_BASE_NAME}/pod-test.yaml"
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
 
@@ -18,7 +18,6 @@ pipeline {
             workspaceVolume genericEphemeralVolume(accessModes: 'ReadWriteOnce', requestsSize: '300Gi', storageClassName: 'ci-rwo')
             defaultContainer 'runner'
             retries 2
-            customWorkspace "/home/jenkins/agent/workspace/tiflash-build-common"
         }
     }
     options {
@@ -49,15 +48,15 @@ pipeline {
             steps {
                 script {
                     dir("tiflash") {
-                        sh label: "config ccache", script: """
-                            ccache -o cache_dir="/tmp/.ccache"
+                        sh label: "config ccache", script: '''
+                            ccache -o cache_dir="$WORKSPACE/.ccache"
                             ccache -o max_size=2G
                             ccache -o hash_dir=false
                             ccache -o compression=true
                             ccache -o compression_level=6
                             ccache -o read_only=false
                             ccache -z
-                        """
+                        '''
                     }
                 }
             }

--- a/pipelines/pingcap/tiflash/latest/pull_unit_next_gen/pod-test.yaml
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_next_gen/pod-test.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    fsGroup: 1000
+  containers:
+    - name: runner
+      image: ghcr.io/pingcap-qe/cd/builders/tiflash:v2025.4.15-rocky8-llvm-17.0.6-v2
+      imagePullPolicy: Always
+      command:
+        - "cat"
+      tty: true
+      # Notice: not set the resources limit, because limit will make unit test failed
+      resources:
+        limits:
+          memory: "24Gi"
+          cpu: "12"
+      volumeMounts:
+        - mountPath: "/tmp-memfs"
+          name: "tmp-memfs"
+          readOnly: false
+  volumes:
+    - name: "tmp-memfs"
+      emptyDir:
+        medium: Memory
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64

--- a/pipelines/pingcap/tiflash/latest/pull_unit_test/pipeline.groovy
+++ b/pipelines/pingcap/tiflash/latest/pull_unit_test/pipeline.groovy
@@ -5,7 +5,7 @@
 
 final K8S_NAMESPACE = "jenkins-tiflash"
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final POD_TEMPLATE_FILE = 'pipelines/pingcap/tiflash/latest/pull_unit_test/pod-test.yaml'
+final POD_TEMPLATE_FILE = "pipelines/pingcap/tiflash/latest/${JOB_BASE_NAME}/pod-test.yaml"
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final PARALLELISM = 12
 


### PR DESCRIPTION
Reorganize the pingcap/tiflash `pull_unit_next_gen` job layout to align with `pull_unit_test`:

- Move `pull_unit_next_gen.groovy` into `pull_unit_next_gen/pipeline.groovy` and update the job DSL script path accordingly.
- Add a dedicated `pull_unit_next_gen/pod-test.yaml` pod template instead of relying on the previous (non-existent) top-level `pod-pull_unit-test.yaml` reference.
- Derive the pod template file path from `JOB_BASE_NAME` in both `pull_unit_next_gen` and `pull_unit_test` pipelines.
- Cache ccache under `$WORKSPACE/.ccache` (workspace volume) and drop the shared `customWorkspace` (tiflash-build-common).