### PR TITLE
fix(ticdc): isolate Pulsar heavy test tmp storage with a PVC

### DIFF
--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
@@ -1,11 +1,9 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
-final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final BRANCH_ALIAS = 'latest'
-final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod-test.yaml"
-final POD_TEMPLATE_FILE_BUILD = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod-build.yaml"
+final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-test.yaml'
+final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-build.yaml'
 final WORKSPACE_STASH_NAME = 'ticdc-workspace'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')
@@ -94,7 +92,7 @@ pipeline {
                         values 'G00', 'G01', 'G02', 'G03', 'G04', 'G05', 'G06', 'G07', 'G08', 'G09', 'G10', 'G11', 'G12', 'G13', 'G14', 'G15'
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         yaml pod_label.withCiLabels(POD_TEMPLATE_FILE, REFS)

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pipeline.groovy
@@ -1,9 +1,11 @@
 @Library('tipipeline') _
 
 final K8S_NAMESPACE = "jenkins-tiflow"
+final GIT_FULL_REPO_NAME = 'pingcap/ticdc'
 final GIT_CREDENTIALS_ID = 'github-sre-bot-ssh'
-final POD_TEMPLATE_FILE = 'pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-test.yaml'
-final POD_TEMPLATE_FILE_BUILD = 'pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-build.yaml'
+final BRANCH_ALIAS = 'latest'
+final POD_TEMPLATE_FILE = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod-test.yaml"
+final POD_TEMPLATE_FILE_BUILD = "pipelines/${GIT_FULL_REPO_NAME}/${BRANCH_ALIAS}/${JOB_BASE_NAME}/pod-build.yaml"
 final WORKSPACE_STASH_NAME = 'ticdc-workspace'
 final REFS = readJSON(text: params.JOB_SPEC).refs
 final OCI_TAG_PD = component.computeArtifactOciTagFromPR('pd', REFS.base_ref, REFS.pulls[0].title, 'master')

--- a/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-test.yaml
+++ b/pipelines/pingcap/ticdc/latest/pull_cdc_pulsar_integration_heavy/pod-test.yaml
@@ -11,6 +11,20 @@ spec:
         limits:
           memory: 24Gi
           cpu: "6"
+      volumeMounts:
+        - name: test-tmp
+          mountPath: /tmp
+  volumes:
+    - name: test-tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            storageClassName: ci-rwo
+            resources:
+              requests:
+                storage: 100Gi
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Database integration tests write PD, TiKV, CDC, and Pulsar data under `/tmp`, which currently uses the test container's overlay filesystem and shares the node's system disk. In the staging failure linked below, PD lease expiry and CDC session loss coincided with multi-second etcd delays. Shared disk contention is a suspected contributor, not a confirmed physical root cause.

Give each Pulsar heavy test pod a separate 100Gi `ci-rwo` generic ephemeral PVC mounted at `/tmp`. Keep the existing 150Gi workspace PVC separate. On the target TKE cluster, `ci-rwo` provisions CBS `CLOUD_HSSD` disks with `WaitForFirstConsumer` and a `Delete` reclaim policy. The temporary PVC follows the test pod's lifecycle. A full 16-group matrix can provision 16 additional disks.

Preserve the pipeline's first eight lines and dynamic pod-template paths unchanged; only normalize the matrix agent block formatting. Replay-only copies resolve the template paths before embedding both PR versions and remove both cache checks and cache writes to execute every group. Normal pipeline matrix caching remains unchanged.

Validation:
- Target TKE API server accepted the test pod template with server-side dry run.
- Both Jenkins controllers validated the replay Jenkinsfile with the PR's build/test YAML embedded and all matrix-cache calls removed.
- `git diff --check` and repository-wide pre-commit checks passed (EOF, trailing whitespace, and gitleaks).
- Jenkins replay validation on both controllers will be tracked in one status comment, including source parameters, replay URLs, and outcomes.

Related runs: [staging failure](https://do.pingcap.net/jenkins-staging/job/pingcap/job/ticdc/job/pull_cdc_pulsar_integration_heavy/12/), [same-parameter source success](https://prow.tidb.net/jenkins/job/pingcap/job/ticdc/job/pull_cdc_pulsar_integration_heavy/1896/).
