### PR TITLE
fix(tidb): unblock pingcap/tidb release-7.1 jenkins jobs

### DIFF
--- a/libraries/tipipeline/tests/TestBazel.groovy
+++ b/libraries/tipipeline/tests/TestBazel.groovy
@@ -262,6 +262,15 @@ class TestBazel {
         }
 
         @Test
+        void shouldAlsoPatchBazelCoverageTestTarget() {
+            makefile.text = 'check: check-bazel-prepare all\n' +
+                'bazel_coverage_test: check-bazel-prepare failpoint-enable bazel_ci_prepare\n'
+            runScript([BAZEL_STRIP_URLS: stripPattern()])
+            assert makefile.text == 'check: all\nbazel_coverage_test: failpoint-enable bazel_ci_prepare\n' :
+                "Makefile should drop check-bazel-prepare from check and bazel_coverage_test, got: ${makefile.text}"
+        }
+
+        @Test
         void shouldSkipMakefilePatchWhenDisabled() {
             runScript([BAZEL_STRIP_URLS: stripPattern(), BAZEL_PATCH_CHECK_TARGET: 'false'])
             assert makefile.text == 'check: check-bazel-prepare all\n' : 'Makefile should be untouched'

--- a/libraries/tipipeline/vars/bazel.groovy
+++ b/libraries/tipipeline/vars/bazel.groovy
@@ -67,7 +67,7 @@ def stripPattern(List<String> urls) {
 // opts:
 //   cloud:            override cloud env name (default: CI_CLOUD_ENV or 'gcp')
 //   stripUrls:        override stale URLs to remove (default: envConfig)
-//   patchCheckTarget: patch Makefile "check:" target (default: true)
+//   patchCheckTarget: patch Makefile "check:"/"bazel_coverage_test:" targets (default: true)
 //   remoteCache:      null, [mode: 'disable'] or [mode: 'set', url: '...'] (default: envConfig)
 //   repositoryCache:  null, '/path' or [path: '/path', guard: true|false] (default: envConfig)
 //   tmpDir:           bazel output root / repository cache parent (default:

--- a/pipelines/pingcap/tidb/release-7.1/ghpr_check.groovy
+++ b/pipelines/pingcap/tidb/release-7.1/ghpr_check.groovy
@@ -49,7 +49,7 @@ pipeline {
             // !!! concurrent go builds will encounter conflicts probabilistically.
             steps {
                 dir(REFS.repo) {
-                    sh script: 'make gogenerate check integrationtest'
+                    sh script: 'make gogenerate check explaintest'
                 }
             }
             post {

--- a/scripts/pingcap/tidb/integrationtest_with_tikv.sh
+++ b/scripts/pingcap/tidb/integrationtest_with_tikv.sh
@@ -38,14 +38,16 @@ EOF
     wait_for_http "http://${pd_addr2}/pd/api/v1/health" "PD-2" || return 1
     wait_for_http "http://${pd_addr3}/pd/api/v1/health" "PD-3" || return 1
 
-    bin/tikv-server --pd=${pd_addr1} -s tikv1 --addr=0.0.0.0:20160 --advertise-addr=127.0.0.1:20160 --advertise-status-addr=127.0.0.1:20165 -C tikv.toml -f tikv1.log &
-    bin/tikv-server --pd=${pd_addr2} -s tikv2 --addr=0.0.0.0:20170 --advertise-addr=127.0.0.1:20170 --advertise-status-addr=127.0.0.1:20175 -C tikv.toml -f tikv2.log &
-    bin/tikv-server --pd=${pd_addr3} -s tikv3 --addr=0.0.0.0:20180 --advertise-addr=127.0.0.1:20180 --advertise-status-addr=127.0.0.1:20185 -C tikv.toml -f tikv3.log &
+    # Each TiKV must bind a distinct status-addr: the TiKV default is
+    # 127.0.0.1:20180, which collides with the third instance's --addr.
+    bin/tikv-server --pd=${pd_addr1} -s tikv1 --addr=0.0.0.0:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20165 --advertise-status-addr=127.0.0.1:20165 -C tikv.toml -f tikv1.log &
+    bin/tikv-server --pd=${pd_addr2} -s tikv2 --addr=0.0.0.0:20170 --advertise-addr=127.0.0.1:20170 --status-addr=127.0.0.1:20175 --advertise-status-addr=127.0.0.1:20175 -C tikv.toml -f tikv2.log &
+    bin/tikv-server --pd=${pd_addr3} -s tikv3 --addr=0.0.0.0:20180 --advertise-addr=127.0.0.1:20180 --status-addr=127.0.0.1:20185 --advertise-status-addr=127.0.0.1:20185 -C tikv.toml -f tikv3.log &
 
     if [ -d "cmd/explaintest" ]; then
         chmod +x cmd/explaintest/run-tests.sh
 
-        export TIDB_SERVER_PATH="$(pwd)/bin/explain_test_tidb-server"
+        export TIDB_SERVER_PATH="$(pwd)/bin/integration_test_tidb-server"
         export TIKV_PATH="${pd_addr1}"
         export TIDB_TEST_STORE_NAME="tikv"
         pushd cmd/explaintest &&

--- a/scripts/pingcap/tidb/prepare-bazel-workspace.sh
+++ b/scripts/pingcap/tidb/prepare-bazel-workspace.sh
@@ -8,7 +8,8 @@
 #   BAZEL_STRIP_URLS             sed -E alternation of legacy cache/mirror
 #                                URLs to remove from WORKSPACE/DEPS.bzl
 #   BAZEL_PATCH_CHECK_TARGET     "true" to drop check-bazel-prepare from the
-#                                Makefile "check:" target (default: true)
+#                                Makefile "check:" and "bazel_coverage_test:"
+#                                targets (default: true)
 #   BAZEL_TMP_DIR                bazel output root and repository cache
 #                                parent (default: ${WORKSPACE}/.cache/bazel)
 #   BAZEL_ENSURE_TMP_DIR         "true" to create the bazel tmp dir
@@ -88,9 +89,11 @@ for f in WORKSPACE DEPS.bzl; do
     "${SED_I[@]}" -E "/${BAZEL_STRIP_URLS}/d" "$f"
 done
 
-# Avoid "check" targets re-writing legacy cache settings during replay validation.
+# Avoid "check"/"bazel_coverage_test" targets running check-bazel-prepare:
+# it re-writes legacy cache settings and is incompatible with the stripped
+# WORKSPACE/DEPS.bzl on this environment (and can break on new Bazel defaults).
 if [ "${BAZEL_PATCH_CHECK_TARGET:-true}" = "true" ]; then
-    "${SED_I[@]}" 's/^check: check-bazel-prepare /check: /' Makefile || true
+    "${SED_I[@]}" -E 's/^(check|bazel_coverage_test): check-bazel-prepare /\1: /' Makefile || true
 fi
 
 # Remote cache handling in .bazelrc.


### PR DESCRIPTION
## Summary

Split out from PingCAP-QE/ci#5135: the `pull-verify-jenkins-migration` check surfaced three real failures in the `pingcap/tidb` release-7.1 Jenkins jobs. All three reproduce on the **source** Jenkins, so they are pre-existing job bugs, not migration regressions. They are submitted separately so `main` is fixed first — the triggered Jenkins jobs load their pipeline from `main`, so the migration PR cannot go green until these land.

## Fixes

### 1. `ghpr_check`: wrong make target
`make gogenerate check integrationtest` fails with `No rule to make target 'integrationtest'` because the release-7.1 Makefile only defines `explaintest` (`integrationtest` exists on master/7.5/8.1). Regression from `cec63552`.
- `pipelines/pingcap/tidb/release-7.1/ghpr_check.groovy`

### 2. `ghpr_check2`: TiKV status port collision + wrong tidb-server path
- `integrationtest_with_tikv.sh` started three TiKVs without distinct `--status-addr`; all defaulted to `127.0.0.1:20180`, colliding with the third instance's `--addr=0.0.0.0:20180` (`tikv3`: `failed to build server: BindFail("0.0.0.0", 20180)`), so the explaintest tidb-server could not connect.
- The `cmd/explaintest` path pointed at `bin/explain_test_tidb-server`, but every ghpr_check2 pipeline renames the built server to `bin/integration_test_tidb-server`, so the server never started.
- `scripts/pingcap/tidb/integrationtest_with_tikv.sh`

### 3. `ghpr_unit_test`: `check-bazel-prepare` still runs via `bazel_coverage_test`
`build/jenkins_unit_test.sh` runs `make bazel_coverage_test`, which depends on `check-bazel-prepare`. The existing CI patch only removed it from `check:`; extend it to `bazel_coverage_test:`. The target fails with new Bazel defaults (`find: paths must precede expression: MODULE.bazel`).
- `scripts/pingcap/tidb/prepare-bazel-workspace.sh`
- `libraries/tipipeline/vars/bazel.groovy`
- `libraries/tipipeline/tests/TestBazel.groovy`

## Validation
- `bash -n` on both shell scripts.
- `groovy libraries/tipipeline/tests/TestBazel.groovy` -> 31 tests, 0 failures.
- Confirmed the Makefile sed drops `check-bazel-prepare` from both `check:` and `bazel_coverage_test:` on the release-7.1 Makefile.

## Follow-up
The tidb-side root cause of (3) is the unquoted glob in `tools/check/check-bazel-prepare.sh` (`-name *.bazel` / `-name *.bzl`); the CI patch works around it for now.