### PR TITLE
fix(libraries): keep .git/refs non-empty for stashed workspaces

### DIFF
--- a/libraries/tipipeline/tests/TestProw.groovy
+++ b/libraries/tipipeline/tests/TestProw.groovy
@@ -97,6 +97,22 @@ class TestProw {
                 checkoutScript.contains(
                     '+refs/pull/123/head:refs/remotes/origin/pr/123/head'))
         }
+
+        @Test
+        void shouldKeepRefsDirNonEmptyForStashTransfer() {
+            def shCalls = []
+            def script = loadProw(sh: { Map args -> shCalls << args })
+
+            script.checkoutPublicRefs(refs(), 7, false, 'https://github.example')
+
+            def checkoutScript = shCalls[0].script
+            assertTrue(
+                'checkout must leave a file under .git/refs so the directory survives stash/unstash',
+                checkoutScript.contains('mkdir -p .git/refs'))
+            assertTrue(
+                'checkout must leave a file under .git/refs so the directory survives stash/unstash',
+                checkoutScript.contains('touch .git/refs/.keep'))
+        }
     }
 
     static class PrivateCheckout {

--- a/libraries/tipipeline/vars/prow.groovy
+++ b/libraries/tipipeline/vars/prow.groovy
@@ -204,6 +204,15 @@ def _checkoutRefsImpl(refs, remoteUrl, timeout, withSubmodule) {
             fi
         ) >/dev/null 2>&1 || true
 
+        # Jenkins `stash` archives only files, so an empty directory is dropped.
+        # `git gc` packs all refs and leaves .git/refs empty; without any file in
+        # it, a workspace restored via `unstash` is not recognized as a valid git
+        # repository, and git commands fall back to an ancestor repository (e.g.
+        # the CI checkout at the workspace root). Keep a sentinel so a
+        # transferred .git stays valid.
+        mkdir -p .git/refs
+        touch .git/refs/.keep
+
         echo "✅ ~~~~~All done.~~~~~~"
     """
 }


### PR DESCRIPTION
### Problem

Jobs that transfer a workspace between the build pod and the matrix test pods with `stash`/`unstash` end up with an invalid target-repo `.git` in the test pod. When a test runner uses `git rev-parse --show-toplevel` to locate the repo, git walks up to an ancestor repository (the CI checkout at the workspace root) and returns the wrong root, so it discovers zero test cases and the job passes vacuously.

This is what happened to `pingcap/tiflow/release-6.5/pull_cdc_integration_kafka_test`: all 16 matrix groups reported `Total number of valid directories: 0` and the build stayed green.

### Root cause

Jenkins `stash` archives only files (`DirScanner` -> Ant `getIncludedFiles()`), so empty directories are not written into the tarball. The checkout runs `git gc`, which packs all refs and leaves `.git/refs` empty. After `unstash`, the restored `.git` has no `refs/` directory, so git's `is_git_directory()` rejects it and repository discovery falls back to the nearest ancestor `.git` (the CI repo checked out at the workspace root).

Reproduced locally: a `.git` without `refs/` under a parent git repo makes `git rev-parse --show-toplevel` return the parent; adding `refs/` back makes it return the inner repo.

### Fix

At the end of `_checkoutRefsImpl`, keep a sentinel file under `.git/refs` so the directory is non-empty and survives the `stash`/`unstash` round trip. Git ignores entries starting with `.` in `refs/`, so this is inert for normal git operations.

```bash
mkdir -p .git/refs
touch .git/refs/.keep
```

With this, `git rev-parse --show-toplevel` returns the correct repo root in the test pod, and `git`-based test runners (e.g. tiflow release-6.5 `cdc_run_group.sh`) work as before.

### Verification

- `groovy libraries/tipipeline/tests/TestProw.groovy` — the new test `shouldKeepRefsDirNonEmptyForStashTransfer` passes.
- Manually verified that `git gc` neither removes nor complains about `.git/refs/.keep`, and that `git rev-parse --show-toplevel` resolves correctly with it present.

Note: `TestProw.groovy` already has 2 failing `AskPass` tests before this change (stale since PingCAP-QE/ci#5072 changed `withGitAskPass`). They are unrelated to this PR and left untouched.
