### PR TITLE
fix(scripts/tidb): wait for PD readiness

### DIFF
--- a/scripts/PingCAP-QE/tidb-test/start_tikv.sh
+++ b/scripts/PingCAP-QE/tidb-test/start_tikv.sh
@@ -1,9 +1,25 @@
 #! /usr/bin/env bash
 
+function wait_for_http() {
+    local url="$1"
+    local name="$2"
+
+    for attempt in $(seq 1 30); do
+        if curl -fsS --max-time 2 "${url}" >/dev/null 2>&1; then
+            echo "${name} is ready"
+            return 0
+        fi
+        echo "Waiting for ${name}... (attempt ${attempt}/30)"
+        sleep 1
+    done
+
+    echo "${name} did not become ready: ${url}" >&2
+    return 1
+}
+
 chmod +x bin/pd-server bin/tikv-server
 bin/pd-server --name=pd --data-dir=pd &> pd.log &
-echo "wait pd ready..."
-sleep 10
+wait_for_http "http://127.0.0.1:2379/pd/api/v1/health" "PD" || exit 1
 bin/tikv-server -C tikv_config.toml --pd=127.0.0.1:2379 -s tikv --addr=0.0.0.0:20160 --advertise-addr=127.0.0.1:20160 &> tikv.log &
 echo "wait tikv ready..."
 sleep 10

--- a/scripts/pingcap/tidb/integrationtest.sh
+++ b/scripts/pingcap/tidb/integrationtest.sh
@@ -1,5 +1,22 @@
 #! /usr/bin/env bash
 
+function wait_for_http() {
+    local url="$1"
+    local name="$2"
+
+    for attempt in $(seq 1 30); do
+        if curl -fsS --max-time 2 "${url}" >/dev/null 2>&1; then
+            echo "${name} is ready"
+            return 0
+        fi
+        echo "Waiting for ${name}... (attempt ${attempt}/30)"
+        sleep 1
+    done
+
+    echo "${name} did not become ready: ${url}" >&2
+    return 1
+}
+
 function main() {
     # Disable pipelined pessimistic lock temporarily until tikv#11649 is resolved
     cat <<EOF > tikv.toml
@@ -17,6 +34,10 @@ EOF
     bin/pd-server -name=pd1 --data-dir=pd1 --client-urls=http://${pd_addr1} --peer-urls=http://${pd_peer_addr1} -force-new-cluster &> pd1.log &
     bin/pd-server -name=pd2 --data-dir=pd2 --client-urls=http://${pd_addr2} --peer-urls=http://${pd_peer_addr1} -force-new-cluster &> pd2.log &
     bin/pd-server -name=pd3 --data-dir=pd3 --client-urls=http://${pd_addr3} --peer-urls=http://${pd_peer_addr3} -force-new-cluster &> pd3.log &
+    wait_for_http "http://${pd_addr1}/pd/api/v1/health" "PD-1" || return 1
+    wait_for_http "http://${pd_addr2}/pd/api/v1/health" "PD-2" || return 1
+    wait_for_http "http://${pd_addr3}/pd/api/v1/health" "PD-3" || return 1
+
     bin/tikv-server --pd=${pd_addr1} -s tikv1 --addr=0.0.0.0:20160 --advertise-addr=127.0.0.1:20160 --advertise-status-addr=127.0.0.1:20165 -C tikv.toml -f tikv1.log &
     bin/tikv-server --pd=${pd_addr2} -s tikv2 --addr=0.0.0.0:20170 --advertise-addr=127.0.0.1:20170 --advertise-status-addr=127.0.0.1:20175 -C tikv.toml -f tikv2.log &
     bin/tikv-server --pd=${pd_addr3} -s tikv3 --addr=0.0.0.0:20180 --advertise-addr=127.0.0.1:20180 --advertise-status-addr=127.0.0.1:20185 -C tikv.toml -f tikv3.log &

--- a/scripts/pingcap/tidb/integrationtest_v2.sh
+++ b/scripts/pingcap/tidb/integrationtest_v2.sh
@@ -1,5 +1,22 @@
 #! /usr/bin/env bash
 
+function wait_for_http() {
+    local url="$1"
+    local name="$2"
+
+    for attempt in $(seq 1 30); do
+        if curl -fsS --max-time 2 "${url}" >/dev/null 2>&1; then
+            echo "${name} is ready"
+            return 0
+        fi
+        echo "Waiting for ${name}... (attempt ${attempt}/30)"
+        sleep 1
+    done
+
+    echo "${name} did not become ready: ${url}" >&2
+    return 1
+}
+
 function main() {
     # Disable pipelined pessimistic lock temporarily until tikv#11649 is resolved
     cat <<EOF > tikv.toml
@@ -17,6 +34,10 @@ EOF
     bin/pd-server --name=pd1 --data-dir=pd1 --client-urls=http://${pd_addr1} --peer-urls=http://${pd_peer_addr1} --force-new-cluster &> pd1.log &
     bin/pd-server --name=pd2 --data-dir=pd2 --client-urls=http://${pd_addr2} --peer-urls=http://${pd_peer_addr2} --force-new-cluster &> pd2.log &
     bin/pd-server --name=pd3 --data-dir=pd3 --client-urls=http://${pd_addr3} --peer-urls=http://${pd_peer_addr3} --force-new-cluster &> pd3.log &
+    wait_for_http "http://${pd_addr1}/pd/api/v1/health" "PD-1" || return 1
+    wait_for_http "http://${pd_addr2}/pd/api/v1/health" "PD-2" || return 1
+    wait_for_http "http://${pd_addr3}/pd/api/v1/health" "PD-3" || return 1
+
     bin/tikv-server --pd=${pd_addr1} -s tikv1 --addr=0.0.0.0:20160 --advertise-addr=127.0.0.1:20160 --advertise-status-addr=127.0.0.1:20165 -C tikv.toml -f tikv1.log &
     bin/tikv-server --pd=${pd_addr2} -s tikv2 --addr=0.0.0.0:20170 --advertise-addr=127.0.0.1:20170 --advertise-status-addr=127.0.0.1:20175 -C tikv.toml -f tikv2.log &
     bin/tikv-server --pd=${pd_addr3} -s tikv3 --addr=0.0.0.0:20180 --advertise-addr=127.0.0.1:20180 --advertise-status-addr=127.0.0.1:20185 -C tikv.toml -f tikv3.log &

--- a/scripts/pingcap/tidb/integrationtest_with_tikv.sh
+++ b/scripts/pingcap/tidb/integrationtest_with_tikv.sh
@@ -1,5 +1,22 @@
 #! /usr/bin/env bash
 
+function wait_for_http() {
+    local url="$1"
+    local name="$2"
+
+    for attempt in $(seq 1 30); do
+        if curl -fsS --max-time 2 "${url}" >/dev/null 2>&1; then
+            echo "${name} is ready"
+            return 0
+        fi
+        echo "Waiting for ${name}... (attempt ${attempt}/30)"
+        sleep 1
+    done
+
+    echo "${name} did not become ready: ${url}" >&2
+    return 1
+}
+
 function main() {
     # Disable pipelined pessimistic lock temporarily until tikv#11649 is resolved
     cat <<EOF > tikv.toml
@@ -17,6 +34,10 @@ EOF
     bin/pd-server --name=pd1 --data-dir=pd1 --client-urls=http://${pd_addr1} --peer-urls=http://${pd_peer_addr1} --force-new-cluster &> pd1.log &
     bin/pd-server --name=pd2 --data-dir=pd2 --client-urls=http://${pd_addr2} --peer-urls=http://${pd_peer_addr2} --force-new-cluster &> pd2.log &
     bin/pd-server --name=pd3 --data-dir=pd3 --client-urls=http://${pd_addr3} --peer-urls=http://${pd_peer_addr3} --force-new-cluster &> pd3.log &
+    wait_for_http "http://${pd_addr1}/pd/api/v1/health" "PD-1" || return 1
+    wait_for_http "http://${pd_addr2}/pd/api/v1/health" "PD-2" || return 1
+    wait_for_http "http://${pd_addr3}/pd/api/v1/health" "PD-3" || return 1
+
     bin/tikv-server --pd=${pd_addr1} -s tikv1 --addr=0.0.0.0:20160 --advertise-addr=127.0.0.1:20160 --advertise-status-addr=127.0.0.1:20165 -C tikv.toml -f tikv1.log &
     bin/tikv-server --pd=${pd_addr2} -s tikv2 --addr=0.0.0.0:20170 --advertise-addr=127.0.0.1:20170 --advertise-status-addr=127.0.0.1:20175 -C tikv.toml -f tikv2.log &
     bin/tikv-server --pd=${pd_addr3} -s tikv3 --addr=0.0.0.0:20180 --advertise-addr=127.0.0.1:20180 --advertise-status-addr=127.0.0.1:20185 -C tikv.toml -f tikv3.log &

--- a/scripts/pingcap/tidb/run_real_tikv_tests.sh
+++ b/scripts/pingcap/tidb/run_real_tikv_tests.sh
@@ -1,5 +1,27 @@
 #! /usr/bin/env bash
 
+function wait_for_pd_cluster() {
+    local url="$1"
+    local expected_members="$2"
+    local name="$3"
+    local response
+    local healthy_members
+
+    for attempt in $(seq 1 30); do
+        response="$(curl -fsS --max-time 2 "${url}" 2>/dev/null || true)"
+        healthy_members="$(printf '%s' "${response}" | grep -o '"health"[[:space:]]*:[[:space:]]*true' | wc -l | tr -d '[:space:]')"
+        if [[ "${healthy_members}" == "${expected_members}" ]]; then
+            echo "${name} is ready"
+            return 0
+        fi
+        echo "Waiting for ${name}... (attempt ${attempt}/30)"
+        sleep 1
+    done
+
+    echo "${name} did not become ready: ${url}; last response: ${response:-<unavailable>}" >&2
+    return 1
+}
+
 function main() {
     local test_suite="$1"
     local timeout="$2"
@@ -28,6 +50,8 @@ EOF
     bin/pd-server --name=pd-0 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd1.log &
     bin/pd-server --name=pd-1 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-1/data --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd2.log &
     bin/pd-server --name=pd-2 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-2/data --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd3.log &
+    wait_for_pd_cluster "http://127.0.0.1:2379/pd/api/v1/health" 3 "PD cluster" || return 1
+
     bin/tikv-server --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-0/data -f tikv1.log &
     bin/tikv-server --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-1/data -f tikv2.log &
     bin/tikv-server --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-2/data -f tikv3.log &

--- a/scripts/pingcap/tidb/run_real_tikv_tests_with_gotest.sh
+++ b/scripts/pingcap/tidb/run_real_tikv_tests_with_gotest.sh
@@ -1,5 +1,27 @@
 #! /usr/bin/env bash
 
+function wait_for_pd_cluster() {
+    local url="$1"
+    local expected_members="$2"
+    local name="$3"
+    local response
+    local healthy_members
+
+    for attempt in $(seq 1 30); do
+        response="$(curl -fsS --max-time 2 "${url}" 2>/dev/null || true)"
+        healthy_members="$(printf '%s' "${response}" | grep -o '"health"[[:space:]]*:[[:space:]]*true' | wc -l | tr -d '[:space:]')"
+        if [[ "${healthy_members}" == "${expected_members}" ]]; then
+            echo "${name} is ready"
+            return 0
+        fi
+        echo "Waiting for ${name}... (attempt ${attempt}/30)"
+        sleep 1
+    done
+
+    echo "${name} did not become ready: ${url}; last response: ${response:-<unavailable>}" >&2
+    return 1
+}
+
 function main() {
     local test_suite="$1"
     local timeout="$2"
@@ -20,6 +42,8 @@ EOF
     bin/pd-server --name=pd-0 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd1.log &
     bin/pd-server --name=pd-1 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-1/data --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd2.log &
     bin/pd-server --name=pd-2 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-2/data --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd3.log &
+    wait_for_pd_cluster "http://127.0.0.1:2379/pd/api/v1/health" 3 "PD cluster" || return 1
+
     bin/tikv-server --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-0/data -f tikv1.log &
     bin/tikv-server --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-1/data -f tikv2.log &
     bin/tikv-server --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-2/data -f tikv3.log &


### PR DESCRIPTION
## Problem

`ghpr_check2 #17` started TiKV while the three local PD processes were still electing a leader. Each TiKV received a transient `not leader` TSO response, its TSO worker terminated, and no TiKV could bootstrap PD.

## Changes

- Before starting TiKV, require the real-TiKV runners to receive a PD health response that reports all three PD members healthy.
- Apply bounded PD readiness gates to the active integration-test helpers and tidb-test helper.
- Fail with a clear timeout after 30 seconds instead of racing the test-cluster startup.

## Validation

- `bash -n` for all six changed scripts.
- A representative three-member health response is verified to require three `health: true` entries.
- `git diff --check`.
- Jenkins replay is not applicable: replay can inject Pipeline Groovy and pod YAML, but cannot inject the changed runtime scripts under `${WORKSPACE}/scripts`; a replay would execute the deployed `main` scripts instead.

## Replay validation

Replayed [`pingcap/tidb/ghpr_check2` build 17](https://do.pingcap.net/jenkins-staging/job/pingcap/job/tidb/job/ghpr_check2/17/) with the scripts downloaded from this branch into the replay workspace. The final replay, [build 21](https://do.pingcap.net/jenkins-staging/job/pingcap/job/tidb/job/ghpr_check2/21/), logged `PD cluster is ready` 15 times and no longer showed `NOT_BOOTSTRAPPED`, `Timestamp channel is dropped`, or the early TiKV `not leader` failure from build 17. The build reached the DDL add-index test and then failed independently because the TiDB pod had 15,428,419,584 bytes free while the test required 17,032,420,148 bytes.