### PR TITLE
ci(prow): migrate pingcap/tidb release-7.1 verified jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_check
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev
@@ -32,7 +32,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/ghpr_check2
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       skip_if_only_changed: "(\\.(md|png|jpeg|jpg|gif|svg|pdf)|Dockerfile|OWNERS|OWNERS_ALIASES)$"
       context: idc-jenkins-ci-tidb/check_dev_2


### PR DESCRIPTION
Split from #5135 — only the jobs that verified **SUCCESS** on the to Jenkins (verification: https://github.com/PingCAP-QE/ci/pull/5135#issuecomment-5538720928):

- `ghpr_check`
- `ghpr_check2`
