### PR TITLE
ci(prow): migrate pingcap/tidb ghpr_check2 job to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/latest-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/latest-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
       name: pingcap/tidb/ghpr_check2
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: *skip_if_only_changed
       context: idc-jenkins-ci-tidb/check_dev_2


### PR DESCRIPTION
## Summary

Split the `pingcap/tidb/ghpr_check2` change out of PingCAP-QE/ci#5096 into its own PR.

Flip `labels.master` `"1"` -> `"0"` for `pingcap/tidb/ghpr_check2` in `prow-jobs/pingcap/tidb/latest-presubmits.yaml`, so the job is scheduled on the **to** (target) Jenkins.

Part of #4942.

## Verification

- `.ci/update-prow-job-kustomization.sh` (no change), YAML parse, and `git diff --check` all pass.
- `/test pull-verify-jenkins-migration` to verify the job on the **to** Jenkins.

Ref: PingCAP-QE/ci#5096
