### PR TITLE
fix(scripts): put real-tikv PD/TiKV data dir under /tmp

### DIFF
--- a/scripts/pingcap/tidb/run_real_tikv_tests.sh
+++ b/scripts/pingcap/tidb/run_real_tikv_tests.sh
@@ -46,15 +46,16 @@ max-open-files = 20480
 max-open-files = 20480
 EOF
 
-    local pd_data_base_dir=$(mktemp -d)
-    bin/pd-server --name=pd-0 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd1.log &
-    bin/pd-server --name=pd-1 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-1/data --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd2.log &
-    bin/pd-server --name=pd-2 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-2/data --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd3.log &
+    data_base_dir="$(mktemp -d /tmp/tidb-real-tikv-data.XXXXXX)" || { echo "failed to create data dir" >&2; return 1; }
+    mkdir -p "${data_base_dir}"/{pd-0,pd-1,pd-2,tikv-0,tikv-1,tikv-2}
+    bin/pd-server --name=pd-0 --data-dir="${data_base_dir}/pd-0/data" --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd1.log &
+    bin/pd-server --name=pd-1 --data-dir="${data_base_dir}/pd-1/data" --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd2.log &
+    bin/pd-server --name=pd-2 --data-dir="${data_base_dir}/pd-2/data" --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd3.log &
     wait_for_pd_cluster "http://127.0.0.1:2379/pd/api/v1/health" 3 "PD cluster" || return 1
 
-    bin/tikv-server --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-0/data -f tikv1.log &
-    bin/tikv-server --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-1/data -f tikv2.log &
-    bin/tikv-server --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-2/data -f tikv3.log &
+    bin/tikv-server --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir="${data_base_dir}/tikv-0/data" -f tikv1.log &
+    bin/tikv-server --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir="${data_base_dir}/tikv-1/data" -f tikv2.log &
+    bin/tikv-server --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir="${data_base_dir}/tikv-2/data" -f tikv3.log &
 
     sleep 10
     make ${test_suite}
@@ -63,6 +64,7 @@ EOF
 function cleanup() {
     killall -9 -r -q tikv-server
     killall -9 -r -q pd-server
+    [[ -n "${data_base_dir:-}" ]] && rm -rf "${data_base_dir}"
 }
 
 exit_code=0

--- a/scripts/pingcap/tidb/run_real_tikv_tests_with_gotest.sh
+++ b/scripts/pingcap/tidb/run_real_tikv_tests_with_gotest.sh
@@ -38,15 +38,16 @@ max-open-files = 20480
 max-open-files = 20480
 EOF
 
-    local pd_data_base_dir=$(mktemp -d)
-    bin/pd-server --name=pd-0 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-0/data --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd1.log &
-    bin/pd-server --name=pd-1 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-1/data --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd2.log &
-    bin/pd-server --name=pd-2 --data-dir=/home/jenkins/.tiup/data/T9Z9nII/pd-2/data --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd3.log &
+    data_base_dir="$(mktemp -d /tmp/tidb-real-tikv-data.XXXXXX)" || { echo "failed to create data dir" >&2; return 1; }
+    mkdir -p "${data_base_dir}"/{pd-0,pd-1,pd-2,tikv-0,tikv-1,tikv-2}
+    bin/pd-server --name=pd-0 --data-dir="${data_base_dir}/pd-0/data" --peer-urls=http://127.0.0.1:2380 --advertise-peer-urls=http://127.0.0.1:2380 --client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd1.log &
+    bin/pd-server --name=pd-1 --data-dir="${data_base_dir}/pd-1/data" --peer-urls=http://127.0.0.1:2381 --advertise-peer-urls=http://127.0.0.1:2381 --client-urls=http://127.0.0.1:2382 --advertise-client-urls=http://127.0.0.1:2382 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd2.log &
+    bin/pd-server --name=pd-2 --data-dir="${data_base_dir}/pd-2/data" --peer-urls=http://127.0.0.1:2383 --advertise-peer-urls=http://127.0.0.1:2383 --client-urls=http://127.0.0.1:2384 --advertise-client-urls=http://127.0.0.1:2384 --initial-cluster=pd-0=http://127.0.0.1:2380,pd-1=http://127.0.0.1:2381,pd-2=http://127.0.0.1:2383 --force-new-cluster &> pd3.log &
     wait_for_pd_cluster "http://127.0.0.1:2379/pd/api/v1/health" 3 "PD cluster" || return 1
 
-    bin/tikv-server --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-0/data -f tikv1.log &
-    bin/tikv-server --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-1/data -f tikv2.log &
-    bin/tikv-server --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir=/home/jenkins/.tiup/data/T9Z9nII/tikv-2/data -f tikv3.log &
+    bin/tikv-server --addr=127.0.0.1:20160 --advertise-addr=127.0.0.1:20160 --status-addr=127.0.0.1:20180 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir="${data_base_dir}/tikv-0/data" -f tikv1.log &
+    bin/tikv-server --addr=127.0.0.1:20161 --advertise-addr=127.0.0.1:20161 --status-addr=127.0.0.1:20181 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir="${data_base_dir}/tikv-1/data" -f tikv2.log &
+    bin/tikv-server --addr=127.0.0.1:20162 --advertise-addr=127.0.0.1:20162 --status-addr=127.0.0.1:20182 --pd=http://127.0.0.1:2379,http://127.0.0.1:2382,http://127.0.0.1:2384 --config=tikv.toml --data-dir="${data_base_dir}/tikv-2/data" -f tikv3.log &
 
     sleep 10
     go test ./tests/realtikvtest/${test_suite} -v --tags=intest  -with-real-tikv -timeout 40m
@@ -55,6 +56,7 @@ EOF
 function cleanup() {
     killall -9 -r -q tikv-server
     killall -9 -r -q pd-server
+    [[ -n "${data_base_dir:-}" ]] && rm -rf "${data_base_dir}"
 }
 
 exit_code=0


### PR DESCRIPTION
## Why

The real-tikv test scripts (`scripts/pingcap/tidb/run_real_tikv_tests.sh` and `run_real_tikv_tests_with_gotest.sh`) started local PD/TiKV with a hardcoded `--data-dir=/home/jenkins/.tiup/data/T9Z9nII`, which lives on the container overlay (node disk).

On the target Jenkins the node disk is slower than the pod's `ci-rwo` volume that the check2 pods mount at `/tmp`, so TiKV/PD RocksDB I/O was slow and the tests were flaky / timeout-prone.

## What

- Create a per-run random directory under `/tmp` (`mktemp -d /tmp/tidb-real-tikv-data.XXXXXX`) and point all 6 `--data-dir` (3 PD + 3 TiKV) at it, so the data lands on the `ci-rwo` `/tmp` volume.
- Remove the directory in `cleanup()`.
- Drop the unused `pd_data_base_dir=$(mktemp -d)` dead code.
- Applied to both scripts (the `_with_gotest` variant has the same hardcoded path; it is currently not referenced by any pipeline).

## Impact

Only the 8 jobs that use these scripts are affected (`latest`/`release-6.5`/`7.1`/`7.5`/`8.1` `ghpr_check2`, `release-8.5`/`9.0-beta` and `pingcap-inc/release-8.5` `pull_check2`). All of them already mount `/tmp` as a 100Gi `ci-rwo` volume.

## Verification

- `bash -n` on both scripts.
- Replayed `pingcap/tidb/release-7.5/ghpr_check2` on the target Jenkins with these scripts injected (download-overwrite from this PR's head SHA): https://do.pingcap.net/jenkins/job/pingcap/job/tidb/job/release-7.5/job/ghpr_check2/6
  - The injected new script was confirmed in the console (`mktemp -d /tmp/tidb-real-tikv-data.XXXXXX`, all 6 `--data-dir` rewritten).
  - The replay still aborted: `//tests/realtikvtest/addindextest4:addindextest4_test` exceeded the bazel 900s test timeout and was retried (`--flaky_test_attempts=5`), so the job could not finish within its 65-minute budget. This is a pre-existing timeout on the target Jenkins and is not fixed by moving the PD/TiKV data dir alone.
