### PR TITLE
fix(pipelines): mount ghpr DDL tmp on workspace

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -89,7 +89,7 @@ pipeline {
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
@@ -103,7 +103,7 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
+                    stage('Test') {
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -19,8 +19,6 @@ spec:
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
-        - mountPath: /tmp/tidb
-          name: workspace-volume
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,7 +29,13 @@ spec:
           exec:
             command:
               - /bin/sh
-              - /data/bazel-prepare-in-container.sh
+              - -ec
+              - |
+                if [ ! -e /tmp/tidb ]; then
+                  mkdir -p /home/jenkins/agent/tidb-tmp
+                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
+                fi
+                /bin/sh /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -19,6 +19,10 @@ spec:
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
+        # TiDB writes DDL ingest sort files under /tmp/tidb by default. Jenkins injects
+        # this writable 150Gi workspace volume through workspaceVolume in the Pipeline.
+        - mountPath: /tmp/tidb
+          name: workspace-volume
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -27,18 +31,10 @@ spec:
       lifecycle:
         postStart:
           exec:
+            # ConfigMap-mounted scripts do not have executable mode; invoke through sh.
             command:
               - /bin/sh
-              - -ec
-              - |
-                # TiDB writes DDL ingest sort files to /tmp/tidb/tmp_ddl-{port} by default.
-                # Keep them on the 150Gi Jenkins workspace volume instead of pod-local /tmp.
-                if [ ! -e /tmp/tidb ]; then
-                  mkdir -p /home/jenkins/agent/tidb-tmp
-                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
-                fi
-                # The ConfigMap-mounted script is not executable; preserve the original shell invocation.
-                /bin/sh /data/bazel-prepare-in-container.sh
+              - /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -19,6 +19,8 @@ spec:
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged
+        - mountPath: /tmp/tidb
+          name: workspace-volume
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -29,13 +31,7 @@ spec:
           exec:
             command:
               - /bin/sh
-              - -ec
-              - |
-                if [ ! -e /tmp/tidb ]; then
-                  mkdir -p /home/jenkins/agent/tidb-tmp
-                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
-                fi
-                exec /data/bazel-prepare-in-container.sh
+              - /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -29,7 +29,13 @@ spec:
           exec:
             command:
               - /bin/sh
-              - /data/bazel-prepare-in-container.sh
+              - -ec
+              - |
+                if [ ! -e /tmp/tidb ]; then
+                  mkdir -p /home/jenkins/agent/tidb-tmp
+                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
+                fi
+                exec /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -31,10 +31,13 @@ spec:
               - /bin/sh
               - -ec
               - |
+                # TiDB writes DDL ingest sort files to /tmp/tidb/tmp_ddl-{port} by default.
+                # Keep them on the 150Gi Jenkins workspace volume instead of pod-local /tmp.
                 if [ ! -e /tmp/tidb ]; then
                   mkdir -p /home/jenkins/agent/tidb-tmp
                   ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
                 fi
+                # The ConfigMap-mounted script is not executable; preserve the original shell invocation.
                 /bin/sh /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c


### PR DESCRIPTION
## Problem

[`pingcap/tidb/ghpr_check2` build 21](https://do.pingcap.net/jenkins-staging/job/pingcap/job/tidb/job/ghpr_check2/21/) reached DDL ingest but failed error 8256 because TiDB uses `/tmp/tidb/tmp_ddl-4000` on the pod-local filesystem, which had insufficient free space.

## Change

Mount Jenkins' injected writable `workspace-volume` directly at `/tmp/tidb` in the `golang` container. The Pipeline uses a 150Gi `ci-rwo` generic ephemeral workspace volume for both preparation and matrix agents. The pod already sets `fsGroup: 1000`, matching the Jenkins CI step user, so the mounted workspace is writable without a root-created handoff directory.

The existing Bazel `postStart` hook remains unchanged and invokes the ConfigMap script through `/bin/sh`.

## Validation

- `git diff --check`
- Kubernetes client schema validation against an in-memory equivalent pod containing the Jenkins-injected workspace volume
- Asserted the `/tmp/tidb` mount and original Bazel hook structure
- Asserted both Pipeline workspace-volume declarations
- [staging replay build 26](https://do.pingcap.net/jenkins-staging/job/pingcap/job/tidb/job/ghpr_check2/26/) is running with this exact code and inline pod YAML