### PR TITLE
fix(pipelines): mount ephemeral tmp volume for ghpr_check2 DDL tests

### DIFF
--- a/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/latest/ghpr_check2.groovy
@@ -89,7 +89,7 @@ pipeline {
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
@@ -103,7 +103,7 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
+                    stage('Test') {
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }
@@ -140,7 +140,6 @@ pipeline {
                             success {
                                 dir(REFS.repo) {
                                     script {
-
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 24Gi
           cpu: "3"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -41,7 +41,7 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:


### PR DESCRIPTION
### What problem does this PR solve?

`ghpr_check2` DDL integration tests write a lot of temporary data to `/tmp`, which can exhaust the node ephemeral disk. Previous attempts redirected the DDL tmp to the workspace (https://github.com/PingCAP-QE/ci/pull/5188, https://github.com/PingCAP-QE/ci/pull/5189, https://github.com/PingCAP-QE/ci/pull/5191) but were rolled back (https://github.com/PingCAP-QE/ci/pull/5190).

### What is changed?

- Mount a dedicated 150Gi ephemeral volume at `/tmp` in the golang container, so DDL scratch data no longer fills the node disk.
- Clean up whitespace in `ghpr_check2.groovy` (cosmetic).

### How to test?

Replayed `pingcap/tidb/ghpr_check2` on Jenkins with the changed pod template:

- https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_check2/8157 (with matrix cache): SUCCESS
- https://prow.tidb.net/jenkins/job/pingcap/job/tidb/job/ghpr_check2/8158 (matrix cache disabled): in progress