### PR TITLE
ci(prow): migrate pingcap/tidb release-7.1 optional jobs to target jenkins

### DIFF
--- a/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
+++ b/prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_br_integration_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       context: pull-br-integration-test
       always_run: false
@@ -129,7 +129,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_e2e_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -142,7 +142,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -155,7 +155,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_common_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -168,7 +168,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_sqllogic_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -181,7 +181,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_tiflash_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -194,7 +194,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_tidb_tools_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true
@@ -207,7 +207,7 @@ presubmits:
     - name: pingcap/tidb/release-7.1/pull_integration_binlog_test
       agent: jenkins
       labels:
-        master: "1"
+        master: "0"
       decorate: false # need add this.
       always_run: false
       optional: true


### PR DESCRIPTION
Split from #5135 — only the `optional: true` (non-blocking) jobs whose `labels.master` is flipped `1 -> 0`.

The migration verifier skips these jobs because there is no parameter provenance on the from Jenkins (they need `--source-build` or a prior successful build). Since they are `optional: true` in `prow-jobs/pingcap/tidb/release-7.1-presubmits.yaml`, they do not gate tidb PRs, so their migration is safe to land separately.

Jobs:

- `pull_br_integration_test`
- `pull_e2e_test`
- `pull_common_test`
- `pull_integration_common_test`
- `pull_sqllogic_test`
- `pull_tiflash_test`
- `pull_integration_tidb_tools_test`
- `pull_integration_binlog_test`

Parent verification comment: https://github.com/PingCAP-QE/ci/pull/5135#issuecomment-5538720928
