### PR TITLE
feat(prow): migrate seven verified latest jobs

### DIFF
--- a/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/ticdc/latest-presubmits.yaml
@@ -58,7 +58,7 @@ presubmits:
     - <<: *jenkins_job
       name: pingcap/ticdc/pull_cdc_pulsar_integration_light
       labels:
-        master: "1"
+        master: "0"
       # skip_if_only_changed: *skip_if_only_changed
       run_before_merge: true
       context: pull-cdc-pulsar-integration-light

--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -74,7 +74,7 @@ presubmits:
       name: pingcap/tidb/pull_unit_test_ddlv1
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       run_if_changed: "pkg/(ddl|meta)/.*"
       context: pull-unit-test-ddlv1
@@ -108,7 +108,7 @@ presubmits:
       name: pingcap/tidb/pull_integration_copr_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       optional: true
       context: pull-integration-copr-test
@@ -152,7 +152,7 @@ presubmits:
       name: pingcap/tidb/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       run_if_changed: "(br|pkg/(ddl|domain|infoschema))/.*"

--- a/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tiflow/latest-presubmits.yaml
@@ -109,7 +109,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -122,7 +122,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_storage_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files
@@ -135,7 +135,7 @@ presubmits:
     - name: pingcap/tiflow/pull_cdc_integration_pulsar_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       skip_if_only_changed: *skip_if_only_changed_non_ticdc_files


### PR DESCRIPTION
Split verified successes from PingCAP-QE/ci#5181.

The following latest-branch jobs completed successfully on Jenkins staging and now use `master: "0"`:

- `pingcap/ticdc/pull_cdc_pulsar_integration_light`
- `pingcap/tidb/pull_unit_test_ddlv1`
- `pingcap/tidb/pull_integration_copr_test`
- `pingcap/tidb/pull_br_integration_test`
- `pingcap/tiflow/pull_cdc_integration_test`
- `pingcap/tiflow/pull_cdc_integration_storage_test`
- `pingcap/tiflow/pull_cdc_integration_pulsar_test`

The source branch of PingCAP-QE/ci#5181 was reduced to its sole non-successful job, `pingcap/ticdc/pull_cdc_storage_integration_heavy`; its Jenkins build was aborted.

Validation: `.ci/update-prow-job-kustomization.sh` and `git diff --check` pass.