### PR TITLE
refactor(pipelines): remove unused tiflow coveralls credential declarations

### DIFF
--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test.groovy
@@ -132,7 +132,6 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-6.5/pull_cdc_integration_mysql_test.groovy
@@ -132,7 +132,6 @@ pipeline {
                         options { timeout(time: 60, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_kafka_test.groovy
@@ -135,7 +135,6 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_mysql_test.groovy
@@ -135,7 +135,6 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.1/pull_cdc_integration_storage_test.groovy
@@ -135,7 +135,6 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_kafka_test.groovy
@@ -135,7 +135,6 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_mysql_test.groovy
@@ -135,7 +135,6 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-7.5/pull_cdc_integration_storage_test.groovy
@@ -135,7 +135,6 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_kafka_test.groovy
@@ -136,7 +136,6 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_mysql_test.groovy
@@ -136,7 +136,6 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.1/pull_cdc_integration_storage_test.groovy
@@ -136,7 +136,6 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_kafka_test.groovy
@@ -136,7 +136,6 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_mysql_test.groovy
@@ -136,7 +136,6 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-8.5/pull_cdc_integration_storage_test.groovy
@@ -136,7 +136,6 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_kafka_test.groovy
@@ -136,7 +136,6 @@ pipeline {
                         options { timeout(time: 45, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_mysql_test.groovy
@@ -136,7 +136,6 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {

--- a/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
+++ b/pipelines/pingcap/tiflow/release-9.0-beta/pull_cdc_integration_storage_test.groovy
@@ -136,7 +136,6 @@ pipeline {
                         options { timeout(time: 40, unit: 'MINUTES') }
                         environment {
                             TICDC_CODECOV_TOKEN = credentials('codecov-token-tiflow')
-                            TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')
                         }
                         steps {
                             dir(REFS.repo) {


### PR DESCRIPTION
## Summary

Remove the unused `TICDC_COVERALLS_TOKEN` credential declaration from 17 supported `pingcap/tiflow` CDC integration pipelines.

These pipelines execute `tests/integration_tests/run_group.sh` and do not invoke the upstream `integration_test_coverage` target. Keeping the unused Jenkins credential declaration can fail the build when `coveralls-token-tiflow` is not provisioned.

## Changes

- Remove `TICDC_COVERALLS_TOKEN = credentials('coveralls-token-tiflow')` from CDC integration pipelines on `release-6.5`, `release-7.1`, `release-7.5`, `release-8.1`, `release-8.5`, and `release-9.0-beta`.
- Preserve the adjacent Codecov credential declarations.
- Leave Jenkins job DSL, Prow configuration, and kustomization unchanged.

## Not changed

- The upstream TiFlow `Makefile` `integration_test_coverage` target still consumes `COVERALLS_TOKEN` for Coveralls uploads when `JenkinsCI=1`; that functional coverage path is outside this cleanup.
- `latest`, `pingcap-inc/tiflow/release-8.5`, and EOL branches have no remaining `coveralls-token-tiflow` declaration in this repository.

## Verification

- `git diff --check`
- Confirmed no `coveralls-token-tiflow` references remain in this repository.
- Confirmed all 17 changed pipelines retain `TICDC_CODECOV_TOKEN`.
- Parsed all 17 changed pipeline scripts locally with Groovy after stripping the Jenkins-only `@Library` annotation.

Jenkins online pipeline validation and pre-commit were unavailable locally because `JENKINS_URL`/crumb and `pre-commit` are not configured.
