### PR TITLE
fix(libraries): redirect bazel output root off node-local .tidb dir

### DIFF
--- a/docs/guides/bazel-workspace-preparation.md
+++ b/docs/guides/bazel-workspace-preparation.md
@@ -41,7 +41,16 @@ Runs the workspace preparation script. Options:
 | `patchCheckTarget` | `true` | Patch the Makefile `check:` target to drop `check-bazel-prepare` |
 | `remoteCache` | from `envConfig` | `null`, `[mode: 'disable']` or `[mode: 'set', url: '...']` |
 | `repositoryCache` | from `envConfig` | `null`, `'/path'` or `[path: '/path', guard: true|false]` |
-| `ensureTmpDir` | `false` | Create the bazel tmp dir (default `/home/jenkins/.tidb/tmp`) |
+| `tmpDir` | `${WORKSPACE}/.cache/bazel` | Bazel output root and repository cache parent |
+| `ensureTmpDir` | `false` | Create the default bazel tmp dir when no `tmpDir`/`WORKSPACE` is set |
+
+The script always rewrites `--output_user_root=/home/jenkins/.tidb/tmp` and
+`repository_cache=/home/jenkins/.tidb/tmp` in `Makefile.common`/`Makefile` to
+`tmpDir` (or `${WORKSPACE}/.cache/bazel`). This keeps bazel's output root and
+repository cache on the large mounted workspace volume instead of the
+node-local `/home/jenkins/.tidb` disk, which bazel builds easily exhaust. A
+`repositoryCache` with `guard: true` still takes precedence for the repository
+cache when the shared path is writable.
 
 `remoteCache: [mode: 'disable']` removes `try-import /data/bazel` from
 `.bazelrc` and appends `--noremote_accept_cached` / `--noremote_upload_local_results`

--- a/libraries/tipipeline/tests/TestBazel.groovy
+++ b/libraries/tipipeline/tests/TestBazel.groovy
@@ -114,6 +114,7 @@ class TestBazel {
             assert env.BAZEL_STRIP_URLS == 'bazel-cache[.]pingcap[.]net:8080|ats[.]apps[.]svc|cache[.]hawkingrei[.]com|mirror[.]bazel[.]build' :
                 "unexpected strip urls: ${env.BAZEL_STRIP_URLS}"
             assert env.BAZEL_PATCH_CHECK_TARGET == 'true' : 'should patch check target by default'
+            assert env.BAZEL_TMP_DIR == '' : 'should resolve tmp dir from WORKSPACE by default'
             assert env.BAZEL_ENSURE_TMP_DIR == 'false' : 'should not create tmp dir by default'
             assert env.BAZEL_REPOSITORY_CACHE_PATH == '' : 'should not switch repository cache by default'
             assert env.BAZEL_REPOSITORY_CACHE_GUARD == '' : 'guard should be empty without a path'
@@ -188,6 +189,12 @@ class TestBazel {
             def env = workspaceEnv([cloud: 'gcp', ensureTmpDir: true])
             assert env.BAZEL_ENSURE_TMP_DIR == 'true'
         }
+
+        @Test
+        void shouldPassExplicitTmpDir() {
+            def env = workspaceEnv([cloud: 'gcp', tmpDir: '/workspace/.cache/bazel'])
+            assert env.BAZEL_TMP_DIR == '/workspace/.cache/bazel' : "unexpected tmp dir: ${env.BAZEL_TMP_DIR}"
+        }
     }
 
     // ============================================================
@@ -227,8 +234,11 @@ class TestBazel {
         private String runScript(Map<String, String> env) {
             def builder = new ProcessBuilder('bash', RESOURCE.absolutePath)
             builder.directory(workDir)
-            builder.environment().putAll(env)
+            // Keep the environment deterministic: these variables are normally
+            // injected by Jenkins and would otherwise leak into the fixtures.
             builder.environment().remove('BAZEL_GUARDED')
+            builder.environment().remove('WORKSPACE')
+            builder.environment().putAll(env)
             def proc = builder.start()
             def out = proc.inputStream.text
             def err = proc.errorStream.text
@@ -274,6 +284,7 @@ class TestBazel {
                 mf.text = 'check: check-bazel-prepare all\n'
                 def builder = new ProcessBuilder('bash', RESOURCE.absolutePath)
                 builder.directory(dir)
+                builder.environment().remove('WORKSPACE')
                 builder.environment().putAll([BAZEL_STRIP_URLS: stripPattern(), BAZEL_GUARDED: 'true'])
                 def proc = builder.start()
                 def exit = proc.waitFor()
@@ -295,6 +306,7 @@ class TestBazel {
                 new File(dir, 'Makefile').text = 'check: check-bazel-prepare all\n'
                 def builder = new ProcessBuilder('bash', RESOURCE.absolutePath)
                 builder.directory(dir)
+                builder.environment().remove('WORKSPACE')
                 builder.environment().putAll([BAZEL_STRIP_URLS: stripPattern(), BAZEL_GUARDED: 'true'])
                 def proc = builder.start()
                 def exit = proc.waitFor()
@@ -371,6 +383,41 @@ class TestBazel {
             def tmpDir = new File(workDir, 'tmp-dir')
             runScript([BAZEL_STRIP_URLS: stripPattern(), BAZEL_ENSURE_TMP_DIR: 'true', BAZEL_TMP_DIR: tmpDir.absolutePath])
             assert tmpDir.isDirectory() : 'tmp dir should be created'
+        }
+
+        @Test
+        void shouldRedirectBazelDirsToWorkspaceVolume() {
+            def makefileCommon = new File(workDir, 'Makefile.common')
+            makefileCommon.text = 'BAZEL_GLOBAL_CONFIG := --output_user_root=/home/jenkins/.tidb/tmp\n' +
+                'BAZEL_CMD_CONFIG := --config=ci --repository_cache=/home/jenkins/.tidb/tmp\n'
+            runScript([BAZEL_STRIP_URLS: stripPattern(), WORKSPACE: workDir.absolutePath])
+            def content = makefileCommon.text
+            assert content.contains("--output_user_root=${workDir.absolutePath}/.cache/bazel") :
+                "output root should move to the workspace volume, got: ${content}"
+            assert content.contains("repository_cache=${workDir.absolutePath}/.cache/bazel/repository_cache") :
+                "repository cache should move to the workspace volume, got: ${content}"
+            assert !content.contains('/home/jenkins/.tidb/tmp') :
+                "node-local .tidb dir should not be referenced, got: ${content}"
+        }
+
+        @Test
+        void shouldPreferExplicitTmpDirOverWorkspace() {
+            def makefileCommon = new File(workDir, 'Makefile.common')
+            makefileCommon.text = 'BAZEL_GLOBAL_CONFIG := --output_user_root=/home/jenkins/.tidb/tmp\n'
+            def tmpDir = new File(workDir, 'explicit-tmp')
+            runScript([BAZEL_STRIP_URLS: stripPattern(), BAZEL_TMP_DIR: tmpDir.absolutePath,
+                       WORKSPACE: workDir.absolutePath])
+            assert makefileCommon.text.contains("--output_user_root=${tmpDir.absolutePath}") :
+                "explicit BAZEL_TMP_DIR should win over WORKSPACE, got: ${makefileCommon.text}"
+        }
+
+        @Test
+        void shouldRedirectBazelDirsWhenStripUrlsEmpty() {
+            def makefileCommon = new File(workDir, 'Makefile.common')
+            makefileCommon.text = 'BAZEL_GLOBAL_CONFIG := --output_user_root=/home/jenkins/.tidb/tmp\n'
+            runScript([BAZEL_STRIP_URLS: '', WORKSPACE: workDir.absolutePath])
+            assert makefileCommon.text.contains("--output_user_root=${workDir.absolutePath}/.cache/bazel") :
+                "tmp redirect should not depend on strip urls, got: ${makefileCommon.text}"
         }
     }
 }

--- a/libraries/tipipeline/vars/bazel.groovy
+++ b/libraries/tipipeline/vars/bazel.groovy
@@ -70,11 +70,14 @@ def stripPattern(List<String> urls) {
 //   patchCheckTarget: patch Makefile "check:" target (default: true)
 //   remoteCache:      null, [mode: 'disable'] or [mode: 'set', url: '...'] (default: envConfig)
 //   repositoryCache:  null, '/path' or [path: '/path', guard: true|false] (default: envConfig)
+//   tmpDir:           bazel output root / repository cache parent (default:
+//                     ${WORKSPACE}/.cache/bazel, resolved by the script)
 //   ensureTmpDir:     create the bazel tmp dir (default: false)
 def workspaceEnv(Map opts = [:]) {
     def cfg = envConfig(opts.cloud)
     def stripUrls = opts.containsKey('stripUrls') ? opts.stripUrls : cfg.stripUrls
     def patchCheckTarget = opts.containsKey('patchCheckTarget') ? opts.patchCheckTarget : true
+    def tmpDir = opts.containsKey('tmpDir') ? opts.tmpDir : null
     def ensureTmpDir = opts.containsKey('ensureTmpDir') ? opts.ensureTmpDir : false
     def repositoryCache = opts.containsKey('repositoryCache') ? opts.repositoryCache : (cfg.repositoryCachePath ? [path: cfg.repositoryCachePath, guard: true] : null)
     if (repositoryCache instanceof String) {
@@ -92,6 +95,7 @@ def workspaceEnv(Map opts = [:]) {
     return [
         'BAZEL_STRIP_URLS': stripUrls ? stripPattern(stripUrls) : '',
         'BAZEL_PATCH_CHECK_TARGET': patchCheckTarget ? 'true' : 'false',
+        'BAZEL_TMP_DIR': tmpDir ?: '',
         'BAZEL_ENSURE_TMP_DIR': ensureTmpDir ? 'true' : 'false',
         'BAZEL_REPOSITORY_CACHE_PATH': repositoryCache ? repositoryCache.path : '',
         'BAZEL_REPOSITORY_CACHE_GUARD': repositoryCache ? ((repositoryCache.containsKey('guard') ? repositoryCache.guard : true) ? 'true' : 'false') : '',

--- a/scripts/pingcap/tidb/prepare-bazel-workspace.sh
+++ b/scripts/pingcap/tidb/prepare-bazel-workspace.sh
@@ -9,10 +9,11 @@
 #                                URLs to remove from WORKSPACE/DEPS.bzl
 #   BAZEL_PATCH_CHECK_TARGET     "true" to drop check-bazel-prepare from the
 #                                Makefile "check:" target (default: true)
+#   BAZEL_TMP_DIR                bazel output root and repository cache
+#                                parent (default: ${WORKSPACE}/.cache/bazel)
 #   BAZEL_ENSURE_TMP_DIR         "true" to create the bazel tmp dir
-#   BAZEL_TMP_DIR                bazel tmp dir (default: /home/jenkins/.tidb/tmp)
-#   BAZEL_REPOSITORY_CACHE_PATH  shared repository cache dir, empty to keep
-#                                the default path (default: empty)
+#   BAZEL_REPOSITORY_CACHE_PATH  shared repository cache dir, empty to use
+#                                ${BAZEL_TMP_DIR}/repository_cache
 #   BAZEL_REPOSITORY_CACHE_GUARD "true" to only use the shared cache when it
 #                                is writable (default: true)
 #   BAZEL_REMOTE_CACHE_MODE      "disable" to turn remote cache off in
@@ -29,6 +30,46 @@ if sed --version >/dev/null 2>&1; then
     SED_I=(sed -i)
 else
     SED_I=(sed -i '')
+fi
+
+# Redirect bazel's output root and repository cache off the node-local
+# /home/jenkins/.tidb disk, which bazel builds can exhaust quickly. Prefer an
+# explicit BAZEL_TMP_DIR, then the large mounted Jenkins workspace volume.
+BAZEL_OUTPUT_ROOT="${BAZEL_TMP_DIR:-}"
+if [ -z "${BAZEL_OUTPUT_ROOT}" ] && [ -n "${WORKSPACE:-}" ]; then
+    BAZEL_OUTPUT_ROOT="${WORKSPACE}/.cache/bazel"
+fi
+
+if [ -n "${BAZEL_OUTPUT_ROOT}" ]; then
+    mkdir -p "${BAZEL_OUTPUT_ROOT}"
+    for f in Makefile.common Makefile; do
+        [ -f "$f" ] || continue
+        "${SED_I[@]}" "s|--output_user_root=/home/jenkins/.tidb/tmp|--output_user_root=${BAZEL_OUTPUT_ROOT}|g" "$f"
+    done
+elif [ "${BAZEL_ENSURE_TMP_DIR:-false}" = "true" ]; then
+    mkdir -p /home/jenkins/.tidb/tmp
+fi
+
+# Resolve the repository cache: an opt-in shared cache first, otherwise a
+# workspace-local directory so the node disk is not filled.
+BAZEL_REPO_CACHE="${BAZEL_REPOSITORY_CACHE_PATH:-}"
+if [ -n "${BAZEL_REPO_CACHE}" ] && [ "${BAZEL_REPOSITORY_CACHE_GUARD:-true}" = "true" ]; then
+    if [ -d "${BAZEL_REPO_CACHE}" ] && mkdir -p "${BAZEL_REPO_CACHE}/content_addressable/sha256" 2>/dev/null; then
+        echo "using shared bazel repository cache: ${BAZEL_REPO_CACHE}"
+    else
+        echo "shared bazel repository cache unavailable or not writable, falling back"
+        BAZEL_REPO_CACHE=""
+    fi
+fi
+if [ -z "${BAZEL_REPO_CACHE}" ] && [ -n "${BAZEL_OUTPUT_ROOT}" ]; then
+    BAZEL_REPO_CACHE="${BAZEL_OUTPUT_ROOT}/repository_cache"
+    mkdir -p "${BAZEL_REPO_CACHE}"
+fi
+if [ -n "${BAZEL_REPO_CACHE}" ]; then
+    for f in Makefile.common Makefile; do
+        [ -f "$f" ] || continue
+        "${SED_I[@]}" "s|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=${BAZEL_REPO_CACHE}|g" "$f"
+    done
 fi
 
 if [ -z "${BAZEL_STRIP_URLS:-}" ]; then
@@ -50,24 +91,6 @@ done
 # Avoid "check" targets re-writing legacy cache settings during replay validation.
 if [ "${BAZEL_PATCH_CHECK_TARGET:-true}" = "true" ]; then
     "${SED_I[@]}" 's/^check: check-bazel-prepare /check: /' Makefile || true
-fi
-
-if [ "${BAZEL_ENSURE_TMP_DIR:-false}" = "true" ]; then
-    mkdir -p "${BAZEL_TMP_DIR:-/home/jenkins/.tidb/tmp}"
-fi
-
-# Prefer shared local repository cache when writable, fallback to default path.
-if [ -n "${BAZEL_REPOSITORY_CACHE_PATH:-}" ]; then
-    if [ "${BAZEL_REPOSITORY_CACHE_GUARD:-true}" = "true" ]; then
-        if [ -d "${BAZEL_REPOSITORY_CACHE_PATH}" ] && mkdir -p "${BAZEL_REPOSITORY_CACHE_PATH}/content_addressable/sha256" 2>/dev/null; then
-            "${SED_I[@]}" "s|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=${BAZEL_REPOSITORY_CACHE_PATH}|g" Makefile.common
-            echo "using shared bazel repository cache: ${BAZEL_REPOSITORY_CACHE_PATH}"
-        else
-            echo "shared bazel repository cache unavailable or not writable, keep repository_cache=/home/jenkins/.tidb/tmp"
-        fi
-    else
-        "${SED_I[@]}" "s|repository_cache=/home/jenkins/.tidb/tmp|repository_cache=${BAZEL_REPOSITORY_CACHE_PATH}|g" Makefile.common
-    fi
 fi
 
 # Remote cache handling in .bazelrc.


### PR DESCRIPTION
### What problem does this PR solve?

`ghpr_check2` (and other bazel jobs) failed with `No space left on device` at `/home/jenkins/.tidb/tmp`.

The root cause is in `pingcap/tidb` `Makefile.common`, which sets both paths to the node-local `.tidb` dir whenever `CI` is set:

```makefile
ifneq ("$(CI)", "")
	BAZEL_GLOBAL_CONFIG := --output_user_root=/home/jenkins/.tidb/tmp
	BAZEL_CMD_CONFIG := --config=ci --repository_cache=/home/jenkins/.tidb/tmp
	BAZEL_SYNC_CONFIG := --repository_cache=/home/jenkins/.tidb/tmp
endif
```

That path is not a mounted volume in the job pod (only `/tmp` and `/home/jenkins/agent` are), so bazel filled the node ephemeral disk and the build died.

Example failed build: https://do.pingcap.net/jenkins-staging/job/pingcap/job/tidb/job/ghpr_check2/34/

### What is changed?

- `scripts/pingcap/tidb/prepare-bazel-workspace.sh`: before running build/test, rewrite `--output_user_root=/home/jenkins/.tidb/tmp` and `repository_cache=/home/jenkins/.tidb/tmp` in `Makefile.common`/`Makefile` to `BAZEL_TMP_DIR`, defaulting to `${WORKSPACE}/.cache/bazel` (the large mounted workspace volume).
- `libraries/tipipeline/vars/bazel.groovy`: expose an optional `tmpDir` option (`BAZEL_TMP_DIR`) so a job can override the location.
- A shared `repositoryCache` still takes precedence for the repository cache when writable.
- Tests and docs updated.

### How to test?

```bash
groovy libraries/tipipeline/tests/TestBazel.groovy
# JUnit 4 Runner, Tests: 30, Failures: 0
```

Replay `pingcap/tidb/ghpr_check2` on Jenkins staging and confirm the bazel commands use `${WORKSPACE}/.cache/bazel` and the build no longer hits `No space left on device`.