### PR TITLE
fix(pipelines): mount bazel volume as tmp at /tmp with 100Gi

### DIFF
--- a/pipelines/pingcap-inc/enterprise-extensions/latest/pod-pr-verify.yaml
+++ b/pipelines/pingcap-inc/enterprise-extensions/latest/pod-pr-verify.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_build.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc # migration: keep
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,8 +31,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
-      emptyDir: {}
+    - name: tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check2.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_check2.yaml
@@ -14,8 +14,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -38,8 +38,16 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: bazel-out-merged
-      emptyDir: {}
+    - name: tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap-inc/tidb/release-8.5/pod-pull_unit_test.yaml
@@ -19,8 +19,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 300Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/latest/ghpr_build/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/ghpr_build/pod.yaml
@@ -17,8 +17,8 @@ spec:
           cpu: "8"
           memory: 64Gi
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc # migration: keep
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_check.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,8 +31,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
-      emptyDir: {}
+    - name: tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-ghpr_unit_test.yaml
@@ -19,8 +19,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test.yaml
@@ -19,8 +19,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
+++ b/pipelines/pingcap/tidb/latest/pod-merged_unit_test_ddlv1.yaml
@@ -19,8 +19,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/latest/pull_build_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_build_next_gen/pod.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 64Gi
           cpu: "16"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/latest/pull_check_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_check_next_gen/pod.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb/tmp
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-out-lower
           subPath: tidb/go1.19.2
           mountPath: /bazel-out-lower
@@ -41,8 +41,16 @@ spec:
         claimName: bazel-out-data
     - name: bazel-out-overlay
       emptyDir: {}
-    - name: bazel-out-merged
-      emptyDir: {}
+    - name: tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
       secret:
         secretName: bazel

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -137,12 +137,6 @@ pipeline {
                             dir(REFS.repo) {
                                 unstash 'ws'
                                 sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
-
-                                sh '''
-                                    mkdir -p /home/jenkins/.tidb/tmp
-                                    git diff . || true
-                                    git status || true
-                                '''
                                 sh """#! /usr/bin/env bash
                                     set -o pipefail
 

--- a/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_integration_realcluster_test_next_gen/pod.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 48Gi
           cpu: "12"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -41,7 +41,7 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -49,7 +49,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
+++ b/pipelines/pingcap/tidb/latest/pull_unit_test_next_gen/pod.yaml
@@ -19,8 +19,8 @@ spec:
           memory: 64Gi
           cpu: "20"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 300Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_build.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 64Gi
           cpu: "16"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,8 +31,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
-      emptyDir: {}
+    - name: tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_check2.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 24Gi
           cpu: "3"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -41,7 +41,7 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -49,7 +49,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-6.5/pod-ghpr_unit_test.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_build.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 64Gi
           cpu: "16"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc # migration: keep
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,8 +31,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
-      emptyDir: {}
+    - name: tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_check2.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 24Gi
           cpu: "3"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -41,7 +41,7 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -49,7 +49,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.1/pod-ghpr_unit_test.yaml
@@ -19,8 +19,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_build.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 64Gi
           cpu: "16"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc # migration: keep
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_check.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,8 +31,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
-      emptyDir: {}
+    - name: tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-7.5/pod-ghpr_unit_test.yaml
@@ -19,8 +19,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_build.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_build.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 64Gi
           cpu: "16"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc # migration: keep
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,8 +31,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
-      emptyDir: {}
+    - name: tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_check2.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 24Gi
           cpu: "3"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -41,7 +41,7 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -49,7 +49,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-8.1/pod-ghpr_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.1/pod-ghpr_unit_test.yaml
@@ -19,8 +19,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_build.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc # migration: keep
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_check.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_check.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,8 +31,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
-      emptyDir: {}
+    - name: tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_check2.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 24Gi
           cpu: "3"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -41,7 +41,7 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -49,7 +49,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-8.5/pod-pull_unit_test.yaml
@@ -19,8 +19,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 300Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_build.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_build.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc # migration: keep
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,8 +31,16 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
-      emptyDir: {}
+    - name: tmp
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: ci-rwo
     - name: bazel-rc
       configMap:
         name: bazel

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check2.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_check2.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 32Gi
           cpu: "8"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -41,7 +41,7 @@ spec:
           cpu: "1"
           memory: 4Gi
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -49,7 +49,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 150Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_unit_test.yaml
+++ b/pipelines/pingcap/tidb/release-9.0-beta/pod-pull_unit_test.yaml
@@ -19,8 +19,8 @@ spec:
           memory: 64Gi
           cpu: "24"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -33,7 +33,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -41,7 +41,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 300Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/tidbcloud/cloud-storage-engine/latest/pull_integration_realcluster_test_next_gen/test-pod.yaml
+++ b/pipelines/tidbcloud/cloud-storage-engine/latest/pull_integration_realcluster_test_next_gen/test-pod.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 48Gi
           cpu: "12"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/pipeline.groovy
@@ -152,12 +152,6 @@ pipeline {
                             dir('tidb') {
                                 unstash 'ws'
                                 sh "ls -l rev-${REFS.pulls[0].sha}" // will fail when not found in cache or no cached.
-
-                                sh """
-                                mkdir -p /home/jenkins/.tidb/tmp
-                                git diff . || true
-                                git status || true
-                                """
                                 sh """#! /usr/bin/env bash
                                     set -o pipefail
 

--- a/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/test-pod.yaml
+++ b/pipelines/tikv/pd/latest/pull_integration_realcluster_test_next_gen/test-pod.yaml
@@ -17,8 +17,8 @@ spec:
           memory: 48Gi
           cpu: "12"
       volumeMounts:
-        - mountPath: /home/jenkins/.tidb
-          name: bazel-out-merged
+        - mountPath: /tmp
+          name: tmp
         - name: bazel-rc
           mountPath: /data/
           readOnly: true
@@ -31,7 +31,7 @@ spec:
               - /bin/sh
               - /data/bazel-prepare-in-container.sh
   volumes:
-    - name: bazel-out-merged
+    - name: tmp
       ephemeral:
         volumeClaimTemplate:
           spec:
@@ -39,7 +39,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 200Gi
+                storage: 100Gi
             storageClassName: ci-rwo
     - name: bazel-rc
       configMap:


### PR DESCRIPTION
## Changes

Unify the bazel workspace volume across all pod templates under `pipelines/`:

- Rename the `bazel-out-merged` volume to `tmp`.
- Mount it at `/tmp` instead of `/home/jenkins/.tidb` (and `/home/jenkins/.tidb/tmp`).
- Provision it uniformly with an ephemeral `volumeClaimTemplate` (ReadWriteOnce, `100Gi`, storage class `ci-rwo`).
- Convert the 10 `emptyDir` volumes (check jobs) to the same `volumeClaimTemplate`.
- Resize the 29 existing ephemeral PVCs from `150Gi`/`200Gi`/`300Gi` to `100Gi`.

39 pod YAMLs updated. This follows the same pattern already applied to the tidb `ghpr_check2` pods.

## Motivation

The `bazel-out-merged` volume no longer needs to be mounted at the node-local `/home/jenkins/.tidb` directory. Mounting at `/tmp` and standardizing on a `100Gi` ephemeral `volumeClaimTemplate` keeps provisioning consistent and right-sizes the PVCs.

## Notes

- `pull_check_next_gen/pod.yaml` keeps its sibling `bazel-out-lower` (PVC) and `bazel-out-overlay` (emptyDir) volumes untouched.
- `bazel-rc` and `containerinfo` volumes are unchanged.
- Only `pipelines/` pod templates are touched; pipeline `.groovy` files are not part of this PR.

## Verification

- `.ci/verify-storage-class-policy.sh` — passed.
- `.ci/verify-k8s-pod-yaml.sh` on all 39 changed files (kubectl client + server dry-run) — passed.
- No remaining `bazel-out-merged` or `/home/jenkins/.tidb` references in `pipelines/` pod YAMLs.
