### PR TITLE
feat(prow): migrate five verified latest jobs

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_mysql_integration_heavy
       labels:
-        master: "1"
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-mysql-integration-heavy
@@ -47,7 +47,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_kafka_integration_heavy
       labels:
-        master: "1"
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-kafka-integration-heavy

--- a/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-postsubmits.yaml
@@ -55,7 +55,7 @@ postsubmits:
       name: pingcap/tidb/merged_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: ci/sqllogic-test
@@ -110,7 +110,7 @@ postsubmits:
       name: pingcap/tidb/merged_integration_lightning_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: wip/integration-lightning-test

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -161,7 +161,7 @@ presubmits:
     - name: pingcap/tiflow/pull_dm_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       run_if_changed: "^(dm/.*|pkg/.*|sync_diff_inspector/.*|go\\.mod)$"


### PR DESCRIPTION
## Scope

Extract the five jobs which succeeded in the latest verification of [PingCAP-QE/ci#5096](https://github.com/PingCAP-QE/ci/pull/5096):

- `pingcap/tidb/merged_sqllogic_test`
- `pingcap/tidb/merged_integration_lightning_test`
- `pingcap/tiflow/pull_dm_integration_test`
- `pingcap/ticdc/pull_cdc_kafka_integration_heavy`
- `pingcap/ticdc/pull_cdc_mysql_integration_heavy`

Each moves the latest Jenkins label from `master: "1"` to `master: "0"`. The source branch of PingCAP-QE/ci#5096 now retains only the six failed and three skipped jobs, so this PR does not overlap it.

## Validation

- `.ci/update-prow-job-kustomization.sh`
- `git diff --check`