### PR TITLE
fix(pipelines): reduce tidb ghpr_check2 storage to 100Gi

### DIFF
--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml
@@ -49,7 +49,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
+++ b/pipelines/pingcap/tidb/release-7.5/ghpr_check2.groovy
@@ -88,7 +88,7 @@ pipeline {
                         )
                     }
                 }
-                agent{
+                agent {
                     kubernetes {
                         namespace K8S_NAMESPACE
                         defaultContainer 'golang'
@@ -102,7 +102,7 @@ pipeline {
                     expression { return !matrixCache.shouldSkip(REFS, 'Test', [script_and_args: env.SCRIPT_AND_ARGS]) }
                 }
                 stages {
-                    stage('Test')  {
+                    stage('Test') {
                         environment {
                             CODECOV_TOKEN = credentials('codecov-token-tidb')
                         }
@@ -139,7 +139,6 @@ pipeline {
                             success {
                                 dir(REFS.repo) {
                                     script {
-
                                         prow.uploadCoverageToCodecov(REFS, 'integration', './coverage.dat')
                                     }
                                 }

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 24Gi
           cpu: "3"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -41,7 +41,7 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -49,7 +49,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:


### PR DESCRIPTION
## Changes

Align the `pingcap/tidb` `ghpr_check2` pod configuration across branches:

- `pipelines/pingcap/tidb/latest/pod-ghpr_check2.yaml`: reduce the ephemeral volume request from `150Gi` to `100Gi`.
- `pipelines/pingcap/tidb/release-7.5/pod-ghpr_check2.yaml`: reduce the ephemeral volume request from `150Gi` to `100Gi`, and mount the ephemeral volume at `/tmp` instead of `/home/jenkins/.tidb` (renaming `bazel-out-merged` to `tmp`), matching the `latest` branch and redirecting the bazel output root off the node-local `.tidb` directory.

## Motivation

Keep the check2 pod definitions consistent between `latest` and `release-7.5`, lower the PVC size to what the job actually needs, and avoid the node-local `.tidb` mount.