### PR TITLE
fix(pipelines): redirect ghpr check2 DDL tmp to workspace

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -89,7 +89,7 @@ pipeline {
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
@@ -103,7 +103,7 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
+                    stage('Test') {
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -19,8 +19,6 @@ spec:
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - mountPath: /tmp/tidb
-          name: workspace-volume
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,7 +29,13 @@ spec:
           exec:
             command:
               - /bin/sh
-              - /data/bazel-prepare-in-container.sh
+              - -ec
+              - |
+                if [ ! -e /tmp/tidb ]; then
+                  mkdir -p /home/jenkins/agent/tidb-tmp
+                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
+                fi
+                /bin/sh /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -19,6 +19,8 @@ spec:
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
+        - mountPath: /tmp/tidb
+          name: workspace-volume
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -29,13 +31,7 @@ spec:
           exec:
             command:
               - /bin/sh
-              - -ec
-              - |
-                if [ ! -e /tmp/tidb ]; then
-                  mkdir -p /home/jenkins/agent/tidb-tmp
-                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
-                fi
-                exec /data/bazel-prepare-in-container.sh
+              - /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -29,7 +29,13 @@ spec:
           exec:
             command:
               - /bin/sh
-              - /data/bazel-prepare-in-container.sh
+              - -ec
+              - |
+                if [ ! -e /tmp/tidb ]; then
+                  mkdir -p /home/jenkins/agent/tidb-tmp
+                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
+                fi
+                exec /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -31,10 +31,13 @@ spec:
               - /bin/sh
               - -ec
               - |
+                # TiDB writes DDL ingest sort files to /tmp/tidb/tmp_ddl-{port} by default.
+                # Keep them on the 150Gi Jenkins workspace volume instead of pod-local /tmp.
                 if [ ! -e /tmp/tidb ]; then
                   mkdir -p /home/jenkins/agent/tidb-tmp
                   ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
                 fi
+                # The ConfigMap-mounted script is not executable; preserve the original shell invocation.
                 /bin/sh /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c


### PR DESCRIPTION
## Problem

The PD-readiness replay of [`pingcap/tidb/ghpr_check2` build 21](https://do.pingcap.net/jenkins-staging/job/pingcap/job/tidb/job/ghpr_check2/21/) reached `addindextest` but failed DDL ingest with error 8256. TiDB uses `/tmp/tidb/tmp_ddl-4000` for local sort files; that pod-local filesystem had 15,428,419,584 bytes free, below the required 17,032,420,148 bytes.

## Change

Mount Jenkins' injected `workspace-volume` directly at `/tmp/tidb` in the `golang` container. The Pipeline configures this volume as a writable 150Gi `ci-rwo` generic ephemeral volume for both the preparation and matrix agents.

A hook-based attempt was rejected after replay: the image already has `/tmp/tidb`, so an existence-guarded symlink was skipped and tests kept using the container root filesystem. Direct mounting safely hides that image directory without deleting it and does not modify the existing Bazel `postStart` behavior.

## Validation

- `git diff --check`
- Kubernetes client schema validation against an in-memory equivalent pod containing the Jenkins-injected workspace volume
- Asserted the `/tmp/tidb` mount and original Bazel hook structure
- Asserted both Pipeline workspace-volume declarations