### PR TITLE
revert(pipelines): rollback ghpr DDL tmp hook

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -89,7 +89,7 @@ pipeline {
                         )
                     }
                 }
-                agent {
+                agent{
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
@@ -103,7 +103,7 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test') {
+                    stage('Test')  {
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -29,16 +29,7 @@ spec:
           exec:
             command:
               - /bin/sh
-              - -ec
-              - |
-                # TiDB writes DDL ingest sort files to /tmp/tidb/tmp_ddl-{port} by default.
-                # Keep them on the 150Gi Jenkins workspace volume instead of pod-local /tmp.
-                if [ ! -e /tmp/tidb ]; then
-                  mkdir -p /home/jenkins/agent/tidb-tmp
-                  ln -s /home/jenkins/agent/tidb-tmp /tmp/tidb
-                fi
-                # The ConfigMap-mounted script is not executable; preserve the original shell invocation.
-                /bin/sh /data/bazel-prepare-in-container.sh
+              - /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true


### PR DESCRIPTION
## Emergency rollback

Revert the merged `PingCAP-QE/ci#5188` implementation. Its existence-guarded `/tmp/tidb` symlink does not replace the image-precreated directory, so `ghpr_check2` continued using the pod-local path and produced read-only filesystem failures.

A corrected `postStart` implementation will follow in a separate PR after this rollback is merged.

## Validation

- `git diff --check`