### PR TITLE
fix(pipelines): align check2 pod resources to 24Gi/3C across release branches

### DIFF
--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
@@ -11,11 +11,11 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 8Gi
-          cpu: "2"
+          memory: 24Gi
+          cpu: "3"
         limits:
-          memory: 32Gi
-          cpu: "8"
+          memory: 24Gi
+          cpu: "3"
       volumeMounts:
         - mountPath: /home/jenkins/.tidb
           name: bazel-out-merged

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
@@ -11,10 +11,10 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 12Gi
+          memory: 24Gi
           cpu: "3"
         limits:
-          memory: 12Gi
+          memory: 24Gi
           cpu: "3"
       volumeMounts:
         - mountPath: /home/jenkins/.tidb

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
@@ -11,10 +11,10 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 12Gi
+          memory: 24Gi
           cpu: "3"
         limits:
-          memory: 12Gi
+          memory: 24Gi
           cpu: "3"
       volumeMounts:
         - mountPath: /home/jenkins/.tidb

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
@@ -11,10 +11,10 @@ spec:
       tty: true
       resources:
         requests:
-          memory: 12Gi
+          memory: 24Gi
           cpu: "3"
         limits:
-          memory: 12Gi
+          memory: 24Gi
           cpu: "3"
       volumeMounts:
         - mountPath: /home/jenkins/.tidb


### PR DESCRIPTION
## Why

The check2 (`ghpr_check2` / `pull_check2`) pod resources diverge across release branches, and `release-7.5` is the tightest:

| branch | requests | limits |
|---|---|---|
| release-6.5 | 8Gi / 2C | 32Gi / 8C |
| release-7.1 | 12Gi / 3C | 12Gi / 3C |
| release-7.5 | 12Gi / 3C | 12Gi / 3C |
| release-8.1 | 12Gi / 3C | 12Gi / 3C |
| release-8.5 | 24Gi / 3C | 24Gi / 3C |
| latest | 24Gi / 3C | 24Gi / 3C |

PingCAP-QE/ci#4982 reduced `release-7.5` from `24Gi/6C req + 32Gi/8C lim` to `12Gi/3C` (the only branch whose memory was lowered). Its real-tikv import tests (`bazel_importintotest4`) then started failing with PD TSO timeouts and bazel test timeouts; `12Gi` is below the `~12.3Gi` peak that PingCAP-QE/ci#4982 measured for the heavy bazel targets.

## What

Align the `golang` container of `release-6.5`, `release-7.1`, `release-7.5` and `release-8.1` with `latest` / `release-8.5`:

```yaml
resources:
  requests:
    memory: 24Gi
    cpu: "3"
  limits:
    memory: 24Gi
    cpu: "3"
```

`release-8.5` already uses `24Gi/3C`, so it is unchanged.

## Notes

- Only `spec.containers[golang].resources` changes; no image / volume / affinity changes.
- Verified with `.ci/verify-k8s-pod-yaml.sh` on the changed files.

Related to the release-7.5 jenkins migration verification in PingCAP-QE/ci#5136.