### PR TITLE
chore(pipelines): use ghcr.io release image instead of ghcr-remote mirror

### DIFF
--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check2.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check2.yaml
@@ -28,7 +28,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_br_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: utils
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_copr_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "12"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_jdbc_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_lightning_test.yaml
@@ -26,7 +26,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: utils
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_mysql_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_integration_python_orm_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_sqllogic_test.yaml
@@ -18,7 +18,7 @@ spec:
         - name: test-data
           mountPath: /git
     - name: utils
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_br_integration_test.yaml
@@ -36,7 +36,7 @@ spec:
         - mountPath: "/tmp/tidb"
           name: "tidb-temp-dir-volume"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_copr_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "10"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_ddl_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_jdbc_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_nodejs_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_integration_python_orm_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_lightning_integration_test.yaml
@@ -26,7 +26,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: utils
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-pull_sqllogic_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: download-sqllogic
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       command:
         - /bin/sh
         - -c

--- a/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_e2e_test_next_gen/pod.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_tici_test/pod.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_mysql_test_next_gen/pod.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 6Gi
           cpu: "3"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_br_integration_test.yaml
@@ -36,7 +36,7 @@ spec:
         - mountPath: "/tmp/tidb"
           name: "tidb-temp-dir-volume"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_binlog_test.yaml
@@ -61,7 +61,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_copr_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "10"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_ddl_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_jdbc_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_integration_tidb_tools_test.yaml
@@ -26,7 +26,7 @@ spec:
           memory: 2Gi
           cpu: "1"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_sqllogic_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: download-sqllogic
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       command:
         - /bin/sh
         - -c

--- a/pipelines/pingcap/tidb/release-7.1/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-pull_tiflash_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 12Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_br_integration_test.yaml
@@ -36,7 +36,7 @@ spec:
         - mountPath: "/tmp/tidb"
           name: "tidb-temp-dir-volume"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_binlog_test.yaml
@@ -61,7 +61,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_copr_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "10"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_ddl_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_jdbc_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_nodejs_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_python_orm_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_integration_tidb_tools_test.yaml
@@ -26,7 +26,7 @@ spec:
           memory: 2Gi
           cpu: "1"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_sqllogic_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: download-sqllogic
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       command:
         - /bin/sh
         - -c

--- a/pipelines/pingcap/tidb/release-7.5/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-pull_tiflash_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 12Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_br_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_br_integration_test.yaml
@@ -36,7 +36,7 @@ spec:
         - mountPath: "/tmp/tidb"
           name: "tidb-temp-dir-volume"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_binlog_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_binlog_test.yaml
@@ -61,7 +61,7 @@ spec:
         - mountPath: /tmp
           name: volume-0
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_copr_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "10"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_ddl_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_jdbc_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_nodejs_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_python_orm_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_integration_tidb_tools_test.yaml
@@ -26,7 +26,7 @@ spec:
           memory: 2Gi
           cpu: "1"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_lightning_integration_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_lightning_integration_test.yaml
@@ -26,7 +26,7 @@ spec:
           memory: 16Gi
           cpu: "4"
     - name: utils
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_sqllogic_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: download-sqllogic
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       command:
         - /bin/sh
         - -c

--- a/pipelines/pingcap/tidb/release-8.1/pod-pull_tiflash_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-pull_tiflash_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_check2.yaml
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_br_test.yaml
@@ -30,7 +30,7 @@ spec:
                 ssl-mode=DISABLED
                 EOF
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_copr_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "20"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_ddl_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_jdbc_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_lightning_test.yaml
@@ -26,7 +26,7 @@ spec:
           memory: 32Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_mysql_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_nodejs_test.yaml
@@ -18,7 +18,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_python_orm_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_integration_tidb_tools_test.yaml
@@ -26,7 +26,7 @@ spec:
           memory: 2Gi
           cpu: "1"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_sqllogic_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: download-sqllogic
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       command:
         - /bin/sh
         - -c

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check2.yaml
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_br_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_br_test.yaml
@@ -30,7 +30,7 @@ spec:
                 ssl-mode=DISABLED
                 EOF
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_copr_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_copr_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "20"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_ddl_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_ddl_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_e2e_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_e2e_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_jdbc_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_jdbc_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 8Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_lightning_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_lightning_test.yaml
@@ -26,7 +26,7 @@ spec:
           memory: 32Gi
           cpu: "4"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_mysql_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_mysql_test.yaml
@@ -15,7 +15,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_nodejs_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_nodejs_test.yaml
@@ -18,7 +18,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_python_orm_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_python_orm_test.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 16Gi
           cpu: "6"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_tidb_tools_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_integration_tidb_tools_test.yaml
@@ -26,7 +26,7 @@ spec:
           memory: 2Gi
           cpu: "1"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c
       tty: true
       resources:
         requests:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_sqllogic_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_sqllogic_test.yaml
@@ -5,7 +5,7 @@ spec:
     fsGroup: 1000
   initContainers:
     - name: download-sqllogic
-      image: "us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
+      image: "ghcr.io/pingcap-qe/cd/utils/release:v2025.10.12-7-gfdd779c"
       command:
         - /bin/sh
         - -c

--- a/pipelines/tidbcloud/cloud-storage-engine/latest/pull_integration_realcluster_test_next_gen/main-pod.yaml
+++ b/pipelines/tidbcloud/cloud-storage-engine/latest/pull_integration_realcluster_test_next_gen/main-pod.yaml
@@ -12,7 +12,7 @@ spec:
           memory: 32Gi
           cpu: "8"
     - name: utils
-      image: us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
+      image: ghcr.io/pingcap-qe/cd/utils/release:v2025.5.11-2-gfd3e259
       tty: true
       resources:
         requests:


### PR DESCRIPTION
## Summary

Replace the `us-docker.pkg.dev/pingcap-testing-account/ghcr-remote/pingcap-qe/cd/utils/release` image reference with the upstream `ghcr.io/pingcap-qe/cd/utils/release` in all pod YAMLs under `pipelines/`.

## Changes

- 89 pod YAML files under `pipelines/` updated.
- Image tags are kept unchanged; only the registry/repository prefix is switched from the ghcr-remote mirror to ghcr.io.