### PR TITLE
fix(pipelines): redirect ghpr DDL tmp with postStart

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -89,7 +89,7 @@ pipeline {
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
@@ -103,7 +103,7 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
+                    stage('Test') {
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }

--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -112,6 +112,14 @@ pipeline {
                                 unstash 'ws'
                                 sh "ls -l rev-${REFS.pulls[0].sha}" // sanity: restored from stash.
 
+                                sh label: 'prepare writable TiDB DDL temp dir', script: '''
+                                    # TiDB uses /tmp/tidb for DDL ingest and IMPORT INTO files.
+                                    # Keep it on the workspace volume before Bazel creates its sandbox.
+                                    tidb_tmp="${WORKSPACE}/tidb-tmp"
+                                    mkdir -p "${tidb_tmp}"
+                                    rm -rf /tmp/tidb
+                                    ln -s "${tidb_tmp}" /tmp/tidb
+                                '''
                                 sh 'chmod +x ../scripts/pingcap/tidb/*.sh'
                                 sh "${WORKSPACE}/scripts/pingcap/tidb/${SCRIPT_AND_ARGS}"
                             }

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -38,10 +38,13 @@ spec:
                 chown -R 1000:1000 "${tidb_tmp}"
                 chmod 0775 "${tidb_tmp}"
 
-                # The image pre-creates /tmp/tidb, so an existence guard skips redirection.
-                # It is a disposable TiDB temp directory before any test step starts.
+                # The image pre-creates /tmp/tidb. Replace it before test steps start, then
+                # bind-mount the writable workspace directory so Bazel does not resolve a symlink
+                # to a path it mounts read-only in its test sandbox.
                 rm -rf /tmp/tidb
-                ln -s "${tidb_tmp}" /tmp/tidb
+                mkdir -p /tmp/tidb
+                mount --bind "${tidb_tmp}" /tmp/tidb
+                mount -o remount,bind,rw /tmp/tidb
 
                 # ConfigMap-mounted scripts are not executable; keep the shell invocation.
                 /bin/sh /data/bazel-prepare-in-container.sh

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -8,18 +8,6 @@ spec:
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
-        # postStart must replace the image-owned /tmp/tidb mount point. The image
-        # defaults to UID 1000, so start as root for that lifecycle preparation.
-        runAsUser: 0
-        runAsGroup: 0
-      command:
-        - /bin/sh
-        - -ec
-        - |
-          # Do not let Jenkins connect until postStart has finished the privileged setup.
-          while [ ! -f /tmp/tidb-poststart-ready ]; do sleep 1; done
-          # Keep the container's long-running command at the image's normal identity.
-          exec su -s /bin/bash jenkins
       tty: true
       resources:
         requests:
@@ -41,29 +29,7 @@ spec:
           exec:
             command:
               - /bin/sh
-              - -ec
-              - |
-                # TiDB writes DDL ingest and IMPORT INTO files under /tmp/tidb by default.
-                # postStart runs as root; keep the target owned by the Jenkins UID/GID 1000.
-                tidb_tmp=/home/jenkins/agent/tidb-tmp
-                mkdir -p "${tidb_tmp}"
-                chown -R 1000:1000 "${tidb_tmp}"
-                chmod 0775 "${tidb_tmp}"
-
-                # The image pre-creates /tmp/tidb. Replace it before test steps start, then
-                # bind-mount the writable workspace directory so Bazel does not resolve a symlink
-                # to a path it mounts read-only in its test sandbox.
-                rm -rf /tmp/tidb
-                mkdir -p /tmp/tidb
-                mount -o bind "${tidb_tmp}" /tmp/tidb
-                mount -o remount,bind,rw /tmp/tidb
-
-                # ConfigMap-mounted scripts are not executable; keep the shell invocation.
-                # This script prepares files in /home/jenkins, so retain their usual ownership.
-                su -s /bin/sh jenkins -c 'cd /home/jenkins && /bin/sh /data/bazel-prepare-in-container.sh'
-
-                # Unblock the main process only after all privileged setup has succeeded.
-                touch /tmp/tidb-poststart-ready
+              - /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -29,7 +29,22 @@ spec:
           exec:
             command:
               - /bin/sh
-              - /data/bazel-prepare-in-container.sh
+              - -ec
+              - |
+                # TiDB writes DDL ingest and IMPORT INTO files under /tmp/tidb by default.
+                # postStart runs as root, but Jenkins executes CI steps as UID/GID 1000.
+                tidb_tmp=/home/jenkins/agent/tidb-tmp
+                mkdir -p "${tidb_tmp}"
+                chown -R 1000:1000 "${tidb_tmp}"
+                chmod 0775 "${tidb_tmp}"
+
+                # The image pre-creates /tmp/tidb, so an existence guard skips redirection.
+                # It is a disposable TiDB temp directory before any test step starts.
+                rm -rf /tmp/tidb
+                ln -s "${tidb_tmp}" /tmp/tidb
+
+                # ConfigMap-mounted scripts are not executable; keep the shell invocation.
+                /bin/sh /data/bazel-prepare-in-container.sh
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -8,6 +8,18 @@ spec:
       image: "us-docker.pkg.dev/pingcap-testing-account/internal/test/wangweizhen/tidb_image:go12320241009"
       securityContext:
         privileged: true
+        # postStart must replace the image-owned /tmp/tidb mount point. The image
+        # defaults to UID 1000, so start as root for that lifecycle preparation.
+        runAsUser: 0
+        runAsGroup: 0
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          # Do not let Jenkins connect until postStart has finished the privileged setup.
+          while [ ! -f /tmp/tidb-poststart-ready ]; do sleep 1; done
+          # Keep the container's long-running command at the image's normal identity.
+          exec su -s /bin/bash jenkins
       tty: true
       resources:
         requests:
@@ -32,7 +44,7 @@ spec:
               - -ec
               - |
                 # TiDB writes DDL ingest and IMPORT INTO files under /tmp/tidb by default.
-                # postStart runs as root, but Jenkins executes CI steps as UID/GID 1000.
+                # postStart runs as root; keep the target owned by the Jenkins UID/GID 1000.
                 tidb_tmp=/home/jenkins/agent/tidb-tmp
                 mkdir -p "${tidb_tmp}"
                 chown -R 1000:1000 "${tidb_tmp}"
@@ -43,11 +55,15 @@ spec:
                 # to a path it mounts read-only in its test sandbox.
                 rm -rf /tmp/tidb
                 mkdir -p /tmp/tidb
-                mount --bind "${tidb_tmp}" /tmp/tidb
+                mount -o bind "${tidb_tmp}" /tmp/tidb
                 mount -o remount,bind,rw /tmp/tidb
 
                 # ConfigMap-mounted scripts are not executable; keep the shell invocation.
-                /bin/sh /data/bazel-prepare-in-container.sh
+                # This script prepares files in /home/jenkins, so retain their usual ownership.
+                su -s /bin/sh jenkins -c 'cd /home/jenkins && /bin/sh /data/bazel-prepare-in-container.sh'
+
+                # Unblock the main process only after all privileged setup has succeeded.
+                touch /tmp/tidb-poststart-ready
     - name: utils
       image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true


### PR DESCRIPTION
## Problem

The previous postStart symlink implementation did not solve the failure. Replay build 28 confirms the hook ran, the workspace mount was declared writable, and the temporary target was assigned to UID/GID 1000; TiDB still received `read-only file system` under `make bazel_*`.

## Change

Keep the postStart ownership setup, but replace the symlink with a bind mount:

1. create `/home/jenkins/agent/tidb-tmp` on the workspace PVC and set `1000:1000` / `0775`;
2. remove the image-precreated `/tmp/tidb` before tests begin;
3. bind-mount the temporary directory at `/tmp/tidb`, then explicitly remount that bind mount read-write;
4. invoke the existing Bazel ConfigMap script through `/bin/sh`.

The privileged `golang` container already has the capability required for bind mounts. A separate mount point prevents the Bazel test sandbox from resolving a symlink target that it makes read-only.

## Validation

- `git diff --check`
- Kubernetes pod template client schema validation
- Ruby YAML parse
- Extracted postStart shell syntax check
- staging replay: build 29 (source build 25)